### PR TITLE
Move unit inference to inventory package and update forms

### DIFF
--- a/inventory/forms.py
+++ b/inventory/forms.py
@@ -10,7 +10,7 @@ from .models import (
     GoodsReceivedNote,
     GRNItem,
 )
-from legacy_streamlit.app.core.unit_inference import infer_units
+from .unit_inference import infer_units
 
 
 class ItemForm(forms.ModelForm):

--- a/inventory/unit_inference.py
+++ b/inventory/unit_inference.py
@@ -1,0 +1,128 @@
+"""Utility to infer sensible units for items.
+
+This module provides a small heuristic function :func:`infer_units` which tries
+to guess an item's base unit and optional purchase unit from its name or
+category.  The goal is not to be perfect but to offer sensible defaults so that
+users can add items quickly without having to manually specify units every
+single time.
+
+The implementation intentionally keeps things lightweight – a couple of keyword
+lookups and fallbacks – so that it remains fast and free from heavy ML
+dependencies.
+"""
+from __future__ import annotations
+
+from typing import Dict, Tuple, Optional
+from pathlib import Path
+import warnings
+
+try:  # yaml is optional but recommended
+    import yaml
+except Exception:  # pragma: no cover - fallback if PyYAML isn't installed
+    yaml = None
+    warnings.warn(
+        "PyYAML not installed; units.yaml overrides will be ignored.",
+        RuntimeWarning,
+    )
+
+# Maps a keyword found in the *item name* to a tuple of (base_unit, purchase_unit)
+_NAME_KEYWORD_MAP: Dict[str, Tuple[str, Optional[str]]] = {
+    # Liquids
+    "milk": ("ltr", "carton"),
+    "water": ("ltr", "bottle"),
+    "oil": ("ltr", "bottle"),
+    # Dry goods
+    "flour": ("kg", "bag"),
+    "rice": ("kg", "bag"),
+    "sugar": ("kg", "bag"),
+    # Proteins / others
+    "egg": ("pcs", "dozen"),
+    "bread": ("pcs", "loaf"),
+    "apple": ("kg", "crate"),
+}
+
+# Fallback mapping based purely on *category* if no keyword matched.
+_CATEGORY_DEFAULT_MAP: Dict[str, Tuple[str, Optional[str]]] = {
+    "dairy": ("ltr", "carton"),
+    "beverage": ("ltr", "bottle"),
+    "beverages": ("ltr", "bottle"),
+    "produce": ("kg", None),
+    "vegetable": ("kg", None),
+    "vegetables": ("kg", None),
+    "baking": ("kg", "bag"),
+    "bakery": ("pcs", "loaf"),
+}
+
+
+def _parse_units(value) -> Tuple[str, Optional[str]]:
+    """Normalize a value from YAML to a ``(base, purchase)`` tuple."""
+
+    if isinstance(value, str):
+        return value, None
+    if isinstance(value, (list, tuple)):
+        base = value[0]
+        purchase = value[1] if len(value) > 1 else None
+        return base, purchase
+    raise ValueError(f"Invalid units mapping: {value!r}")
+
+
+def _load_overrides() -> None:
+    """Load unit mapping overrides from ``units.yaml`` if present."""
+
+    if yaml is None:  # pragma: no cover - PyYAML not installed
+        return  # overrides ignored without PyYAML
+
+    # ``units.yaml`` lives at the project root. ``inventory`` sits one level
+    # beneath it so we only need to traverse up a single parent directory here
+    # (whereas the legacy location was nested deeper).
+    config_path = Path(__file__).resolve().parents[1] / "units.yaml"
+    if not config_path.is_file():
+        return
+    try:
+        data = yaml.safe_load(config_path.read_text()) or {}
+    except Exception:  # pragma: no cover - invalid YAML
+        return
+
+    for key, units in (data.get("name_keywords") or {}).items():
+        _NAME_KEYWORD_MAP[key.lower()] = _parse_units(units)
+
+    for key, units in (data.get("categories") or {}).items():
+        _CATEGORY_DEFAULT_MAP[key.lower()] = _parse_units(units)
+
+
+_load_overrides()
+
+
+def infer_units(name: str, category: str | None) -> tuple[str, str | None]:
+    """Infer base and purchase units for an item.
+
+    Parameters
+    ----------
+    name:
+        The name of the item. Keyword heuristics are applied on the lowercase
+        name.
+    category:
+        Optional category for the item. Used as a secondary signal when the
+        name alone is not sufficient.
+
+    Returns
+    -------
+    tuple[str, str | None]
+        A tuple containing the inferred base unit and, if applicable, the
+        purchase unit.  If no specific match is found, defaults to ``("pcs",
+        None)``.
+    """
+
+    name_l = (name or "").lower()
+    category_l = (category or "").lower()
+
+    for keyword, units in _NAME_KEYWORD_MAP.items():
+        if keyword in name_l:
+            return units
+
+    for cat, units in _CATEGORY_DEFAULT_MAP.items():
+        if category_l == cat:
+            return units
+
+    # Generic fallback – assume individual pieces with no purchase unit.
+    return "pcs", None


### PR DESCRIPTION
## Summary
- Add `inventory/unit_inference.py` ported from the legacy Streamlit app
- Update inventory forms to import `infer_units` from the new module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f6dbe7978832697ae2501599153b2