### PR TITLE
Add centralized warning helper

### DIFF
--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -18,6 +18,7 @@ from app.ui import (
     render_search_toggle,
     show_success,
     show_error,
+    show_warning,
 )
 
 try:
@@ -148,10 +149,10 @@ with st.expander("➕ Add New Inventory Item", expanded=False):
         ):
             is_valid_add = True
             if not name_add_widget.strip():
-                st.warning("Item Name is required.")
+                show_warning("Item Name is required.")
                 is_valid_add = False
             if not unit_add_widget.strip():
-                st.warning("Unit of Measure (UoM) is required.")
+                show_warning("Unit of Measure (UoM) is required.")
                 is_valid_add = False
 
             if is_valid_add:
@@ -507,10 +508,10 @@ else:
                     ):
                         is_valid_edit_form = True
                         if not e_name.strip():
-                            st.warning("Item Name is required.")
+                            show_warning("Item Name is required.")
                             is_valid_edit_form = False
                         if not e_unit.strip():
-                            st.warning("Unit of Measure (UoM) is required.")
+                            show_warning("Unit of Measure (UoM) is required.")
                             is_valid_edit_form = False
 
                         if is_valid_edit_form:

--- a/app/pages/2_Suppliers.py
+++ b/app/pages/2_Suppliers.py
@@ -18,6 +18,7 @@ from app.ui import (
     render_search_toggle,
     show_success,
     show_error,
+    show_warning,
 )
 
 try:
@@ -119,7 +120,7 @@ with st.expander("➕ Add New Supplier Record", expanded=False):
 
         if st.form_submit_button("💾 Save Supplier Information"):
             if not s_name_add_pg2.strip():  # Check for empty stripped name
-                st.warning("Supplier Name is required.")
+                show_warning("Supplier Name is required.")
             else:
                 supplier_data_add_pg2 = {
                     "name": s_name_add_pg2.strip(),
@@ -385,7 +386,7 @@ else:
 
                     if st.form_submit_button("💾 Update Supplier Details"):
                         if not es_name_pg2.strip():
-                            st.warning("Supplier Name is required.")
+                            show_warning("Supplier Name is required.")
                         else:
                             update_s_data_pg2 = {
                                 "name": es_name_pg2.strip(),

--- a/app/pages/3_Stock_Movements.py
+++ b/app/pages/3_Stock_Movements.py
@@ -23,7 +23,7 @@ try:
     )
     from app.ui.theme import load_css, render_sidebar_logo
     from app.ui.navigation import render_sidebar_nav
-    from app.ui import show_success, show_error
+    from app.ui import show_success, show_error, show_warning
 except ImportError as e:
     show_error(f"Import error in 3_Stock_Movements.py: {e}.")
     st.stop()
@@ -321,32 +321,32 @@ with st.form(form_key_main_pg3, clear_on_submit=False):
 
         is_valid_submission_pg3 = True
         if not selected_item_id_submit_pg3 or selected_item_id_submit_pg3 == -1:
-            st.warning("⚠️ Please select an item first.")
+            show_warning("⚠️ Please select an item first.")
             is_valid_submission_pg3 = False
 
         try:
             qty_float_submit_pg3 = float(qty_to_process_submit_pg3)
             if active_section_prefix_val_pg3 == "adjust" and qty_float_submit_pg3 == 0:
-                st.warning(
+                show_warning(
                     "⚠️ For 'Stock Adjustment', the quantity adjusted cannot be zero."
                 )
                 is_valid_submission_pg3 = False
             elif (
                 active_section_prefix_val_pg3 != "adjust" and qty_float_submit_pg3 <= 0
             ):
-                st.warning(
+                show_warning(
                     f"⚠️ Quantity for '{SECTIONS_PG3[active_section_prefix_val_pg3]}' must be greater than 0."
                 )
                 is_valid_submission_pg3 = False
         except (ValueError, TypeError):
-            st.warning("⚠️ Invalid quantity entered. Please enter a valid number.")
+            show_warning("⚠️ Invalid quantity entered. Please enter a valid number.")
             is_valid_submission_pg3 = False
 
         if (
             active_section_prefix_val_pg3 in ["adjust", "waste"]
             and not notes_to_process_submit_pg3.strip()
         ):
-            st.warning(
+            show_warning(
                 f"⚠️ A reason/note is mandatory for '{SECTIONS_PG3[active_section_prefix_val_pg3]}'."
             )
             is_valid_submission_pg3 = False
@@ -361,7 +361,7 @@ with st.form(form_key_main_pg3, clear_on_submit=False):
                     st.session_state.get(current_po_id_ss_key_pg3).strip()
                 )
             except ValueError:
-                st.warning(
+                show_warning(
                     "⚠️ Related PO ID must be a numeric value if provided (enter only the number part)."
                 )
                 is_valid_submission_pg3 = False

--- a/app/pages/4_History_Reports.py
+++ b/app/pages/4_History_Reports.py
@@ -27,7 +27,7 @@ try:
     )
     from app.ui.theme import load_css, render_sidebar_logo
     from app.ui.navigation import render_sidebar_nav
-    from app.ui import show_success, show_error
+    from app.ui import show_success, show_error, show_warning
 except ImportError as e:
     show_error(f"Import error in 4_History_Reports.py: {e}.")
     st.stop()
@@ -221,7 +221,7 @@ with st.expander("More Filters (User, MRN)"):
         )  # .strip() will be applied when using the value
 
 if st.session_state.pg4_start_date_val > st.session_state.pg4_end_date_val:
-    st.warning("Start date cannot be after end date. Please adjust the dates.")
+    show_warning("Start date cannot be after end date. Please adjust the dates.")
 
 st.divider()
 st.subheader("📋 Transaction Records")

--- a/app/pages/5_Indents.py
+++ b/app/pages/5_Indents.py
@@ -43,7 +43,7 @@ try:
     )
     from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
     from app.ui.navigation import render_sidebar_nav
-    from app.ui import show_success, show_error
+    from app.ui import show_success, show_error, show_warning
     from app.ui.choices import build_item_choice_label
 except ImportError as e:
     show_error(
@@ -1328,7 +1328,7 @@ if st.session_state.pg5_active_indent_section == "create":
                     and actual_qty_row_disp_pg5 > 0
                 ):
                     if actual_qty_row_disp_pg5 > median_qty_row_disp_pg5 * 3:
-                        st.warning(f"High! (Avg:~{median_qty_row_disp_pg5:.1f})", icon="❗")
+                        show_warning(f"High! (Avg:~{median_qty_row_disp_pg5:.1f})")
                     elif actual_qty_row_disp_pg5 < median_qty_row_disp_pg5 / 3:
                         st.info(f"Low (Avg:~{median_qty_row_disp_pg5:.1f})", icon="ℹ️")
 

--- a/app/pages/6_Purchase_Orders.py
+++ b/app/pages/6_Purchase_Orders.py
@@ -29,7 +29,7 @@ try:
     )
     from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
     from app.ui.navigation import render_sidebar_nav
-    from app.ui import show_success, show_error
+    from app.ui import show_success, show_error, show_warning
 except ImportError as e:
     show_error(
         f"Import error in 6_Purchase_Orders.py: {e}. Please ensure all modules are correctly placed."
@@ -520,7 +520,7 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
                 st.stop()
 
             if po_data_to_edit.get("status") != PO_STATUS_DRAFT:
-                st.warning(
+                show_warning(
                     f"⚠️ PO {po_data_to_edit.get('po_number')} is in '{po_data_to_edit.get('status')}' status and cannot be edited."
                 )
                 change_view_mode("list_po")
@@ -890,7 +890,7 @@ elif st.session_state.po_grn_view_mode in ["create_po", "edit_po"]:
     if submit_button_po_form:
         # Validation for header
         if not selected_supplier_id_for_submit:
-            st.warning("⚠️ Supplier is required. Please select a supplier from the list.")
+            show_warning("⚠️ Supplier is required. Please select a supplier from the list.")
         else:
             # Prepare header data
             po_header_data_for_submit = {  # Renamed var
@@ -1013,7 +1013,7 @@ elif st.session_state.po_grn_view_mode == "create_grn_for_po":
         st.rerun()
 
     if not active_grn_po_details_data_ui or not st.session_state.grn_line_items:
-        st.warning(
+        show_warning(
             "⚠️ PO details not fully loaded or no items to receive. Attempting to reload or please go back to the PO list."
         )
         if st.session_state.po_for_grn_id:  # If po_id is known, try to re-trigger data load
@@ -1086,7 +1086,7 @@ elif st.session_state.po_grn_view_mode == "create_grn_for_po":
         if not grn_items_to_submit and at_least_one_item_received_flag:
             pass
         elif not at_least_one_item_received_flag:
-            st.warning("⚠️ Please enter a quantity for at least one item to record the GRN.")
+            show_warning("⚠️ Please enter a quantity for at least one item to record the GRN.")
         else:
             (
                 success_grn_create,
@@ -1114,7 +1114,7 @@ elif st.session_state.po_grn_view_mode == "view_po_details":
 
     po_id_to_view_ui = st.session_state.get("po_to_view_id")
     if not po_id_to_view_ui:
-        st.warning("⚠️ No PO selected to view. Please go back to the list.")
+        show_warning("⚠️ No PO selected to view. Please go back to the list.")
         st.stop()
 
     po_details_data_view_ui = purchase_order_service.get_po_by_id(db_engine, po_id_to_view_ui)

--- a/app/pages/7_Recipes.py
+++ b/app/pages/7_Recipes.py
@@ -13,7 +13,7 @@ if _REPO_ROOT not in sys.path:
 
 from app.ui.theme import load_css, render_sidebar_logo
 from app.ui.navigation import render_sidebar_nav
-from app.ui import show_success, show_error
+from app.ui import show_success, show_error, show_warning
 from app.ui.choices import build_item_choice_label, build_recipe_choice_label
 
 try:
@@ -206,9 +206,9 @@ with st.expander("➕ Add New Recipe", expanded=False):
         )
         if errors or not name.strip() or not components:
             for err in errors:
-                st.warning(err)
+                show_warning(err)
             if not name.strip() or not components:
-                st.warning("Name and at least one component required.")
+                show_warning("Name and at least one component required.")
         else:
             ok, msg, _ = recipe_service.create_recipe(
                 engine,
@@ -228,7 +228,7 @@ with st.expander("➕ Add New Recipe", expanded=False):
             if ok:
                 show_success(msg)
             else:
-                st.warning(msg)
+                show_warning(msg)
 
 st.divider()
 
@@ -350,9 +350,9 @@ else:
                     )
                     if errors or not components:
                         for err in errors:
-                            st.warning(err)
+                            show_warning(err)
                         if not components:
-                            st.warning("At least one component required.")
+                            show_warning("At least one component required.")
                     else:
                         ok, msg = recipe_service.update_recipe(
                             engine,
@@ -376,7 +376,7 @@ else:
                             show_success(msg)
                             st.session_state.pg7_edit_recipe_id = None
                         else:
-                            st.warning(msg)
+                            show_warning(msg)
 
             if st.button("Clone", key=f"clone_{rid}"):
                 st.session_state.pg7_clone_recipe_id = rid
@@ -397,4 +397,4 @@ else:
                         show_success(msg)
                         st.session_state.pg7_clone_recipe_id = None
                     else:
-                        st.warning(msg)
+                        show_warning(msg)

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -2,5 +2,6 @@ from .helpers import (
     pagination_controls,
     render_search_toggle,
     show_success,
+    show_warning,
     show_error,
 )

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -99,6 +99,14 @@ def show_success(msg: str) -> None:
         st.success(msg)
 
 
+def show_warning(msg: str) -> None:
+    """Display a warning message using toast if available."""
+    if hasattr(st, "toast"):
+        st.toast(msg, icon="⚠️")
+    else:
+        st.warning(msg)
+
+
 def show_error(msg: str) -> None:
     """Display an error message using toast if available."""
     if hasattr(st, "toast"):


### PR DESCRIPTION
## Summary
- Add `show_warning` helper that uses toasts when available and falls back to `st.warning`
- Replace direct `st.warning` calls across pages with unified `show_warning`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895c1a663ec8326a8d8652969f9db6b