### PR TITLE
feat: base template with Tailwind CDN and HTMX, home page and health check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DJANGO_SECRET_KEY=
 DATABASE_URL=
+# For local runs, you can set DATABASE_URL=sqlite:///db.sqlite3
 DJANGO_DEBUG=True
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -1,0 +1,9 @@
+{% extends "_base.html" %}
+
+{% block content %}
+  <div class="flex items-center justify-center">
+    <div class="bg-white p-6 rounded shadow text-center">
+      <p class="text-xl">Django is running</p>
+    </div>
+  </div>
+{% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -1,5 +1,10 @@
 from django.http import HttpResponse
+from django.shortcuts import render
 
 
-def index(request):
-    return HttpResponse("OK")
+def home(request):
+    return render(request, "core/home.html")
+
+
+def health_check(request):
+    return HttpResponse("ok")

--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -61,7 +61,7 @@ ROOT_URLCONF = "inventory_app.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -80,7 +80,7 @@ WSGI_APPLICATION = "inventory_app.wsgi.application"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
 DATABASES = {
-    "default": env.db("DATABASE_URL"),
+    "default": env.db("DATABASE_URL", default="sqlite:///db.sqlite3"),
 }
 
 

--- a/inventory_app/urls.py
+++ b/inventory_app/urls.py
@@ -17,9 +17,10 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path
-from core.views import index
+from core.views import health_check, home
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("", index, name="root"),
+    path("", home, name="root"),
+    path("healthz", health_check, name="health-check"),
 ]

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Inventory App</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+  </head>
+  <body class="bg-gray-100 min-h-screen">
+    <nav class="bg-gray-800">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex items-center justify-between h-16">
+          <div class="flex-shrink-0">
+            <a href="/" class="text-white font-bold">Inventory App</a>
+          </div>
+        </div>
+      </div>
+    </nav>
+    <div class="max-w-7xl mx-auto p-4">
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add project-wide base template with Tailwind and HTMX
- serve new home page and health check endpoint
- configure templates directory and SQLite fallback

## Testing
- `python manage.py check`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app.core')*

------
https://chatgpt.com/codex/tasks/task_e_689b1ff5bf7c8326b9753f222b7a3dd4