### PR TITLE
Expose component options helper

### DIFF
--- a/app/ui/choices.py
+++ b/app/ui/choices.py
@@ -1,6 +1,12 @@
 """Shared helpers for building choice labels in dropdowns."""
 from typing import Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 
+__all__ = [
+    "build_item_choice_label",
+    "build_recipe_choice_label",
+    "build_component_options",
+]
+
 def build_item_choice_label(item: Mapping) -> str:
     """Return standardized label for item choices.
 

--- a/tests/test_ui_choices.py
+++ b/tests/test_ui_choices.py
@@ -1,0 +1,38 @@
+from app.ui.choices import build_component_options
+
+
+def test_build_component_options_basic():
+    items = [
+        {
+            "item_id": 1,
+            "name": "Flour",
+            "unit": "kg",
+            "category": "Baking",
+            "current_stock": 10,
+        }
+    ]
+    recipes = [
+        {
+            "recipe_id": 10,
+            "name": "Bread",
+            "default_yield_unit": "loaf",
+            "tags": "baked",
+        }
+    ]
+    options, meta = build_component_options(items, recipes, placeholder="Choose")
+    assert options == [
+        "Choose",
+        "Flour (1) | kg | Baking | 10.00",
+        "Bread | loaf | baked",
+    ]
+    flour_label = "Flour (1) | kg | Baking | 10.00"
+    bread_label = "Bread | loaf | baked"
+    assert meta[flour_label] == {
+        "kind": "ITEM",
+        "id": 1,
+        "unit": "kg",
+        "category": "Baking",
+        "name": "Flour",
+    }
+    assert meta[bread_label]["kind"] == "RECIPE"
+    assert meta[bread_label]["id"] == 10


### PR DESCRIPTION
## Summary
- export `build_component_options` from `app.ui.choices` via `__all__`
- add test covering `build_component_options`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895cce4da2c8326b100ecf74ab59775