### PR TITLE
Remove inline page links after sidebar update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Inventory-App is a Streamlit application for managing restaurant inventory. It h
 - Stock movement logging and history reports
 - Indents and purchase order tracking
 - Dashboard showing key metrics such as low-stock items
+- Unified sidebar navigation for quick access to all pages
 
 ## Installation
 

--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -169,11 +169,8 @@ with st.expander("➕ Add New Inventory Item", expanded=False):
                     engine, item_data_to_add
                 )
                 if success_add:
-                    show_success(message_add)
-                    st.page_link(
-                        "pages/3_Stock_Movements.py",
-                        label="Record Stock Movement",
-                        icon="➡️",
+                    show_success(
+                        f"{message_add} Use the sidebar to record a stock movement."
                     )
                     fetch_all_items_df_for_items_page.clear()
                     st.rerun()
@@ -530,11 +527,8 @@ else:
                                 )
                             )
                             if ok_update_item:
-                                show_success(msg_update_item)
-                                st.page_link(
-                                    "pages/3_Stock_Movements.py",
-                                    label="Record Stock Movement",
-                                    icon="➡️",
+                                show_success(
+                                    f"{msg_update_item} Use the sidebar to record a stock movement."
                                 )
                                 st.session_state.ss_items_show_edit_form_flag = None
                                 st.session_state.ss_items_edit_form_data_dict = None

--- a/app/pages/2_Suppliers.py
+++ b/app/pages/2_Suppliers.py
@@ -134,11 +134,8 @@ with st.expander("➕ Add New Supplier Record", expanded=False):
                     engine, supplier_data_add_pg2
                 )
                 if success_add_pg2:
-                    show_success(message_add_pg2)
-                    st.page_link(
-                        "pages/6_Purchase_Orders.py",
-                        label="Create Purchase Order",
-                        icon="➡️",
+                    show_success(
+                        f"{message_add_pg2} Use the sidebar to create a purchase order."
                     )
                     fetch_all_suppliers_df_pg2.clear()  # Clear page-specific cache
                     st.rerun()
@@ -402,11 +399,8 @@ else:
                                 )
                             )
                             if ok_update_pg2:
-                                show_success(msg_update_pg2)
-                                st.page_link(
-                                    "pages/6_Purchase_Orders.py",
-                                    label="Create Purchase Order",
-                                    icon="➡️",
+                                show_success(
+                                    f"{msg_update_pg2} Use the sidebar to create a purchase order."
                                 )
                                 st.session_state.pg2_show_edit_form_for_supplier_id = (
                                     None  # Close form

--- a/app/pages/3_Stock_Movements.py
+++ b/app/pages/3_Stock_Movements.py
@@ -397,12 +397,7 @@ with st.form(form_key_main_pg3, clear_on_submit=False):
                     else "Selected Item"
                 )
                 show_success(
-                    f"✅ Successfully recorded {active_section_prefix_val_pg3} for '{item_display_name_success_pg3}'."
-                )
-                st.page_link(
-                    "pages/4_History_Reports.py",
-                    label="View History Reports",
-                    icon="➡️",
+                    f"✅ Successfully recorded {active_section_prefix_val_pg3} for '{item_display_name_success_pg3}'. Use the sidebar to view reports."
                 )
 
                 fetch_active_items_for_stock_mv_page_pg3.clear()

--- a/app/pages/5_Indents.py
+++ b/app/pages/5_Indents.py
@@ -908,11 +908,8 @@ def process_indent_form_pg5(
                         selected_mrn_pg5,
                     )
                 if success_p_pg5:
-                    show_success(message_p_pg5)
-                    st.page_link(
-                        "pages/6_Purchase_Orders.py",
-                        label="Create Purchase Order",
-                        icon="➡️",
+                    show_success(
+                        f"{message_p_pg5} Use the sidebar to create a purchase order."
                     )
                     st.session_state.pg5_process_indent_selected_tuple = (
                         pg5_placeholder_indent_process_tuple
@@ -950,11 +947,8 @@ if st.session_state.pg5_active_indent_section == "create":
         # ... (Success message and PDF/WhatsApp section - use pg5_ prefixed session state keys) ...
         # This section seems okay, just ensure all st.session_state access uses pg5_ prefixes if they were changed.
         mrn_to_print_pg5 = st.session_state.pg5_last_created_mrn_for_print  # Use pg5_ variable
-        show_success(f"Indent **{mrn_to_print_pg5}** was created successfully!")
-        st.page_link(
-            "pages/6_Purchase_Orders.py",
-            label="Create Purchase Order",
-            icon="➡️",
+        show_success(
+            f"Indent **{mrn_to_print_pg5}** was created successfully! Use the sidebar to create a purchase order."
         )
         if st.session_state.get("pg5_last_submitted_indent_details"):
             summary_header_pg5 = st.session_state.pg5_last_submitted_indent_details["header"]

--- a/app/pages/6_Purchase_Orders.py
+++ b/app/pages/6_Purchase_Orders.py
@@ -986,11 +986,8 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
                         db_engine, po_header_data_for_submit, po_items_to_submit
                     )
                     if success_create:
-                        show_success(f"✅ {msg_create} (ID: {new_po_id_create})")
-                        st.page_link(
-                            "pages/6_Purchase_Orders.py",
-                            label="Record Goods Received",
-                            icon="➡️",
+                        show_success(
+                            f"✅ {msg_create} (ID: {new_po_id_create}) Use the sidebar to record goods received."
                         )
                         change_view_mode("list_po", clear_po_form_state=True)
                         st.rerun()
@@ -1095,11 +1092,8 @@ elif st.session_state.po_grn_view_mode == "create_grn_for_po":
                 db_engine, grn_header_to_submit, grn_items_to_submit
             )
             if success_grn_create:
-                show_success(f"✅ {msg_grn_create} (GRN ID: {new_grn_id_created})")
-                st.page_link(
-                    "pages/4_History_Reports.py",
-                    label="View in History Reports",
-                    icon="➡️",
+                show_success(
+                    f"✅ {msg_grn_create} (GRN ID: {new_grn_id_created}) Use the sidebar to view reports."
                 )
                 change_view_mode("list_po", clear_grn_state=True, clear_po_form_state=True)
                 purchase_order_service.list_pos.clear()


### PR DESCRIPTION
## Summary
- remove deprecated `st.page_link` use from all pages
- mention new sidebar navigation in README
- show hint text guiding users to the sidebar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f47c316883268b2c88bf7ebb0447