### PR TITLE
Migrate recipe items into recipe_components

### DIFF
--- a/app/db/sql/migrations/migrate_recipe_items_to_components.sql
+++ b/app/db/sql/migrations/migrate_recipe_items_to_components.sql
@@ -1,0 +1,33 @@
+-- Migration: Move data from recipe_items into recipe_components
+-- Backs up recipe_items, migrates data, and drops the deprecated table.
+
+BEGIN;
+
+-- Backup the old table for rollback purposes
+CREATE TABLE IF NOT EXISTS recipe_items_backup AS TABLE recipe_items;
+
+-- Migrate item components into recipe_components
+INSERT INTO recipe_components (
+    parent_recipe_id,
+    component_kind,
+    component_id,
+    quantity,
+    unit,
+    loss_pct,
+    sort_order
+)
+SELECT
+    ri.recipe_id AS parent_recipe_id,
+    'ITEM' AS component_kind,
+    ri.item_id AS component_id,
+    ri.quantity,
+    i.unit,
+    0 AS loss_pct,
+    row_number() OVER (PARTITION BY ri.recipe_id ORDER BY ri.recipe_item_id) AS sort_order
+FROM recipe_items ri
+JOIN items i ON ri.item_id = i.item_id;
+
+-- Drop the deprecated table
+DROP TABLE IF EXISTS recipe_items;
+
+COMMIT;

--- a/app/db/sql/migrations/rollback_recipe_items_to_components.sql
+++ b/app/db/sql/migrations/rollback_recipe_items_to_components.sql
@@ -1,0 +1,11 @@
+-- Rollback: Restore recipe_items from backup and remove migrated components
+BEGIN;
+
+-- Remove components that originated from recipe_items
+DELETE FROM recipe_components
+WHERE component_kind = 'ITEM';
+
+-- Restore the backup of recipe_items
+ALTER TABLE IF EXISTS recipe_items_backup RENAME TO recipe_items;
+
+COMMIT;

--- a/app/db/sql/recipes.sql
+++ b/app/db/sql/recipes.sql
@@ -18,15 +18,7 @@ ALTER TABLE recipes
     ADD COLUMN IF NOT EXISTS effective_from TIMESTAMP,
     ADD COLUMN IF NOT EXISTS effective_to TIMESTAMP;
 
-CREATE TABLE IF NOT EXISTS recipe_items (
-    recipe_item_id SERIAL PRIMARY KEY,
-    recipe_id INTEGER NOT NULL REFERENCES recipes(recipe_id) ON DELETE CASCADE,
-    item_id INTEGER NOT NULL REFERENCES items(item_id),
-    quantity REAL NOT NULL,
-    created_at TIMESTAMP DEFAULT NOW(),
-    updated_at TIMESTAMP DEFAULT NOW(),
-    UNIQUE (recipe_id, item_id)
-);
+-- Table recipe_items has been migrated into recipe_components and is no longer created.
 
 -- Table to store components for recipes (items or sub-recipes)
 CREATE TABLE IF NOT EXISTS recipe_components (


### PR DESCRIPTION
## Summary
- Add SQL migration to backup and transfer recipe_items into recipe_components
- Provide rollback SQL to restore recipe_items and remove migrated components
- Remove deprecated recipe_items table definition from recipes schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ab4dd2b48326bed1637b61208632