### PR TITLE
feat(ui): Suppliers list with HTMX search and pagination

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -5,4 +5,6 @@ from . import views_ui
 urlpatterns = [
     path("items/", views_ui.items_list, name="items_list"),
     path("items/table/", views_ui.items_table, name="items_table"),
+    path("suppliers/", views_ui.suppliers_list, name="suppliers_list"),
+    path("suppliers/table/", views_ui.suppliers_table, name="suppliers_table"),
 ]

--- a/inventory/views_ui.py
+++ b/inventory/views_ui.py
@@ -1,7 +1,8 @@
 from django.shortcuts import render
 from django.core.paginator import Paginator
+from django.db.models import Q
 
-from .models import Item
+from .models import Item, Supplier
 
 
 def items_list(request):
@@ -19,3 +20,25 @@ def items_table(request):
     page_obj = paginator.get_page(page_number)
     ctx = {"page_obj": page_obj, "q": q}
     return render(request, "inventory/_items_table.html", ctx)
+
+
+def suppliers_list(request):
+    return render(request, "inventory/suppliers_list.html")
+
+
+def suppliers_table(request):
+    q = (request.GET.get("q") or "").strip()
+    qs = Supplier.objects.all()
+    if q:
+        qs = qs.filter(
+            Q(name__icontains=q)
+            | Q(email__icontains=q)
+            | Q(phone__icontains=q)
+            | Q(contact_person__icontains=q)
+        )
+    qs = qs.order_by("name")
+    paginator = Paginator(qs, 25)
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
+    ctx = {"page_obj": page_obj, "q": q}
+    return render(request, "inventory/_suppliers_table.html", ctx)

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -17,7 +17,7 @@
           <div class="flex space-x-4">
             <a href="/" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Home</a>
             <a href="/items/" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
-            <a href="/suppliers/" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
+            <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
             <a href="#" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock</a>
             <a href="#" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
           </div>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -1,0 +1,40 @@
+<div class="overflow-x-auto">
+  <table class="min-w-full border divide-y">
+    <thead>
+      <tr class="bg-gray-50">
+        <th class="px-3 py-2 text-left">ID</th>
+        <th class="px-3 py-2 text-left">Name</th>
+        <th class="px-3 py-2 text-left">Contact</th>
+        <th class="px-3 py-2 text-left">Email</th>
+        <th class="px-3 py-2 text-left">Phone</th>
+        <th class="px-3 py-2 text-left">Active</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y">
+      {% for row in page_obj %}
+      <tr>
+        <td class="px-3 py-2">{{ row.supplier_id }}</td>
+        <td class="px-3 py-2">{{ row.name }}</td>
+        <td class="px-3 py-2">{{ row.contact_person }}</td>
+        <td class="px-3 py-2">{{ row.email }}</td>
+        <td class="px-3 py-2">{{ row.phone }}</td>
+        <td class="px-3 py-2">{{ row.is_active }}</td>
+      </tr>
+      {% empty %}
+      <tr><td class="px-3 py-4" colspan="6">No suppliers found.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+<div class="flex items-center gap-3 mt-3">
+  {% if page_obj.has_previous %}
+    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}"
+       hx-target="#suppliers_table" class="px-3 py-1 border rounded">Prev</a>
+  {% endif %}
+  <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+  {% if page_obj.has_next %}
+    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}"
+       hx-target="#suppliers_table" class="px-3 py-1 border rounded">Next</a>
+  {% endif %}
+</div>
+

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -1,0 +1,21 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-5xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">Suppliers</h1>
+  <input
+    type="text"
+    name="q"
+    placeholder="Search suppliers..."
+    class="w-full border rounded p-2 mb-4"
+    hx-get="{% url 'suppliers_table' %}"
+    hx-target="#suppliers_table"
+    hx-trigger="keyup changed delay:300ms"
+    hx-include="[name='q']"
+  />
+  <div id="suppliers_table"
+       hx-get="{% url 'suppliers_table' %}"
+       hx-trigger="load">
+  </div>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add supplier routes and views with search and pagination
- add HTMX templates for suppliers
- link suppliers in main navigation

## Testing
- `flake8 inventory/ui_urls.py inventory/views_ui.py`
- `PYTHONPATH=legacy_streamlit pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cee1dde148326bb2a01133d29ec26