### PR TITLE
Add sidebar navigation and message helpers

### DIFF
--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -3,17 +3,23 @@ import streamlit as st
 import pandas as pd
 
 from app.ui.theme import load_css, render_sidebar_logo
-from app.ui import pagination_controls, render_search_toggle
+from app.ui import (
+    pagination_controls,
+    render_search_toggle,
+    render_sidebar_nav,
+    show_success,
+    show_error,
+)
 
 try:
     from app.db.database_utils import connect_db
     from app.services import item_service
     from app.core.constants import FILTER_ALL_CATEGORIES, FILTER_ALL_SUBCATEGORIES
 except ImportError as e:
-    st.error(f"Import error in 1_Items.py: {e}.")
+    show_error(f"Import error in 1_Items.py: {e}.")
     st.stop()
 except Exception as e:
-    st.error(f"An unexpected error occurred during import in 1_Items.py: {e}")
+    show_error(f"An unexpected error occurred during import in 1_Items.py: {e}")
     st.stop()
 
 # --- Session State (prefixed with ss_items_ for this page) ---
@@ -54,6 +60,7 @@ def fetch_all_items_df_for_items_page(
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 
 st.title("📦 Item Master Management")
@@ -64,7 +71,7 @@ st.divider()
 
 engine = connect_db()
 if not engine:
-    st.error(
+    show_error(
         "Database connection failed. Item Management functionality is unavailable."
     )
     st.stop()
@@ -155,11 +162,11 @@ with st.expander("➕ Add New Inventory Item", expanded=False):
                     engine, item_data_to_add
                 )
                 if success_add:
-                    st.success(message_add)
+                    show_success(message_add)
                     fetch_all_items_df_for_items_page.clear()
                     st.rerun()
                 else:
-                    st.error(message_add)
+                    show_error(message_add)
 st.divider()
 
 # --- VIEW & MANAGE EXISTING ITEMS ---
@@ -384,11 +391,11 @@ else:
                             item_service.deactivate_item(engine, item_id_disp)
                         )
                         if success_deact_item:
-                            st.success(msg_deact_item)
+                            show_success(msg_deact_item)
                             fetch_all_items_df_for_items_page.clear()
                             st.rerun()
                         else:
-                            st.error(msg_deact_item)
+                            show_error(msg_deact_item)
                 else:
                     if action_buttons_cols[0].button(
                         "✅",
@@ -400,11 +407,11 @@ else:
                             item_service.reactivate_item(engine, item_id_disp)
                         )
                         if success_react_item:
-                            st.success(msg_react_item)
+                            show_success(msg_react_item)
                             fetch_all_items_df_for_items_page.clear()
                             st.rerun()
                         else:
-                            st.error(msg_react_item)
+                            show_error(msg_react_item)
         st.divider()
 
         if st.session_state.get("ss_items_show_edit_form_flag") == item_id_disp:
@@ -511,11 +518,11 @@ else:
                                 )
                             )
                             if ok_update_item:
-                                st.success(msg_update_item)
+                                show_success(msg_update_item)
                                 st.session_state.ss_items_show_edit_form_flag = None
                                 st.session_state.ss_items_edit_form_data_dict = None
                                 fetch_all_items_df_for_items_page.clear()
                                 st.rerun()
                             else:
-                                st.error(msg_update_item)
+                                show_error(msg_update_item)
                 st.divider()

--- a/app/pages/2_Suppliers.py
+++ b/app/pages/2_Suppliers.py
@@ -3,7 +3,13 @@ import streamlit as st
 import pandas as pd
 
 from app.ui.theme import load_css, render_sidebar_logo
-from app.ui import pagination_controls, render_search_toggle
+from app.ui import (
+    pagination_controls,
+    render_search_toggle,
+    render_sidebar_nav,
+    show_success,
+    show_error,
+)
 
 try:
     from app.db.database_utils import connect_db
@@ -13,10 +19,12 @@ try:
     # but good to keep imports organized if they are added later.
     # from app.core.constants import SOME_CONSTANT
 except ImportError as e:
-    st.error(f"Import error in 2_Suppliers.py: {e}.")
+    show_error(f"Import error in 2_Suppliers.py: {e}.")
     st.stop()
 except Exception as e:
-    st.error(f"An unexpected error occurred during import in 2_Suppliers.py: {e}")
+    show_error(
+        f"An unexpected error occurred during import in 2_Suppliers.py: {e}"
+    )
     st.stop()
 
 # --- Session State (prefixed with pg2_ for page-specific scope) ---
@@ -45,6 +53,7 @@ def fetch_all_suppliers_df_pg2(
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 
 st.title("🤝 Supplier Management")
@@ -55,7 +64,7 @@ st.divider()
 
 engine = connect_db()
 if not engine:
-    st.error(
+    show_error(
         "Database connection failed. Supplier Management functionality is unavailable."
     )
     st.stop()
@@ -118,11 +127,11 @@ with st.expander("➕ Add New Supplier Record", expanded=False):
                     engine, supplier_data_add_pg2
                 )
                 if success_add_pg2:
-                    st.success(message_add_pg2)
+                    show_success(message_add_pg2)
                     fetch_all_suppliers_df_pg2.clear()  # Clear page-specific cache
                     st.rerun()
                 else:
-                    st.error(message_add_pg2)
+                    show_error(message_add_pg2)
 st.divider()
 
 # --- VIEW & MANAGE EXISTING SUPPLIERS ---
@@ -273,11 +282,11 @@ else:
                             )
                         )
                         if success_deact_pg2:
-                            st.success(msg_deact_pg2)
+                            show_success(msg_deact_pg2)
                             fetch_all_suppliers_df_pg2.clear()
                             st.rerun()
                         else:
-                            st.error(msg_deact_pg2)
+                            show_error(msg_deact_pg2)
                 else:  # Supplier is inactive
                     if action_buttons_cols_pg2[0].button(
                         "✅",
@@ -291,11 +300,11 @@ else:
                             )
                         )
                         if success_react_pg2:
-                            st.success(msg_react_pg2)
+                            show_success(msg_react_pg2)
                             fetch_all_suppliers_df_pg2.clear()
                             st.rerun()
                         else:
-                            st.error(msg_react_pg2)
+                            show_error(msg_react_pg2)
         st.divider()
 
         # Inline Edit Form for selected supplier
@@ -381,7 +390,7 @@ else:
                                 )
                             )
                             if ok_update_pg2:
-                                st.success(msg_update_pg2)
+                                show_success(msg_update_pg2)
                                 st.session_state.pg2_show_edit_form_for_supplier_id = (
                                     None  # Close form
                                 )
@@ -391,5 +400,5 @@ else:
                                 fetch_all_suppliers_df_pg2.clear()  # Clear cache
                                 st.rerun()
                             else:
-                                st.error(msg_update_pg2)
+                                show_error(msg_update_pg2)
                 st.divider()

--- a/app/pages/3_Stock_Movements.py
+++ b/app/pages/3_Stock_Movements.py
@@ -12,11 +12,12 @@ try:
         PLACEHOLDER_SELECT_ITEM,
     )
     from app.ui.theme import load_css, render_sidebar_logo
+    from app.ui import render_sidebar_nav, show_success, show_error
 except ImportError as e:
-    st.error(f"Import error in 3_Stock_Movements.py: {e}.")
+    show_error(f"Import error in 3_Stock_Movements.py: {e}.")
     st.stop()
 except Exception as e:
-    st.error(f"An unexpected error occurred during import in 3_Stock_Movements.py: {e}")
+    show_error(f"An unexpected error occurred during import in 3_Stock_Movements.py: {e}")
     st.stop()
 
 SECTIONS_PG3 = {
@@ -64,6 +65,7 @@ for section_key_pg3 in SECTION_KEYS_PG3:
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 st.title("🚚 Stock Movements Log")
 st.write(
@@ -73,7 +75,7 @@ st.divider()
 
 db_engine = connect_db()
 if not db_engine:
-    st.error("❌ Database connection failed. Cannot proceed with stock movements.")
+    show_error("❌ Database connection failed. Cannot proceed with stock movements.")
     st.stop()
 
 
@@ -390,7 +392,7 @@ with st.form(form_key_main_pg3, clear_on_submit=False):
                     if item_display_name_success_pg3_tuple
                     else "Selected Item"
                 )
-                st.success(
+                show_success(
                     f"✅ Successfully recorded {active_section_prefix_val_pg3} for '{item_display_name_success_pg3}'."
                 )
 
@@ -409,6 +411,6 @@ with st.form(form_key_main_pg3, clear_on_submit=False):
                     st.session_state[current_po_id_ss_key_pg3] = ""
                 st.rerun()
             else:
-                st.error(
+                show_error(
                     f"❌ Failed to record stock {active_section_prefix_val_pg3}. Check console for specific database errors."
                 )

--- a/app/pages/4_History_Reports.py
+++ b/app/pages/4_History_Reports.py
@@ -17,15 +17,17 @@ try:
         FILTER_ALL_TYPES,
     )
     from app.ui.theme import load_css, render_sidebar_logo
+    from app.ui import render_sidebar_nav, show_success, show_error
 except ImportError as e:
-    st.error(f"Import error in 4_History_Reports.py: {e}.")
+    show_error(f"Import error in 4_History_Reports.py: {e}.")
     st.stop()
 except Exception as e:
-    st.error(f"An unexpected error occurred during import in 4_History_Reports.py: {e}")
+    show_error(f"An unexpected error occurred during import in 4_History_Reports.py: {e}")
     st.stop()
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 st.title("📜 Stock Transaction History & Reports")
 st.write(
@@ -35,7 +37,7 @@ st.divider()
 
 db_engine = connect_db()
 if not db_engine:
-    st.error("Database connection failed. Cannot load history reports.")
+    show_error("Database connection failed. Cannot load history reports.")
     st.stop()
 
 
@@ -229,7 +231,7 @@ if st.session_state.pg4_start_date_val <= st.session_state.pg4_end_date_val:
     if transactions_df_pg4.empty:
         st.info("No stock transactions found matching the selected filters.")
     else:
-        st.success(f"Found {len(transactions_df_pg4)} transaction(s).")
+        show_success(f"Found {len(transactions_df_pg4)} transaction(s).")
 
         display_df_pg4 = transactions_df_pg4.copy()
         if "transaction_date" in display_df_pg4.columns:

--- a/app/pages/5_Indents.py
+++ b/app/pages/5_Indents.py
@@ -32,14 +32,15 @@ try:
         PLACEHOLDER_ERROR_LOADING_ITEMS,  # If applicable
     )
     from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
+    from app.ui import render_sidebar_nav, show_success, show_error
 except ImportError as e:
-    st.error(
+    show_error(
         "Import error in 5_Indents.py: "
         f"{e}. Please ensure all service files and utility modules are correctly placed and named."
     )
     st.stop()
 except Exception as e:
-    st.error(f"An unexpected error occurred during an import in 5_Indents.py: {e}")
+    show_error(f"An unexpected error occurred during an import in 5_Indents.py: {e}")
     st.stop()
 
 # --- Session State Initialization ---
@@ -119,6 +120,7 @@ for key, default_val in [
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 st.title("📝 Material Indents Management")
 st.write(
@@ -128,7 +130,7 @@ st.divider()
 
 db_engine = connect_db()
 if not db_engine:
-    st.error(
+    show_error(
         "Database connection failed. Indent management functionality is unavailable."
     )
     st.stop()
@@ -722,7 +724,7 @@ if st.session_state.pg5_active_indent_section == "create":
         mrn_to_print_pg5 = (
             st.session_state.pg5_last_created_mrn_for_print
         )  # Use pg5_ variable
-        st.success(f"Indent **{mrn_to_print_pg5}** was created successfully!")
+        show_success(f"Indent **{mrn_to_print_pg5}** was created successfully!")
         if st.session_state.get("pg5_last_submitted_indent_details"):
             summary_header_pg5 = st.session_state.pg5_last_submitted_indent_details[
                 "header"
@@ -789,7 +791,7 @@ if st.session_state.pg5_active_indent_section == "create":
                                 )
                                 st.rerun()
                         else:
-                            st.error(
+                            show_error(
                                 f"Could not fetch details for PDF: {mrn_to_print_pg5}."
                             )
         with whatsapp_col_pg5:
@@ -1217,11 +1219,11 @@ if st.session_state.pg5_active_indent_section == "create":
                 items_to_submit_list_pg5 = []
                 seen_item_ids_in_form_pg5 = set()
                 if not header_data_submit_pg5["department"]:
-                    st.error("Department required.")
+                    show_error("Department required.")
                     is_valid_pg5 = False
                 # ... (rest of validation and submission logic, ensuring pg5_ variables and keys) ...
                 if not header_data_submit_pg5["requested_by"]:
-                    st.error("Requested By required.")
+                    show_error("Requested By required.")
                     is_valid_pg5 = False
 
                 current_item_options_for_validation_pg5 = (
@@ -1249,11 +1251,11 @@ if st.session_state.pg5_active_indent_section == "create":
                         )
 
                     if item_id_v_pg5 is None or item_id_v_pg5 == -1:
-                        st.error(f"Row {i_r_pg5+1}: Select item.")
+                        show_error(f"Row {i_r_pg5+1}: Select item.")
                         is_valid_pg5 = False
                         continue
                     if item_id_v_pg5 in seen_item_ids_in_form_pg5:
-                        st.error(
+                        show_error(
                             f"Row {i_r_pg5+1}: Item '{item_name_val_pg5}' duplicated."
                         )
                         is_valid_pg5 = False
@@ -1262,12 +1264,12 @@ if st.session_state.pg5_active_indent_section == "create":
                         if not (
                             isinstance(qty_v_pg5, (float, int)) and float(qty_v_pg5) > 0
                         ):
-                            st.error(
+                            show_error(
                                 f"Row {i_r_pg5+1}: Qty for '{item_name_val_pg5}' > 0. Got: {qty_v_pg5}"
                             )
                             is_valid_pg5 = False
                     except:
-                        st.error(
+                        show_error(
                             f"Row {i_r_pg5+1}: Invalid Qty for '{item_name_val_pg5}'. Got: {qty_v_pg5}"
                         )
                         is_valid_pg5 = False
@@ -1289,7 +1291,7 @@ if st.session_state.pg5_active_indent_section == "create":
                         seen_item_ids_in_form_pg5.add(item_id_v_pg5)
 
                 if not items_to_submit_list_pg5 and is_valid_pg5:
-                    st.error("Indent needs at least one valid item.")
+                    show_error("Indent needs at least one valid item.")
                     is_valid_pg5 = False
 
                 if is_valid_pg5:
@@ -1339,9 +1341,9 @@ if st.session_state.pg5_active_indent_section == "create":
                             item_service.get_suggested_items_for_department.clear()
                             st.rerun()
                         else:
-                            st.error(f"Failed to create indent: {message_pg5}")
+                            show_error(f"Failed to create indent: {message_pg5}")
                     else:
-                        st.error("Failed to generate MRN.")
+                        show_error("Failed to generate MRN.")
                 # else: st.warning("Fix errors before submitting.") # Already handled by individual error messages
 
 # --- VIEW INDENTS SECTION ---
@@ -1411,7 +1413,7 @@ elif st.session_state.pg5_active_indent_section == "view":
     else:
         # ... (Display DataFrame - use pg5_ prefixed vars) ...
         # ... (PDF Download Section - use pg5_ prefixed vars, PLACEHOLDER_SELECT_MRN_PDF, and unique keys) ...
-        st.success(f"Found {len(indents_df_pg5)} indent(s).")
+        show_success(f"Found {len(indents_df_pg5)} indent(s).")
         # ... (DataFrame display logic, ensure column names match what get_indents returns) ...
         # (The display logic was okay, just needs variable renaming if any done above)
         display_df_pg5 = indents_df_pg5.copy()
@@ -1540,7 +1542,7 @@ elif st.session_state.pg5_active_indent_section == "view":
                                     )
                                     st.rerun()
                             else:
-                                st.error(
+                                show_error(
                                     f"Could not fetch details to generate PDF for MRN {selected_mrn_for_pdf_pg5}."
                                 )
 
@@ -1778,7 +1780,7 @@ elif st.session_state.pg5_active_indent_section == "process":
                                     )
                                     has_items_with_qty_pg5 = True
                             except (ValueError, TypeError):
-                                st.error(
+                                show_error(
                                     f"Invalid quantity for {item_row_s_pg5['item_name']}."
                                 )
                                 items_to_submit_list_proc_pg5 = []
@@ -1801,7 +1803,7 @@ elif st.session_state.pg5_active_indent_section == "process":
                                     )
                                 )
                                 if success_p_pg5:
-                                    st.success(message_p_pg5)
+                                    show_success(message_p_pg5)
                                     st.session_state.pg5_process_indent_selected_tuple = (
                                         pg5_placeholder_indent_process_tuple
                                     )
@@ -1814,7 +1816,7 @@ elif st.session_state.pg5_active_indent_section == "process":
                                     indent_service.get_indents_for_processing.clear()
                                     st.rerun()
                                 else:
-                                    st.error(f"Processing Failed: {message_p_pg5}")
+                                    show_error(f"Processing Failed: {message_p_pg5}")
 
             # Other Actions (Mark as Completed / Cancel Indent) - Placed correctly outside the form
             st.markdown("---")
@@ -1842,13 +1844,13 @@ elif st.session_state.pg5_active_indent_section == "process":
                                 selected_mrn_pg5,
                             )
                             if s_mark:
-                                st.success(m_mark)
+                                show_success(m_mark)
                                 st.session_state.pg5_process_indent_selected_tuple = (
                                     pg5_placeholder_indent_process_tuple
                                 )
                                 st.rerun()  # Simplified reset
                             else:
-                                st.error(f"Failed: {m_mark}")
+                                show_error(f"Failed: {m_mark}")
 
             with action_cols_proc_pg5[1]:
                 if st.button(
@@ -1873,13 +1875,13 @@ elif st.session_state.pg5_active_indent_section == "process":
                                 selected_mrn_pg5,
                             )
                             if s_cancel:
-                                st.success(m_cancel)
+                                show_success(m_cancel)
                                 st.session_state.pg5_process_indent_selected_tuple = (
                                     pg5_placeholder_indent_process_tuple
                                 )
                                 st.rerun()  # Simplified reset
                             else:
-                                st.error(f"Failed: {m_cancel}")
+                                show_error(f"Failed: {m_cancel}")
 
         elif selected_indent_id_pg5:
             st.info(

--- a/app/pages/6_Purchase_Orders.py
+++ b/app/pages/6_Purchase_Orders.py
@@ -18,19 +18,21 @@ try:
         PO_STATUS_PARTIALLY_RECEIVED,
     )
     from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
+    from app.ui import render_sidebar_nav, show_success, show_error
 except ImportError as e:
-    st.error(
+    show_error(
         f"Import error in 6_Purchase_Orders.py: {e}. Please ensure all modules are correctly placed."
     )
     st.stop()  # Stop execution if imports fail
 except Exception as e:  # Catch any other potential import errors
-    st.error(
+    show_error(
         f"An unexpected error occurred during an import in 6_Purchase_Orders.py: {e}"
     )
     st.stop()
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 # --- Page Config and Title ---
 st.title("🛒 Purchase Order & Goods Receiving")
@@ -40,7 +42,7 @@ st.divider()
 # --- Database Connection ---
 db_engine = connect_db()
 if not db_engine:
-    st.error("❌ Database connection failed. Cannot manage Purchase Orders/GRNs.")
+    show_error("❌ Database connection failed. Cannot manage Purchase Orders/GRNs.")
     st.stop()
 
 # --- Session State Initialization ---
@@ -402,7 +404,7 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
     # Load data if in Edit Mode and reset signal is active or PO ID changed
     if is_edit_mode:
         if not st.session_state.po_to_edit_id:
-            st.error(
+            show_error(
                 "❌ PO ID for editing is missing. Please return to the list and select a PO."
             )
             if st.button("⬅️ Back to PO List", key="back_edit_po_no_id_v2_page6"):
@@ -420,7 +422,7 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
                 db_engine, st.session_state.po_to_edit_id
             )
             if not po_data_to_edit:
-                st.error(
+                show_error(
                     f"❌ Could not load details for PO ID: {st.session_state.po_to_edit_id}. It might have been deleted."
                 )
                 change_view_mode("list_po")
@@ -692,13 +694,13 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
                     )
                 )
                 if success_status_update:
-                    st.success(
+                    show_success(
                         f"PO status successfully updated to '{PO_STATUS_ORDERED}'. {msg_status_update}"
                     )
                     change_view_mode("list_po", clear_po_form_state=True)
                     st.rerun()
                 else:
-                    st.error(f"❌ Failed to submit PO: {msg_status_update}")
+                    show_error(f"❌ Failed to submit PO: {msg_status_update}")
 
         st.divider()
         form_submit_button_label = (
@@ -858,7 +860,7 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
                 is None
                 for l in st.session_state.form_po_line_items
             ):
-                st.error("🛑 Please add at least one valid item to the Purchase Order.")
+                show_error("🛑 Please add at least one valid item to the Purchase Order.")
                 are_all_items_valid = False
 
             if are_all_items_valid:  # Proceed if initial check passes
@@ -870,7 +872,7 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
                     )
 
                     if item_id_for_submit is None:
-                        st.error(
+                        show_error(
                             f"🛑 Item '{line_item_data_submit['item_key']}' is invalid or not selected. Please select a valid item for all lines."
                         )
                         are_all_items_valid = False
@@ -879,20 +881,20 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
                         qty_for_submit = float(line_item_data_submit["quantity"])
                         price_for_submit = float(line_item_data_submit["unit_price"])
                     except (ValueError, TypeError):
-                        st.error(
+                        show_error(
                             f"🛑 Invalid quantity or price for item '{line_item_data_submit['item_key']}'. Please enter valid numbers."
                         )
                         are_all_items_valid = False
                         break
 
                     if qty_for_submit <= 0:
-                        st.error(
+                        show_error(
                             f"🛑 Quantity for item '{line_item_data_submit['item_key']}' must be greater than 0."
                         )
                         are_all_items_valid = False
                         break
                     if price_for_submit < 0:
-                        st.error(
+                        show_error(
                             f"🛑 Unit price for item '{line_item_data_submit['item_key']}' cannot be negative."
                         )
                         are_all_items_valid = False
@@ -909,7 +911,7 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
             if (
                 not po_items_to_submit and are_all_items_valid
             ):  # If loop completed but list is empty (e.g. only placeholder items)
-                st.error(
+                show_error(
                     "🛑 No valid items to submit. Please add items to the Purchase Order."
                 )
                 are_all_items_valid = False
@@ -931,11 +933,11 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
                         )
                     )
                     if success_update:
-                        st.success(f"✅ {msg_update}")
+                        show_success(f"✅ {msg_update}")
                         change_view_mode("list_po", clear_po_form_state=True)
                         st.rerun()
                     else:
-                        st.error(f"❌ Failed to update PO: {msg_update}")
+                        show_error(f"❌ Failed to update PO: {msg_update}")
                 else:  # Create mode
                     po_header_data_for_submit["created_by_user_id"] = (
                         current_user_id_for_submit
@@ -950,11 +952,11 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
                         )
                     )
                     if success_create:
-                        st.success(f"✅ {msg_create} (ID: {new_po_id_create})")
+                        show_success(f"✅ {msg_create} (ID: {new_po_id_create})")
                         change_view_mode("list_po", clear_po_form_state=True)
                         st.rerun()
                     else:
-                        st.error(f"❌ Failed to create PO: {msg_create}")
+                        show_error(f"❌ Failed to create PO: {msg_create}")
 
 # --- CREATE GRN VIEW ---
 elif st.session_state.po_grn_view_mode == "create_grn_for_po":
@@ -1133,7 +1135,7 @@ elif st.session_state.po_grn_view_mode == "create_grn_for_po":
 
                     # Validate quantity received now against pending quantity
                     if qty_rcv_now_submit > max_allowed_for_item_submit:
-                        st.error(
+                        show_error(
                             f"🛑 For item {line_data_grn_submit['item_name']}, quantity received ({qty_rcv_now_submit:.2f}) "
                             f"cannot exceed pending quantity ({max_allowed_for_item_submit:.2f}). Please correct."
                         )
@@ -1180,7 +1182,7 @@ elif st.session_state.po_grn_view_mode == "create_grn_for_po":
                         )
                     )
                     if success_grn_create:
-                        st.success(
+                        show_success(
                             f"✅ {msg_grn_create} (GRN ID: {new_grn_id_created})"
                         )
                         change_view_mode(
@@ -1189,7 +1191,7 @@ elif st.session_state.po_grn_view_mode == "create_grn_for_po":
                         purchase_order_service.list_pos.clear()  # Ensure PO list refreshes with updated statuses
                         st.rerun()
                     else:
-                        st.error(f"❌ Failed to create GRN: {msg_grn_create}")
+                        show_error(f"❌ Failed to create GRN: {msg_grn_create}")
 
 # --- VIEW PO DETAILS VIEW ---
 elif st.session_state.po_grn_view_mode == "view_po_details":
@@ -1207,7 +1209,7 @@ elif st.session_state.po_grn_view_mode == "view_po_details":
         db_engine, po_id_to_view_ui
     )
     if not po_details_data_view_ui:
-        st.error(
+        show_error(
             f"❌ Could not load details for PO ID: {po_id_to_view_ui}. It might have been deleted."
         )
         st.stop()
@@ -1316,13 +1318,13 @@ elif st.session_state.po_grn_view_mode == "view_po_details":
                 )
             )
             if success_submit_view:
-                st.success(
+                show_success(
                     f"PO {po_details_data_view_ui.get('po_number')} status updated to 'Ordered'. {msg_submit_view}"
                 )
                 change_view_mode("list_po")  # Go back to list
                 st.rerun()
             else:
-                st.error(f"❌ Failed to submit PO: {msg_submit_view}")
+                show_error(f"❌ Failed to submit PO: {msg_submit_view}")
 
 # --- Display Recent GRNs at the bottom of PO list view ---
 # This condition should be outside other elif blocks if it's always shown with list_po

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,1 +1,7 @@
-from .helpers import pagination_controls, render_search_toggle
+from .helpers import (
+    pagination_controls,
+    render_search_toggle,
+    show_success,
+    show_error,
+)
+from .navigation import render_sidebar_nav

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -89,3 +89,19 @@ def pagination_controls(
     start_idx = (st.session_state[current_page_key] - 1) * st.session_state[items_per_page_key]
     end_idx = start_idx + st.session_state[items_per_page_key]
     return start_idx, end_idx
+
+
+def show_success(msg: str) -> None:
+    """Display a success message using toast if available."""
+    if hasattr(st, "toast"):
+        st.toast(msg, icon="✅")
+    else:
+        st.success(msg)
+
+
+def show_error(msg: str) -> None:
+    """Display an error message using toast if available."""
+    if hasattr(st, "toast"):
+        st.toast(msg, icon="❌")
+    else:
+        st.error(msg)

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -1,0 +1,13 @@
+import streamlit as st
+
+
+def render_sidebar_nav() -> None:
+    """Render sidebar navigation links to all app pages."""
+    with st.sidebar:
+        st.page_link("app/item_manager_app.py", label="🏠 Dashboard")
+        st.page_link("app/pages/1_Items.py", label="Items")
+        st.page_link("app/pages/2_Suppliers.py", label="Suppliers")
+        st.page_link("app/pages/3_Stock_Movements.py", label="Stock Movements")
+        st.page_link("app/pages/4_History_Reports.py", label="History Reports")
+        st.page_link("app/pages/5_Indents.py", label="Indents")
+        st.page_link("app/pages/6_Purchase_Orders.py", label="Purchase Orders")


### PR DESCRIPTION
## Summary
- add sidebar navigation links
- wrap success/error messages with helper functions
- update pages to use new helpers and navigation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ad44c9a0832693cd171949111f32