### PR TITLE
Fix sidebar logo function

### DIFF
--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -23,3 +23,6 @@ def format_status_badge(status: str) -> str:
 
 
 def render_sidebar_logo() -> None:
+    """Render the logo image in the Streamlit sidebar."""
+    logo_bytes = get_logo_bytes()
+    st.sidebar.image(logo_bytes, use_column_width=True)


### PR DESCRIPTION
## Summary
- implement `render_sidebar_logo` to avoid `IndentationError`
- compile Python files for sanity

## Testing
- `python -m py_compile app/ui/theme.py`
- `find app -maxdepth 3 -name '*.py' | while read f; do python -m py_compile "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_6846789c7ff08326846d781e4eba4424