### PR TITLE
Fix Unicode surrogate sequences in Streamlit expanders

### DIFF
--- a/app/pages/1_Items.py
+++ b/app/pages/1_Items.py
@@ -226,7 +226,7 @@ with st.expander("➕ Add New Inventory Item", expanded=False):
                     show_error(message_add)
 
 # --- BULK ADD ITEMS ---
-with st.expander("\ud83d\udce4 Bulk Upload Items", expanded=False):
+with st.expander("📤 Bulk Upload Items", expanded=False):
     st.write(
         "Upload a CSV file with columns such as `name`, `base_unit`, `purchase_unit`, "
         "`category`, `sub_category`, `permitted_departments`, `reorder_point`, "

--- a/app/pages/3_Stock_Movements.py
+++ b/app/pages/3_Stock_Movements.py
@@ -108,7 +108,7 @@ item_options_with_placeholder_list_pg3 = [
 ] + active_item_options_list_pg3
 
 # --- BULK STOCK TRANSACTIONS UPLOAD ---
-with st.expander("\ud83d\udce4 Bulk Upload Stock Transactions", expanded=False):
+with st.expander("📤 Bulk Upload Stock Transactions", expanded=False):
     st.write(
         "Upload a CSV file with columns such as `item_id`, `quantity_change`, `transaction_type`, "
         "`user_id`, and `notes`."


### PR DESCRIPTION
## Summary
- replace surrogate emoji sequences with UTF-8 characters in bulk upload expanders

## Testing
- `flake8 app/pages/1_Items.py app/pages/3_Stock_Movements.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ac236519c8326b9f7309332bea2cd