### PR TITLE
Add simple logo override mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,11 @@ Before running the app, create a `.streamlit/secrets.toml` file containing your 
 
 ## Customizing the Sidebar Logo
 
-The sidebar image displayed in the app is defined in `app/ui/logo.py` as a base64 encoded PNG. To use your own logo:
+To override the default sidebar image, place a file named `logo.png` in
+`app/ui/`. When present, the application loads this file automatically.
+If no such file exists, the built-in base64 image defined in `app/ui/logo.py`
+is used instead.
 
-1. Convert your PNG image to a base64 string:
-
-   ```python
-   import base64
-
-   with open("my_logo.png", "rb") as f:
-       print(base64.b64encode(f.read()).decode())
-   ```
-
-2. Replace the `LOGO_BASE64` value in `app/ui/logo.py` with the string printed above.
-
-Restart the application and your logo will appear in the sidebar.
+Optional fallback: you can still embed a custom image by replacing the value of
+`LOGO_BASE64` in `app/ui/logo.py`. Convert your PNG to a base64 string and
+assign it to `LOGO_BASE64` if you prefer not to keep a separate file.

--- a/app/ui/logo.py
+++ b/app/ui/logo.py
@@ -1,4 +1,5 @@
 from base64 import b64decode
+from pathlib import Path
 
 # Base64-encoded PNG image used for the sidebar logo. Encoding the logo avoids
 # committing binary data so pull requests remain text-only.
@@ -12,5 +13,12 @@ LOGO_BASE64 = (
 
 
 def get_logo_bytes() -> bytes:
-    """Return the decoded logo image bytes."""
+    """Return the sidebar logo bytes.
+
+    If a ``logo.png`` file exists alongside this module, it is used. Otherwise
+    the built-in base64-encoded image is returned.
+    """
+    custom_logo_path = Path(__file__).with_name("logo.png")
+    if custom_logo_path.is_file():
+        return custom_logo_path.read_bytes()
     return b64decode(LOGO_BASE64)


### PR DESCRIPTION
## Summary
- allow overriding the sidebar logo with a `logo.png` file
- document the new behaviour

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846924db828832696931fa0aa377327