### PR TITLE
Add placeholder for recipe component selection

### DIFF
--- a/app/core/constants.py
+++ b/app/core/constants.py
@@ -69,6 +69,7 @@ PLACEHOLDER_SELECT_ITEM = "-- Select an Item --"
 PLACEHOLDER_SELECT_SUPPLIER = "-- Select Supplier --"
 PLACEHOLDER_SELECT_INDENT_PROCESS = "-- Select Indent (MRN) to Process --"
 PLACEHOLDER_SELECT_MRN_PDF = "-- Select MRN for PDF --"  # Used in 5_Indents.py
+PLACEHOLDER_SELECT_COMPONENT = "-- Select Component --"
 
 # Filter Defaults
 FILTER_ALL_TYPES = "-- All Types --"  # For transaction type filters

--- a/tests/test_recipes_components.py
+++ b/tests/test_recipes_components.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from app.services import recipe_service
+from app.core.constants import PLACEHOLDER_SELECT_COMPONENT
 
 def test_build_components_autofill_and_validation():
     df = pd.DataFrame([
@@ -64,3 +65,19 @@ def test_build_components_detects_unit_mismatch():
     comps, errs = recipe_service.build_components_from_editor(df, choice_map)
     assert errs and "Unit mismatch" in errs[0]
     assert not comps
+
+
+def test_build_components_skips_placeholder():
+    df = pd.DataFrame([
+        {
+            "component": PLACEHOLDER_SELECT_COMPONENT,
+            "quantity": 1,
+            "unit": None,
+            "loss_pct": 0,
+            "sort_order": 1,
+            "notes": None,
+        }
+    ])
+    comps, errs = recipe_service.build_components_from_editor(df, {})
+    assert not comps
+    assert not errs


### PR DESCRIPTION
## Summary
- Add PLACEHOLDER_SELECT_COMPONENT constant for recipe component selection.
- Display placeholder as default choice in Recipes page editors and clear metadata when selected.
- Prevent recipe updates without a real component and test skipping of placeholder rows.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895c0326ba483269a410dd659fe7b99