### PR TITLE
Fix item_manager_app relative import issue

### DIFF
--- a/app/item_manager_app.py
+++ b/app/item_manager_app.py
@@ -3,6 +3,13 @@
 import os
 import sys
 
+# Ensure this file works even when executed using a relative path (e.g.
+# `streamlit run app/item_manager_app.py`).
+_CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_CURRENT_DIR, os.pardir))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
 import streamlit as st
 import pandas as pd
 from datetime import datetime


### PR DESCRIPTION
## Summary
- fix module import errors when running `item_manager_app.py` from a path

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846893508988326b00ddb965fe9c20a