### PR TITLE
Add site-wide stylesheet for consistent typography

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,0 +1,25 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+@import url('../../legacy_streamlit/app/ui/styles.css');
+
+/* Global form styling */
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+input,
+select,
+textarea {
+  font-family: 'Roboto', sans-serif;
+  border: 1px solid #cbd5e0;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.4);
+}

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -1,9 +1,11 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Inventory App</title>
+    <link href="{% static 'css/app.css' %}" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
   </head>


### PR DESCRIPTION
## Summary
- introduce `static/css/app.css` bringing in Roboto and legacy UI styles
- add basic label spacing and input focus styles
- include app stylesheet in base template

## Testing
- `pytest`
- `curl -s http://localhost:8000/ | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689f47d2d4a083268ae29f9a9ea4b481