### PR TITLE
Refactor recipe handling to support reusable components and metadata

### DIFF
--- a/app/pages/7_Recipes.py
+++ b/app/pages/7_Recipes.py
@@ -65,18 +65,22 @@ with st.expander("➕ Add New Recipe", expanded=False):
         submit = st.form_submit_button("Save Recipe")
 
     if submit:
-        ingredients = [
-            {"item_id": int(row["item_id"]), "quantity": float(row["Quantity"])}
+        components = [
+            {
+                "component_kind": "ITEM",
+                "component_id": int(row["item_id"]),
+                "quantity": float(row["Quantity"]),
+            }
             for _, row in edited_df.iterrows()
             if row["Quantity"] > 0
         ]
-        if not name.strip() or not ingredients:
+        if not name.strip() or not components:
             st.warning("Name and at least one ingredient required.")
         else:
             ok, msg, _ = recipe_service.create_recipe(
                 engine,
                 {"name": name.strip(), "description": desc.strip()},
-                ingredients,
+                components,
             )
             if ok:
                 show_success(msg)
@@ -93,7 +97,7 @@ else:
         rid = int(row["recipe_id"])
         with st.expander(row["name"], expanded=False):
             st.write(row["description"] or "")
-            items = recipe_service.get_recipe_items(engine, rid)
+            items = recipe_service.get_recipe_components(engine, rid)
             st.dataframe(items[["item_name", "quantity"]], use_container_width=True)
             if st.button("Edit", key=f"edit_{rid}"):
                 st.session_state["edit_recipe_id"] = rid

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,14 @@ def sqlite_engine():
                 name TEXT UNIQUE,
                 description TEXT,
                 is_active BOOLEAN,
+                type TEXT,
+                default_yield_qty REAL,
+                default_yield_unit TEXT,
+                plating_notes TEXT,
+                tags TEXT,
+                version INTEGER,
+                effective_from TEXT,
+                effective_to TEXT,
                 created_at TEXT,
                 updated_at TEXT
             );
@@ -78,14 +86,19 @@ def sqlite_engine():
         ))
         conn.execute(text(
             """
-            CREATE TABLE recipe_items (
-                recipe_item_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                recipe_id INTEGER,
-                item_id INTEGER,
+            CREATE TABLE recipe_components (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                parent_recipe_id INTEGER,
+                component_kind TEXT,
+                component_id INTEGER,
                 quantity REAL,
+                unit TEXT,
+                loss_pct REAL DEFAULT 0,
+                sort_order INTEGER,
+                notes TEXT,
                 created_at TEXT,
                 updated_at TEXT,
-                UNIQUE (recipe_id, item_id)
+                UNIQUE (parent_recipe_id, component_kind, component_id)
             );
             """
         ))

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -17,26 +17,52 @@ def setup_items(engine):
 
 def test_create_recipe_inserts_rows(sqlite_engine):
     item_id = setup_items(sqlite_engine)
-    data = {"name": "Bread", "description": "desc", "is_active": True}
-    ingredients = [{"item_id": item_id, "quantity": 2}]
-    success, msg, rid = recipe_service.create_recipe(sqlite_engine, data, ingredients)
+    data = {
+        "name": "Bread",
+        "description": "desc",
+        "is_active": True,
+        "type": "FOOD",
+        "default_yield_qty": 10,
+        "default_yield_unit": "slice",
+    }
+    components = [
+        {
+            "component_kind": "ITEM",
+            "component_id": item_id,
+            "quantity": 2,
+        }
+    ]
+    success, msg, rid = recipe_service.create_recipe(sqlite_engine, data, components)
     assert success and rid
     with sqlite_engine.connect() as conn:
         count = conn.execute(
-            text("SELECT COUNT(*) FROM recipe_items WHERE recipe_id=:r"), {"r": rid}
+            text("SELECT COUNT(*) FROM recipe_components WHERE parent_recipe_id=:r"),
+            {"r": rid},
         ).scalar_one()
         assert count == 1
+        header = conn.execute(
+            text(
+                "SELECT type, default_yield_qty FROM recipes WHERE recipe_id=:r"
+            ),
+            {"r": rid},
+        ).mappings().fetchone()
+        assert header["type"] == "FOOD" and header["default_yield_qty"] == 10
 
 
 def test_record_sale_reduces_stock(sqlite_engine):
     item_id = setup_items(sqlite_engine)
     with sqlite_engine.begin() as conn:
-        conn.execute(text("INSERT INTO recipes (name, is_active) VALUES ('Toast', 1)"))
+        conn.execute(
+            text(
+                "INSERT INTO recipes (name, is_active, default_yield_unit) VALUES ('Toast', 1, 'kg')"
+            )
+        )
         recipe_id = conn.execute(text("SELECT recipe_id FROM recipes WHERE name='Toast'"))
         recipe_id = recipe_id.scalar_one()
         conn.execute(
             text(
-                "INSERT INTO recipe_items (recipe_id, item_id, quantity) VALUES (:r, :i, 3)"
+                "INSERT INTO recipe_components (parent_recipe_id, component_kind, component_id, quantity, unit)"
+                " VALUES (:r, 'ITEM', :i, 3, 'kg')"
             ),
             {"r": recipe_id, "i": item_id},
         )
@@ -52,8 +78,15 @@ def test_record_sale_reduces_stock(sqlite_engine):
 def test_clone_recipe_duplicates_rows(sqlite_engine):
     item_id = setup_items(sqlite_engine)
     data = {"name": "Pie", "description": "sweet", "is_active": True}
-    ingredients = [{"item_id": item_id, "quantity": 4}]
-    ok, _, rid = recipe_service.create_recipe(sqlite_engine, data, ingredients)
+    components = [
+        {
+            "component_kind": "ITEM",
+            "component_id": item_id,
+            "quantity": 4,
+            "unit": "kg",
+        }
+    ]
+    ok, _, rid = recipe_service.create_recipe(sqlite_engine, data, components)
     assert ok and rid
 
     ok, msg, new_id = recipe_service.clone_recipe(
@@ -67,13 +100,38 @@ def test_clone_recipe_duplicates_rows(sqlite_engine):
         ).mappings().fetchone()
         assert header["description"] == "sweet"
         count = conn.execute(
-            text("SELECT COUNT(*) FROM recipe_items WHERE recipe_id=:r"), {"r": new_id}
+            text(
+                "SELECT COUNT(*) FROM recipe_components WHERE parent_recipe_id=:r"
+            ),
+            {"r": new_id},
         ).scalar_one()
         assert count == 1
         qty = conn.execute(
             text(
-                "SELECT quantity FROM recipe_items WHERE recipe_id=:r AND item_id=:i"
+                "SELECT quantity FROM recipe_components WHERE parent_recipe_id=:r AND component_id=:i AND component_kind='ITEM'"
             ),
             {"r": new_id, "i": item_id},
         ).scalar_one()
         assert qty == 4
+
+
+def test_cycle_detection(sqlite_engine):
+    item_id = setup_items(sqlite_engine)
+    data_a = {"name": "A", "is_active": True}
+    comps_a = [
+        {"component_kind": "ITEM", "component_id": item_id, "quantity": 1}
+    ]
+    ok, _, rid_a = recipe_service.create_recipe(sqlite_engine, data_a, comps_a)
+    assert ok and rid_a
+
+    data_b = {"name": "B", "is_active": True}
+    comps_b = [
+        {"component_kind": "RECIPE", "component_id": rid_a, "quantity": 1}
+    ]
+    ok, _, rid_b = recipe_service.create_recipe(sqlite_engine, data_b, comps_b)
+    assert ok and rid_b
+
+    comps_a.append({"component_kind": "RECIPE", "component_id": rid_b, "quantity": 1})
+    ok, msg = recipe_service.update_recipe(sqlite_engine, rid_a, data_a, comps_a)
+    assert not ok
+


### PR DESCRIPTION
## Summary
- Replace `get_recipe_items` with `get_recipe_components` returning items or sub-recipes with quantities, units, loss pct, sort order, and notes
- Extend `create_recipe`/`update_recipe` to manage `recipe_components`, validate units, apply defaults, store metadata, and detect recursive cycles
- Traverse nested components in `record_sale` to update stock for sub-recipes
- Update tests and pages for component-based recipes and cycle detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689591e7ca048326b72fe8a0f1c33bb7