### PR TITLE
Add history reports view with CSV export

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -28,4 +28,5 @@ urlpatterns = [
         name="suppliers_bulk_delete",
     ),
     path("stock-movements/", views_ui.stock_movements, name="stock_movements"),
+    path("history-reports/", views_ui.history_reports, name="history_reports"),
 ]

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -18,8 +18,8 @@
             <a href="/" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Home</a>
             <a href="/items/" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
             <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
-            <a href="#" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock</a>
-            <a href="#" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
+            <a href="{% url 'stock_movements' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock</a>
+            <a href="{% url 'history_reports' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
           </div>
         </div>
       </div>

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -1,0 +1,71 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-5xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">History Reports</h1>
+  <form method="get" class="flex flex-wrap gap-2 mb-4">
+    <select name="item" class="border rounded p-2">
+      <option value="">All Items</option>
+      {% for it in items %}
+      <option value="{{ it.item_id }}" {% if item|default:'' == it.item_id|stringformat:"s" %}selected{% endif %}>{{ it.name }}</option>
+      {% endfor %}
+    </select>
+    <select name="type" class="border rounded p-2">
+      <option value="">All Types</option>
+      {% for t in transaction_types %}
+      <option value="{{ t }}" {% if type == t %}selected{% endif %}>{{ t }}</option>
+      {% endfor %}
+    </select>
+    <select name="user" class="border rounded p-2">
+      <option value="">All Users</option>
+      {% for u in users %}
+      <option value="{{ u }}" {% if user == u %}selected{% endif %}>{{ u }}</option>
+      {% endfor %}
+    </select>
+    <input type="date" name="start_date" value="{{ start_date }}" class="border rounded p-2" />
+    <input type="date" name="end_date" value="{{ end_date }}" class="border rounded p-2" />
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Filter</button>
+    <a href="?{% if query_string %}{{ query_string }}&{% endif %}export=csv" class="px-4 py-2 border rounded">Export CSV</a>
+  </form>
+  <div class="overflow-x-auto">
+    <table class="min-w-full border divide-y">
+      <thead>
+        <tr class="bg-gray-50">
+          <th class="px-3 py-2 text-left">ID</th>
+          <th class="px-3 py-2 text-left">Item</th>
+          <th class="px-3 py-2 text-left">Type</th>
+          <th class="px-3 py-2 text-left">Qty</th>
+          <th class="px-3 py-2 text-left">User</th>
+          <th class="px-3 py-2 text-left">Date</th>
+          <th class="px-3 py-2 text-left">Notes</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y">
+        {% for row in page_obj %}
+        <tr>
+          <td class="px-3 py-2">{{ row.transaction_id }}</td>
+          <td class="px-3 py-2">{{ row.item.name }}</td>
+          <td class="px-3 py-2">{{ row.transaction_type }}</td>
+          <td class="px-3 py-2">{{ row.quantity_change }}</td>
+          <td class="px-3 py-2">{{ row.user_id }}</td>
+          <td class="px-3 py-2">{{ row.transaction_date }}</td>
+          <td class="px-3 py-2">{{ row.notes }}</td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td class="px-3 py-4" colspan="7">No transactions found.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="flex items-center gap-3 mt-3">
+    {% if page_obj.has_previous %}
+    <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.previous_page_number }}" class="px-3 py-1 border rounded">Prev</a>
+    {% endif %}
+    <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+    {% if page_obj.has_next %}
+    <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.next_page_number }}" class="px-3 py-1 border rounded">Next</a>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Implement history reports view with filters for item, type, user, and date range
- Add CSV export and navigation link for report page
- Create history reports template with filter form and paginated table

## Testing
- `PYTHONPATH=legacy_streamlit pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f3b3fe2ec83268540f3fb0ca2edba