### PR TITLE
Make sidebar more compact

### DIFF
--- a/app/ui/styles.css
+++ b/app/ui/styles.css
@@ -5,6 +5,18 @@ body { font-family: 'Roboto', sans-serif; }
     background-color: #f0f2f6;
 }
 
+/* Compact sidebar layout */
+[data-testid="stSidebar"] {
+    width: 12rem;
+}
+[data-testid="stSidebar"] .sidebar-content {
+    padding: 0.5rem;
+}
+[data-testid="stSidebar"] img {
+    margin-top: -0.5rem;
+    margin-bottom: 0.5rem;
+}
+
 /* Status badge classes */
 .badge-success { background: #21ba45; color: white; padding: 2px 6px; border-radius: 4px; }
 .badge-warning { background: #f2c037; color: black; padding: 2px 6px; border-radius: 4px; }

--- a/app/ui/theme.py
+++ b/app/ui/theme.py
@@ -25,5 +25,5 @@ def format_status_badge(status: str) -> str:
 def render_sidebar_logo() -> None:
     """Render the logo image in the Streamlit sidebar."""
     logo_bytes = get_logo_bytes()
-    # use_container_width avoids deprecation warnings from Streamlit
-    st.sidebar.image(logo_bytes, use_container_width=True)
+    # Explicit width keeps the logo from filling the entire sidebar
+    st.sidebar.image(logo_bytes, width=120)


### PR DESCRIPTION
## Summary
- shrink logo size in sidebar
- add CSS rules for a compact sidebar layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847027983988326a1620a413625466b