### PR TITLE
Use psycopg 3 binary package

### DIFF
--- a/legacy_streamlit/requirements.txt
+++ b/legacy_streamlit/requirements.txt
@@ -1,7 +1,7 @@
 streamlit
 pandas
 sqlalchemy
-psycopg2-binary # Or psycopg2 if not using binary
+psycopg[binary]  # Postgres driver
 fpdf2
 pytest
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Django==5.2.5
 djangorestframework==3.16.1
 django-environ==0.12.0
 whitenoise==6.9.0
-psycopg2-binary==2.9.9
+psycopg[binary]==3.2.9


### PR DESCRIPTION
## Summary
- replace psycopg2-binary with psycopg[binary] for PostgreSQL support under Python 3.13
- align legacy streamlit requirements with psycopg 3

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f2de9bbb4832699cea0f1a53ff949