### PR TITLE
Handle non-numeric stock fields in item view

### DIFF
--- a/inventory/models.py
+++ b/inventory/models.py
@@ -1,6 +1,23 @@
 from django.db import models
 
 
+class CoerceFloatField(models.FloatField):
+    """FloatField that silently coerces invalid values to ``None``."""
+
+    def to_python(self, value):  # type: ignore[override]
+        if value in self.empty_values:
+            return None
+        if isinstance(value, float):
+            return value
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def from_db_value(self, value, expression, connection):  # type: ignore[override]
+        return self.to_python(value)
+
+
 class Item(models.Model):
     item_id = models.AutoField(primary_key=True)
     name = models.TextField(blank=True, null=True)
@@ -9,8 +26,8 @@ class Item(models.Model):
     category = models.TextField(blank=True, null=True)
     sub_category = models.TextField(blank=True, null=True)
     permitted_departments = models.TextField(blank=True, null=True)
-    reorder_point = models.FloatField(blank=True, null=True)
-    current_stock = models.FloatField(blank=True, null=True)
+    reorder_point = CoerceFloatField(blank=True, null=True)
+    current_stock = CoerceFloatField(blank=True, null=True)
     notes = models.TextField(blank=True, null=True)
     is_active = models.BooleanField(blank=True, null=True)
     updated_at = models.TextField(blank=True, null=True)

--- a/tests/test_aa_views.py
+++ b/tests/test_aa_views.py
@@ -81,6 +81,20 @@ def test_item_edit_handles_save_error():
     assert resp.status_code == 200
 
 
+def test_item_edit_handles_non_numeric_values():
+    item = Item.objects.create(name="Flour")
+    with connection.cursor() as cur:
+        cur.execute(
+            "UPDATE items SET reorder_point='abc', current_stock='xyz' WHERE item_id=?",
+            [item.pk],
+        )
+    rf = RequestFactory()
+    request = rf.get(f"/items/{item.pk}/edit/")
+    with patch("inventory.views_ui.render", return_value=HttpResponse()):
+        resp = item_edit(request, pk=item.pk)
+    assert resp.status_code == 200
+
+
 def test_indent_create_atomic_on_error():
     item = Item.objects.create(name="Salt")
     rf = RequestFactory()


### PR DESCRIPTION
## Summary
- replace item numeric fields with custom `CoerceFloatField`
- ensure items with non-numeric stock values render in edit view
- test `item_edit` with previously invalid numeric fields

## Testing
- `flake8 inventory/models.py tests/test_aa_views.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f52a4ae408326b03f706a123e4f81