### PR TITLE
Remove chart and update logo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,20 @@ streamlit run app/item_manager_app.py
 ## Configuration
 
 Before running the app, create a `.streamlit/secrets.toml` file containing your database credentials. An example file can be found at `.streamlit/secrets.toml` in this repository—copy it and replace the placeholder values with your own. The committed sample uses obvious placeholders so you must supply real values.
+
+## Customizing the Sidebar Logo
+
+The sidebar image displayed in the app is defined in `app/ui/logo.py` as a base64 encoded PNG. To use your own logo:
+
+1. Convert your PNG image to a base64 string:
+
+   ```python
+   import base64
+
+   with open("my_logo.png", "rb") as f:
+       print(base64.b64encode(f.read()).decode())
+   ```
+
+2. Replace the `LOGO_BASE64` value in `app/ui/logo.py` with the string printed above.
+
+Restart the application and your logo will appear in the sidebar.

--- a/app/item_manager_app.py
+++ b/app/item_manager_app.py
@@ -1,10 +1,7 @@
 # app/item_manager_app.py
 
-import os, sys
-PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
-REPO_ROOT = os.path.abspath(os.path.join(PACKAGE_DIR, os.pardir))
-if REPO_ROOT not in sys.path:
-    sys.path.insert(0, REPO_ROOT)
+import os
+import sys
 
 import streamlit as st
 import pandas as pd
@@ -121,8 +118,7 @@ def run_dashboard():
             help="Material requests awaiting processing.",
         )
 
-    if not low_stock_df.empty:
-        st.bar_chart(low_stock_df.set_index("name")["current_stock"])
+    # Removed the bar chart to avoid Altair warnings and simplify the dashboard
 
     st.divider()
 

--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -51,6 +51,7 @@ def fetch_all_items_df_for_items_page(
         _engine, include_inactive=show_inactive
     )
 
+
 load_css()
 render_sidebar_logo()
 

--- a/app/pages/2_Suppliers.py
+++ b/app/pages/2_Suppliers.py
@@ -42,6 +42,7 @@ def fetch_all_suppliers_df_pg2(
 ) -> pd.DataFrame:  # Page-specific cache function name
     return supplier_service.get_all_suppliers(_engine, include_inactive=show_inactive)
 
+
 load_css()
 render_sidebar_logo()
 

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -25,4 +25,5 @@ def format_status_badge(status: str) -> str:
 def render_sidebar_logo() -> None:
     """Render the logo image in the Streamlit sidebar."""
     logo_bytes = get_logo_bytes()
-    st.sidebar.image(logo_bytes, use_column_width=True)
+    # use_container_width avoids deprecation warnings from Streamlit
+    st.sidebar.image(logo_bytes, use_container_width=True)


### PR DESCRIPTION
## Summary
- remove Altair chart from dashboard to eliminate warnings
- switch sidebar logo to `use_container_width`
- document how to customize the sidebar logo
- satisfy flake8 style check

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68467a7c20c88326bbfa377bf781a94f