### PR TITLE
feat: centralize component option builder

### DIFF
--- a/app/pages/7_Recipes.py
+++ b/app/pages/7_Recipes.py
@@ -14,7 +14,7 @@ if _REPO_ROOT not in sys.path:
 from app.ui.theme import load_css, render_sidebar_logo
 from app.ui.navigation import render_sidebar_nav
 from app.ui import show_success, show_error, show_warning
-from app.ui.choices import build_item_choice_label, build_recipe_choice_label
+from app.ui.choices import build_component_options
 
 try:
     from app.db.database_utils import connect_db
@@ -67,36 +67,14 @@ sub_recipes_df = recipe_service.list_recipes(
     engine, rtype="SUBRECIPE", include_inactive=False
 )
 
-# Build mapping from display label to metadata for quick lookups
-component_choice_map = {}
-item_labels = []
-for _, row in all_items_df.iterrows():
-    label = build_item_choice_label(row)
-    component_choice_map[label] = {
-        "kind": "ITEM",
-        "id": int(row["item_id"]),
-        "unit": row.get("unit"),
-        "category": row.get("category"),
-        "name": row.get("name"),
-    }
-    item_labels.append(label)
-
-subrecipe_labels = []
-for _, row in sub_recipes_df.iterrows():
-    label = build_recipe_choice_label(row)
-    component_choice_map[label] = {
-        "kind": "RECIPE",
-        "id": int(row["recipe_id"]),
-        "unit": row.get("default_yield_unit"),
-        "category": "Sub-recipe",
-        "name": row.get("name"),
-    }
-    subrecipe_labels.append(label)
-
-component_options = [PLACEHOLDER_SELECT_COMPONENT] + item_labels + subrecipe_labels
+# Build combined options and metadata map
+component_options, component_choice_map = build_component_options(
+    all_items_df.to_dict("records"),
+    sub_recipes_df.to_dict("records"),
+    placeholder=PLACEHOLDER_SELECT_COMPONENT,
+)
 reverse_choice_map = {
-    (meta["kind"], meta["id"]): label
-    for label, meta in component_choice_map.items()
+    (meta["kind"], meta["id"]): label for label, meta in component_choice_map.items()
 }
 
 

--- a/app/ui/choices.py
+++ b/app/ui/choices.py
@@ -1,5 +1,5 @@
 """Shared helpers for building choice labels in dropdowns."""
-from typing import Mapping
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 
 def build_item_choice_label(item: Mapping) -> str:
     """Return standardized label for item choices.
@@ -25,3 +25,66 @@ def build_recipe_choice_label(recipe: Mapping) -> str:
     unit = recipe.get("default_yield_unit") or ""
     tags = recipe.get("tags") or ""
     return f"{name} | {unit} | {tags}"
+
+
+def build_component_options(
+    items: Iterable[Mapping] = (),
+    sub_recipes: Iterable[Mapping] = (),
+    *,
+    placeholder: Optional[str] = None,
+    item_filter: Optional[Callable[[Mapping], bool]] = None,
+    recipe_filter: Optional[Callable[[Mapping], bool]] = None,
+) -> Tuple[List[str], Dict[str, Dict]]:
+    """Return option labels and metadata map for items and sub-recipes.
+
+    Parameters
+    ----------
+    items : Iterable[Mapping]
+        Iterable of item-like mappings.
+    sub_recipes : Iterable[Mapping]
+        Iterable of sub-recipe mappings.
+    placeholder : str, optional
+        If provided, inserted at the start of the options list.
+    item_filter : Callable[[Mapping], bool], optional
+        Function returning True for items to include.
+    recipe_filter : Callable[[Mapping], bool], optional
+        Function returning True for recipes to include.
+
+    Returns
+    -------
+    Tuple[List[str], Dict[str, Dict]]
+        A tuple of option labels and a metadata mapping keyed by label.
+    """
+    options: List[str] = []
+    meta_map: Dict[str, Dict] = {}
+
+    if placeholder is not None:
+        options.append(placeholder)
+
+    for item in items or []:
+        if item_filter and not item_filter(item):
+            continue
+        label = build_item_choice_label(item)
+        meta_map[label] = {
+            "kind": "ITEM",
+            "id": int(item.get("item_id")),
+            "unit": item.get("unit"),
+            "category": item.get("category"),
+            "name": item.get("name"),
+        }
+        options.append(label)
+
+    for recipe in sub_recipes or []:
+        if recipe_filter and not recipe_filter(recipe):
+            continue
+        label = build_recipe_choice_label(recipe)
+        meta_map[label] = {
+            "kind": "RECIPE",
+            "id": int(recipe.get("recipe_id")),
+            "unit": recipe.get("default_yield_unit"),
+            "category": "Sub-recipe",
+            "name": recipe.get("name"),
+        }
+        options.append(label)
+
+    return options, meta_map


### PR DESCRIPTION
## Summary
- provide build_component_options helper to merge item and recipe options with metadata
- use shared option builder on Recipes page
- use shared option builder with department filter on Indents page

## Testing
- `pytest`
- `flake8` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6895c341e99483268f7596fde69338d0