### PR TITLE
Improve navigation and add smart links

### DIFF
--- a/app/item_manager_app.py
+++ b/app/item_manager_app.py
@@ -14,6 +14,7 @@ import streamlit as st
 import pandas as pd
 from datetime import datetime
 from app.ui.theme import load_css, render_sidebar_logo
+from app.ui.navigation import render_sidebar_nav
 
 # --- Import from our new/refactored modules ---
 from app.core.constants import STATUS_SUBMITTED
@@ -37,6 +38,7 @@ def run_dashboard():
     )
     load_css()
     render_sidebar_logo()
+    render_sidebar_nav()
     if not login_sidebar():
         st.stop()
     st.title("🍲 Restaurant Inventory Dashboard")

--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -10,6 +10,7 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 from app.ui.theme import load_css, render_sidebar_logo
+from app.ui.navigation import render_sidebar_nav
 from app.ui import (
     pagination_controls,
     render_search_toggle,
@@ -66,6 +67,7 @@ def fetch_all_items_df_for_items_page(
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 
 st.title("📦 Item Master Management")
@@ -168,6 +170,11 @@ with st.expander("➕ Add New Inventory Item", expanded=False):
                 )
                 if success_add:
                     show_success(message_add)
+                    st.page_link(
+                        "pages/3_Stock_Movements.py",
+                        label="Record Stock Movement",
+                        icon="➡️",
+                    )
                     fetch_all_items_df_for_items_page.clear()
                     st.rerun()
                 else:
@@ -524,6 +531,11 @@ else:
                             )
                             if ok_update_item:
                                 show_success(msg_update_item)
+                                st.page_link(
+                                    "pages/3_Stock_Movements.py",
+                                    label="Record Stock Movement",
+                                    icon="➡️",
+                                )
                                 st.session_state.ss_items_show_edit_form_flag = None
                                 st.session_state.ss_items_edit_form_data_dict = None
                                 fetch_all_items_df_for_items_page.clear()

--- a/app/pages/2_Suppliers.py
+++ b/app/pages/2_Suppliers.py
@@ -10,6 +10,7 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 from app.ui.theme import load_css, render_sidebar_logo
+from app.ui.navigation import render_sidebar_nav
 from app.ui import (
     pagination_controls,
     render_search_toggle,
@@ -59,6 +60,7 @@ def fetch_all_suppliers_df_pg2(
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 
 st.title("🤝 Supplier Management")
@@ -133,6 +135,11 @@ with st.expander("➕ Add New Supplier Record", expanded=False):
                 )
                 if success_add_pg2:
                     show_success(message_add_pg2)
+                    st.page_link(
+                        "pages/6_Purchase_Orders.py",
+                        label="Create Purchase Order",
+                        icon="➡️",
+                    )
                     fetch_all_suppliers_df_pg2.clear()  # Clear page-specific cache
                     st.rerun()
                 else:
@@ -396,6 +403,11 @@ else:
                             )
                             if ok_update_pg2:
                                 show_success(msg_update_pg2)
+                                st.page_link(
+                                    "pages/6_Purchase_Orders.py",
+                                    label="Create Purchase Order",
+                                    icon="➡️",
+                                )
                                 st.session_state.pg2_show_edit_form_for_supplier_id = (
                                     None  # Close form
                                 )

--- a/app/pages/3_Stock_Movements.py
+++ b/app/pages/3_Stock_Movements.py
@@ -20,6 +20,7 @@ try:
         PLACEHOLDER_SELECT_ITEM,
     )
     from app.ui.theme import load_css, render_sidebar_logo
+    from app.ui.navigation import render_sidebar_nav
     from app.ui import show_success, show_error
 except ImportError as e:
     show_error(f"Import error in 3_Stock_Movements.py: {e}.")
@@ -73,6 +74,7 @@ for section_key_pg3 in SECTION_KEYS_PG3:
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 st.title("🚚 Stock Movements Log")
 st.write(
@@ -396,6 +398,11 @@ with st.form(form_key_main_pg3, clear_on_submit=False):
                 )
                 show_success(
                     f"✅ Successfully recorded {active_section_prefix_val_pg3} for '{item_display_name_success_pg3}'."
+                )
+                st.page_link(
+                    "pages/4_History_Reports.py",
+                    label="View History Reports",
+                    icon="➡️",
                 )
 
                 fetch_active_items_for_stock_mv_page_pg3.clear()

--- a/app/pages/4_History_Reports.py
+++ b/app/pages/4_History_Reports.py
@@ -24,6 +24,7 @@ try:
         FILTER_ALL_TYPES,
     )
     from app.ui.theme import load_css, render_sidebar_logo
+    from app.ui.navigation import render_sidebar_nav
     from app.ui import show_success, show_error
 except ImportError as e:
     show_error(f"Import error in 4_History_Reports.py: {e}.")
@@ -34,6 +35,7 @@ except Exception as e:
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 st.title("📜 Stock Transaction History & Reports")
 st.write(

--- a/app/pages/5_Indents.py
+++ b/app/pages/5_Indents.py
@@ -40,6 +40,7 @@ try:
         PLACEHOLDER_ERROR_LOADING_ITEMS,  # If applicable
     )
     from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
+    from app.ui.navigation import render_sidebar_nav
     from app.ui import show_success, show_error
 except ImportError as e:
     show_error(
@@ -126,6 +127,7 @@ for key, default_val in [
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 st.title("📝 Material Indents Management")
 st.write(
@@ -907,6 +909,11 @@ def process_indent_form_pg5(
                     )
                 if success_p_pg5:
                     show_success(message_p_pg5)
+                    st.page_link(
+                        "pages/6_Purchase_Orders.py",
+                        label="Create Purchase Order",
+                        icon="➡️",
+                    )
                     st.session_state.pg5_process_indent_selected_tuple = (
                         pg5_placeholder_indent_process_tuple
                     )
@@ -944,6 +951,11 @@ if st.session_state.pg5_active_indent_section == "create":
         # This section seems okay, just ensure all st.session_state access uses pg5_ prefixes if they were changed.
         mrn_to_print_pg5 = st.session_state.pg5_last_created_mrn_for_print  # Use pg5_ variable
         show_success(f"Indent **{mrn_to_print_pg5}** was created successfully!")
+        st.page_link(
+            "pages/6_Purchase_Orders.py",
+            label="Create Purchase Order",
+            icon="➡️",
+        )
         if st.session_state.get("pg5_last_submitted_indent_details"):
             summary_header_pg5 = st.session_state.pg5_last_submitted_indent_details["header"]
             summary_items_pg5 = st.session_state.pg5_last_submitted_indent_details["items"]

--- a/app/pages/6_Purchase_Orders.py
+++ b/app/pages/6_Purchase_Orders.py
@@ -26,6 +26,7 @@ try:
         PO_STATUS_PARTIALLY_RECEIVED,
     )
     from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
+    from app.ui.navigation import render_sidebar_nav
     from app.ui import show_success, show_error
 except ImportError as e:
     show_error(
@@ -38,6 +39,7 @@ except Exception as e:  # Catch any other potential import errors
 
 load_css()
 render_sidebar_logo()
+render_sidebar_nav()
 
 # --- Page Config and Title ---
 st.title("🛒 Purchase Order & Goods Receiving")
@@ -276,11 +278,39 @@ def grn_form_pg6(active_grn_po_details_data_ui):
             st.caption("")
 
         st.divider()
+# Submit GRN form
         submit_grn_button_ui = st.form_submit_button(
             "💾 Record Goods Received", type="primary", use_container_width=True
-            )
+        )
 
         return submit_grn_button_ui
+
+# --- Quick Navigation Tabs ---
+VIEW_MODE_LABELS_PG6 = {
+    "📋 PO List": "list_po",
+    "📝 Create/Edit PO": "create_po",
+    "📥 Record GRN": "create_grn_for_po",
+}
+
+def _pg6_tab_switch_callback():
+    label_selected_pg6 = st.session_state.po_tab_radio_pg6
+    change_view_mode(
+        VIEW_MODE_LABELS_PG6[label_selected_pg6],
+        clear_grn_state=False,
+        clear_po_form_state=False,
+    )
+
+st.radio(
+    "Select Section:",
+    options=list(VIEW_MODE_LABELS_PG6.keys()),
+    index=list(VIEW_MODE_LABELS_PG6.values()).index(
+        st.session_state.po_grn_view_mode
+    ),
+    key="po_tab_radio_pg6",
+    horizontal=True,
+    on_change=_pg6_tab_switch_callback,
+)
+st.divider()
 # --- Main Page Logic (Router) ---
 if st.session_state.po_grn_view_mode == "list_po":
     st.subheader("📋 Existing Purchase Orders")
@@ -957,6 +987,11 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
                     )
                     if success_create:
                         show_success(f"✅ {msg_create} (ID: {new_po_id_create})")
+                        st.page_link(
+                            "pages/6_Purchase_Orders.py",
+                            label="Record Goods Received",
+                            icon="➡️",
+                        )
                         change_view_mode("list_po", clear_po_form_state=True)
                         st.rerun()
                     else:
@@ -1061,6 +1096,11 @@ elif st.session_state.po_grn_view_mode == "create_grn_for_po":
             )
             if success_grn_create:
                 show_success(f"✅ {msg_grn_create} (GRN ID: {new_grn_id_created})")
+                st.page_link(
+                    "pages/4_History_Reports.py",
+                    label="View in History Reports",
+                    icon="➡️",
+                )
                 change_view_mode("list_po", clear_grn_state=True, clear_po_form_state=True)
                 purchase_order_service.list_pos.clear()
                 st.rerun()


### PR DESCRIPTION
## Summary
- show sidebar navigation on every page
- add quick links after actions (item, supplier, indent, stock movement, purchase orders)
- include radio selector for Purchase Orders page to reduce scrolling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ef6a9e4c832689c5771590a4d548