### PR TITLE
Add dark mode toggle and responsive CSS

### DIFF
--- a/app/item_manager_app.py
+++ b/app/item_manager_app.py
@@ -13,7 +13,11 @@ if _REPO_ROOT not in sys.path:
 import streamlit as st
 import pandas as pd
 from datetime import datetime
-from app.ui.theme import load_css, render_sidebar_logo
+from app.ui.theme import (
+    load_css,
+    render_sidebar_logo,
+    render_dark_mode_toggle,
+)
 
 # --- Import from our new/refactored modules ---
 from app.core.constants import STATUS_SUBMITTED
@@ -35,6 +39,7 @@ def run_dashboard():
         page_title="Restaurant Inventory Manager", page_icon="🍲", layout="wide"
     )
     load_css()
+    render_dark_mode_toggle()
     render_sidebar_logo()
     st.title("🍲 Restaurant Inventory Dashboard")
     st.caption(

--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -2,7 +2,11 @@
 import streamlit as st
 import pandas as pd
 
-from app.ui.theme import load_css, render_sidebar_logo
+from app.ui.theme import (
+    load_css,
+    render_sidebar_logo,
+    render_dark_mode_toggle,
+)
 from app.ui import pagination_controls, render_search_toggle
 
 try:
@@ -53,6 +57,7 @@ def fetch_all_items_df_for_items_page(
 
 
 load_css()
+render_dark_mode_toggle()
 render_sidebar_logo()
 
 

--- a/app/pages/2_Suppliers.py
+++ b/app/pages/2_Suppliers.py
@@ -2,7 +2,11 @@
 import streamlit as st
 import pandas as pd
 
-from app.ui.theme import load_css, render_sidebar_logo
+from app.ui.theme import (
+    load_css,
+    render_sidebar_logo,
+    render_dark_mode_toggle,
+)
 from app.ui import pagination_controls, render_search_toggle
 
 try:
@@ -44,6 +48,7 @@ def fetch_all_suppliers_df_pg2(
 
 
 load_css()
+render_dark_mode_toggle()
 render_sidebar_logo()
 
 

--- a/app/pages/3_Stock_Movements.py
+++ b/app/pages/3_Stock_Movements.py
@@ -11,7 +11,11 @@ try:
         TX_WASTAGE,
         PLACEHOLDER_SELECT_ITEM,
     )
-    from app.ui.theme import load_css, render_sidebar_logo
+    from app.ui.theme import (
+        load_css,
+        render_sidebar_logo,
+        render_dark_mode_toggle,
+    )
 except ImportError as e:
     st.error(f"Import error in 3_Stock_Movements.py: {e}.")
     st.stop()
@@ -63,6 +67,7 @@ for section_key_pg3 in SECTION_KEYS_PG3:
         st.session_state.pg3_receive_po_id_form_val = ""
 
 load_css()
+render_dark_mode_toggle()
 render_sidebar_logo()
 
 st.title("🚚 Stock Movements Log")

--- a/app/pages/4_History_Reports.py
+++ b/app/pages/4_History_Reports.py
@@ -16,7 +16,11 @@ try:
         PLACEHOLDER_SELECT_ITEM,
         FILTER_ALL_TYPES,
     )
-    from app.ui.theme import load_css, render_sidebar_logo
+    from app.ui.theme import (
+        load_css,
+        render_sidebar_logo,
+        render_dark_mode_toggle,
+    )
 except ImportError as e:
     st.error(f"Import error in 4_History_Reports.py: {e}.")
     st.stop()
@@ -25,6 +29,7 @@ except Exception as e:
     st.stop()
 
 load_css()
+render_dark_mode_toggle()
 render_sidebar_logo()
 
 st.title("📜 Stock Transaction History & Reports")

--- a/app/pages/5_Indents.py
+++ b/app/pages/5_Indents.py
@@ -31,7 +31,12 @@ try:
         PLACEHOLDER_NO_ITEMS_AVAILABLE,  # If applicable for item lists
         PLACEHOLDER_ERROR_LOADING_ITEMS,  # If applicable
     )
-    from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
+    from app.ui.theme import (
+        load_css,
+        format_status_badge,
+        render_sidebar_logo,
+        render_dark_mode_toggle,
+    )
 except ImportError as e:
     st.error(
         "Import error in 5_Indents.py: "
@@ -118,6 +123,7 @@ for key, default_val in [
         st.session_state[key] = default_val
 
 load_css()
+render_dark_mode_toggle()
 render_sidebar_logo()
 
 st.title("📝 Material Indents Management")

--- a/app/pages/6_Purchase_Orders.py
+++ b/app/pages/6_Purchase_Orders.py
@@ -17,7 +17,12 @@ try:
         PO_STATUS_ORDERED,
         PO_STATUS_PARTIALLY_RECEIVED,
     )
-    from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
+    from app.ui.theme import (
+        load_css,
+        format_status_badge,
+        render_sidebar_logo,
+        render_dark_mode_toggle,
+    )
 except ImportError as e:
     st.error(
         f"Import error in 6_Purchase_Orders.py: {e}. Please ensure all modules are correctly placed."
@@ -30,6 +35,7 @@ except Exception as e:  # Catch any other potential import errors
     st.stop()
 
 load_css()
+render_dark_mode_toggle()
 render_sidebar_logo()
 
 # --- Page Config and Title ---

--- a/app/ui/styles.css
+++ b/app/ui/styles.css
@@ -10,3 +10,26 @@ body { font-family: 'Roboto', sans-serif; }
 .badge-warning { background: #f2c037; color: black; padding: 2px 6px; border-radius: 4px; }
 .badge-error   { background: #db2828; color: white; padding: 2px 6px; border-radius: 4px; }
 
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #1e1e1e;
+    color: #f0f0f0;
+}
+
+body.dark-mode .sidebar .sidebar-content {
+    background-color: #111;
+}
+
+/* Responsive layout breakpoints */
+@media (max-width: 480px) {
+    body { font-size: 14px; }
+}
+
+@media (min-width: 481px) and (max-width: 768px) {
+    body { font-size: 15px; }
+}
+
+@media (min-width: 769px) {
+    body { font-size: 16px; }
+}
+

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -3,6 +3,7 @@ import streamlit as st
 from .logo import get_logo_bytes
 
 CSS_PATH = Path(__file__).with_name("styles.css")
+DARK_MODE_STATE_KEY = "dark_mode"
 
 STATUS_CLASSES = {
     "Completed": "badge-success",
@@ -16,10 +17,31 @@ def load_css():
         css = CSS_PATH.read_text()
         st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
 
+    if st.session_state.get(DARK_MODE_STATE_KEY):
+        st.markdown(
+            "<script>document.body.classList.add('dark-mode');</script>",
+            unsafe_allow_html=True,
+        )
+    else:
+        st.markdown(
+            "<script>document.body.classList.remove('dark-mode');</script>",
+            unsafe_allow_html=True,
+        )
+
 
 def format_status_badge(status: str) -> str:
     css_class = STATUS_CLASSES.get(status, "badge-success")
     return f"<span class='{css_class}'>{status}</span>"
+
+
+def render_dark_mode_toggle() -> None:
+    """Render a sidebar checkbox that toggles dark mode."""
+    if DARK_MODE_STATE_KEY not in st.session_state:
+        st.session_state[DARK_MODE_STATE_KEY] = False
+    st.session_state[DARK_MODE_STATE_KEY] = st.sidebar.checkbox(
+        "Dark mode",
+        value=st.session_state[DARK_MODE_STATE_KEY],
+    )
 
 
 def render_sidebar_logo() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
+
 # Fixture to provide in-memory SQLite engine with tables for tests
 @pytest.fixture
 def sqlite_engine():

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -21,4 +21,3 @@ def test_add_new_item_inserts_row(sqlite_engine):
     with sqlite_engine.connect() as conn:
         row = conn.execute(text("SELECT name FROM items WHERE name='Widget'"))
         assert row.fetchone() is not None
-

--- a/tests/test_stock_service.py
+++ b/tests/test_stock_service.py
@@ -28,4 +28,3 @@ def test_record_stock_transaction_updates_stock_and_logs(sqlite_engine):
         assert current == 15
         count = conn.execute(text("SELECT COUNT(*) FROM stock_transactions WHERE item_id=:i"), {"i": item_id}).scalar_one()
         assert count == 1
-


### PR DESCRIPTION
## Summary
- add media queries and dark mode styles
- support dark mode toggle and JS injection
- show dark mode toggle on all pages
- clean up test whitespace for flake8

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ad50fe8c83269d89049d97da791f