### PR TITLE
refactor: drop app alias and fix imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To extend the behaviour programmatically, edit `app/core/unit_inference.py`:
 ### Example
 
 ```python
-from app.services.item_service import add_new_item
+from inventory.services.item_service import add_new_item
 
 # base_unit becomes 'ltr' and purchase_unit 'carton'
 success, msg = add_new_item(engine, {"name": "Whole Milk", "category": "Dairy"})

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,0 @@
-"""Compatibility package mapping to legacy_streamlit.app.* modules."""
-from importlib import import_module
-import sys
-
-for _pkg in ("core", "services", "ui", "db", "config"):
-    module = import_module(f"legacy_streamlit.app.{_pkg}")
-    sys.modules[f"{__name__}.{_pkg}"] = module

--- a/legacy_streamlit/app/db/database_utils.py
+++ b/legacy_streamlit/app/db/database_utils.py
@@ -23,8 +23,8 @@ from sqlalchemy.engine import Engine, Connection
 import pandas as pd
 from typing import Any, Optional, Dict, Tuple
 
-from app.core.logging import get_logger
-from app.config import load_db_config
+from ..core.logging import get_logger
+from ..config import load_db_config
 
 logger = get_logger(__name__)
 

--- a/legacy_streamlit/app/item_manager_app.py
+++ b/legacy_streamlit/app/item_manager_app.py
@@ -11,7 +11,7 @@ _REPO_ROOT = os.path.abspath(os.path.join(_CURRENT_DIR, os.pardir))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-from app.core.logging import configure_logging, flush_logs, LOG_FILE
+from .core.logging import configure_logging, flush_logs, LOG_FILE
 
 # Configure logging before importing modules that use it
 configure_logging()
@@ -19,19 +19,19 @@ configure_logging()
 import streamlit as st
 import pandas as pd
 from datetime import datetime
-from app.ui.theme import load_css, render_sidebar_logo
-from app.ui.navigation import render_sidebar_nav
-from app.ui.helpers import read_recent_logs
+from .ui.theme import load_css, render_sidebar_logo
+from .ui.navigation import render_sidebar_nav
+from .ui.helpers import read_recent_logs
 
 # --- Import from our new/refactored modules ---
-from app.core.constants import STATUS_SUBMITTED
-from app.db.database_utils import connect_db
-from app.services import item_service
-from app.services import supplier_service
-from app.services import indent_service
-from app.auth.auth import login_sidebar
+from .core.constants import STATUS_SUBMITTED
+from .db.database_utils import connect_db
+from .services import item_service
+from .services import supplier_service
+from .services import indent_service
+from .auth.auth import login_sidebar
 
-# STATUS_SUBMITTED is already imported from app.core.constants above, no need to re-import separately
+# STATUS_SUBMITTED is already imported from core.constants above, no need to re-import separately
 
 # NOTE: Item Master functions and Department Helper functions have been MOVED to app/services/item_service.py
 

--- a/legacy_streamlit/app/pages/1_Items.py
+++ b/legacy_streamlit/app/pages/1_Items.py
@@ -11,9 +11,9 @@ _REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-from app.ui.theme import load_css, render_sidebar_logo
-from app.ui.navigation import render_sidebar_nav
-from app.ui import (
+from ..ui.theme import load_css, render_sidebar_logo
+from ..ui.navigation import render_sidebar_nav
+from ..ui import (
     pagination_controls,
     render_search_toggle,
     show_success,
@@ -22,10 +22,10 @@ from app.ui import (
 )
 
 try:
-    from app.db.database_utils import connect_db
-    from app.services import item_service
-    from app.core.constants import FILTER_ALL_CATEGORIES, FILTER_ALL_SUBCATEGORIES
-    from app.core.unit_inference import infer_units
+    from ..db.database_utils import connect_db
+    from ..services import item_service
+    from ..core.constants import FILTER_ALL_CATEGORIES, FILTER_ALL_SUBCATEGORIES
+    from ..core.unit_inference import infer_units
 except ImportError as e:
     show_error(f"Import error in 1_Items.py: {e}.")
     st.stop()

--- a/legacy_streamlit/app/pages/2_Suppliers.py
+++ b/legacy_streamlit/app/pages/2_Suppliers.py
@@ -11,9 +11,9 @@ _REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-from app.ui.theme import load_css, render_sidebar_logo
-from app.ui.navigation import render_sidebar_nav
-from app.ui import (
+from ..ui.theme import load_css, render_sidebar_logo
+from ..ui.navigation import render_sidebar_nav
+from ..ui import (
     pagination_controls,
     render_search_toggle,
     show_success,
@@ -22,12 +22,12 @@ from app.ui import (
 )
 
 try:
-    from app.db.database_utils import connect_db
-    from app.services import supplier_service
+    from ..db.database_utils import connect_db
+    from ..services import supplier_service
 
     # No specific UI placeholders from constants.py are heavily used here yet,
     # but good to keep imports organized if they are added later.
-    # from app.core.constants import SOME_CONSTANT
+    # from ..core.constants import SOME_CONSTANT
 except ImportError as e:
     show_error(f"Import error in 2_Suppliers.py: {e}.")
     st.stop()

--- a/legacy_streamlit/app/pages/3_Stock_Movements.py
+++ b/legacy_streamlit/app/pages/3_Stock_Movements.py
@@ -12,19 +12,19 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 try:
-    from app.db.database_utils import connect_db
-    from app.services import item_service
-    from app.services import stock_service
-    from app.auth.auth import get_current_user_id
-    from app.core.constants import (
+    from ..db.database_utils import connect_db
+    from ..services import item_service
+    from ..services import stock_service
+    from ..auth.auth import get_current_user_id
+    from ..core.constants import (
         TX_RECEIVING,
         TX_ADJUSTMENT,
         TX_WASTAGE,
         PLACEHOLDER_SELECT_ITEM,
     )
-    from app.ui.theme import load_css, render_sidebar_logo
-    from app.ui.navigation import render_sidebar_nav
-    from app.ui import show_success, show_error, show_warning
+    from ..ui.theme import load_css, render_sidebar_logo
+    from ..ui.navigation import render_sidebar_nav
+    from ..ui import show_success, show_error, show_warning
 except ImportError as e:
     show_error(f"Import error in 3_Stock_Movements.py: {e}.")
     st.stop()

--- a/legacy_streamlit/app/pages/4_History_Reports.py
+++ b/legacy_streamlit/app/pages/4_History_Reports.py
@@ -13,10 +13,10 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 try:
-    from app.db.database_utils import connect_db
-    from app.services import item_service
-    from app.services import stock_service
-    from app.core.constants import (
+    from ..db.database_utils import connect_db
+    from ..services import item_service
+    from ..services import stock_service
+    from ..core.constants import (
         TX_RECEIVING,
         TX_ADJUSTMENT,
         TX_WASTAGE,
@@ -25,9 +25,9 @@ try:
         PLACEHOLDER_SELECT_ITEM,
         FILTER_ALL_TYPES,
     )
-    from app.ui.theme import load_css, render_sidebar_logo
-    from app.ui.navigation import render_sidebar_nav
-    from app.ui import show_success, show_error, show_warning
+    from ..ui.theme import load_css, render_sidebar_logo
+    from ..ui.navigation import render_sidebar_nav
+    from ..ui import show_success, show_error, show_warning
 except ImportError as e:
     show_error(f"Import error in 4_History_Reports.py: {e}.")
     st.stop()

--- a/legacy_streamlit/app/pages/5_Indents.py
+++ b/legacy_streamlit/app/pages/5_Indents.py
@@ -18,11 +18,11 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 try:
-    from app.db.database_utils import connect_db
-    from app.services import item_service
-    from app.services import indent_service
-    from app.auth.auth import get_current_user_id
-    from app.core.constants import (
+    from ..db.database_utils import connect_db
+    from ..services import item_service
+    from ..services import indent_service
+    from ..auth.auth import get_current_user_id
+    from ..core.constants import (
         ALL_INDENT_STATUSES,
         STATUS_SUBMITTED,
         STATUS_PROCESSING,
@@ -41,10 +41,10 @@ try:
         PLACEHOLDER_NO_ITEMS_AVAILABLE,  # If applicable for item lists
         PLACEHOLDER_ERROR_LOADING_ITEMS,  # If applicable
     )
-    from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
-    from app.ui.navigation import render_sidebar_nav
-    from app.ui import show_success, show_error, show_warning
-    from app.ui.choices import build_component_options
+    from ..ui.theme import load_css, format_status_badge, render_sidebar_logo
+    from ..ui.navigation import render_sidebar_nav
+    from ..ui import show_success, show_error, show_warning
+    from ..ui.choices import build_component_options
 except ImportError as e:
     show_error(
         "Import error in 5_Indents.py: "

--- a/legacy_streamlit/app/pages/6_Purchase_Orders.py
+++ b/legacy_streamlit/app/pages/6_Purchase_Orders.py
@@ -15,21 +15,21 @@ if _REPO_ROOT not in sys.path:
 
 # --- Assuming your project structure for imports ---
 try:
-    from app.db.database_utils import connect_db
-    from app.services import purchase_order_service
-    from app.services import supplier_service
-    from app.services import item_service
-    from app.services import goods_receiving_service
-    from app.auth.auth import get_current_user_id
-    from app.core.constants import (
+    from ..db.database_utils import connect_db
+    from ..services import purchase_order_service
+    from ..services import supplier_service
+    from ..services import item_service
+    from ..services import goods_receiving_service
+    from ..auth.auth import get_current_user_id
+    from ..core.constants import (
         ALL_PO_STATUSES,
         PO_STATUS_DRAFT,
         PO_STATUS_ORDERED,
         PO_STATUS_PARTIALLY_RECEIVED,
     )
-    from app.ui.theme import load_css, format_status_badge, render_sidebar_logo
-    from app.ui.navigation import render_sidebar_nav
-    from app.ui import show_success, show_error, show_warning
+    from ..ui.theme import load_css, format_status_badge, render_sidebar_logo
+    from ..ui.navigation import render_sidebar_nav
+    from ..ui import show_success, show_error, show_warning
 except ImportError as e:
     show_error(
         f"Import error in 6_Purchase_Orders.py: {e}. Please ensure all modules are correctly placed."

--- a/legacy_streamlit/app/pages/7_Recipes.py
+++ b/legacy_streamlit/app/pages/7_Recipes.py
@@ -13,16 +13,16 @@ _REPO_ROOT = os.path.abspath(os.path.join(_CUR_DIR, os.pardir, os.pardir))
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
-from app.ui.theme import load_css, render_sidebar_logo
-from app.ui.navigation import render_sidebar_nav
-from app.ui import show_success, show_error, show_warning
-from app.ui.helpers import autofill_component_meta
-from app.ui.choices import build_component_options
+from ..ui.theme import load_css, render_sidebar_logo
+from ..ui.navigation import render_sidebar_nav
+from ..ui import show_success, show_error, show_warning
+from ..ui.helpers import autofill_component_meta
+from ..ui.choices import build_component_options
 
 try:
-    from app.db.database_utils import connect_db
-    from app.services import recipe_service, item_service
-    from app.core.constants import PLACEHOLDER_SELECT_COMPONENT
+    from ..db.database_utils import connect_db
+    from ..services import recipe_service, item_service
+    from ..core.constants import PLACEHOLDER_SELECT_COMPONENT
 except ImportError as e:
     show_error(f"Import error in 7_Recipes.py: {e}.")
     st.stop()

--- a/legacy_streamlit/app/services/goods_receiving_service.py
+++ b/legacy_streamlit/app/services/goods_receiving_service.py
@@ -9,11 +9,11 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.engine import Engine
 
-from app.core.logging import get_logger
-from app.db.database_utils import fetch_data
-from app.services import stock_service
-from app.services import purchase_order_service
-from app.core.constants import (
+from ..core.logging import get_logger
+from ..db.database_utils import fetch_data
+from . import stock_service
+from . import purchase_order_service
+from ..core.constants import (
     TX_RECEIVING,
     PO_STATUS_PARTIALLY_RECEIVED,
     PO_STATUS_FULLY_RECEIVED,

--- a/legacy_streamlit/app/services/indent_service.py
+++ b/legacy_streamlit/app/services/indent_service.py
@@ -10,9 +10,9 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.engine import Engine, Connection
 
 
-from app.core.logging import get_logger
-from app.db.database_utils import fetch_data
-from app.core.constants import (
+from ..core.logging import get_logger
+from ..db.database_utils import fetch_data
+from ..core.constants import (
     STATUS_SUBMITTED,
     STATUS_PROCESSING,
     STATUS_COMPLETED,
@@ -23,8 +23,8 @@ from app.core.constants import (
     ITEM_STATUS_CANCELLED_ITEM,
     TX_INDENT_FULFILL,
 )
-from app.services import item_service
-from app.services import stock_service
+from . import item_service
+from . import stock_service
 
 logger = get_logger(__name__)
 

--- a/legacy_streamlit/app/services/item_service.py
+++ b/legacy_streamlit/app/services/item_service.py
@@ -10,9 +10,9 @@ from sqlalchemy import text, bindparam
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.engine import Engine
 
-from app.core.logging import get_logger
-from app.db.database_utils import fetch_data
-from app.core.unit_inference import infer_units
+from ..core.logging import get_logger
+from ..db.database_utils import fetch_data
+from ..core.unit_inference import infer_units
 
 logger = get_logger(__name__)
 

--- a/legacy_streamlit/app/services/purchase_order_service.py
+++ b/legacy_streamlit/app/services/purchase_order_service.py
@@ -9,9 +9,9 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.engine import Engine
 
-from app.core.logging import get_logger
-from app.db.database_utils import fetch_data
-from app.core.constants import (
+from ..core.logging import get_logger
+from ..db.database_utils import fetch_data
+from ..core.constants import (
     PO_STATUS_DRAFT,
     PO_STATUS_ORDERED,
     PO_STATUS_FULLY_RECEIVED,

--- a/legacy_streamlit/app/services/recipe_service.py
+++ b/legacy_streamlit/app/services/recipe_service.py
@@ -7,9 +7,9 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.engine import Engine, Connection
 
-from app.core.logging import get_logger
-from app.db.database_utils import fetch_data
-from app.core.constants import TX_SALE
+from ..core.logging import get_logger
+from ..db.database_utils import fetch_data
+from ..core.constants import TX_SALE
 from . import stock_service
 
 logger = get_logger(__name__)

--- a/legacy_streamlit/app/services/stock_service.py
+++ b/legacy_streamlit/app/services/stock_service.py
@@ -8,11 +8,11 @@ from . import cache_data
 from sqlalchemy import text, exc as sqlalchemy_exc
 from sqlalchemy.engine import Engine, Connection
 
-from app.core.logging import get_logger
-from app.db.database_utils import fetch_data
+from ..core.logging import get_logger
+from ..db.database_utils import fetch_data
 
 # Assuming item_service might be needed for future validation or fetching item names, though not directly used in current functions
-# from app.services import item_service
+# from . import item_service
 
 logger = get_logger(__name__)
 
@@ -182,7 +182,7 @@ def record_stock_transaction(
             return False
 
         # Clear relevant caches that depend on stock levels or transaction history
-        # Example: from app.services import item_service (if item_service had relevant caches)
+        # Example: from . import item_service (if item_service had relevant caches)
         # item_service.get_all_items_with_stock.clear() # Assuming get_all_items_with_stock is affected
         get_stock_transactions.clear()  # Defined below, depends on this data
 
@@ -190,7 +190,7 @@ def record_stock_transaction(
         # This requires item_service to be imported.
         # For loose coupling, this clear could be signaled differently, but for now, direct clear is acceptable.
         try:
-            from app.services import item_service
+            from . import item_service
 
             item_service.get_all_items_with_stock.clear()
         except ImportError:
@@ -380,7 +380,7 @@ def remove_stock_transactions_bulk(
         # Clear caches that depend on these tables
         get_stock_transactions.clear()
         try:
-            from app.services import item_service
+            from . import item_service
 
             item_service.get_all_items_with_stock.clear()
         except ImportError:

--- a/legacy_streamlit/app/services/supplier_service.py
+++ b/legacy_streamlit/app/services/supplier_service.py
@@ -8,8 +8,8 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.engine import Engine
 
-from app.core.logging import get_logger
-from app.db.database_utils import fetch_data
+from ..core.logging import get_logger
+from ..db.database_utils import fetch_data
 
 logger = get_logger(__name__)
 

--- a/legacy_streamlit/app/ui/helpers.py
+++ b/legacy_streamlit/app/ui/helpers.py
@@ -4,7 +4,7 @@ from typing import List, Tuple, Dict, Any
 import pandas as pd
 import streamlit as st
 
-from app.core.logging import LOG_FILE
+from ..core.logging import LOG_FILE
 
 
 def read_recent_logs(limit: int = 100, log_file: str | Path = LOG_FILE) -> str:

--- a/legacy_streamlit/app/ui/navigation.py
+++ b/legacy_streamlit/app/ui/navigation.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from app.core.logging import flush_logs
+from ..core.logging import flush_logs
 
 
 def render_sidebar_nav(include_clear_logs_button: bool = True) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-from app.core.logging import configure_logging
+from legacy_streamlit.app.core.logging import configure_logging
 
 # Configure logging for tests once before other modules import loggers
 configure_logging()

--- a/tests/test_autofill_component_meta.py
+++ b/tests/test_autofill_component_meta.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from app.ui.helpers import autofill_component_meta
+from legacy_streamlit.app.ui.helpers import autofill_component_meta
 
 
 def test_autofill_component_meta_populates_unit_and_category():

--- a/tests/test_logging_retention.py
+++ b/tests/test_logging_retention.py
@@ -19,7 +19,7 @@ def test_purge_old_logs(tmp_path, monkeypatch):
     monkeypatch.setenv("LOG_FILE", str(log_file))
     monkeypatch.setenv("LOG_RETENTION_DAYS", "7")
 
-    import app.core.logging as logging_mod
+    import legacy_streamlit.app.core.logging as logging_mod
     importlib.reload(logging_mod)
 
     logging_mod.configure_logging()

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -3,7 +3,7 @@
 import pytest
 from sqlalchemy import text
 
-from app.services import recipe_service
+from legacy_streamlit.app.services import recipe_service
 
 
 def _create_item(conn, name="Flour", base_unit="kg", purchase_unit="bag", stock=20):

--- a/tests/test_recipes_components.py
+++ b/tests/test_recipes_components.py
@@ -1,6 +1,6 @@
 import pandas as pd
-from app.services import recipe_service
-from app.core.constants import PLACEHOLDER_SELECT_COMPONENT
+from legacy_streamlit.app.services import recipe_service
+from legacy_streamlit.app.core.constants import PLACEHOLDER_SELECT_COMPONENT
 
 def test_build_components_autofill_and_validation():
     df = pd.DataFrame([

--- a/tests/test_stock_service.py
+++ b/tests/test_stock_service.py
@@ -1,6 +1,6 @@
 from sqlalchemy import text
 
-from app.services import stock_service
+from legacy_streamlit.app.services import stock_service
 
 
 def test_record_stock_transaction_updates_stock_and_logs(sqlite_engine):

--- a/tests/test_supplier_service.py
+++ b/tests/test_supplier_service.py
@@ -1,6 +1,6 @@
 from sqlalchemy import text
 
-from app.services import supplier_service
+from legacy_streamlit.app.services import supplier_service
 
 
 

--- a/tests/test_ui_choices.py
+++ b/tests/test_ui_choices.py
@@ -1,4 +1,4 @@
-from app.ui.choices import build_component_options
+from legacy_streamlit.app.ui.choices import build_component_options
 
 
 def test_build_component_options_basic():


### PR DESCRIPTION
## Summary
- remove compatibility package `app` now that modules live under new packages
- update remaining imports to use `legacy_streamlit` or project modules directly
- adjust docs to reference new module paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f7b14a81083268d80aadd2836cf3d