### PR TITLE
Fix sidebar collapse layout

### DIFF
--- a/app/ui/styles.css
+++ b/app/ui/styles.css
@@ -7,8 +7,8 @@ body { font-family: 'Roboto', sans-serif; }
 
 /* Compact sidebar layout */
 [data-testid="stSidebar"] {
-    width: 10rem !important;
-    min-width: 10rem;
+    /* Let Streamlit manage the sidebar width dynamically so the page content
+       expands when the sidebar is collapsed. */
     max-width: 10rem;
 }
 [data-testid="stSidebar"] .sidebar-content {


### PR DESCRIPTION
## Summary
- let Streamlit handle the sidebar width dynamically to allow proper collapse

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684709f5328c8326a4e5f40d8b6e3bca