### PR TITLE
Fix ValueError with purchase order view mode

### DIFF
--- a/app/pages/6_Purchase_Orders.py
+++ b/app/pages/6_Purchase_Orders.py
@@ -303,8 +303,10 @@ def _pg6_tab_switch_callback():
 st.radio(
     "Select Section:",
     options=list(VIEW_MODE_LABELS_PG6.keys()),
-    index=list(VIEW_MODE_LABELS_PG6.values()).index(
-        st.session_state.po_grn_view_mode
+    index=(
+        list(VIEW_MODE_LABELS_PG6.values()).index(st.session_state.po_grn_view_mode)
+        if st.session_state.po_grn_view_mode in VIEW_MODE_LABELS_PG6.values()
+        else 0
     ),
     key="po_tab_radio_pg6",
     horizontal=True,


### PR DESCRIPTION
## Summary
- prevent ValueError when current view mode isn't in radio options

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847a6c770bc8326af8c9884a1c25e9e