### PR TITLE
Add log retention cleanup for rotated logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,24 @@ DB_NAME
 ### Logging
 
 Logging output is written to a rotating file handler (`app.log` by default).
-You can control verbosity or the log file location with environment variables:
+You can control verbosity, log file location, and retention with environment variables:
 
 - `LOG_LEVEL` – set the minimum log level (`DEBUG`, `INFO`, etc.). Defaults to
   `INFO`.
 - `LOG_FILE` – path to the log file. Defaults to `app.log` in the project root.
+- `LOG_RETENTION_DAYS` – number of days to keep rotated log files. Defaults to
+  `30`.
 
-Call `flush_logs()` from `app.core.logging` to truncate the log file when
+Example `.env` entries:
+
+```
+LOG_LEVEL=INFO
+LOG_FILE=app.log
+LOG_RETENTION_DAYS=30
+```
+
+Rotated logs older than the retention period are removed when logging is configured.
+Call `flush_logs()` from `app.core.logging` to truncate the current log file when
 needed.
 
 ## Customizing the Sidebar Logo

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -6,10 +6,14 @@ handler and helper functions to obtain loggers and manage log files.
 
 import logging
 import os
+from datetime import datetime, timedelta
 from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from stat import ST_MTIME
 
 LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 LOG_FILE = os.getenv("LOG_FILE", "app.log")
+LOG_RETENTION_DAYS = int(os.getenv("LOG_RETENTION_DAYS", "30"))
 
 _configured = False
 
@@ -45,6 +49,7 @@ def configure_logging() -> None:
     root.addHandler(stream_handler)
 
     _configured = True
+    _purge_old_logs()
 
 
 def get_logger(name: str) -> logging.Logger:
@@ -58,3 +63,25 @@ def flush_logs() -> None:
     for handler in logging.getLogger().handlers:
         handler.flush()
     open(LOG_FILE, "w").close()
+
+
+def _purge_old_logs() -> None:
+    """Delete rotated log files older than ``LOG_RETENTION_DAYS``."""
+
+    if LOG_RETENTION_DAYS <= 0:
+        return
+
+    log_path = Path(LOG_FILE).resolve()
+    cutoff = datetime.now() - timedelta(days=LOG_RETENTION_DAYS)
+    for file in log_path.parent.glob(f"{log_path.name}*"):
+        if file == log_path:
+            continue
+        try:
+            mtime = datetime.fromtimestamp(file.stat()[ST_MTIME])
+        except FileNotFoundError:
+            continue
+        if mtime < cutoff:
+            try:
+                file.unlink()
+            except FileNotFoundError:
+                pass

--- a/tests/test_logging_retention.py
+++ b/tests/test_logging_retention.py
@@ -1,0 +1,34 @@
+import importlib
+import os
+from datetime import datetime, timedelta
+
+
+def test_purge_old_logs(tmp_path, monkeypatch):
+    log_file = tmp_path / "test.log"
+    old_file = log_file.with_name(log_file.name + ".1")
+    new_file = log_file.with_name(log_file.name + ".2")
+
+    old_file.write_text("old")
+    new_file.write_text("new")
+
+    old_time = (datetime.now() - timedelta(days=8)).timestamp()
+    new_time = (datetime.now() - timedelta(days=1)).timestamp()
+    os.utime(old_file, (old_time, old_time))
+    os.utime(new_file, (new_time, new_time))
+
+    monkeypatch.setenv("LOG_FILE", str(log_file))
+    monkeypatch.setenv("LOG_RETENTION_DAYS", "7")
+
+    import app.core.logging as logging_mod
+    importlib.reload(logging_mod)
+
+    logging_mod.configure_logging()
+
+    assert not old_file.exists()
+    assert new_file.exists()
+
+    # cleanup handlers
+    import logging
+    for h in logging.getLogger().handlers[:]:
+        h.close()
+        logging.getLogger().removeHandler(h)


### PR DESCRIPTION
## Summary
- add `LOG_RETENTION_DAYS` option and startup cleanup for rotated logs
- document logging retention configuration in README
- test log cleanup routine

## Testing
- `pytest`
- `flake8` *(fails: E305, E302, E303, W391 in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689ad6aa66988326b23b96ef8e58e8b4