### PR TITLE
Add unit conversion columns

### DIFF
--- a/app/db/sql/items_units_migration.sql
+++ b/app/db/sql/items_units_migration.sql
@@ -1,0 +1,13 @@
+-- Rename existing 'unit' column to 'purchase_unit'
+ALTER TABLE items RENAME COLUMN unit TO purchase_unit;
+
+-- Add base unit and conversion factor columns if they do not already exist
+ALTER TABLE items ADD COLUMN IF NOT EXISTS base_unit TEXT;
+ALTER TABLE items ADD COLUMN IF NOT EXISTS conversion_factor REAL;
+
+-- Table for storing unit conversion definitions
+CREATE TABLE IF NOT EXISTS units (
+    unit_name TEXT PRIMARY KEY,
+    base_unit TEXT NOT NULL,
+    conversion_factor REAL NOT NULL
+);

--- a/app/item_manager_app.py
+++ b/app/item_manager_app.py
@@ -92,7 +92,7 @@ def run_dashboard():
                 & (items_df["current_stock_num"] <= items_df["reorder_point_num"])
             )
             low_stock_df = items_df.loc[
-                mask, ["name", "unit", "current_stock", "reorder_point"]
+                mask, ["name", "purchase_unit", "current_stock", "reorder_point"]
             ].copy()
             low_stock_count = len(low_stock_df)
         except KeyError as e:
@@ -143,7 +143,7 @@ def run_dashboard():
             hide_index=True,
             column_config={
                 "name": st.column_config.TextColumn("Item Name"),
-                "unit": st.column_config.TextColumn(
+                "purchase_unit": st.column_config.TextColumn(
                     "UoM", width="small", help="Unit of Measure"
                 ),
                 "current_stock": st.column_config.NumberColumn(

--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -157,7 +157,7 @@ with st.expander("➕ Add New Inventory Item", expanded=False):
             if is_valid_add:
                 item_data_to_add = {
                     "name": name_add_widget.strip(),
-                    "unit": unit_add_widget.strip(),
+                    "purchase_unit": unit_add_widget.strip(),
                     "category": category_add_widget.strip() or "Uncategorized",
                     "sub_category": sub_category_add_widget.strip() or "General",
                     "permitted_departments": permitted_departments_add_widget.strip()
@@ -355,7 +355,7 @@ else:
 
         cols_item_row = st.columns((3, 1, 2, 1, 1, 1, 2.5, 2.5))
         cols_item_row[0].write(item_name_disp)
-        cols_item_row[1].write(item_row_display.get("unit", "N/A"))
+        cols_item_row[1].write(item_row_display.get("purchase_unit", "N/A"))
         cols_item_row[2].write(item_row_display.get("category", "N/A"))
         cols_item_row[3].write(f"{item_row_display.get('current_stock', 0.0):.2f}")
         cols_item_row[4].write(f"{item_row_display.get('reorder_point', 0.0):.2f}")
@@ -459,7 +459,7 @@ else:
                         )
                         e_unit = st.text_input(
                             "UoM*",
-                            value=current_values_for_edit_form.get("unit", ""),
+                            value=current_values_for_edit_form.get("purchase_unit", ""),
                             key=f"widget_items_edit_form_unit_input_{item_id_disp}",
                         )
                         e_category = st.text_input(
@@ -516,7 +516,7 @@ else:
                         if is_valid_edit_form:
                             update_data_for_service = {
                                 "name": e_name.strip(),
-                                "unit": e_unit.strip(),
+                                "purchase_unit": e_unit.strip(),
                                 "category": e_category.strip() or "Uncategorized",
                                 "sub_category": e_sub_category.strip() or "General",
                                 "permitted_departments": e_permitted.strip() or None,

--- a/app/pages/3_Stock_Movements.py
+++ b/app/pages/3_Stock_Movements.py
@@ -95,7 +95,7 @@ def fetch_active_items_for_stock_mv_page_pg3(_engine):
     items_df = item_service.get_all_items_with_stock(_engine, include_inactive=False)
     if not items_df.empty:
         return [
-            (f"{r['name']} ({r['unit']})", r["item_id"])
+            (f"{r['name']} ({r['purchase_unit']})", r["item_id"])
             for _, r in items_df.sort_values("name").iterrows()
         ]
     return []

--- a/app/pages/4_History_Reports.py
+++ b/app/pages/4_History_Reports.py
@@ -80,7 +80,7 @@ def fetch_filter_options_pg4(_engine):
             sorted(
                 [
                     (
-                        f"{r['name']} ({r.get('unit','N/A')}){' [Inactive]' if not r['is_active'] else ''}",
+                        f"{r['name']} ({r.get('purchase_unit','N/A')}){' [Inactive]' if not r['is_active'] else ''}",
                         r["item_id"],
                     )
                     for _, r in items_df.dropna(subset=["name"]).iterrows()

--- a/app/pages/5_Indents.py
+++ b/app/pages/5_Indents.py
@@ -1158,9 +1158,9 @@ if st.session_state.pg5_active_indent_section == "create":
                             args=(
                                 sugg_item_pg5["item_id"],
                                 sugg_item_pg5["item_name"],
-                                sugg_item_pg5["unit"],
+                                sugg_item_pg5["purchase_unit"],
                             ),
-                            help=f"Add {sugg_item_pg5['item_name']} ({sugg_item_pg5['unit']})",
+                            help=f"Add {sugg_item_pg5['item_name']} ({sugg_item_pg5['purchase_unit']})",
                             use_container_width=True,
                         )
                 elif items_in_current_indent_ids_pg5 and any(
@@ -1202,7 +1202,7 @@ if st.session_state.pg5_active_indent_section == "create":
                     else:
                         item_options_dict_pg5.update(
                             {
-                                f"{r['name']} ({r['unit']})": r["item_id"]
+                                f"{r['name']} ({r['purchase_unit']})": r["item_id"]
                                 for _, r in available_items_df_pg5.sort_values("name").iterrows()
                             }
                         )

--- a/app/pages/6_Purchase_Orders.py
+++ b/app/pages/6_Purchase_Orders.py
@@ -485,12 +485,12 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
     if not item_df_form.empty:
         item_dict_form.update(
             {
-                f"{r['name'].strip()} ({r['unit'].strip()}) {'[Inactive]' if not r['is_active'] else ''}": (
+                f"{r['name'].strip()} ({r['purchase_unit'].strip()}) {'[Inactive]' if not r['is_active'] else ''}": (
                     r["item_id"],
-                    r["unit"].strip(),
+                    r["purchase_unit"].strip(),
                 )
                 for _, r in item_df_form.iterrows()
-                if r["name"] and r["unit"]  # Ensure name and unit exist
+                if r["name"] and r["purchase_unit"]  # Ensure name and unit exist
             }
         )
 

--- a/app/pages/7_Recipes.py
+++ b/app/pages/7_Recipes.py
@@ -41,7 +41,8 @@ with st.expander("➕ Add New Recipe", expanded=False):
         desc = st.text_area("Description", key="recipe_desc")
         items_df = item_service.get_all_items_with_stock(engine)
         item_opts = {
-            f"{row['name']} ({row['unit']})": int(row["item_id"]) for _, row in items_df.iterrows()
+            f"{row['name']} ({row.get('base_unit') or 'N/A'})": int(row["item_id"])
+            for _, row in items_df.iterrows()
         }
         selected = st.multiselect("Ingredients", list(item_opts.keys()))
         qty_inputs = {}

--- a/app/services/goods_receiving_service.py
+++ b/app/services/goods_receiving_service.py
@@ -381,7 +381,7 @@ def get_grn_details(_engine: Engine, grn_id: int) -> Optional[Dict[str, Any]]:
                                JOIN suppliers s ON g.supplier_id = s.supplier_id
                                LEFT JOIN purchase_orders po ON g.po_id = po.po_id 
                                WHERE g.grn_id = :grn_id;"""
-    grn_items_query_str = """SELECT gi.grn_item_id, gi.item_id, i.name as item_name, i.unit as item_unit,
+    grn_items_query_str = """SELECT gi.grn_item_id, gi.item_id, i.name as item_name, i.purchase_unit as item_unit,
                                    gi.po_item_id, gi.quantity_ordered_on_po, gi.quantity_received,
                                    gi.unit_price_at_receipt, gi.notes as item_notes
                                FROM grn_items gi 

--- a/app/services/indent_service.py
+++ b/app/services/indent_service.py
@@ -341,7 +341,7 @@ def get_indent_items_for_display(engine: Engine, indent_id: int) -> pd.DataFrame
         return pd.DataFrame()
 
     query_str = """
-        SELECT ii.indent_item_id, ii.item_id, i.name AS item_name, i.unit AS item_unit,
+        SELECT ii.indent_item_id, ii.item_id, i.name AS item_name, i.purchase_unit AS item_unit,
                i.current_stock AS stock_on_hand, ii.requested_qty,
                ii.issued_qty, ii.item_status, ii.notes AS item_notes
         FROM indent_items ii
@@ -439,7 +439,7 @@ def get_indent_details_for_pdf(
 
             items_query = text(
                 """
-                SELECT ii.item_id, i.name AS item_name, i.unit AS item_unit,
+                SELECT ii.item_id, i.name AS item_name, i.purchase_unit AS item_unit,
                        COALESCE(i.category, 'Uncategorized') AS item_category,
                        COALESCE(i.sub_category, 'General') AS item_sub_category,
                        ii.requested_qty, ii.notes AS item_notes

--- a/app/services/purchase_order_service.py
+++ b/app/services/purchase_order_service.py
@@ -141,7 +141,7 @@ def get_po_by_id(_engine: Engine, po_id: int) -> Optional[Dict[str, Any]]:
     )
     po_items_query = text(
         """
-        SELECT poi.po_item_id, poi.item_id, i.name as item_name, i.unit as item_unit,
+        SELECT poi.po_item_id, poi.item_id, i.name as item_name, i.purchase_unit as item_unit,
                poi.quantity_ordered, poi.unit_price, poi.line_total
         FROM purchase_order_items poi JOIN items i ON poi.item_id = i.item_id
         WHERE poi.po_id = :po_id ORDER BY i.name;

--- a/app/services/stock_service.py
+++ b/app/services/stock_service.py
@@ -275,7 +275,7 @@ def get_stock_transactions(
         return pd.DataFrame()
 
     query = """
-        SELECT st.transaction_id, st.transaction_date, i.name AS item_name, i.unit AS item_unit, 
+        SELECT st.transaction_id, st.transaction_date, i.name AS item_name, i.purchase_unit AS item_unit,
                st.transaction_type, st.quantity_change, st.user_id, st.notes, 
                st.related_mrn, st.related_po_id, st.item_id
         FROM stock_transactions st

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,9 @@ def sqlite_engine():
             CREATE TABLE items (
                 item_id INTEGER PRIMARY KEY AUTOINCREMENT,
                 name TEXT,
-                unit TEXT,
+                purchase_unit TEXT,
+                base_unit TEXT,
+                conversion_factor REAL,
                 category TEXT,
                 sub_category TEXT,
                 permitted_departments TEXT,
@@ -33,6 +35,15 @@ def sqlite_engine():
                 notes TEXT,
                 is_active BOOLEAN,
                 updated_at TEXT
+            );
+            """
+        ))
+        conn.execute(text(
+            """
+            CREATE TABLE units (
+                unit_name TEXT PRIMARY KEY,
+                base_unit TEXT NOT NULL,
+                conversion_factor REAL NOT NULL
             );
             """
         ))

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -1,4 +1,5 @@
 from sqlalchemy import text
+import pytest
 
 from app.services import recipe_service
 
@@ -7,8 +8,9 @@ def setup_items(engine):
     with engine.begin() as conn:
         conn.execute(
             text(
-                "INSERT INTO items (name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active)"
-                " VALUES ('Flour', 'kg', 'cat', 'sub', 'dept', 0, 20, 'n', 1)"
+                "INSERT INTO items (name, purchase_unit, base_unit, conversion_factor, "
+                "category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active)"
+                " VALUES ('Flour', 'bag', 'g', 1000, 'cat', 'sub', 'dept', 0, 20, 'n', 1)"
             )
         )
         item_id = conn.execute(text("SELECT item_id FROM items WHERE name='Flour'"))
@@ -46,4 +48,4 @@ def test_record_sale_reduces_stock(sqlite_engine):
         stock = conn.execute(
             text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item_id}
         ).scalar_one()
-        assert stock == 17
+        assert stock == pytest.approx(19.997)

--- a/tests/test_stock_service.py
+++ b/tests/test_stock_service.py
@@ -8,8 +8,9 @@ def test_record_stock_transaction_updates_stock_and_logs(sqlite_engine):
     with sqlite_engine.begin() as conn:
         conn.execute(
             text(
-                "INSERT INTO items (name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) "
-                "VALUES ('Sample', 'pcs', 'cat', 'sub', 'dept', 0, 10, 'n', 1)"
+                "INSERT INTO items (name, purchase_unit, base_unit, conversion_factor, "
+                "category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) "
+                "VALUES ('Sample', 'box', 'each', 1, 'cat', 'sub', 'dept', 0, 10, 'n', 1)"
             )
         )
         item_id = conn.execute(text("SELECT item_id FROM items LIMIT 1")).scalar_one()


### PR DESCRIPTION
## Summary
- add migration for `purchase_unit`, `base_unit` and `conversion_factor`
- support new columns in `item_service`
- show ingredients using `base_unit`
- extend SQLite schema for tests
- expand item service unit tests for new fields
- fix unit conversion when recording recipe sales
- rename leftover `unit` references to `purchase_unit`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847c5f565dc832681035d496ff8f154