### PR TITLE
fix(db): add psycopg2-binary and enforce sslmode=require for Supabase

### DIFF
--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -81,8 +81,14 @@ WSGI_APPLICATION = "inventory_app.wsgi.application"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
 DATABASES = {
-    "default": env.db("DATABASE_URL", default="sqlite:///db.sqlite3"),
+    "default": env.db("DATABASE_URL", default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}")
 }
+# Force SSL for Supabase
+if DATABASES["default"]["ENGINE"].endswith("postgresql"):
+    DATABASES["default"].setdefault("OPTIONS", {})
+    DATABASES["default"]["OPTIONS"]["sslmode"] = "require"
+# Modest keep-alive
+DATABASES["default"]["CONN_MAX_AGE"] = 60
 
 
 # Password validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==5.2.5
 djangorestframework==3.16.1
 django-environ==0.12.0
 whitenoise==6.9.0
+psycopg2-binary==2.9.9


### PR DESCRIPTION
## Summary
- install psycopg2-binary for PostgreSQL connections
- enforce SSL and keep-alive settings for Supabase databases

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_689b71bab3648326a999161d73e21b98