### PR TITLE
Add pytest tests for stock and item services

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 sqlalchemy
 psycopg2-binary # Or psycopg2 if not using binary
 fpdf2
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+import os
+import sys
+import pytest
+from sqlalchemy import create_engine, event, text
+
+# Ensure project root is on sys.path
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+# Fixture to provide in-memory SQLite engine with tables for tests
+@pytest.fixture
+def sqlite_engine():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+
+    @event.listens_for(engine, "connect")
+    def register_now(dbapi_connection, connection_record):
+        dbapi_connection.create_function("NOW", 0, lambda: datetime.now().isoformat())
+
+    with engine.begin() as conn:
+        conn.execute(text(
+            """
+            CREATE TABLE items (
+                item_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT,
+                unit TEXT,
+                category TEXT,
+                sub_category TEXT,
+                permitted_departments TEXT,
+                reorder_point REAL,
+                current_stock REAL,
+                notes TEXT,
+                is_active BOOLEAN,
+                updated_at TEXT
+            );
+            """
+        ))
+        conn.execute(text("""
+            CREATE TABLE stock_transactions (
+                transaction_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                item_id INTEGER,
+                quantity_change REAL,
+                transaction_type TEXT,
+                user_id TEXT,
+                related_mrn TEXT,
+                related_po_id INTEGER,
+                notes TEXT,
+                transaction_date TEXT
+            );
+        """))
+    return engine

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -1,0 +1,24 @@
+from sqlalchemy import text
+
+from app.services import item_service
+
+
+def test_add_new_item_inserts_row(sqlite_engine):
+    details = {
+        "name": "Widget",
+        "unit": "pcs",
+        "category": "cat",
+        "sub_category": "sub",
+        "permitted_departments": "dept",
+        "reorder_point": 1,
+        "current_stock": 0,
+        "notes": "n",
+        "is_active": True,
+    }
+    success, msg = item_service.add_new_item(sqlite_engine, details)
+    assert success
+
+    with sqlite_engine.connect() as conn:
+        row = conn.execute(text("SELECT name FROM items WHERE name='Widget'"))
+        assert row.fetchone() is not None
+

--- a/tests/test_stock_service.py
+++ b/tests/test_stock_service.py
@@ -1,0 +1,31 @@
+from sqlalchemy import text
+
+from app.services import stock_service
+
+
+def test_record_stock_transaction_updates_stock_and_logs(sqlite_engine):
+    # Insert a sample item with initial stock 10
+    with sqlite_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO items (name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) "
+                "VALUES ('Sample', 'pcs', 'cat', 'sub', 'dept', 0, 10, 'n', 1)"
+            )
+        )
+        item_id = conn.execute(text("SELECT item_id FROM items LIMIT 1")).scalar_one()
+
+    success = stock_service.record_stock_transaction(
+        item_id=item_id,
+        quantity_change=5,
+        transaction_type="RECEIVING",
+        user_id="tester",
+        db_engine_param=sqlite_engine,
+    )
+    assert success
+
+    with sqlite_engine.connect() as conn:
+        current = conn.execute(text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item_id}).scalar_one()
+        assert current == 15
+        count = conn.execute(text("SELECT COUNT(*) FROM stock_transactions WHERE item_id=:i"), {"i": item_id}).scalar_one()
+        assert count == 1
+


### PR DESCRIPTION
## Summary
- add pytest to requirements
- create fixtures for in-memory SQLite for tests
- add tests for `record_stock_transaction` and `add_new_item`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68469862294c8326b727a3278eabbec7