### PR TITLE
feat: split item unit into base and purchase units

### DIFF
--- a/app/item_manager_app.py
+++ b/app/item_manager_app.py
@@ -92,7 +92,7 @@ def run_dashboard():
                 & (items_df["current_stock_num"] <= items_df["reorder_point_num"])
             )
             low_stock_df = items_df.loc[
-                mask, ["name", "unit", "current_stock", "reorder_point"]
+                mask, ["name", "base_unit", "current_stock", "reorder_point"]
             ].copy()
             low_stock_count = len(low_stock_df)
         except KeyError as e:
@@ -143,7 +143,7 @@ def run_dashboard():
             hide_index=True,
             column_config={
                 "name": st.column_config.TextColumn("Item Name"),
-                "unit": st.column_config.TextColumn(
+                "base_unit": st.column_config.TextColumn(
                     "UoM", width="small", help="Unit of Measure"
                 ),
                 "current_stock": st.column_config.NumberColumn(

--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -97,10 +97,15 @@ with st.expander("➕ Add New Inventory Item", expanded=False):
                 help="Unique name for the item.",
                 key="widget_items_add_form_name_input",
             )
-            unit_add_widget = st.text_input(
-                "Unit of Measure (UoM)*",
+            base_unit_add_widget = st.text_input(
+                "Base Unit*",
                 help="e.g., KG, LTR, PCS",
-                key="widget_items_add_form_unit_input",
+                key="widget_items_add_form_base_unit_input",
+            )
+            purchase_unit_add_widget = st.text_input(
+                "Purchase Unit",
+                help="e.g., case, box (leave blank if same as base unit)",
+                key="widget_items_add_form_purchase_unit_input",
             )
             category_add_widget = st.text_input(
                 "Category",
@@ -151,14 +156,15 @@ with st.expander("➕ Add New Inventory Item", expanded=False):
             if not name_add_widget.strip():
                 show_warning("Item Name is required.")
                 is_valid_add = False
-            if not unit_add_widget.strip():
-                show_warning("Unit of Measure (UoM) is required.")
+            if not base_unit_add_widget.strip():
+                show_warning("Base Unit is required.")
                 is_valid_add = False
 
             if is_valid_add:
                 item_data_to_add = {
                     "name": name_add_widget.strip(),
-                    "unit": unit_add_widget.strip(),
+                    "base_unit": base_unit_add_widget.strip(),
+                    "purchase_unit": purchase_unit_add_widget.strip() or None,
                     "category": category_add_widget.strip() or "Uncategorized",
                     "sub_category": sub_category_add_widget.strip() or "General",
                     "permitted_departments": permitted_departments_add_widget.strip()
@@ -356,7 +362,7 @@ else:
 
         cols_item_row = st.columns((3, 1, 2, 1, 1, 1, 2.5, 2.5))
         cols_item_row[0].write(item_name_disp)
-        cols_item_row[1].write(item_row_display.get("unit", "N/A"))
+        cols_item_row[1].write(item_row_display.get("base_unit", "N/A"))
         cols_item_row[2].write(item_row_display.get("category", "N/A"))
         cols_item_row[3].write(f"{item_row_display.get('current_stock', 0.0):.2f}")
         cols_item_row[4].write(f"{item_row_display.get('reorder_point', 0.0):.2f}")
@@ -458,10 +464,15 @@ else:
                             value=current_values_for_edit_form.get("name", ""),
                             key=f"widget_items_edit_form_name_input_{item_id_disp}",
                         )
-                        e_unit = st.text_input(
-                            "UoM*",
-                            value=current_values_for_edit_form.get("unit", ""),
-                            key=f"widget_items_edit_form_unit_input_{item_id_disp}",
+                        e_base_unit = st.text_input(
+                            "Base Unit*",
+                            value=current_values_for_edit_form.get("base_unit", ""),
+                            key=f"widget_items_edit_form_base_unit_input_{item_id_disp}",
+                        )
+                        e_purchase_unit = st.text_input(
+                            "Purchase Unit",
+                            value=current_values_for_edit_form.get("purchase_unit", ""),
+                            key=f"widget_items_edit_form_purchase_unit_input_{item_id_disp}",
                         )
                         e_category = st.text_input(
                             "Category",
@@ -510,14 +521,15 @@ else:
                         if not e_name.strip():
                             show_warning("Item Name is required.")
                             is_valid_edit_form = False
-                        if not e_unit.strip():
-                            show_warning("Unit of Measure (UoM) is required.")
+                        if not e_base_unit.strip():
+                            show_warning("Base Unit is required.")
                             is_valid_edit_form = False
 
                         if is_valid_edit_form:
                             update_data_for_service = {
                                 "name": e_name.strip(),
-                                "unit": e_unit.strip(),
+                                "base_unit": e_base_unit.strip(),
+                                "purchase_unit": e_purchase_unit.strip() or None,
                                 "category": e_category.strip() or "Uncategorized",
                                 "sub_category": e_sub_category.strip() or "General",
                                 "permitted_departments": e_permitted.strip() or None,

--- a/app/pages/7_Recipes.py
+++ b/app/pages/7_Recipes.py
@@ -96,8 +96,8 @@ reverse_choice_map = {
 # Build a sorted list of unit choices from both items and sub-recipes.
 # Items can expose a base unit and an optional purchase unit.
 item_units = set(
-    all_items_df["unit"].dropna().astype(str).unique()
-    if "unit" in all_items_df.columns
+    all_items_df["base_unit"].dropna().astype(str).unique()
+    if "base_unit" in all_items_df.columns
     else []
 )
 if "purchase_unit" in all_items_df.columns:
@@ -147,9 +147,9 @@ def build_components(df: pd.DataFrame, current_recipe_id: Optional[int] = None):
         if key in seen:
             errors.append(f"Duplicate component {label}.")
             continue
-        unit = row.get("unit") or meta.get("unit")
+        unit = row.get("unit") or meta.get("base_unit") or meta.get("unit")
         if kind == "ITEM":
-            base_unit = meta.get("unit")
+            base_unit = meta.get("base_unit")
             purchase_unit = meta.get("purchase_unit")
             allowed_units = {u for u in [base_unit, purchase_unit] if u}
             if unit not in allowed_units:

--- a/app/services/goods_receiving_service.py
+++ b/app/services/goods_receiving_service.py
@@ -381,10 +381,10 @@ def get_grn_details(_engine: Engine, grn_id: int) -> Optional[Dict[str, Any]]:
                                JOIN suppliers s ON g.supplier_id = s.supplier_id
                                LEFT JOIN purchase_orders po ON g.po_id = po.po_id 
                                WHERE g.grn_id = :grn_id;"""
-    grn_items_query_str = """SELECT gi.grn_item_id, gi.item_id, i.name as item_name, i.unit as item_unit,
+    grn_items_query_str = """SELECT gi.grn_item_id, gi.item_id, i.name as item_name, i.purchase_unit as item_unit,
                                    gi.po_item_id, gi.quantity_ordered_on_po, gi.quantity_received,
                                    gi.unit_price_at_receipt, gi.notes as item_notes
-                               FROM grn_items gi 
+                               FROM grn_items gi
                                JOIN items i ON gi.item_id = i.item_id
                                WHERE gi.grn_id = :grn_id ORDER BY i.name;"""
     try:

--- a/app/services/indent_service.py
+++ b/app/services/indent_service.py
@@ -341,7 +341,7 @@ def get_indent_items_for_display(engine: Engine, indent_id: int) -> pd.DataFrame
         return pd.DataFrame()
 
     query_str = """
-        SELECT ii.indent_item_id, ii.item_id, i.name AS item_name, i.unit AS item_unit,
+        SELECT ii.indent_item_id, ii.item_id, i.name AS item_name, i.base_unit AS item_unit,
                i.current_stock AS stock_on_hand, ii.requested_qty,
                ii.issued_qty, ii.item_status, ii.notes AS item_notes
         FROM indent_items ii
@@ -439,7 +439,7 @@ def get_indent_details_for_pdf(
 
             items_query = text(
                 """
-                SELECT ii.item_id, i.name AS item_name, i.unit AS item_unit,
+                SELECT ii.item_id, i.name AS item_name, i.base_unit AS item_unit,
                        COALESCE(i.category, 'Uncategorized') AS item_category,
                        COALESCE(i.sub_category, 'General') AS item_sub_category,
                        ii.requested_qty, ii.notes AS item_notes

--- a/app/services/purchase_order_service.py
+++ b/app/services/purchase_order_service.py
@@ -141,7 +141,7 @@ def get_po_by_id(_engine: Engine, po_id: int) -> Optional[Dict[str, Any]]:
     )
     po_items_query = text(
         """
-        SELECT poi.po_item_id, poi.item_id, i.name as item_name, i.unit as item_unit,
+        SELECT poi.po_item_id, poi.item_id, i.name as item_name, i.purchase_unit as item_unit,
                poi.quantity_ordered, poi.unit_price, poi.line_total
         FROM purchase_order_items poi JOIN items i ON poi.item_id = i.item_id
         WHERE poi.po_id = :po_id ORDER BY i.name;

--- a/app/services/stock_service.py
+++ b/app/services/stock_service.py
@@ -275,8 +275,8 @@ def get_stock_transactions(
         return pd.DataFrame()
 
     query = """
-        SELECT st.transaction_id, st.transaction_date, i.name AS item_name, i.unit AS item_unit, 
-               st.transaction_type, st.quantity_change, st.user_id, st.notes, 
+        SELECT st.transaction_id, st.transaction_date, i.name AS item_name, i.base_unit AS item_unit,
+               st.transaction_type, st.quantity_change, st.user_id, st.notes,
                st.related_mrn, st.related_po_id, st.item_id
         FROM stock_transactions st
         JOIN items i ON st.item_id = i.item_id

--- a/app/ui/choices.py
+++ b/app/ui/choices.py
@@ -15,7 +15,7 @@ def build_item_choice_label(item: Mapping) -> str:
     """
     name = item.get("name", "")
     sku = item.get("sku") or item.get("item_id")
-    unit = item.get("unit", "")
+    unit = item.get("base_unit", "")
     category = item.get("category", "")
     stock = item.get("current_stock")
     stock_part = f"{float(stock):.2f}" if isinstance(stock, (int, float)) else "?"
@@ -74,8 +74,7 @@ def build_component_options(
         meta_map[label] = {
             "kind": "ITEM",
             "id": int(item.get("item_id")),
-            # Base unit is stored under "unit" for backward compatibility
-            "unit": item.get("unit"),
+            "base_unit": item.get("base_unit"),
             # Include the purchase unit so downstream UIs can offer a choice
             # between the base unit and the purchase unit when selecting
             # component quantities.

--- a/app/ui/helpers.py
+++ b/app/ui/helpers.py
@@ -130,7 +130,7 @@ def autofill_component_meta(
     for idx, comp in df["component"].items():
         meta = choice_map.get(comp)
         if meta:
-            df.at[idx, "unit"] = meta.get("unit")
+            df.at[idx, "unit"] = meta.get("base_unit")
             df.at[idx, "category"] = meta.get("category")
         else:
             df.at[idx, "unit"] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,8 @@ def sqlite_engine():
             CREATE TABLE items (
                 item_id INTEGER PRIMARY KEY AUTOINCREMENT,
                 name TEXT,
-                unit TEXT,
+                base_unit TEXT,
+                purchase_unit TEXT,
                 category TEXT,
                 sub_category TEXT,
                 permitted_departments TEXT,

--- a/tests/test_autofill_component_meta.py
+++ b/tests/test_autofill_component_meta.py
@@ -11,7 +11,7 @@ def test_autofill_component_meta_populates_unit_and_category():
         }
     )
     choice_map = {
-        "Flour (1) | kg | Baking | 10.00": {"unit": "kg", "category": "Baking"}
+        "Flour (1) | kg | Baking | 10.00": {"base_unit": "kg", "category": "Baking"}
     }
     result = autofill_component_meta(df, choice_map)
     assert result.loc[0, "unit"] == "kg"

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -6,7 +6,8 @@ from app.services import item_service
 def test_add_new_item_inserts_row(sqlite_engine):
     details = {
         "name": "Widget",
-        "unit": "pcs",
+        "base_unit": "pcs",
+        "purchase_unit": "box",
         "category": "cat",
         "sub_category": "sub",
         "permitted_departments": "dept",

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -6,17 +6,17 @@ from sqlalchemy import text
 from app.services import recipe_service
 
 
-def _create_item(conn, name="Flour", unit="kg", stock=20):
+def _create_item(conn, name="Flour", base_unit="kg", purchase_unit="bag", stock=20):
     conn.execute(
         text(
             """
             INSERT INTO items (
-                name, unit, category, sub_category, permitted_departments,
+                name, base_unit, purchase_unit, category, sub_category, permitted_departments,
                 reorder_point, current_stock, notes, is_active
-            ) VALUES (:n, :u, 'cat', 'sub', 'dept', 0, :s, 'n', 1)
+            ) VALUES (:n, :bu, :pu, 'cat', 'sub', 'dept', 0, :s, 'n', 1)
             """
         ),
-        {"n": name, "u": unit, "s": stock},
+        {"n": name, "bu": base_unit, "pu": purchase_unit, "s": stock},
     )
     return conn.execute(
         text("SELECT item_id FROM items WHERE name=:n"), {"n": name}

--- a/tests/test_recipes_components.py
+++ b/tests/test_recipes_components.py
@@ -25,7 +25,7 @@ def test_build_components_autofill_and_validation():
         "Flour (1) | kg | Baking | 10.00": {
             "kind": "ITEM",
             "id": 1,
-            "unit": "kg",
+            "base_unit": "kg",
             "purchase_unit": "bag",
             "category": "Baking",
             "name": "Flour",
@@ -58,7 +58,7 @@ def test_build_components_detects_unit_mismatch():
         "Flour (1) | kg | Baking | 10.00": {
             "kind": "ITEM",
             "id": 1,
-            "unit": "kg",
+            "base_unit": "kg",
             "purchase_unit": "bag",
             "category": "Baking",
             "name": "Flour",
@@ -84,7 +84,7 @@ def test_build_components_allows_purchase_unit():
         "Flour (1) | kg | Baking | 10.00": {
             "kind": "ITEM",
             "id": 1,
-            "unit": "kg",
+            "base_unit": "kg",
             "purchase_unit": "bag",
             "category": "Baking",
             "name": "Flour",

--- a/tests/test_stock_service.py
+++ b/tests/test_stock_service.py
@@ -8,8 +8,8 @@ def test_record_stock_transaction_updates_stock_and_logs(sqlite_engine):
     with sqlite_engine.begin() as conn:
         conn.execute(
             text(
-                "INSERT INTO items (name, unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) "
-                "VALUES ('Sample', 'pcs', 'cat', 'sub', 'dept', 0, 10, 'n', 1)"
+                "INSERT INTO items (name, base_unit, purchase_unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) "
+                "VALUES ('Sample', 'pcs', 'box', 'cat', 'sub', 'dept', 0, 10, 'n', 1)"
             )
         )
         item_id = conn.execute(text("SELECT item_id FROM items LIMIT 1")).scalar_one()

--- a/tests/test_ui_choices.py
+++ b/tests/test_ui_choices.py
@@ -6,7 +6,7 @@ def test_build_component_options_basic():
         {
             "item_id": 1,
             "name": "Flour",
-            "unit": "kg",
+            "base_unit": "kg",
             "purchase_unit": "bag",
             "category": "Baking",
             "current_stock": 10,
@@ -31,7 +31,7 @@ def test_build_component_options_basic():
     assert meta[flour_label] == {
         "kind": "ITEM",
         "id": 1,
-        "unit": "kg",
+        "base_unit": "kg",
         "purchase_unit": "bag",
         "category": "Baking",
         "name": "Flour",


### PR DESCRIPTION
## Summary
- rename item `unit` field to `base_unit` and add `purchase_unit`
- update services, UI helpers, and pages to handle both units
- adjust tests and schema to use `base_unit`/`purchase_unit`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899c346e7ec8326b434a25fdd78b059