### PR TITLE
feat(ui): Items list page with HTMX search and pagination

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from .views_ui import items_list, items_table
+
+urlpatterns = [
+    path("items/", items_list, name="items_list"),
+    path("items/table/", items_table, name="items_table"),
+]

--- a/inventory/views_ui.py
+++ b/inventory/views_ui.py
@@ -1,0 +1,28 @@
+from django.core.paginator import Paginator
+from django.shortcuts import render
+
+from .models import Item
+
+
+def items_list(request):
+    """Render the items search page."""
+    return render(request, "inventory/items_list.html")
+
+
+def items_table(request):
+    """Render the items table partial with optional search and pagination."""
+    q = request.GET.get("q", "")
+    items = Item.objects.all()
+    if q:
+        items = items.filter(name__icontains=q)
+    items = items.order_by("name")
+
+    paginator = Paginator(items, 25)
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
+
+    context = {
+        "page_obj": page_obj,
+        "q": q,
+    }
+    return render(request, "inventory/_items_table.html", context)

--- a/inventory_app/urls.py
+++ b/inventory_app/urls.py
@@ -21,7 +21,10 @@ from core.views import health_check, home
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    # HTML pages
     path("", home, name="root"),
+    path("", include("inventory.ui_urls")),
+    # API endpoints
     path("healthz", health_check, name="health-check"),
     path("api/", include("inventory.urls")),
 ]

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -14,6 +14,13 @@
           <div class="flex-shrink-0">
             <a href="/" class="text-white font-bold">Inventory App</a>
           </div>
+          <div class="flex space-x-4">
+            <a href="/" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Home</a>
+            <a href="/items/" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
+            <a href="/suppliers/" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
+            <a href="#" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock</a>
+            <a href="#" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
+          </div>
         </div>
       </div>
     </nav>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,0 +1,48 @@
+<table class="min-w-full divide-y divide-gray-200">
+  <thead class="bg-gray-50">
+    <tr>
+      <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">ID</th>
+      <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Name</th>
+      <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Unit</th>
+      <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Category</th>
+      <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Current Stock</th>
+      <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Reorder Point</th>
+      <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Active</th>
+    </tr>
+  </thead>
+  <tbody class="bg-white divide-y divide-gray-200">
+    {% for item in page_obj %}
+      <tr>
+        <td class="px-4 py-2">{{ item.item_id }}</td>
+        <td class="px-4 py-2">{{ item.name }}</td>
+        <td class="px-4 py-2">{{ item.base_unit }}</td>
+        <td class="px-4 py-2">{{ item.category }}</td>
+        <td class="px-4 py-2">{{ item.current_stock }}</td>
+        <td class="px-4 py-2">{{ item.reorder_point }}</td>
+        <td class="px-4 py-2">{{ item.is_active }}</td>
+      </tr>
+    {% empty %}
+      <tr>
+        <td colspan="7" class="px-4 py-2 text-center">No items found.</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<div class="flex justify-between mt-2">
+  {% if page_obj.has_previous %}
+    <a
+      hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}"
+      hx-target="#items_table"
+      class="text-blue-600 hover:underline"
+    >Previous</a>
+  {% else %}
+    <span></span>
+  {% endif %}
+  {% if page_obj.has_next %}
+    <a
+      hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}"
+      hx-target="#items_table"
+      class="text-blue-600 hover:underline"
+    >Next</a>
+  {% endif %}
+</div>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -1,0 +1,21 @@
+{% extends "_base.html" %}
+
+{% block content %}
+  <div class="mb-4">
+    <input
+      type="text"
+      name="q"
+      placeholder="Search items..."
+      class="border rounded px-2 py-1 w-full"
+      hx-get="{% url 'items_table' %}"
+      hx-target="#items_table"
+      hx-trigger="keyup changed delay:300ms"
+      hx-include="[name='q']"
+    />
+  </div>
+  <div
+    id="items_table"
+    hx-get="{% url 'items_table' %}"
+    hx-trigger="load"
+  ></div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add HTML url section including inventory.ui_urls
- implement HTMX-based items list and table views
- provide search & pagination templates and nav links

## Testing
- `PYTHONPATH=legacy_streamlit pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ca3fb68688326b674d7119d8d6260