### PR TITLE
Add indent management views with PDF export and status workflow

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility package mapping to legacy_streamlit.app.* modules."""
+from importlib import import_module
+import sys
+
+for _pkg in ("core", "services", "ui", "db", "config"):
+    module = import_module(f"legacy_streamlit.app.{_pkg}")
+    sys.modules[f"{__name__}.{_pkg}"] = module

--- a/inventory/forms.py
+++ b/inventory/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import Item, Supplier, StockTransaction
+from .models import Item, Supplier, StockTransaction, Indent, IndentItem
 from legacy_streamlit.app.core.unit_inference import infer_units
 
 
@@ -110,3 +110,26 @@ class StockWastageForm(forms.ModelForm):
 
 class StockBulkUploadForm(forms.Form):
     file = forms.FileField()
+
+
+class IndentForm(forms.ModelForm):
+    class Meta:
+        model = Indent
+        fields = ["requested_by", "department", "date_required", "notes"]
+
+    def save(self, commit: bool = True):
+        obj = super().save(commit=False)
+        if not obj.status:
+            obj.status = "SUBMITTED"
+        if commit:
+            obj.save()
+        return obj
+
+
+IndentItemFormSet = forms.inlineformset_factory(
+    Indent,
+    IndentItem,
+    fields=["item", "requested_qty", "notes"],
+    extra=1,
+    can_delete=True,
+)

--- a/inventory/indent_pdf.py
+++ b/inventory/indent_pdf.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+from io import BytesIO
+from typing import Iterable
+
+from fpdf import FPDF
+
+from .models import Indent, IndentItem
+
+
+def generate_indent_pdf(indent: Indent, items: Iterable[IndentItem]) -> bytes:
+    """Generate a simple PDF for an indent with its items.
+
+    Parameters
+    ----------
+    indent: Indent instance
+    items: Iterable of IndentItem instances
+
+    Returns
+    -------
+    bytes: PDF content
+    """
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    title = f"Indent {indent.mrn or indent.pk}"
+    pdf.cell(0, 10, title, ln=True)
+    if getattr(indent, "requested_by", None):
+        pdf.cell(0, 10, f"Requested by: {indent.requested_by}", ln=True)
+    pdf.ln(4)
+    # Table header
+    pdf.set_font("Arial", size=10)
+    pdf.cell(120, 8, "Item", border=1)
+    pdf.cell(30, 8, "Qty", border=1, ln=True)
+    for line in items:
+        name = getattr(getattr(line, "item", None), "name", str(getattr(line, "item", "")))
+        qty = getattr(line, "requested_qty", "")
+        pdf.cell(120, 8, str(name), border=1)
+        pdf.cell(30, 8, str(qty), border=1, ln=True)
+    buffer = BytesIO()
+    pdf.output(buffer)
+    return buffer.getvalue()

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -29,4 +29,15 @@ urlpatterns = [
     ),
     path("stock-movements/", views_ui.stock_movements, name="stock_movements"),
     path("history-reports/", views_ui.history_reports, name="history_reports"),
+
+    path("indents/", views_ui.indents_list, name="indents_list"),
+    path("indents/table/", views_ui.indents_table, name="indents_table"),
+    path("indents/create/", views_ui.indent_create, name="indent_create"),
+    path("indents/<int:pk>/", views_ui.indent_detail, name="indent_detail"),
+    path(
+        "indents/<int:pk>/status/<str:status>/",
+        views_ui.indent_update_status,
+        name="indent_update_status",
+    ),
+    path("indents/<int:pk>/pdf/", views_ui.indent_pdf, name="indent_pdf"),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ django-environ==0.12.0
 whitenoise==6.9.0
 gunicorn
 psycopg[binary]==3.2.9
+fpdf2

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -1,0 +1,37 @@
+<div class="overflow-x-auto">
+  <table class="min-w-full border divide-y">
+    <thead>
+      <tr class="bg-gray-50">
+        <th class="px-3 py-2 text-left">ID</th>
+        <th class="px-3 py-2 text-left">MRN</th>
+        <th class="px-3 py-2 text-left">Requested By</th>
+        <th class="px-3 py-2 text-left">Department</th>
+        <th class="px-3 py-2 text-left">Status</th>
+        <th class="px-3 py-2 text-left">Actions</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y">
+      {% for row in page_obj %}
+      <tr>
+        <td class="px-3 py-2">{{ row.indent_id }}</td>
+        <td class="px-3 py-2">{{ row.mrn }}</td>
+        <td class="px-3 py-2">{{ row.requested_by }}</td>
+        <td class="px-3 py-2">{{ row.department }}</td>
+        <td class="px-3 py-2"><span class="px-2 py-1 rounded {{ badges[row.status|upper] }}">{{ row.status }}</span></td>
+        <td class="px-3 py-2"><a href="{% url 'indent_detail' row.indent_id %}" class="text-blue-600">View</a></td>
+      </tr>
+      {% empty %}
+      <tr><td class="px-3 py-4" colspan="6">No indents found.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+<div class="flex items-center gap-3 mt-3">
+  {% if page_obj.has_previous %}
+    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.previous_page_number }}&status={{ status|urlencode }}" hx-target="#indents_table" class="px-3 py-1 border rounded">Prev</a>
+  {% endif %}
+  <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+  {% if page_obj.has_next %}
+    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.next_page_number }}&status={{ status|urlencode }}" hx-target="#indents_table" class="px-3 py-1 border rounded">Next</a>
+  {% endif %}
+</div>

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -1,0 +1,26 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-3xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">Indent {{ indent.indent_id }}</h1>
+  <div class="mb-2">Status: <span class="px-2 py-1 rounded {{ badges[indent.status|upper] }}">{{ indent.status }}</span></div>
+  <div class="mb-2">Requested By: {{ indent.requested_by }}</div>
+  <div class="mb-2">Department: {{ indent.department }}</div>
+  <div class="mb-4">
+    <a href="{% url 'indent_pdf' indent.indent_id %}" class="text-blue-600">Download PDF</a>
+  </div>
+  <h2 class="text-xl font-semibold mb-2">Items</h2>
+  <table class="min-w-full border divide-y">
+    <thead><tr class="bg-gray-50"><th class="px-3 py-2 text-left">Item</th><th class="px-3 py-2 text-left">Qty</th></tr></thead>
+    <tbody class="divide-y">
+    {% for row in items %}
+      <tr><td class="px-3 py-2">{{ row.item.name }}</td><td class="px-3 py-2">{{ row.requested_qty }}</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <div class="mt-4 flex gap-2">
+    <a href="{% url 'indent_update_status' indent.indent_id 'PROCESSING' %}" class="px-3 py-2 border rounded">Mark Processing</a>
+    <a href="{% url 'indent_update_status' indent.indent_id 'COMPLETED' %}" class="px-3 py-2 border rounded">Mark Completed</a>
+    <a href="{% url 'indent_update_status' indent.indent_id 'CANCELLED' %}" class="px-3 py-2 border rounded">Cancel</a>
+  </div>
+</div>
+{% endblock %}

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -1,0 +1,67 @@
+{% extends "_base.html" %}
+{% load static %}
+{% block content %}
+<div class="max-w-3xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">New Indent</h1>
+  <form method="post" id="indent-form">
+    {% csrf_token %}
+    <div class="mb-4">{{ form.as_p }}</div>
+    {{ formset.management_form }}
+    <table class="min-w-full border divide-y" id="items-table">
+      <thead>
+        <tr class="bg-gray-50">
+          <th class="px-3 py-2 text-left">Item</th>
+          <th class="px-3 py-2 text-left">Qty</th>
+          <th class="px-3 py-2 text-left">Notes</th>
+          <th class="px-3 py-2"></th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for form in formset %}
+        <tr class="form-row">
+          <td class="px-3 py-2">{{ form.item }}</td>
+          <td class="px-3 py-2">{{ form.requested_qty }}</td>
+          <td class="px-3 py-2">{{ form.notes }}</td>
+          <td class="px-3 py-2"><button type="button" class="remove-row text-red-600">Remove</button></td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    <div class="mt-2">
+      <button type="button" id="add-row" class="px-4 py-2 border rounded">Add Item</button>
+    </div>
+    <div class="mt-4">
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Submit</button>
+    </div>
+  </form>
+</div>
+<script>
+(function() {
+  const addBtn = document.getElementById('add-row');
+  const table = document.getElementById('items-table').getElementsByTagName('tbody')[0];
+  const totalForms = document.getElementById('id_items-TOTAL_FORMS');
+  addBtn.addEventListener('click', function() {
+    const newIndex = parseInt(totalForms.value, 10);
+    const emptyRow = table.querySelector('.form-row').cloneNode(true);
+    emptyRow.querySelectorAll('input,select,textarea').forEach(function(el) {
+      const name = el.getAttribute('name').replace(/-\d+-/, '-' + newIndex + '-');
+      const id = 'id_' + name;
+      el.setAttribute('name', name);
+      el.setAttribute('id', id);
+      if (el.type !== 'hidden') { el.value = ''; }
+    });
+    table.appendChild(emptyRow);
+    totalForms.value = newIndex + 1;
+  });
+  table.addEventListener('click', function(e){
+    if(e.target.classList.contains('remove-row')){
+      const rows = table.querySelectorAll('.form-row');
+      if(rows.length > 1){
+        e.target.closest('.form-row').remove();
+        totalForms.value = rows.length - 1;
+      }
+    }
+  });
+})();
+</script>
+{% endblock %}

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -1,0 +1,24 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-5xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">Indents</h1>
+  <div class="mb-4 flex gap-2">
+    <a href="{% url 'indent_create' %}" class="px-4 py-2 bg-green-600 text-white rounded">New Indent</a>
+  </div>
+  <form id="filters" class="flex flex-wrap gap-2 mb-4">
+    <select name="status" class="border rounded p-2"
+            hx-get="{% url 'indents_table' %}" hx-target="#indents_table" hx-trigger="change" hx-include="#filters">
+      <option value="">All Statuses</option>
+      <option value="SUBMITTED" {% if status == 'SUBMITTED' %}selected{% endif %}>Submitted</option>
+      <option value="PROCESSING" {% if status == 'PROCESSING' %}selected{% endif %}>Processing</option>
+      <option value="COMPLETED" {% if status == 'COMPLETED' %}selected{% endif %}>Completed</option>
+      <option value="CANCELLED" {% if status == 'CANCELLED' %}selected{% endif %}>Cancelled</option>
+    </select>
+  </form>
+  <div id="indents_table"
+       hx-get="{% url 'indents_table' %}"
+       hx-trigger="load"
+       hx-include="#filters">
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_indent_forms.py
+++ b/tests/test_indent_forms.py
@@ -1,0 +1,59 @@
+import django
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        INSTALLED_APPS=["django.contrib.contenttypes", "django.contrib.auth", "inventory"],
+        DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}},
+        USE_TZ=True,
+    )
+    django.setup()
+
+from django.db import connection
+from inventory.models import Item, Indent, IndentItem
+from inventory.forms import IndentForm, IndentItemFormSet
+
+
+def setup_module(module):
+    with connection.schema_editor() as editor:
+        editor.create_model(Item)
+        editor.create_model(Indent)
+        editor.create_model(IndentItem)
+
+
+def teardown_module(module):
+    with connection.schema_editor() as editor:
+        editor.delete_model(IndentItem)
+        editor.delete_model(Indent)
+        editor.delete_model(Item)
+
+
+def test_indent_form_and_formset_save():
+    item = Item.objects.create(name="Sugar")
+    form = IndentForm(
+        {
+            "requested_by": "Alice",
+            "department": "Kitchen",
+            "date_required": "2024-01-01",
+            "notes": "Urgent",
+        }
+    )
+    formset_data = {
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "0",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-item": str(item.pk),
+        "items-0-requested_qty": "5",
+        "items-0-notes": "",
+    }
+    formset = IndentItemFormSet(formset_data, prefix="items")
+    assert form.is_valid()
+    assert formset.is_valid()
+    indent = form.save()
+    formset.instance = indent
+    formset.save()
+    indent.refresh_from_db()
+    assert indent.status == "SUBMITTED"
+    assert indent.indentitem_set.count() == 1
+    assert indent.indentitem_set.first().item_id == item.pk

--- a/tests/test_indent_pdf.py
+++ b/tests/test_indent_pdf.py
@@ -1,0 +1,11 @@
+from types import SimpleNamespace
+
+from inventory.indent_pdf import generate_indent_pdf
+
+
+def test_generate_indent_pdf_basic():
+    indent = SimpleNamespace(mrn="MRN1", pk=1, requested_by="Alice")
+    item = SimpleNamespace(item=SimpleNamespace(name="Sugar"), requested_qty=5)
+    pdf = generate_indent_pdf(indent, [item])
+    assert pdf.startswith(b"%PDF")
+    assert len(pdf) > 100


### PR DESCRIPTION
## Summary
- support indent creation with line items via dynamic formset
- list and process indents with status badges and PDF download
- alias legacy modules as `app` for test compatibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f3fe9273483268bd9fd289dcdbec9