### PR TITLE
Implement basic recipe tracking

### DIFF
--- a/app/db/sql/recipes.sql
+++ b/app/db/sql/recipes.sql
@@ -1,0 +1,19 @@
+-- SQL script for recipe tables
+CREATE TABLE IF NOT EXISTS recipes (
+    recipe_id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    description TEXT,
+    is_active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS recipe_items (
+    recipe_item_id SERIAL PRIMARY KEY,
+    recipe_id INTEGER NOT NULL REFERENCES recipes(recipe_id) ON DELETE CASCADE,
+    item_id INTEGER NOT NULL REFERENCES items(item_id),
+    quantity REAL NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE (recipe_id, item_id)
+);

--- a/app/pages/7_Recipes.py
+++ b/app/pages/7_Recipes.py
@@ -1,0 +1,120 @@
+# app/pages/7_Recipes.py
+import os
+import sys
+import streamlit as st
+import pandas as pd
+
+st.set_page_config(page_title="Recipes", layout="wide")
+
+_CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from app.ui.theme import load_css, render_sidebar_logo
+from app.ui.navigation import render_sidebar_nav
+from app.ui import show_success, show_error
+
+try:
+    from app.db.database_utils import connect_db
+    from app.services import recipe_service, item_service
+    from app.auth.auth import get_current_user_id
+except Exception as e:
+    st.error(f"Import error in Recipes page: {e}")
+    st.stop()
+
+load_css()
+render_sidebar_logo()
+render_sidebar_nav()
+
+engine = connect_db()
+if engine is None:
+    show_error("Database connection failed.")
+    st.stop()
+
+st.title("Recipe Management")
+
+# --- Add Recipe ---
+with st.expander("➕ Add New Recipe", expanded=False):
+    with st.form("add_recipe_form"):
+        name = st.text_input("Recipe Name*", key="recipe_name")
+        desc = st.text_area("Description", key="recipe_desc")
+        items_df = item_service.get_all_items_with_stock(engine)
+        item_opts = {
+            f"{row['name']} ({row['unit']})": int(row["item_id"]) for _, row in items_df.iterrows()
+        }
+        selected = st.multiselect("Ingredients", list(item_opts.keys()))
+        qty_inputs = {}
+        for label in selected:
+            iid = item_opts[label]
+            qty_inputs[iid] = st.number_input(
+                f"Qty of {label}", min_value=0.0, step=0.01, format="%.2f", key=f"qty_{iid}"
+            )
+        submit = st.form_submit_button("Save Recipe")
+    if submit:
+        ingredients = [
+            {"item_id": iid, "quantity": q}
+            for iid, q in qty_inputs.items()
+            if q > 0
+        ]
+        if not name.strip() or not ingredients:
+            st.warning("Name and at least one ingredient required.")
+        else:
+            ok, msg, _ = recipe_service.create_recipe(
+                engine,
+                {"name": name.strip(), "description": desc.strip()},
+                ingredients,
+            )
+            if ok:
+                show_success(msg)
+            else:
+                st.warning(msg)
+
+# --- List and Edit Recipes ---
+recipes_df = recipe_service.list_recipes(engine, include_inactive=True)
+if recipes_df.empty:
+    st.info("No recipes found.")
+else:
+    st.subheader("Existing Recipes")
+    for _, row in recipes_df.iterrows():
+        rid = int(row["recipe_id"])
+        with st.expander(row["name"], expanded=False):
+            st.write(row["description"] or "")
+            items = recipe_service.get_recipe_items(engine, rid)
+            st.dataframe(items[["item_name", "quantity"]], use_container_width=True)
+            if st.button("Edit", key=f"edit_{rid}"):
+                st.session_state["edit_recipe_id"] = rid
+            if st.session_state.get("edit_recipe_id") == rid:
+                with st.form(f"edit_form_{rid}"):
+                    new_name = st.text_input("Recipe Name*", value=row["name"], key=f"ename_{rid}")
+                    new_desc = st.text_area("Description", value=row["description"] or "", key=f"edesc_{rid}")
+                    item_opts_local = item_opts  # from earlier
+                    selected_local = st.multiselect(
+                        "Ingredients", list(item_opts_local.keys()),
+                        default=[k for k, v in item_opts_local.items() if v in items["item_id"].tolist()],
+                        key=f"sel_{rid}"
+                    )
+                    qty_inputs_local = {}
+                    for label in selected_local:
+                        iid = item_opts_local[label]
+                        current_qty = items.loc[items["item_id"] == iid, "quantity"].iloc[0] if iid in items["item_id"].tolist() else 0
+                        qty_inputs_local[iid] = st.number_input(
+                            f"Qty of {label}", min_value=0.0, step=0.01, format="%.2f", value=float(current_qty), key=f"eqty_{iid}_{rid}"
+                        )
+                    save = st.form_submit_button("Update")
+                if save:
+                    ing = [
+                        {"item_id": iid, "quantity": qty}
+                        for iid, qty in qty_inputs_local.items() if qty > 0
+                    ]
+                    ok, msg = recipe_service.update_recipe(
+                        engine,
+                        rid,
+                        {"name": new_name.strip(), "description": new_desc.strip()},
+                        ing,
+                    )
+                    if ok:
+                        show_success(msg)
+                        st.session_state["edit_recipe_id"] = None
+                    else:
+                        st.warning(msg)

--- a/app/services/recipe_service.py
+++ b/app/services/recipe_service.py
@@ -1,0 +1,237 @@
+"""Service layer for recipe management."""
+from typing import Dict, List, Tuple, Any, Optional
+import traceback
+import pandas as pd
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.engine import Engine, Connection
+
+from app.core.logging import get_logger
+from app.db.database_utils import fetch_data
+from app.core.constants import TX_SALE
+from . import stock_service
+
+logger = get_logger(__name__)
+
+
+# ─────────────────────────────────────────────────────────
+# RECIPE CRUD FUNCTIONS
+# ─────────────────────────────────────────────────────────
+
+def list_recipes(engine: Engine, include_inactive: bool = False) -> pd.DataFrame:
+    """Return all recipes."""
+    if engine is None:
+        logger.error(
+            "ERROR [recipe_service.list_recipes]: Database engine not available."
+        )
+        return pd.DataFrame()
+    query = "SELECT recipe_id, name, description, is_active FROM recipes"
+    if not include_inactive:
+        query += " WHERE is_active = TRUE"
+    query += " ORDER BY name;"
+    return fetch_data(engine, query)
+
+
+def get_recipe_items(engine: Engine, recipe_id: int) -> pd.DataFrame:
+    """Return ingredient breakdown for a recipe."""
+    if engine is None:
+        logger.error(
+            "ERROR [recipe_service.get_recipe_items]: Database engine not available."
+        )
+        return pd.DataFrame()
+    query = text(
+        """
+        SELECT ri.recipe_item_id, ri.recipe_id, ri.item_id, i.name AS item_name, ri.quantity
+        FROM recipe_items ri
+        JOIN items i ON ri.item_id = i.item_id
+        WHERE ri.recipe_id = :rid
+        ORDER BY i.name;
+        """
+    )
+    return fetch_data(engine, query.text, {"rid": recipe_id})
+
+
+def create_recipe(
+    engine: Engine,
+    recipe_data: Dict[str, Any],
+    ingredients: List[Dict[str, Any]],
+) -> Tuple[bool, str, Optional[int]]:
+    """Create a recipe and its ingredient rows."""
+    if engine is None:
+        return False, "Database engine not available.", None
+    if not recipe_data.get("name") or not str(recipe_data.get("name")).strip():
+        return False, "Recipe name is required.", None
+    if not ingredients:
+        return False, "At least one ingredient is required.", None
+    clean_name = recipe_data["name"].strip()
+    desc = recipe_data.get("description")
+    desc_clean = desc.strip() if isinstance(desc, str) and desc.strip() else None
+    is_active = bool(recipe_data.get("is_active", True))
+    insert_recipe_q = text(
+        """INSERT INTO recipes (name, description, is_active) VALUES (:n, :d, :a) RETURNING recipe_id;"""
+    )
+    insert_item_q = text(
+        "INSERT INTO recipe_items (recipe_id, item_id, quantity) VALUES (:r, :i, :q);"
+    )
+    try:
+        with engine.connect() as conn:
+            with conn.begin():
+                rid = conn.execute(insert_recipe_q, {"n": clean_name, "d": desc_clean, "a": is_active}).scalar_one_or_none()
+                if not rid:
+                    raise Exception("Failed to insert recipe header.")
+                for ing in ingredients:
+                    iid = ing.get("item_id")
+                    qty = ing.get("quantity", 0)
+                    if not iid or qty is None or qty <= 0:
+                        raise ValueError("Invalid ingredient data")
+                    conn.execute(insert_item_q, {"r": rid, "i": iid, "q": float(qty)})
+        return True, f"Recipe '{clean_name}' added.", rid
+    except IntegrityError as ie:
+        logger.error(
+            "ERROR [recipe_service.create_recipe]: Integrity error: %s\n%s",
+            ie,
+            traceback.format_exc(),
+        )
+        msg = "Recipe with this name already exists." if "unique" in str(ie).lower() else "Integrity error."
+        return False, msg, None
+    except (SQLAlchemyError, Exception) as e:
+        logger.error(
+            "ERROR [recipe_service.create_recipe]: DB error: %s\n%s",
+            e,
+            traceback.format_exc(),
+        )
+        return False, "A database error occurred.", None
+
+
+def update_recipe(
+    engine: Engine,
+    recipe_id: int,
+    recipe_data: Dict[str, Any],
+    ingredients: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Update recipe details and ingredients."""
+    if engine is None:
+        return False, "Database engine not available."
+    if not recipe_id:
+        return False, "Recipe ID required."
+    if not recipe_data.get("name") or not str(recipe_data.get("name")).strip():
+        return False, "Recipe name is required."
+    if not ingredients:
+        return False, "At least one ingredient is required."
+    clean_name = recipe_data["name"].strip()
+    desc = recipe_data.get("description")
+    desc_clean = desc.strip() if isinstance(desc, str) and desc.strip() else None
+    is_active = bool(recipe_data.get("is_active", True))
+    upd_q = text(
+        "UPDATE recipes SET name=:n, description=:d, is_active=:a, updated_at=NOW() WHERE recipe_id=:rid;"
+    )
+    del_items_q = text("DELETE FROM recipe_items WHERE recipe_id=:rid;")
+    ins_item_q = text(
+        "INSERT INTO recipe_items (recipe_id, item_id, quantity) VALUES (:r, :i, :q);"
+    )
+    try:
+        with engine.connect() as conn:
+            with conn.begin():
+                res = conn.execute(upd_q, {"n": clean_name, "d": desc_clean, "a": is_active, "rid": recipe_id})
+                if res.rowcount == 0:
+                    return False, "Recipe not found."
+                conn.execute(del_items_q, {"rid": recipe_id})
+                for ing in ingredients:
+                    iid = ing.get("item_id")
+                    qty = ing.get("quantity", 0)
+                    if not iid or qty is None or qty <= 0:
+                        raise ValueError("Invalid ingredient data")
+                    conn.execute(ins_item_q, {"r": recipe_id, "i": iid, "q": float(qty)})
+        return True, f"Recipe '{clean_name}' updated."
+    except IntegrityError as ie:
+        logger.error(
+            "ERROR [recipe_service.update_recipe]: Integrity error: %s\n%s",
+            ie,
+            traceback.format_exc(),
+        )
+        msg = "Duplicate recipe name." if "unique" in str(ie).lower() else "Integrity error."
+        return False, msg
+    except (SQLAlchemyError, Exception) as e:
+        logger.error(
+            "ERROR [recipe_service.update_recipe]: DB error: %s\n%s",
+            e,
+            traceback.format_exc(),
+        )
+        return False, "A database error occurred."
+
+
+def delete_recipe(engine: Engine, recipe_id: int) -> Tuple[bool, str]:
+    """Delete a recipe."""
+    if engine is None:
+        return False, "Database engine not available."
+    if not recipe_id:
+        return False, "Recipe ID required."
+    del_q = text("DELETE FROM recipes WHERE recipe_id=:rid;")
+    try:
+        success, _ = fetch_data(engine, "SELECT 1").empty, None
+        with engine.begin() as conn:
+            res = conn.execute(del_q, {"rid": recipe_id})
+            if res.rowcount == 0:
+                return False, "Recipe not found."
+        return True, "Recipe deleted."
+    except (SQLAlchemyError, Exception) as e:
+        logger.error(
+            "ERROR [recipe_service.delete_recipe]: DB error: %s\n%s",
+            e,
+            traceback.format_exc(),
+        )
+        return False, "A database error occurred."
+
+
+# ─────────────────────────────────────────────────────────
+# SALES RECORDING USING RECIPES
+# ─────────────────────────────────────────────────────────
+
+def record_sale(
+    engine: Engine,
+    recipe_id: int,
+    quantity: float,
+    user_id: str,
+    notes: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """Record sale of a recipe and reduce ingredient stock."""
+    if engine is None:
+        return False, "Database engine not available."
+    if not recipe_id or quantity <= 0:
+        return False, "Invalid recipe or quantity."
+    user_id_clean = user_id.strip() if user_id else "System"
+    notes_clean = notes.strip() if isinstance(notes, str) and notes.strip() else None
+    sale_ins_q = text(
+        "INSERT INTO sales_transactions (recipe_id, quantity, user_id, notes) VALUES (:r, :q, :u, :n);"
+    )
+    items_df = get_recipe_items(engine, recipe_id)
+    if items_df.empty:
+        return False, "No ingredients defined for recipe."
+    try:
+        with engine.connect() as conn:
+            with conn.begin():
+                conn.execute(sale_ins_q, {"r": recipe_id, "q": quantity, "u": user_id_clean, "n": notes_clean})
+                for _, row in items_df.iterrows():
+                    total_qty = float(row["quantity"]) * quantity
+                    ok = stock_service.record_stock_transaction(
+                        item_id=int(row["item_id"]),
+                        quantity_change=-total_qty,
+                        transaction_type=TX_SALE,
+                        user_id=user_id_clean,
+                        related_mrn=None,
+                        related_po_id=None,
+                        notes=f"Recipe {recipe_id} sale",  # type: ignore
+                        db_engine_param=None,
+                        db_connection_param=conn,
+                    )
+                    if not ok:
+                        raise Exception(
+                            f"Failed stock tx for item {row['item_id']} during sale.")
+        return True, "Sale recorded."
+    except (SQLAlchemyError, Exception) as e:
+        logger.error(
+            "ERROR [recipe_service.record_sale]: Error recording sale: %s\n%s",
+            e,
+            traceback.format_exc(),
+        )
+        return False, "A database error occurred during sale recording."

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -11,3 +11,4 @@ def render_sidebar_nav() -> None:
         st.page_link("pages/4_History_Reports.py", label="History Reports")
         st.page_link("pages/5_Indents.py", label="Indents")
         st.page_link("pages/6_Purchase_Orders.py", label="Purchase Orders")
+        st.page_link("pages/7_Recipes.py", label="Recipes")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,4 +64,41 @@ def sqlite_engine():
             );
             """
         ))
+        conn.execute(text(
+            """
+            CREATE TABLE recipes (
+                recipe_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE,
+                description TEXT,
+                is_active BOOLEAN,
+                created_at TEXT,
+                updated_at TEXT
+            );
+            """
+        ))
+        conn.execute(text(
+            """
+            CREATE TABLE recipe_items (
+                recipe_item_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                recipe_id INTEGER,
+                item_id INTEGER,
+                quantity REAL,
+                created_at TEXT,
+                updated_at TEXT,
+                UNIQUE (recipe_id, item_id)
+            );
+            """
+        ))
+        conn.execute(text(
+            """
+            CREATE TABLE sales_transactions (
+                sale_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                recipe_id INTEGER,
+                quantity INTEGER,
+                user_id TEXT,
+                sale_date TEXT,
+                notes TEXT
+            );
+            """
+        ))
     return engine

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -1,0 +1,49 @@
+from sqlalchemy import text
+
+from app.services import recipe_service
+
+
+def setup_items(engine):
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO items (name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active)"
+                " VALUES ('Flour', 'kg', 'cat', 'sub', 'dept', 0, 20, 'n', 1)"
+            )
+        )
+        item_id = conn.execute(text("SELECT item_id FROM items WHERE name='Flour'"))
+        return item_id.scalar_one()
+
+
+def test_create_recipe_inserts_rows(sqlite_engine):
+    item_id = setup_items(sqlite_engine)
+    data = {"name": "Bread", "description": "desc", "is_active": True}
+    ingredients = [{"item_id": item_id, "quantity": 2}]
+    success, msg, rid = recipe_service.create_recipe(sqlite_engine, data, ingredients)
+    assert success and rid
+    with sqlite_engine.connect() as conn:
+        count = conn.execute(
+            text("SELECT COUNT(*) FROM recipe_items WHERE recipe_id=:r"), {"r": rid}
+        ).scalar_one()
+        assert count == 1
+
+
+def test_record_sale_reduces_stock(sqlite_engine):
+    item_id = setup_items(sqlite_engine)
+    with sqlite_engine.begin() as conn:
+        conn.execute(text("INSERT INTO recipes (name, is_active) VALUES ('Toast', 1)"))
+        recipe_id = conn.execute(text("SELECT recipe_id FROM recipes WHERE name='Toast'"))
+        recipe_id = recipe_id.scalar_one()
+        conn.execute(
+            text(
+                "INSERT INTO recipe_items (recipe_id, item_id, quantity) VALUES (:r, :i, 3)"
+            ),
+            {"r": recipe_id, "i": item_id},
+        )
+    ok, _ = recipe_service.record_sale(sqlite_engine, recipe_id, 1, "tester")
+    assert ok
+    with sqlite_engine.connect() as conn:
+        stock = conn.execute(
+            text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item_id}
+        ).scalar_one()
+        assert stock == 17


### PR DESCRIPTION
## Summary
- add service layer for recipes with CRUD logic and sale recording
- create SQL script for recipe tables
- add Streamlit page to manage recipes
- expose recipe page in sidebar navigation
- extend tests with recipe service and sqlite schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bdb32230832690a6e5b15ed5dbc9