### PR TITLE
Fix recipe unit column dtype

### DIFF
--- a/app/pages/7_Recipes.py
+++ b/app/pages/7_Recipes.py
@@ -68,12 +68,12 @@ with st.expander("➕ Add New Recipe", expanded=False):
 
         comp_df = pd.DataFrame(
             {
-                "component": [],
-                "quantity": [],
-                "unit": [],
-                "loss_pct": [],
-                "sort_order": [],
-                "notes": [],
+                "component": pd.Series(dtype="str"),
+                "quantity": pd.Series(dtype="float"),
+                "unit": pd.Series(dtype="str"),
+                "loss_pct": pd.Series(dtype="float"),
+                "sort_order": pd.Series(dtype="int"),
+                "notes": pd.Series(dtype="str"),
             }
         )
         edited_df = st.data_editor(
@@ -195,10 +195,10 @@ else:
                                 for _, r in comps.iterrows()
                             ],
                             "quantity": comps["quantity"],
-                            "unit": comps["unit"],
+                            "unit": comps["unit"].astype("string"),
                             "loss_pct": comps["loss_pct"],
                             "sort_order": comps["sort_order"],
-                            "notes": comps["notes"],
+                            "notes": comps["notes"].astype("string"),
                         }
                     )
                     edited_local = st.data_editor(


### PR DESCRIPTION
## Summary
- Ensure recipe data entry tables store `unit` as string to match Streamlit TextColumn expectations
- Cast recipe component grids to string for editable text columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ad3cf9208326af18ac2b5fbb8b79