### PR TITLE
Add environment-based DB config loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ streamlit run app/item_manager_app.py
 
 Before running the app, create a `.streamlit/secrets.toml` file containing your database credentials. An example file can be found at `.streamlit/secrets.toml` in this repository—copy it and replace the placeholder values with your own. The committed sample uses obvious placeholders so you must supply real values.
 
+Alternatively you can provide the database settings via environment variables. If the following variables are set, they will be used instead of the values in `secrets.toml`:
+
+```
+DB_ENGINE
+DB_USER
+DB_PASSWORD
+DB_HOST
+DB_PORT
+DB_NAME
+```
+
 ## Customizing the Sidebar Logo
 
 The sidebar image displayed in the app is defined in `app/ui/logo.py` as a base64 encoded PNG. To use your own logo:

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,28 @@
+import os
+import streamlit as st
+
+# Mapping of configuration keys to their corresponding environment variables
+_DB_ENV_VARS = {
+    "engine": "DB_ENGINE",
+    "user": "DB_USER",
+    "password": "DB_PASSWORD",
+    "host": "DB_HOST",
+    "port": "DB_PORT",
+    "dbname": "DB_NAME",
+}
+
+
+def load_db_config():
+    """Return database configuration from environment or Streamlit secrets."""
+    # Pull values from environment variables first
+    env_config = {k: os.getenv(env) for k, env in _DB_ENV_VARS.items()}
+    if all(env_config.values()):
+        return env_config
+
+    # Fallback to Streamlit secrets
+    if "database" in st.secrets:
+        secrets_config = {k: st.secrets["database"].get(k, "") for k in _DB_ENV_VARS}
+        if all(secrets_config.values()):
+            return secrets_config
+
+    return None

--- a/app/db/database_utils.py
+++ b/app/db/database_utils.py
@@ -14,27 +14,21 @@ import pandas as pd
 from typing import Any, Optional, Dict, Tuple
 
 from app.core.logging import get_logger
+from app.config import load_db_config
 
 logger = get_logger(__name__)
 
 
 @st.cache_resource(show_spinner="Connecting to database…")
 def connect_db() -> Optional[Engine]:
-    """Establishes a connection to the database using credentials from secrets."""
+    """Establish a connection to the database."""
     try:
-        if "database" not in st.secrets:
-            st.error("Database configuration missing in secrets.toml!")
-            st.info(
-                "Ensure `.streamlit/secrets.toml` has [database] section with keys: engine, user, host, etc."
-            )
-            return None
-
-        db_config = st.secrets["database"]
+        db_config = load_db_config()
         required_keys = ["engine", "user", "password", "host", "port", "dbname"]
-        if not all(key in db_config for key in required_keys):
-            missing = [k for k in required_keys if k not in db_config]
-            st.error(f"Missing keys in database secrets: {', '.join(missing)}")
-            st.info(f"Expected keys: {', '.join(required_keys)}.")
+        if not db_config or not all(db_config.get(k) for k in required_keys):
+            st.error(
+                "Database configuration missing. Set environment variables or provide .streamlit/secrets.toml."
+            )
             return None
 
         db_user = db_config.get("user", "")


### PR DESCRIPTION
## Summary
- load DB config from environment or Streamlit secrets
- use new loader in `connect_db`
- document available DB environment variables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ad729c088326a758c7fb0d2b108d