### PR TITLE
Support logo file override

### DIFF
--- a/app/ui/logo.py
+++ b/app/ui/logo.py
@@ -1,4 +1,15 @@
+"""Utilities for loading the sidebar logo.
+
+If a ``logo.png`` file is present in the same directory as this module,
+its bytes will be loaded at runtime. Otherwise the fallback base64
+string below is decoded.
+"""
+
 from base64 import b64decode
+from pathlib import Path
+
+# Path to an optional logo image file that can override the embedded base64
+LOGO_PATH = Path(__file__).with_name("logo.png")
 
 # Base64-encoded PNG image used for the sidebar logo. Encoding the logo avoids
 # committing binary data so pull requests remain text-only.
@@ -12,5 +23,12 @@ LOGO_BASE64 = (
 
 
 def get_logo_bytes() -> bytes:
-    """Return the decoded logo image bytes."""
+    """Return the sidebar logo image bytes.
+
+    If ``logo.png`` exists next to this file, its contents are returned.
+    Otherwise ``LOGO_BASE64`` is decoded.
+    """
+    if LOGO_PATH.exists():
+        return LOGO_PATH.read_bytes()
+
     return b64decode(LOGO_BASE64)


### PR DESCRIPTION
## Summary
- allow overriding sidebar logo with `app/ui/logo.png`
- document fallback behavior in `logo.py`

## Testing
- `flake8 | head`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846924c91888326adcb0be5fb4f9b0c