### PR TITLE
Allow purchase unit selection for recipe components

### DIFF
--- a/app/services/item_service.py
+++ b/app/services/item_service.py
@@ -34,7 +34,11 @@ def get_all_items_with_stock(_engine: Engine, include_inactive=False) -> pd.Data
             "ERROR [item_service.get_all_items_with_stock]: Database engine not available."
         )
         return pd.DataFrame()
-    query = "SELECT item_id, name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active FROM items"
+    # Include purchase_unit so UIs can offer both base and purchasing units
+    query = (
+        "SELECT item_id, name, unit, purchase_unit, category, sub_category, "
+        "permitted_departments, reorder_point, current_stock, notes, is_active FROM items"
+    )
     if not include_inactive:
         query += " WHERE is_active = TRUE"
     query += " ORDER BY name;"
@@ -57,7 +61,10 @@ def get_item_details(engine: Engine, item_id: int) -> Optional[Dict[str, Any]]:
             "ERROR [item_service.get_item_details]: Database engine not available."
         )
         return None
-    query = "SELECT item_id, name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active FROM items WHERE item_id = :item_id;"
+    query = (
+        "SELECT item_id, name, unit, purchase_unit, category, sub_category, permitted_departments, "
+        "reorder_point, current_stock, notes, is_active FROM items WHERE item_id = :item_id;"
+    )
     df = fetch_data(engine, query, {"item_id": item_id})
     if not df.empty:
         return df.iloc[0].to_dict()

--- a/app/services/recipe_service.py
+++ b/app/services/recipe_service.py
@@ -93,12 +93,22 @@ def build_components_from_editor(
         unit = row.get("unit") or meta.get("unit")
         if meta["kind"] == "ITEM":
             base_unit = meta.get("unit")
-            if unit != base_unit:
-                errors.append(
-                    f"Unit mismatch for {meta.get('name')}. Use {base_unit}."
-                )
+            purchase_unit = meta.get("purchase_unit")
+            allowed_units: Set[str] = {
+                u for u in [base_unit, purchase_unit] if u
+            }
+            if unit not in allowed_units:
+                if purchase_unit:
+                    errors.append(
+                        f"Unit mismatch for {meta.get('name')}. Use {base_unit} or {purchase_unit}."
+                    )
+                else:
+                    errors.append(
+                        f"Unit mismatch for {meta.get('name')}. Use {base_unit}."
+                    )
                 continue
-            unit = base_unit
+            # Normalize unit to the provided value (defaulting to base unit)
+            unit = unit or base_unit
         components.append(
             {
                 "component_kind": meta["kind"],

--- a/app/ui/choices.py
+++ b/app/ui/choices.py
@@ -74,7 +74,12 @@ def build_component_options(
         meta_map[label] = {
             "kind": "ITEM",
             "id": int(item.get("item_id")),
+            # Base unit is stored under "unit" for backward compatibility
             "unit": item.get("unit"),
+            # Include the purchase unit so downstream UIs can offer a choice
+            # between the base unit and the purchase unit when selecting
+            # component quantities.
+            "purchase_unit": item.get("purchase_unit"),
             "category": item.get("category"),
             "name": item.get("name"),
         }

--- a/app/ui/styles.css
+++ b/app/ui/styles.css
@@ -67,3 +67,9 @@ body { font-family: 'Roboto', sans-serif; }
     padding: 0.125rem 0.5rem;
 }
 
+/* High contrast styling for dropdowns in data editors */
+div[data-testid="stDataEditor"] select {
+    background-color: #004085;
+    color: #ffffff;
+}
+

--- a/tests/test_recipes_components.py
+++ b/tests/test_recipes_components.py
@@ -26,6 +26,7 @@ def test_build_components_autofill_and_validation():
             "kind": "ITEM",
             "id": 1,
             "unit": "kg",
+            "purchase_unit": "bag",
             "category": "Baking",
             "name": "Flour",
         },
@@ -58,6 +59,7 @@ def test_build_components_detects_unit_mismatch():
             "kind": "ITEM",
             "id": 1,
             "unit": "kg",
+            "purchase_unit": "bag",
             "category": "Baking",
             "name": "Flour",
         }
@@ -65,6 +67,32 @@ def test_build_components_detects_unit_mismatch():
     comps, errs = recipe_service.build_components_from_editor(df, choice_map)
     assert errs and "Unit mismatch" in errs[0]
     assert not comps
+
+
+def test_build_components_allows_purchase_unit():
+    df = pd.DataFrame([
+        {
+            "component": "Flour (1) | kg | Baking | 10.00",
+            "quantity": 3,
+            "unit": "bag",  # purchase unit
+            "loss_pct": 0,
+            "sort_order": 1,
+            "notes": None,
+        }
+    ])
+    choice_map = {
+        "Flour (1) | kg | Baking | 10.00": {
+            "kind": "ITEM",
+            "id": 1,
+            "unit": "kg",
+            "purchase_unit": "bag",
+            "category": "Baking",
+            "name": "Flour",
+        }
+    }
+    comps, errs = recipe_service.build_components_from_editor(df, choice_map)
+    assert not errs
+    assert comps and comps[0]["unit"] == "bag"
 
 
 def test_build_components_skips_placeholder():

--- a/tests/test_ui_choices.py
+++ b/tests/test_ui_choices.py
@@ -7,6 +7,7 @@ def test_build_component_options_basic():
             "item_id": 1,
             "name": "Flour",
             "unit": "kg",
+            "purchase_unit": "bag",
             "category": "Baking",
             "current_stock": 10,
         }
@@ -31,6 +32,7 @@ def test_build_component_options_basic():
         "kind": "ITEM",
         "id": 1,
         "unit": "kg",
+        "purchase_unit": "bag",
         "category": "Baking",
         "name": "Flour",
     }


### PR DESCRIPTION
## Summary
- allow recipe components to use either base unit or purchase unit
- expose purchase units in choice metadata and recipe editor dropdowns
- style data-editor dropdowns with high-contrast colors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899b1524ccc832691c827cfb22ea9f3