### PR TITLE
Add bulk CSV upload for items and stock transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Inventory-App is a Streamlit application for managing restaurant inventory. It h
 - Dashboard showing key metrics such as low-stock items
 - Unified sidebar navigation for quick access to all pages
 - Automatic unit inference so new items get sensible base and purchase units
+- Bulk upload items and stock transactions from CSV files
 
 ## Changelog
 
@@ -90,3 +91,43 @@ The sidebar image displayed in the app is defined in `app/ui/logo.py` as a base6
 2. Replace the `LOGO_BASE64` value in `app/ui/logo.py` with the string printed above.
 
 Restart the application and your logo will appear in the sidebar.
+
+## Bulk Uploading Data
+
+The app supports uploading multiple records at once using CSV files.
+
+### Items
+
+On the **Item Master Management** page open the *Bulk Upload Items* expander and
+upload a CSV containing columns such as:
+
+```
+name,base_unit,purchase_unit,category,sub_category,permitted_departments,reorder_point,current_stock,notes,is_active
+```
+
+Example:
+
+```csv
+name,base_unit,purchase_unit,category,sub_category,permitted_departments,reorder_point,current_stock,notes,is_active
+Tomato,kg,,Vegetables,Fresh,KITCHEN,10,0,Fresh tomatoes,True
+```
+
+### Stock Transactions
+
+On the **Stock Movements Log** page use the *Bulk Upload Stock Transactions*
+expander and provide a CSV with columns:
+
+```
+item_id,quantity_change,transaction_type,user_id,notes
+```
+
+Example:
+
+```csv
+item_id,quantity_change,transaction_type,user_id,notes
+1,5,RECEIVING,manager,Initial stock
+2,-2,WASTAGE,chef,Expired batch
+```
+
+After the upload the app reports how many rows succeeded and lists any errors
+for rows that could not be processed.

--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -112,6 +112,7 @@ def infer_item_units() -> None:
         )
     st.rerun()
 
+
 # --- ADD NEW ITEM Section ---
 with st.expander("➕ Add New Inventory Item", expanded=False):
     st.text_input(
@@ -223,6 +224,32 @@ with st.expander("➕ Add New Inventory Item", expanded=False):
                     st.rerun()
                 else:
                     show_error(message_add)
+
+# --- BULK ADD ITEMS ---
+with st.expander("\ud83d\udce4 Bulk Upload Items", expanded=False):
+    st.write(
+        "Upload a CSV file with columns such as `name`, `base_unit`, `purchase_unit`, "
+        "`category`, `sub_category`, `permitted_departments`, `reorder_point`, "
+        "`current_stock`, `notes`, and `is_active`."
+    )
+    bulk_items_file = st.file_uploader(
+        "Choose CSV file", type=["csv"], key="items_bulk_upload_file"
+    )
+    if bulk_items_file is not None:
+        try:
+            bulk_df = pd.read_csv(bulk_items_file)
+            items_list = bulk_df.to_dict(orient="records")
+            inserted, errors = item_service.add_items_bulk(engine, items_list)
+            if inserted:
+                show_success(f"Successfully added {inserted} item(s).")
+                fetch_all_items_df_for_items_page.clear()
+            if errors:
+                show_error(f"{len(errors)} item(s) failed. Details below:")
+                for err in errors:
+                    st.error(err)
+        except Exception as e:  # pylint: disable=broad-except
+            show_error(f"Failed to process file: {e}")
+
 st.divider()
 
 # --- VIEW & MANAGE EXISTING ITEMS ---


### PR DESCRIPTION
## Summary
- allow CSV-based bulk upload of items with success/error feedback
- support bulk stock transaction uploads and report per-row failures
- document CSV formats and bulk upload steps in README

## Testing
- `flake8 app/pages/1_Items.py app/pages/3_Stock_Movements.py app/services/stock_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689abe2dc7a083269886d429b452c06b