### PR TITLE
Add item forms, filters, and bulk upload support

### DIFF
--- a/inventory/forms.py
+++ b/inventory/forms.py
@@ -1,0 +1,38 @@
+from django import forms
+from .models import Item
+from legacy_streamlit.app.core.unit_inference import infer_units
+
+
+class ItemForm(forms.ModelForm):
+    class Meta:
+        model = Item
+        fields = [
+            "name",
+            "base_unit",
+            "purchase_unit",
+            "category",
+            "sub_category",
+            "permitted_departments",
+            "reorder_point",
+            "current_stock",
+            "notes",
+            "is_active",
+        ]
+
+    def clean(self):
+        cleaned = super().clean()
+        name = cleaned.get("name", "")
+        category = cleaned.get("category")
+        base = cleaned.get("base_unit")
+        purchase = cleaned.get("purchase_unit")
+        if name and (not base or not purchase):
+            inferred_base, inferred_purchase = infer_units(name, category)
+            if not base:
+                cleaned["base_unit"] = inferred_base
+            if not purchase and inferred_purchase:
+                cleaned["purchase_unit"] = inferred_purchase
+        return cleaned
+
+
+class BulkUploadForm(forms.Form):
+    file = forms.FileField()

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -4,6 +4,9 @@ from . import views_ui
 urlpatterns = [
     path("items/", views_ui.items_list, name="items_list"),
     path("items/table/", views_ui.items_table, name="items_table"),
+    path("items/create/", views_ui.item_create, name="item_create"),
+    path("items/<int:pk>/edit/", views_ui.item_edit, name="item_edit"),
+    path("items/bulk-upload/", views_ui.items_bulk_upload, name="items_bulk_upload"),
 
     path("suppliers/", views_ui.suppliers_list, name="suppliers_list"),
     path("suppliers/table/", views_ui.suppliers_table, name="suppliers_table"),

--- a/inventory/views_ui.py
+++ b/inventory/views_ui.py
@@ -1,26 +1,122 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect, get_object_or_404
 from django.core.paginator import Paginator
 from django.db.models import Q
 
 from .models import Item, Supplier
+from .forms import ItemForm, BulkUploadForm
+
+import csv
+import io
 
 
 def items_list(request):
     q = (request.GET.get("q") or "").strip()
-    return render(request, "inventory/items_list.html", {"q": q})
+    category = (request.GET.get("category") or "").strip()
+    subcategory = (request.GET.get("subcategory") or "").strip()
+    active = (request.GET.get("active") or "").strip()
+
+    categories = (
+        Item.objects.exclude(category__isnull=True)
+        .exclude(category="")
+        .order_by("category")
+        .values_list("category", flat=True)
+        .distinct()
+    )
+    subcategories = (
+        Item.objects.exclude(sub_category__isnull=True)
+        .exclude(sub_category="")
+        .order_by("sub_category")
+        .values_list("sub_category", flat=True)
+        .distinct()
+    )
+
+    ctx = {
+        "q": q,
+        "category": category,
+        "subcategory": subcategory,
+        "active": active,
+        "categories": categories,
+        "subcategories": subcategories,
+    }
+    return render(request, "inventory/items_list.html", ctx)
 
 
 def items_table(request):
     q = (request.GET.get("q") or "").strip()
+    category = (request.GET.get("category") or "").strip()
+    subcategory = (request.GET.get("subcategory") or "").strip()
+    active = (request.GET.get("active") or "").strip()
+
     qs = Item.objects.all()
     if q:
         qs = qs.filter(name__icontains=q)
+    if category:
+        qs = qs.filter(category=category)
+    if subcategory:
+        qs = qs.filter(sub_category=subcategory)
+    if active:
+        if active == "1":
+            qs = qs.filter(is_active=True)
+        elif active == "0":
+            qs = qs.filter(is_active=False)
     qs = qs.order_by("name")
     paginator = Paginator(qs, 25)
     page_number = request.GET.get("page")
     page_obj = paginator.get_page(page_number)
-    ctx = {"page_obj": page_obj, "q": q}
+    ctx = {
+        "page_obj": page_obj,
+        "q": q,
+        "category": category,
+        "subcategory": subcategory,
+        "active": active,
+    }
     return render(request, "inventory/_items_table.html", ctx)
+
+
+def item_create(request):
+    if request.method == "POST":
+        form = ItemForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect("items_list")
+    else:
+        form = ItemForm()
+    return render(request, "inventory/item_form.html", {"form": form, "is_edit": False})
+
+
+def item_edit(request, pk: int):
+    item = get_object_or_404(Item, pk=pk)
+    if request.method == "POST":
+        form = ItemForm(request.POST, instance=item)
+        if form.is_valid():
+            form.save()
+            return redirect("items_list")
+    else:
+        form = ItemForm(instance=item)
+    ctx = {"form": form, "is_edit": True, "item": item}
+    return render(request, "inventory/item_form.html", ctx)
+
+
+def items_bulk_upload(request):
+    inserted = 0
+    errors: list[str] = []
+    if request.method == "POST":
+        form = BulkUploadForm(request.POST, request.FILES)
+        if form.is_valid():
+            file = form.cleaned_data["file"]
+            data = io.StringIO(file.read().decode("utf-8"))
+            reader = csv.DictReader(data)
+            for row in reader:
+                form_row = ItemForm(row)
+                if form_row.is_valid():
+                    form_row.save()
+                    inserted += 1
+                else:
+                    errors.append(str(form_row.errors))
+    else:
+        form = BulkUploadForm()
+    ctx = {"form": form, "inserted": inserted, "errors": errors}
+    return render(request, "inventory/bulk_upload.html", ctx)
 
 
 def suppliers_list(request):

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -6,9 +6,11 @@
         <th class="px-3 py-2 text-left">Name</th>
         <th class="px-3 py-2 text-left">Base Unit</th>
         <th class="px-3 py-2 text-left">Category</th>
+        <th class="px-3 py-2 text-left">Subcategory</th>
         <th class="px-3 py-2 text-right">Current Stock</th>
         <th class="px-3 py-2 text-right">Reorder Point</th>
         <th class="px-3 py-2 text-left">Active</th>
+        <th class="px-3 py-2 text-left">Actions</th>
       </tr>
     </thead>
     <tbody class="divide-y">
@@ -18,24 +20,26 @@
         <td class="px-3 py-2">{{ row.name }}</td>
         <td class="px-3 py-2">{{ row.base_unit }}</td>
         <td class="px-3 py-2">{{ row.category }}</td>
+        <td class="px-3 py-2">{{ row.sub_category }}</td>
         <td class="px-3 py-2 text-right">{{ row.current_stock }}</td>
         <td class="px-3 py-2 text-right">{{ row.reorder_point }}</td>
         <td class="px-3 py-2">{{ row.is_active }}</td>
+        <td class="px-3 py-2"><a href="{% url 'item_edit' row.item_id %}" class="text-blue-600">Edit</a></td>
       </tr>
       {% empty %}
-      <tr><td class="px-3 py-4" colspan="7">No items found.</td></tr>
+      <tr><td class="px-3 py-4" colspan="8">No items found.</td></tr>
       {% endfor %}
     </tbody>
   </table>
 </div>
 <div class="flex items-center gap-3 mt-3">
   {% if page_obj.has_previous %}
-    <a hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}"
+    <a hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}"
        hx-target="#items_table" class="px-3 py-1 border rounded">Prev</a>
   {% endif %}
   <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
   {% if page_obj.has_next %}
-    <a hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}"
+    <a hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}"
        hx-target="#items_table" class="px-3 py-1 border rounded">Next</a>
   {% endif %}
 </div>

--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -1,0 +1,27 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">Bulk Upload Items</h1>
+  <form method="post" enctype="multipart/form-data" class="space-y-4">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <div class="flex gap-2">
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Upload</button>
+      <a href="{% url 'items_list' %}" class="px-4 py-2 border rounded">Back</a>
+    </div>
+  </form>
+  {% if inserted %}
+  <p class="mt-4 text-green-700">Inserted {{ inserted }} item(s).</p>
+  {% endif %}
+  {% if errors %}
+  <div class="mt-4">
+    <p class="text-red-700">Errors:</p>
+    <ul class="list-disc pl-5">
+      {% for err in errors %}
+      <li>{{ err }}</li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -1,0 +1,16 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">
+    {% if is_edit %}Edit Item{% else %}Add Item{% endif %}
+  </h1>
+  <form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <div class="flex gap-2">
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
+      <a href="{% url 'items_list' %}" class="px-4 py-2 border rounded">Cancel</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -2,20 +2,47 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Items</h1>
-  <input
-    type="text"
-    name="q"
-    placeholder="Search items..."
-    class="w-full border rounded p-2 mb-4"
-    value="{{ q }}"
-    hx-get="{% url 'items_table' %}"
-    hx-target="#items_table"
-    hx-trigger="keyup changed delay:300ms"
-    hx-include="[name='q']"
-  />
+  <div class="mb-4 flex gap-2">
+    <a href="{% url 'item_create' %}" class="px-4 py-2 bg-green-600 text-white rounded">Add Item</a>
+    <a href="{% url 'items_bulk_upload' %}" class="px-4 py-2 border rounded">Bulk Upload</a>
+  </div>
+  <form id="filters" class="flex flex-wrap gap-2 mb-4">
+    <input
+      type="text"
+      name="q"
+      placeholder="Search items..."
+      class="border rounded p-2 flex-grow"
+      value="{{ q }}"
+      hx-get="{% url 'items_table' %}"
+      hx-target="#items_table"
+      hx-trigger="keyup changed delay:300ms"
+      hx-include="#filters"
+    />
+    <select name="category" class="border rounded p-2"
+            hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters">
+      <option value="">All Categories</option>
+      {% for cat in categories %}
+      <option value="{{ cat }}" {% if cat == category %}selected{% endif %}>{{ cat }}</option>
+      {% endfor %}
+    </select>
+    <select name="subcategory" class="border rounded p-2"
+            hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters">
+      <option value="">All Subcategories</option>
+      {% for sub in subcategories %}
+      <option value="{{ sub }}" {% if sub == subcategory %}selected{% endif %}>{{ sub }}</option>
+      {% endfor %}
+    </select>
+    <select name="active" class="border rounded p-2"
+            hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters">
+      <option value="">All</option>
+      <option value="1" {% if active == '1' %}selected{% endif %}>Active</option>
+      <option value="0" {% if active == '0' %}selected{% endif %}>Inactive</option>
+    </select>
+  </form>
   <div id="items_table"
-       hx-get="{% url 'items_table' %}?q={{ q|urlencode }}"
-       hx-trigger="load">
+       hx-get="{% url 'items_table' %}"
+       hx-trigger="load"
+       hx-include="#filters">
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add ItemForm with unit inference and bulk upload form
- implement create/edit/bulk-upload item views and templates
- add filtering, action links, and subcategory column to items table

## Testing
- `PYTHONPATH=legacy_streamlit pytest`
- `DJANGO_SECRET_KEY=test DJANGO_ALLOWED_HOSTS=localhost PYTHONPATH=legacy_streamlit python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_689f350becf083269126508c0296d7f4