### PR TITLE
Add repo root to sys.path

### DIFF
--- a/app/item_manager_app.py
+++ b/app/item_manager_app.py
@@ -1,5 +1,11 @@
 # app/item_manager_app.py
 
+import os, sys
+PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(PACKAGE_DIR, os.pardir))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
 import streamlit as st
 import pandas as pd
 from datetime import datetime


### PR DESCRIPTION
## Summary
- prepend repository root to Python path in `item_manager_app.py`
- verify the app starts and run `flake8`

## Testing
- `flake8 app`
- `streamlit run app/item_manager_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68453229a9588326b0943e88ca0a8785