### PR TITLE
Add recipe archiving and search functionality

### DIFF
--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -47,3 +47,62 @@ def test_record_sale_reduces_stock(sqlite_engine):
             text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item_id}
         ).scalar_one()
         assert stock == 17
+
+
+def test_archive_and_reactivate_recipe(sqlite_engine):
+    item_id = setup_items(sqlite_engine)
+    data = {"name": "Cake", "description": "sponge"}
+    ingredients = [{"item_id": item_id, "quantity": 1}]
+    success, _, rid = recipe_service.create_recipe(sqlite_engine, data, ingredients)
+    assert success and rid
+
+    success, _ = recipe_service.archive_recipe(sqlite_engine, rid)
+    assert success
+    with sqlite_engine.connect() as conn:
+        active = conn.execute(
+            text("SELECT is_active FROM recipes WHERE recipe_id=:r"), {"r": rid}
+        ).scalar_one()
+        assert active == 0
+
+    success, _ = recipe_service.reactivate_recipe(sqlite_engine, rid)
+    assert success
+    with sqlite_engine.connect() as conn:
+        active = conn.execute(
+            text("SELECT is_active FROM recipes WHERE recipe_id=:r"), {"r": rid}
+        ).scalar_one()
+        assert active == 1
+
+
+def test_list_recipes_search_and_filter(sqlite_engine):
+    item_id = setup_items(sqlite_engine)
+    recipe_service.create_recipe(
+        sqlite_engine,
+        {"name": "Apple Pie", "description": "Sweet"},
+        [{"item_id": item_id, "quantity": 1}],
+    )
+    recipe_service.create_recipe(
+        sqlite_engine,
+        {"name": "Banana Bread", "description": "Sweet bread"},
+        [{"item_id": item_id, "quantity": 1}],
+    )
+    _, _, rid = recipe_service.create_recipe(
+        sqlite_engine,
+        {"name": "Carrot Soup", "description": "Healthy"},
+        [{"item_id": item_id, "quantity": 1}],
+    )
+    recipe_service.archive_recipe(sqlite_engine, rid)
+
+    df = recipe_service.list_recipes(sqlite_engine, search_text="Bread")
+    assert list(df["name"]) == ["Banana Bread"]
+
+    df_active = recipe_service.list_recipes(sqlite_engine)
+    assert len(df_active) == 2
+
+    df_all = recipe_service.list_recipes(sqlite_engine, include_inactive=True)
+    assert len(df_all) == 3
+
+    df_soup = recipe_service.list_recipes(
+        sqlite_engine, search_text="Soup", include_inactive=True
+    )
+    assert list(df_soup["name"]) == ["Carrot Soup"]
+


### PR DESCRIPTION
## Summary
- allow listing recipes with search text and include inactive flag
- enable archiving/reactivating recipes in recipe service
- add UI controls on Recipes page for search, toggle, and archive/restore
- test archiving/reactivating recipes and list filtering

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c6d967008326b6aa7452a36f8560