### PR TITLE
Manually render form fields with Tailwind styling

### DIFF
--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -5,8 +5,40 @@
   <h1 class="text-2xl font-semibold mb-4">New Indent</h1>
   <form method="post" id="indent-form">
     {% csrf_token %}
-    <div class="mb-4">{{ form.as_p }}</div>
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    <div class="mb-4 space-y-4">
+      {% for field in form %}
+      <div>
+        {{ field.label_tag }}
+        {% if field.field.widget.input_type == "checkbox" %}
+        {{ field.as_widget(attrs={'class': 'rounded border-gray-300'}) }}
+        {% else %}
+        {{ field.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
+        {% endif %}
+        {% if field.errors %}
+        <ul class="text-red-600 list-disc pl-5">
+          {% for error in field.errors %}
+          <li>{{ error }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </div>
+      {% endfor %}
+    </div>
     {{ formset.management_form }}
+    {% if formset.non_form_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in formset.non_form_errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
     <table class="min-w-full border divide-y" id="items-table">
       <thead>
         <tr class="bg-gray-50">
@@ -17,11 +49,32 @@
         </tr>
       </thead>
       <tbody>
-      {% for form in formset %}
+      {% for item_form in formset %}
         <tr class="form-row">
-          <td class="px-3 py-2">{{ form.item }}</td>
-          <td class="px-3 py-2">{{ form.requested_qty }}</td>
-          <td class="px-3 py-2">{{ form.notes }}</td>
+          <td class="px-3 py-2">
+            {{ item_form.item.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
+            {% if item_form.item.errors %}
+            <ul class="text-red-600 list-disc pl-5">
+              {% for error in item_form.item.errors %}<li>{{ error }}</li>{% endfor %}
+            </ul>
+            {% endif %}
+          </td>
+          <td class="px-3 py-2">
+            {{ item_form.requested_qty.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
+            {% if item_form.requested_qty.errors %}
+            <ul class="text-red-600 list-disc pl-5">
+              {% for error in item_form.requested_qty.errors %}<li>{{ error }}</li>{% endfor %}
+            </ul>
+            {% endif %}
+          </td>
+          <td class="px-3 py-2">
+            {{ item_form.notes.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
+            {% if item_form.notes.errors %}
+            <ul class="text-red-600 list-disc pl-5">
+              {% for error in item_form.notes.errors %}<li>{{ error }}</li>{% endfor %}
+            </ul>
+            {% endif %}
+          </td>
           <td class="px-3 py-2"><button type="button" class="remove-row text-red-600">Remove</button></td>
         </tr>
       {% endfor %}

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -6,7 +6,30 @@
   </h1>
   <form method="post" class="space-y-4">
     {% csrf_token %}
-    {{ form.as_p }}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    {% for field in form %}
+    <div>
+      {{ field.label_tag }}
+      {% if field.field.widget.input_type == "checkbox" %}
+      {{ field.as_widget(attrs={'class': 'rounded border-gray-300'}) }}
+      {% else %}
+      {{ field.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
+      {% endif %}
+      {% if field.errors %}
+      <ul class="text-red-600 list-disc pl-5">
+        {% for error in field.errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+    {% endfor %}
     <div class="flex gap-2">
       <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
       <a href="{% url 'items_list' %}" class="px-4 py-2 border rounded">Cancel</a>

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -6,7 +6,30 @@
   </h1>
   <form method="post" class="space-y-4">
     {% csrf_token %}
-    {{ form.as_p }}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    {% for field in form %}
+    <div>
+      {{ field.label_tag }}
+      {% if field.field.widget.input_type == "checkbox" %}
+      {{ field.as_widget(attrs={'class': 'rounded border-gray-300'}) }}
+      {% else %}
+      {{ field.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
+      {% endif %}
+      {% if field.errors %}
+      <ul class="text-red-600 list-disc pl-5">
+        {% for error in field.errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </div>
+    {% endfor %}
     <div class="flex gap-2">
       <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
       <a href="{% url 'suppliers_list' %}" class="px-4 py-2 border rounded">Cancel</a>


### PR DESCRIPTION
## Summary
- Manually render item, supplier, and indent forms instead of using `form.as_p`
- Apply consistent Tailwind CSS classes to inputs and textareas and display field errors with bullet lists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f46b5776083269dcf59d0f0f70b51