### PR TITLE
Add supplier management forms and utilities

### DIFF
--- a/inventory/forms.py
+++ b/inventory/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import Item
+from .models import Item, Supplier
 from legacy_streamlit.app.core.unit_inference import infer_units
 
 
@@ -36,3 +36,21 @@ class ItemForm(forms.ModelForm):
 
 class BulkUploadForm(forms.Form):
     file = forms.FileField()
+
+
+class BulkDeleteForm(forms.Form):
+    file = forms.FileField()
+
+
+class SupplierForm(forms.ModelForm):
+    class Meta:
+        model = Supplier
+        fields = [
+            "name",
+            "contact_person",
+            "phone",
+            "email",
+            "address",
+            "notes",
+            "is_active",
+        ]

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -10,4 +10,21 @@ urlpatterns = [
 
     path("suppliers/", views_ui.suppliers_list, name="suppliers_list"),
     path("suppliers/table/", views_ui.suppliers_table, name="suppliers_table"),
+    path("suppliers/create/", views_ui.supplier_create, name="supplier_create"),
+    path("suppliers/<int:pk>/edit/", views_ui.supplier_edit, name="supplier_edit"),
+    path(
+        "suppliers/<int:pk>/toggle/",
+        views_ui.supplier_toggle_active,
+        name="supplier_toggle_active",
+    ),
+    path(
+        "suppliers/bulk-upload/",
+        views_ui.suppliers_bulk_upload,
+        name="suppliers_bulk_upload",
+    ),
+    path(
+        "suppliers/bulk-delete/",
+        views_ui.suppliers_bulk_delete,
+        name="suppliers_bulk_delete",
+    ),
 ]

--- a/inventory/views_ui.py
+++ b/inventory/views_ui.py
@@ -3,7 +3,7 @@ from django.core.paginator import Paginator
 from django.db.models import Q
 
 from .models import Item, Supplier
-from .forms import ItemForm, BulkUploadForm
+from .forms import ItemForm, BulkUploadForm, BulkDeleteForm, SupplierForm
 
 import csv
 import io
@@ -115,28 +115,136 @@ def items_bulk_upload(request):
                     errors.append(str(form_row.errors))
     else:
         form = BulkUploadForm()
-    ctx = {"form": form, "inserted": inserted, "errors": errors}
+    ctx = {
+        "form": form,
+        "inserted": inserted,
+        "errors": errors,
+        "title": "Bulk Upload Items",
+        "back_url": "items_list",
+    }
     return render(request, "inventory/bulk_upload.html", ctx)
 
 
 def suppliers_list(request):
     q = (request.GET.get("q") or "").strip()
-    return render(request, "inventory/suppliers_list.html", {"q": q})
+    show_inactive = (request.GET.get("show_inactive") or "").strip()
+    return render(
+        request,
+        "inventory/suppliers_list.html",
+        {"q": q, "show_inactive": show_inactive},
+    )
 
 
 def suppliers_table(request):
     q = (request.GET.get("q") or "").strip()
+    show_inactive = (request.GET.get("show_inactive") or "").strip()
     qs = Supplier.objects.all()
     if q:
         qs = qs.filter(
             Q(name__icontains=q)
-            | Q(email__icontains=q)
-            | Q(phone__icontains=q)
             | Q(contact_person__icontains=q)
+            | Q(email__icontains=q)
         )
+    if not show_inactive:
+        qs = qs.filter(is_active=True)
     qs = qs.order_by("name")
     paginator = Paginator(qs, 25)
     page_number = request.GET.get("page")
     page_obj = paginator.get_page(page_number)
-    ctx = {"page_obj": page_obj, "q": q}
+    ctx = {"page_obj": page_obj, "q": q, "show_inactive": show_inactive}
     return render(request, "inventory/_suppliers_table.html", ctx)
+
+
+def supplier_create(request):
+    if request.method == "POST":
+        form = SupplierForm(request.POST)
+        if form.is_valid():
+            form.save()
+            return redirect("suppliers_list")
+    else:
+        form = SupplierForm()
+    return render(
+        request,
+        "inventory/supplier_form.html",
+        {"form": form, "is_edit": False},
+    )
+
+
+def supplier_edit(request, pk: int):
+    supplier = get_object_or_404(Supplier, pk=pk)
+    if request.method == "POST":
+        form = SupplierForm(request.POST, instance=supplier)
+        if form.is_valid():
+            form.save()
+            return redirect("suppliers_list")
+    else:
+        form = SupplierForm(instance=supplier)
+    ctx = {"form": form, "is_edit": True, "supplier": supplier}
+    return render(request, "inventory/supplier_form.html", ctx)
+
+
+def supplier_toggle_active(request, pk: int):
+    supplier = get_object_or_404(Supplier, pk=pk)
+    supplier.is_active = not bool(supplier.is_active)
+    supplier.save()
+    return suppliers_table(request)
+
+
+def suppliers_bulk_upload(request):
+    inserted = 0
+    errors: list[str] = []
+    if request.method == "POST":
+        form = BulkUploadForm(request.POST, request.FILES)
+        if form.is_valid():
+            file = form.cleaned_data["file"]
+            data = io.StringIO(file.read().decode("utf-8"))
+            reader = csv.DictReader(data)
+            for row in reader:
+                form_row = SupplierForm(row)
+                if form_row.is_valid():
+                    form_row.save()
+                    inserted += 1
+                else:
+                    errors.append(str(form_row.errors))
+    else:
+        form = BulkUploadForm()
+    ctx = {
+        "form": form,
+        "inserted": inserted,
+        "errors": errors,
+        "title": "Bulk Upload Suppliers",
+        "back_url": "suppliers_list",
+    }
+    return render(request, "inventory/bulk_upload.html", ctx)
+
+
+def suppliers_bulk_delete(request):
+    deleted = 0
+    errors: list[str] = []
+    if request.method == "POST":
+        form = BulkDeleteForm(request.POST, request.FILES)
+        if form.is_valid():
+            file = form.cleaned_data["file"]
+            data = io.StringIO(file.read().decode("utf-8"))
+            reader = csv.DictReader(data)
+            for row in reader:
+                name = (row.get("name") or "").strip()
+                if name:
+                    qs = Supplier.objects.filter(name=name)
+                    count, _ = qs.delete()
+                    if count:
+                        deleted += count
+                    else:
+                        errors.append(f"Supplier '{name}' not found")
+                else:
+                    errors.append("Missing name")
+    else:
+        form = BulkDeleteForm()
+    ctx = {
+        "form": form,
+        "deleted": deleted,
+        "errors": errors,
+        "title": "Bulk Delete Suppliers",
+        "back_url": "suppliers_list",
+    }
+    return render(request, "inventory/bulk_delete.html", ctx)

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -8,6 +8,7 @@
         <th class="px-3 py-2 text-left">Email</th>
         <th class="px-3 py-2 text-left">Phone</th>
         <th class="px-3 py-2 text-left">Active</th>
+        <th class="px-3 py-2 text-left">Actions</th>
       </tr>
     </thead>
     <tbody class="divide-y">
@@ -19,21 +20,26 @@
         <td class="px-3 py-2">{{ row.email }}</td>
         <td class="px-3 py-2">{{ row.phone }}</td>
         <td class="px-3 py-2">{{ row.is_active }}</td>
+        <td class="px-3 py-2">
+          <a href="{% url 'supplier_edit' row.supplier_id %}" class="text-blue-600 mr-2">Edit</a>
+          <a hx-get="{% url 'supplier_toggle_active' row.supplier_id %}?q={{ q|urlencode }}&page={{ page_obj.number }}&show_inactive={{ show_inactive|urlencode }}"
+             hx-target="#suppliers_table" class="text-blue-600">Toggle</a>
+        </td>
       </tr>
       {% empty %}
-      <tr><td class="px-3 py-4" colspan="6">No suppliers found.</td></tr>
+      <tr><td class="px-3 py-4" colspan="7">No suppliers found.</td></tr>
       {% endfor %}
     </tbody>
   </table>
 </div>
 <div class="flex items-center gap-3 mt-3">
   {% if page_obj.has_previous %}
-    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}"
+    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&show_inactive={{ show_inactive|urlencode }}"
        hx-target="#suppliers_table" class="px-3 py-1 border rounded">Prev</a>
   {% endif %}
   <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
   {% if page_obj.has_next %}
-    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}"
+    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&show_inactive={{ show_inactive|urlencode }}"
        hx-target="#suppliers_table" class="px-3 py-1 border rounded">Next</a>
   {% endif %}
 </div>

--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -6,12 +6,12 @@
     {% csrf_token %}
     {{ form.as_p }}
     <div class="flex gap-2">
-      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Upload</button>
+      <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Delete</button>
       <a href="{% url back_url %}" class="px-4 py-2 border rounded">Back</a>
     </div>
   </form>
-  {% if inserted %}
-  <p class="mt-4 text-green-700">Inserted {{ inserted }} record(s).</p>
+  {% if deleted %}
+  <p class="mt-4 text-green-700">Deleted {{ deleted }} supplier(s).</p>
   {% endif %}
   {% if errors %}
   <div class="mt-4">

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -1,0 +1,16 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">
+    {% if is_edit %}Edit Supplier{% else %}Add Supplier{% endif %}
+  </h1>
+  <form method="post" class="space-y-4">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <div class="flex gap-2">
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
+      <a href="{% url 'suppliers_list' %}" class="px-4 py-2 border rounded">Cancel</a>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -2,20 +2,33 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Suppliers</h1>
-  <input
-    type="text"
-    name="q"
-    placeholder="Search suppliers..."
-    class="w-full border rounded p-2 mb-4"
-    value="{{ q }}"
-    hx-get="{% url 'suppliers_table' %}"
-    hx-target="#suppliers_table"
-    hx-trigger="keyup changed delay:300ms"
-    hx-include="[name='q']"
-  />
+  <div class="mb-4 flex gap-2">
+    <a href="{% url 'supplier_create' %}" class="px-4 py-2 bg-green-600 text-white rounded">Add Supplier</a>
+    <a href="{% url 'suppliers_bulk_upload' %}" class="px-4 py-2 border rounded">Bulk Upload</a>
+    <a href="{% url 'suppliers_bulk_delete' %}" class="px-4 py-2 border rounded">Bulk Delete</a>
+  </div>
+  <form id="filters" class="flex flex-wrap gap-2 mb-4">
+    <input
+      type="text"
+      name="q"
+      placeholder="Search suppliers..."
+      class="border rounded p-2 flex-grow"
+      value="{{ q }}"
+      hx-get="{% url 'suppliers_table' %}"
+      hx-target="#suppliers_table"
+      hx-trigger="keyup changed delay:300ms"
+      hx-include="#filters"
+    />
+    <label class="flex items-center gap-2">
+      <input type="checkbox" name="show_inactive" value="1" {% if show_inactive %}checked{% endif %}
+             hx-get="{% url 'suppliers_table' %}" hx-target="#suppliers_table" hx-trigger="change" hx-include="#filters" />
+      Show Inactive
+    </label>
+  </form>
   <div id="suppliers_table"
-       hx-get="{% url 'suppliers_table' %}?q={{ q|urlencode }}"
-       hx-trigger="load">
+       hx-get="{% url 'suppliers_table' %}"
+       hx-trigger="load"
+       hx-include="#filters">
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `SupplierForm` and bulk delete form
- enable supplier CRUD, active toggling, search and bulk operations
- update templates for supplier management and generic bulk upload

## Testing
- `PYTHONPATH=legacy_streamlit pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f37aa9444832686bd8761c7361328