### PR TITLE
Fix login rerun and standalone pages

### DIFF
--- a/app/auth/auth.py
+++ b/app/auth/auth.py
@@ -17,7 +17,7 @@ def login_sidebar() -> bool:
             if st.button("Logout"):
                 st.session_state.logged_in = False
                 st.session_state.user_id = ""
-                st.experimental_rerun()
+                st.rerun()
         return True
 
     with st.sidebar:
@@ -28,7 +28,7 @@ def login_sidebar() -> bool:
             if user:
                 st.session_state.user_id = user
                 st.session_state.logged_in = True
-                st.experimental_rerun()
+                st.rerun()
             else:
                 st.warning("Please enter a user ID to login.")
     return False

--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -1,6 +1,13 @@
 # app/pages/1_Items.py
+import os
+import sys
 import streamlit as st
 import pandas as pd
+
+_CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 from app.ui.theme import load_css, render_sidebar_logo
 from app.ui import (

--- a/app/pages/2_Suppliers.py
+++ b/app/pages/2_Suppliers.py
@@ -1,6 +1,13 @@
 # app/pages/2_Suppliers.py
+import os
+import sys
 import streamlit as st
 import pandas as pd
+
+_CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 from app.ui.theme import load_css, render_sidebar_logo
 from app.ui import (

--- a/app/pages/3_Stock_Movements.py
+++ b/app/pages/3_Stock_Movements.py
@@ -1,5 +1,12 @@
 # app/pages/3_Stock_Movements.py
+import os
+import sys
 import streamlit as st
+
+_CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 try:
     from app.db.database_utils import connect_db

--- a/app/pages/4_History_Reports.py
+++ b/app/pages/4_History_Reports.py
@@ -1,7 +1,14 @@
 # app/pages/4_History_Reports.py
+import os
+import sys
 import streamlit as st
 import pandas as pd
 from datetime import datetime, timedelta
+
+_CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 try:
     from app.db.database_utils import connect_db

--- a/app/pages/5_Indents.py
+++ b/app/pages/5_Indents.py
@@ -1,4 +1,6 @@
 # app/pages/5_Indents.py
+import os
+import sys
 import streamlit as st
 import pandas as pd
 from datetime import datetime, date, timedelta
@@ -7,6 +9,11 @@ import urllib.parse
 from fpdf import FPDF
 from fpdf.enums import XPos, YPos
 import traceback
+
+_CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 try:
     from app.db.database_utils import connect_db

--- a/app/pages/6_Purchase_Orders.py
+++ b/app/pages/6_Purchase_Orders.py
@@ -1,8 +1,15 @@
 # app/pages/6_Purchase_Orders.py
+import os
+import sys
 import streamlit as st
 import pandas as pd
 from datetime import date
 from typing import Dict, Any, Optional, List
+
+_CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
 
 # --- Assuming your project structure for imports ---
 try:


### PR DESCRIPTION
## Summary
- update sidebar login to use `st.rerun`
- add path bootstrapping at the top of each page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c8eb5e8c83269270798cf2cc7b5d