### PR TITLE
Add bulk item operations and tests

### DIFF
--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -65,3 +65,85 @@ def test_get_item_details_includes_unit(sqlite_engine):
     details = item_service.get_item_details(sqlite_engine, item_id)
     assert details["unit"] == "pcs"
 
+
+def test_add_items_bulk_inserts_rows(sqlite_engine):
+    items = [
+        {
+            "name": "Widget",
+            "base_unit": "pcs",
+            "purchase_unit": "box",
+            "category": "cat",
+            "sub_category": "sub",
+            "permitted_departments": "dept",
+            "reorder_point": 1,
+            "current_stock": 0,
+            "notes": "n",
+            "is_active": True,
+        },
+        {
+            "name": "Gadget",
+            "base_unit": "pcs",
+            "purchase_unit": "each",
+            "category": "cat",
+            "sub_category": "sub",
+            "permitted_departments": "dept2",
+            "reorder_point": 2,
+            "current_stock": 0,
+            "notes": "n",
+            "is_active": True,
+        },
+    ]
+    inserted, errors = item_service.add_items_bulk(sqlite_engine, items)
+    assert inserted == 2
+    assert errors == []
+    with sqlite_engine.connect() as conn:
+        count = conn.execute(
+            text("SELECT COUNT(*) FROM items WHERE name IN ('Widget','Gadget')")
+        ).scalar_one()
+        assert count == 2
+
+
+def test_add_items_bulk_validation_failure(sqlite_engine):
+    items = [
+        {"name": "Widget", "base_unit": "pcs"},
+        {"name": "", "base_unit": "pcs"},
+    ]
+    inserted, errors = item_service.add_items_bulk(sqlite_engine, items)
+    assert inserted == 0
+    assert errors
+    with sqlite_engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM items")).scalar_one()
+        assert count == 0
+
+
+def test_remove_items_bulk_marks_inactive(sqlite_engine):
+    with sqlite_engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO items (
+                    name, base_unit, purchase_unit, category, sub_category,
+                    permitted_departments, reorder_point, current_stock, notes, is_active
+                ) VALUES
+                    ('Widget', 'pcs', 'box', 'cat', 'sub', 'dept', 1, 0, 'n', 1),
+                    ('Gadget', 'pcs', 'each', 'cat', 'sub', 'dept2', 2, 0, 'n', 1)
+                """
+            )
+        )
+        ids = conn.execute(text("SELECT item_id FROM items"))
+        item_ids = [row[0] for row in ids.fetchall()]
+    removed, errors = item_service.remove_items_bulk(sqlite_engine, item_ids)
+    assert removed == len(item_ids)
+    assert errors == []
+    with sqlite_engine.connect() as conn:
+        inactive = conn.execute(
+            text("SELECT COUNT(*) FROM items WHERE is_active = 0")
+        ).scalar_one()
+        assert inactive == len(item_ids)
+
+
+def test_remove_items_bulk_requires_ids(sqlite_engine):
+    removed, errors = item_service.remove_items_bulk(sqlite_engine, [])
+    assert removed == 0
+    assert errors
+


### PR DESCRIPTION
## Summary
- implement `add_items_bulk` for inserting multiple items in one transaction with cache clearing
- add `remove_items_bulk` to deactivate multiple items in a single query
- extend item service tests covering bulk insert, validation errors, and bulk deactivation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689abae62dcc832684752f2681edb5e2