### PR TITLE
Unify recipe component selector with shared item labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Inventory-App is a Streamlit application for managing restaurant inventory. It h
 - Dashboard showing key metrics such as low-stock items
 - Unified sidebar navigation for quick access to all pages
 
+## Changelog
+
+- Recipes editor now reuses the Indents item selector and supports selecting stock items or sub-recipes with automatic unit and category population.
+
 ## Installation
 
 Install dependencies using `pip`:

--- a/app/pages/5_Indents.py
+++ b/app/pages/5_Indents.py
@@ -44,6 +44,7 @@ try:
     from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
     from app.ui.navigation import render_sidebar_nav
     from app.ui import show_success, show_error
+    from app.ui.choices import build_item_choice_label
 except ImportError as e:
     show_error(
         "Import error in 5_Indents.py: "
@@ -1202,7 +1203,7 @@ if st.session_state.pg5_active_indent_section == "create":
                     else:
                         item_options_dict_pg5.update(
                             {
-                                f"{r['name']} ({r['unit']})": r["item_id"]
+                                build_item_choice_label(r): r["item_id"]
                                 for _, r in available_items_df_pg5.sort_values("name").iterrows()
                             }
                         )

--- a/app/ui/choices.py
+++ b/app/ui/choices.py
@@ -1,0 +1,27 @@
+"""Shared helpers for building choice labels in dropdowns."""
+from typing import Mapping
+
+def build_item_choice_label(item: Mapping) -> str:
+    """Return standardized label for item choices.
+
+    Displays: Name (ID) | Unit | Category | On-hand
+    SKU is approximated by item_id if explicit SKU is unavailable.
+    """
+    name = item.get("name", "")
+    sku = item.get("sku") or item.get("item_id")
+    unit = item.get("unit", "")
+    category = item.get("category", "")
+    stock = item.get("current_stock")
+    stock_part = f"{float(stock):.2f}" if isinstance(stock, (int, float)) else "?"
+    return f"{name} ({sku}) | {unit} | {category} | {stock_part}"
+
+
+def build_recipe_choice_label(recipe: Mapping) -> str:
+    """Return standardized label for sub-recipe choices.
+
+    Displays: Recipe Name | Default Unit | Tags
+    """
+    name = recipe.get("name", "")
+    unit = recipe.get("default_yield_unit") or ""
+    tags = recipe.get("tags") or ""
+    return f"{name} | {unit} | {tags}"

--- a/tests/test_recipes_components.py
+++ b/tests/test_recipes_components.py
@@ -1,0 +1,66 @@
+import pandas as pd
+from app.services import recipe_service
+
+def test_build_components_autofill_and_validation():
+    df = pd.DataFrame([
+        {
+            "component": "Flour (1) | kg | Baking | 10.00",  # label; irrelevant
+            "quantity": 2,
+            "unit": None,
+            "loss_pct": 0,
+            "sort_order": 1,
+            "notes": None,
+        },
+        {
+            "component": "Dough | kg | tag",  # sub-recipe label
+            "quantity": 1,
+            "unit": None,
+            "loss_pct": 0,
+            "sort_order": 2,
+            "notes": None,
+        },
+    ])
+    choice_map = {
+        "Flour (1) | kg | Baking | 10.00": {
+            "kind": "ITEM",
+            "id": 1,
+            "unit": "kg",
+            "category": "Baking",
+            "name": "Flour",
+        },
+        "Dough | kg | tag": {
+            "kind": "RECIPE",
+            "id": 2,
+            "unit": "kg",
+            "category": "Sub-recipe",
+            "name": "Dough",
+        },
+    }
+    comps, errs = recipe_service.build_components_from_editor(df, choice_map)
+    assert not errs
+    assert comps[0]["unit"] == "kg" and comps[0]["component_id"] == 1
+    assert comps[1]["unit"] == "kg" and comps[1]["component_id"] == 2
+
+def test_build_components_detects_unit_mismatch():
+    df = pd.DataFrame([
+        {
+            "component": "Flour (1) | kg | Baking | 10.00",
+            "quantity": 1,
+            "unit": "g",  # wrong unit
+            "loss_pct": 0,
+            "sort_order": 1,
+            "notes": None,
+        }
+    ])
+    choice_map = {
+        "Flour (1) | kg | Baking | 10.00": {
+            "kind": "ITEM",
+            "id": 1,
+            "unit": "kg",
+            "category": "Baking",
+            "name": "Flour",
+        }
+    }
+    comps, errs = recipe_service.build_components_from_editor(df, choice_map)
+    assert errs and "Unit mismatch" in errs[0]
+    assert not comps


### PR DESCRIPTION
## Summary
- Add shared helper building labels for items and sub-recipes
- Use standardized labels on Indents and Recipes pages
- Enhance recipe component editor with unified selector and validation
- Support filtering recipes by type and payload construction helper
- Test component payload builder for autofill and unit mismatch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895b95ea87c83269bc78f5424714245