### PR TITLE
Add recipe cost calculation

### DIFF
--- a/app/pages/7_Recipes.py
+++ b/app/pages/7_Recipes.py
@@ -50,6 +50,8 @@ with st.expander("➕ Add New Recipe", expanded=False):
             qty_inputs[iid] = st.number_input(
                 f"Qty of {label}", min_value=0.0, step=0.01, format="%.2f", key=f"qty_{iid}"
             )
+        est_cost = recipe_service.calculate_recipe_cost(engine, qty_inputs)
+        st.markdown(f"**Estimated Cost:** {est_cost:.2f}")
         submit = st.form_submit_button("Save Recipe")
     if submit:
         ingredients = [
@@ -101,6 +103,8 @@ else:
                         qty_inputs_local[iid] = st.number_input(
                             f"Qty of {label}", min_value=0.0, step=0.01, format="%.2f", value=float(current_qty), key=f"eqty_{iid}_{rid}"
                         )
+                    est_cost_local = recipe_service.calculate_recipe_cost(engine, qty_inputs_local)
+                    st.markdown(f"**Estimated Cost:** {est_cost_local:.2f}")
                     save = st.form_submit_button("Update")
                 if save:
                     ing = [

--- a/app/services/goods_receiving_service.py
+++ b/app/services/goods_receiving_service.py
@@ -190,6 +190,13 @@ def create_grn(
                             f"Failed to record stock transaction for item_id {item_d['item_id']} on GRN {new_grn_number}."
                         )
 
+                    conn.execute(
+                        text(
+                            "UPDATE items SET last_unit_cost = :cost, updated_at = NOW() WHERE item_id = :iid"
+                        ),
+                        {"cost": price_rcv, "iid": item_d["item_id"]},
+                    )
+
                 if item_p_list_for_db:
                     conn.execute(item_q_obj, item_p_list_for_db)
 

--- a/app/services/recipe_service.py
+++ b/app/services/recipe_service.py
@@ -235,3 +235,23 @@ def record_sale(
             traceback.format_exc(),
         )
         return False, "A database error occurred during sale recording."
+
+
+def calculate_recipe_cost(engine: Engine, item_quantities: Dict[int, float]) -> float:
+    """Return estimated recipe cost based on last_unit_cost of items."""
+    if engine is None or not item_quantities:
+        return 0.0
+    total_cost = 0.0
+    for iid, qty in item_quantities.items():
+        if qty is None or qty <= 0:
+            continue
+        df = fetch_data(
+            engine,
+            "SELECT last_unit_cost FROM items WHERE item_id = :iid",
+            {"iid": iid},
+        )
+        if not df.empty:
+            cost = df.iloc[0]["last_unit_cost"]
+            unit_cost = float(cost) if cost is not None else 0.0
+            total_cost += unit_cost * qty
+    return total_cost

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ def sqlite_engine():
                 permitted_departments TEXT,
                 reorder_point REAL,
                 current_stock REAL,
+                last_unit_cost REAL,
                 notes TEXT,
                 is_active BOOLEAN,
                 updated_at TEXT

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -7,8 +7,8 @@ def setup_items(engine):
     with engine.begin() as conn:
         conn.execute(
             text(
-                "INSERT INTO items (name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active)"
-                " VALUES ('Flour', 'kg', 'cat', 'sub', 'dept', 0, 20, 'n', 1)"
+                "INSERT INTO items (name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, last_unit_cost, notes, is_active)"
+                " VALUES ('Flour', 'kg', 'cat', 'sub', 'dept', 0, 20, 1.5, 'n', 1)"
             )
         )
         item_id = conn.execute(text("SELECT item_id FROM items WHERE name='Flour'"))
@@ -47,3 +47,9 @@ def test_record_sale_reduces_stock(sqlite_engine):
             text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item_id}
         ).scalar_one()
         assert stock == 17
+
+
+def test_calculate_recipe_cost(sqlite_engine):
+    item_id = setup_items(sqlite_engine)
+    cost = recipe_service.calculate_recipe_cost(sqlite_engine, {item_id: 2})
+    assert cost == 3.0

--- a/tests/test_stock_service.py
+++ b/tests/test_stock_service.py
@@ -8,8 +8,8 @@ def test_record_stock_transaction_updates_stock_and_logs(sqlite_engine):
     with sqlite_engine.begin() as conn:
         conn.execute(
             text(
-                "INSERT INTO items (name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) "
-                "VALUES ('Sample', 'pcs', 'cat', 'sub', 'dept', 0, 10, 'n', 1)"
+                "INSERT INTO items (name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, last_unit_cost, notes, is_active) "
+                "VALUES ('Sample', 'pcs', 'cat', 'sub', 'dept', 0, 10, 2.0, 'n', 1)"
             )
         )
         item_id = conn.execute(text("SELECT item_id FROM items LIMIT 1")).scalar_one()


### PR DESCRIPTION
## Summary
- extend `items` table in tests with `last_unit_cost`
- track latest unit cost when creating GRNs
- support last unit cost throughout item service
- add helper to compute recipe cost
- display estimated recipe cost in recipe form
- add tests for cost calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c6019a608326896a4f45ea4e8a7a