### PR TITLE
Add unit field to item service outputs

### DIFF
--- a/app/services/item_service.py
+++ b/app/services/item_service.py
@@ -43,7 +43,10 @@ def get_all_items_with_stock(_engine: Engine, include_inactive=False) -> pd.Data
     if not include_inactive:
         query += " WHERE is_active = TRUE"
     query += " ORDER BY name;"
-    return fetch_data(_engine, query)
+    df = fetch_data(_engine, query)
+    # Duplicate base_unit into a user-facing 'unit' column for convenience
+    df["unit"] = df["base_unit"]
+    return df
 
 
 def get_item_details(engine: Engine, item_id: int) -> Optional[Dict[str, Any]]:
@@ -68,7 +71,10 @@ def get_item_details(engine: Engine, item_id: int) -> Optional[Dict[str, Any]]:
     )
     df = fetch_data(engine, query, {"item_id": item_id})
     if not df.empty:
-        return df.iloc[0].to_dict()
+        result = df.iloc[0].to_dict()
+        # Mirror base_unit into a 'unit' key for downstream consumers
+        result["unit"] = result.get("base_unit")
+        return result
     return None
 
 

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -23,3 +23,45 @@ def test_add_new_item_inserts_row(sqlite_engine):
         row = conn.execute(text("SELECT name FROM items WHERE name='Widget'"))
         assert row.fetchone() is not None
 
+
+def test_get_all_items_with_stock_includes_unit(sqlite_engine):
+    """The service should provide a 'unit' column mirroring 'base_unit'."""
+    with sqlite_engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO items (
+                    name, base_unit, purchase_unit, category, sub_category,
+                    permitted_departments, reorder_point, current_stock, notes, is_active
+                ) VALUES (
+                    'Widget', 'pcs', 'box', 'cat', 'sub', 'dept', 1, 5, 'n', 1
+                )
+                """
+            )
+        )
+    df = item_service.get_all_items_with_stock(sqlite_engine, include_inactive=True)
+    assert "unit" in df.columns
+    assert df.loc[df["name"] == "Widget", "unit"].iloc[0] == "pcs"
+
+
+def test_get_item_details_includes_unit(sqlite_engine):
+    """The detailed item lookup should include a 'unit' key."""
+    with sqlite_engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO items (
+                    name, base_unit, purchase_unit, category, sub_category,
+                    permitted_departments, reorder_point, current_stock, notes, is_active
+                ) VALUES (
+                    'Widget', 'pcs', 'box', 'cat', 'sub', 'dept', 1, 5, 'n', 1
+                )
+                """
+            )
+        )
+        item_id = conn.execute(
+            text("SELECT item_id FROM items WHERE name='Widget'")
+        ).scalar_one()
+    details = item_service.get_item_details(sqlite_engine, item_id)
+    assert details["unit"] == "pcs"
+


### PR DESCRIPTION
## Summary
- Provide a `unit` column in `get_all_items_with_stock` mirroring `base_unit`
- Include a `unit` key in `get_item_details` responses
- Test item service now verifies presence of new `unit` field

## Testing
- `pytest tests/test_item_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a18ebe1e483269fce5414f17bc491