### PR TITLE
chore: limit routine success logging

### DIFF
--- a/app/db/database_utils.py
+++ b/app/db/database_utils.py
@@ -1,4 +1,14 @@
-# app/db/database_utils.py
+"""Database utility helpers.
+
+This module provides helper functions to connect to the database and execute
+queries. Logging guidelines:
+
+* Routine success messages should not be logged. Use ``DEBUG`` for optional
+  diagnostic information.
+* Reserve ``WARNING`` and ``ERROR`` levels for exceptional or unexpected
+  conditions.
+"""
+
 import streamlit as st
 from sqlalchemy import create_engine, text
 
@@ -44,7 +54,7 @@ def connect_db() -> Optional[Engine]:
         engine = create_engine(connection_url, pool_pre_ping=True, echo=False)
 
         with engine.connect():
-            logger.info("Database connection successful using connect_db().")
+            logger.debug("Database connection established using connect_db().")
             return engine
 
     except OperationalError as e:


### PR DESCRIPTION
## Summary
- document logging guidelines in database utilities
- downgrade database connection success message to debug

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ad4e4ec088326a09e034a7319723a