### PR TITLE
Restore Indents link in navigation bar

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -18,6 +18,7 @@
             <a href="{% url 'root' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Home</a>
             <a href="{% url 'items_list' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
             <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
+            <a href="{% url 'indents_list' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Indents</a>
             <a href="{% url 'stock_movements' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock</a>
             <a href="{% url 'history_reports' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
           </div>


### PR DESCRIPTION
## Summary
- show Indents page link in main navigation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f4581a1d88326969e22c3113229fd