### PR TITLE
Enable wide layout on all pages

### DIFF
--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -4,6 +4,8 @@ import sys
 import streamlit as st
 import pandas as pd
 
+st.set_page_config(page_title="Item Management", layout="wide")
+
 _CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
 if _REPO_ROOT not in sys.path:

--- a/app/pages/2_Suppliers.py
+++ b/app/pages/2_Suppliers.py
@@ -4,6 +4,8 @@ import sys
 import streamlit as st
 import pandas as pd
 
+st.set_page_config(page_title="Supplier Management", layout="wide")
+
 _CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
 if _REPO_ROOT not in sys.path:

--- a/app/pages/3_Stock_Movements.py
+++ b/app/pages/3_Stock_Movements.py
@@ -3,6 +3,8 @@ import os
 import sys
 import streamlit as st
 
+st.set_page_config(page_title="Stock Movements", layout="wide")
+
 _CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
 if _REPO_ROOT not in sys.path:

--- a/app/pages/4_History_Reports.py
+++ b/app/pages/4_History_Reports.py
@@ -3,6 +3,8 @@ import os
 import sys
 import streamlit as st
 import pandas as pd
+
+st.set_page_config(page_title="History Reports", layout="wide")
 from datetime import datetime, timedelta
 
 _CUR_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/app/pages/5_Indents.py
+++ b/app/pages/5_Indents.py
@@ -10,6 +10,8 @@ from fpdf import FPDF
 from fpdf.enums import XPos, YPos
 import traceback
 
+st.set_page_config(page_title="Indents", layout="wide")
+
 _CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
 if _REPO_ROOT not in sys.path:

--- a/app/pages/6_Purchase_Orders.py
+++ b/app/pages/6_Purchase_Orders.py
@@ -3,6 +3,8 @@ import os
 import sys
 import streamlit as st
 import pandas as pd
+
+st.set_page_config(page_title="Purchase Orders", layout="wide")
 from datetime import date
 from typing import Dict, Any, Optional, List
 


### PR DESCRIPTION
## Summary
- set page config with `layout="wide"` across item, supplier, stock movement, history report, indent and PO pages
- run the Streamlit app to make sure pages start correctly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `streamlit run app/item_manager_app.py` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_6847b0236fac83269cb20fb504c3ba5e