### PR TITLE
Fix merge conflicts and unit display

### DIFF
--- a/inventory/views_ui.py
+++ b/inventory/views_ui.py
@@ -1,21 +1,14 @@
 from django.shortcuts import render
 from django.core.paginator import Paginator
-<<<<<<< HEAD
 from django.db.models import Q
 
 from .models import Item, Supplier
 
-=======
-from .models import Item
->>>>>>> e582bea (django_refactor_test)
 
 def items_list(request):
     return render(request, "inventory/items_list.html")
 
-<<<<<<< HEAD
 
-=======
->>>>>>> e582bea (django_refactor_test)
 def items_table(request):
     q = (request.GET.get("q") or "").strip()
     qs = Item.objects.all()
@@ -27,7 +20,6 @@ def items_table(request):
     page_obj = paginator.get_page(page_number)
     ctx = {"page_obj": page_obj, "q": q}
     return render(request, "inventory/_items_table.html", ctx)
-<<<<<<< HEAD
 
 
 def suppliers_list(request):
@@ -50,5 +42,3 @@ def suppliers_table(request):
     page_obj = paginator.get_page(page_number)
     ctx = {"page_obj": page_obj, "q": q}
     return render(request, "inventory/_suppliers_table.html", ctx)
-=======
->>>>>>> e582bea (django_refactor_test)

--- a/inventory_app/urls.py
+++ b/inventory_app/urls.py
@@ -17,21 +17,12 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
-<<<<<<< HEAD
-from core.views import health_check, home
-=======
 from core.views import root_view, health_check
->>>>>>> e582bea (django_refactor_test)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", root_view, name="root"),
     path("healthz", health_check, name="health-check"),
-<<<<<<< HEAD
-    path("api/", include("inventory.urls")),
-    path("", include("inventory.ui_urls")),
-=======
     path("api/", include("inventory.urls")),   # DRF API
-    path("", include("inventory.ui_urls")),    # HTML UI routes  <-- add this line
->>>>>>> e582bea (django_refactor_test)
+    path("", include("inventory.ui_urls")),    # HTML UI routes
 ]

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -4,7 +4,7 @@
       <tr class="bg-gray-50">
         <th class="px-3 py-2 text-left">ID</th>
         <th class="px-3 py-2 text-left">Name</th>
-        <th class="px-3 py-2 text-left">Unit</th>
+        <th class="px-3 py-2 text-left">Base Unit</th>
         <th class="px-3 py-2 text-left">Category</th>
         <th class="px-3 py-2 text-right">Current Stock</th>
         <th class="px-3 py-2 text-right">Reorder Point</th>
@@ -16,7 +16,7 @@
       <tr>
         <td class="px-3 py-2">{{ row.item_id }}</td>
         <td class="px-3 py-2">{{ row.name }}</td>
-        <td class="px-3 py-2">{{ row.unit }}</td>
+        <td class="px-3 py-2">{{ row.base_unit }}</td>
         <td class="px-3 py-2">{{ row.category }}</td>
         <td class="px-3 py-2 text-right">{{ row.current_stock }}</td>
         <td class="px-3 py-2 text-right">{{ row.reorder_point }}</td>


### PR DESCRIPTION
## Summary
- remove leftover merge markers in url config and UI views
- display correct base unit in items table

## Testing
- `DJANGO_SECRET_KEY=dummy DJANGO_DEBUG=True DJANGO_ALLOWED_HOSTS=localhost python manage.py check`
- `DJANGO_SECRET_KEY=dummy DJANGO_DEBUG=True DJANGO_ALLOWED_HOSTS=localhost python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689df0997e348326b1b60b291a74cdb0