### PR TITLE
Add rotating file logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ DB_PORT
 DB_NAME
 ```
 
+### Logging
+
+Logging output is written to a rotating file handler (`app.log` by default).
+You can control verbosity or the log file location with environment variables:
+
+- `LOG_LEVEL` – set the minimum log level (`DEBUG`, `INFO`, etc.). Defaults to
+  `INFO`.
+- `LOG_FILE` – path to the log file. Defaults to `app.log` in the project root.
+
+Call `flush_logs()` from `app.core.logging` to truncate the log file when
+needed.
+
 ## Customizing the Sidebar Logo
 
 The sidebar image displayed in the app is defined in `app/ui/logo.py` as a base64 encoded PNG. To use your own logo:

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -1,10 +1,60 @@
+"""Logging utilities for the Inventory App.
+
+This module provides a custom logging configuration using a rotating file
+handler and helper functions to obtain loggers and manage log files.
+"""
+
 import logging
+import os
+from logging.handlers import RotatingFileHandler
 
 LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+LOG_FILE = os.getenv("LOG_FILE", "app.log")
 
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+_configured = False
+
+
+def configure_logging() -> None:
+    """Configure application-wide logging.
+
+    Uses a :class:`~logging.handlers.RotatingFileHandler` that keeps the log
+    file to roughly 1MB with up to three backups. The log level can be
+    controlled via the ``LOG_LEVEL`` environment variable.
+    """
+
+    global _configured
+    if _configured:
+        return
+
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    root = logging.getLogger()
+    root.setLevel(level)
+
+    formatter = logging.Formatter(LOG_FORMAT)
+
+    file_handler = RotatingFileHandler(
+        LOG_FILE, maxBytes=1_000_000, backupCount=3
+    )
+    file_handler.setFormatter(formatter)
+    root.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    root.addHandler(stream_handler)
+
+    _configured = True
 
 
 def get_logger(name: str) -> logging.Logger:
     """Return a logger with the configured settings."""
     return logging.getLogger(name)
+
+
+def flush_logs() -> None:
+    """Truncate the current log file and flush any buffered records."""
+
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+    open(LOG_FILE, "w").close()

--- a/app/item_manager_app.py
+++ b/app/item_manager_app.py
@@ -10,6 +10,11 @@ _REPO_ROOT = os.path.abspath(os.path.join(_CURRENT_DIR, os.pardir))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
+from app.core.logging import configure_logging
+
+# Configure logging before importing modules that use it
+configure_logging()
+
 import streamlit as st
 import pandas as pd
 from datetime import datetime

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,12 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
+from app.core.logging import configure_logging
+
+# Configure logging for tests once before other modules import loggers
+configure_logging()
+
+
 # Fixture to provide in-memory SQLite engine with tables for tests
 @pytest.fixture
 def sqlite_engine():


### PR DESCRIPTION
## Summary
- add `configure_logging` with rotating file handler and `flush_logs`
- initialize logging before service imports in `item_manager_app`
- document `LOG_LEVEL` and `LOG_FILE` environment variables

## Testing
- `flake8` *(fails: E305 expected 2 blank lines after class or function definition, found 1, and other pre-existing issues)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ad100b4a483269b8a7d3da18c09bc