### PR TITLE
Add sidebar option to flush logs

### DIFF
--- a/app/item_manager_app.py
+++ b/app/item_manager_app.py
@@ -10,7 +10,7 @@ _REPO_ROOT = os.path.abspath(os.path.join(_CURRENT_DIR, os.pardir))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-from app.core.logging import configure_logging
+from app.core.logging import configure_logging, flush_logs
 
 # Configure logging before importing modules that use it
 configure_logging()
@@ -43,9 +43,12 @@ def run_dashboard():
     )
     load_css()
     render_sidebar_logo()
-    render_sidebar_nav()
+    render_sidebar_nav(include_clear_logs_button=False)
     if not login_sidebar():
         st.stop()
+    if st.sidebar.button("Clear Logs"):
+        flush_logs()
+        st.toast("Logs cleared")
     st.title("🍲 Restaurant Inventory Dashboard")
     st.caption(
         f"Current Overview as of: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"

--- a/app/ui/navigation.py
+++ b/app/ui/navigation.py
@@ -1,7 +1,8 @@
 import streamlit as st
+from app.core.logging import flush_logs
 
 
-def render_sidebar_nav() -> None:
+def render_sidebar_nav(include_clear_logs_button: bool = True) -> None:
     """Render sidebar navigation links to all app pages."""
     with st.sidebar:
         st.page_link("item_manager_app.py", label="🏠 Dashboard")
@@ -12,3 +13,6 @@ def render_sidebar_nav() -> None:
         st.page_link("pages/5_Indents.py", label="Indents")
         st.page_link("pages/6_Purchase_Orders.py", label="Purchase Orders")
         st.page_link("pages/7_Recipes.py", label="Recipes")
+        if include_clear_logs_button and st.button("Clear Logs"):
+            flush_logs()
+            st.toast("Logs cleared")


### PR DESCRIPTION
## Summary
- add Clear Logs button to dashboard sidebar that flushes log file
- expose optional Clear Logs control in shared navigation for all pages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ad263ec7c83269ef2a83ca7898eef