### PR TITLE
docs: document Django usage and devcontainer runserver

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,7 @@
   "customizations": {
     "codespaces": {
       "openFiles": [
-        "README.md",
-        "app/item_manager_app.py"
+        "README.md"
       ]
     },
     "vscode": {
@@ -17,17 +16,17 @@
       ]
     }
   },
-  "updateContentCommand": "[ -f packages.txt ] && sudo apt update && sudo apt upgrade -y && sudo xargs apt install -y <packages.txt; [ -f requirements.txt ] && pip3 install --user -r requirements.txt; pip3 install --user streamlit; echo '✅ Packages installed and Requirements met'",
+  "updateContentCommand": "[ -f packages.txt ] && sudo apt update && sudo apt upgrade -y && sudo xargs apt install -y <packages.txt; [ -f requirements.txt ] && pip3 install --user -r requirements.txt; echo '✅ Packages installed and requirements met'",
   "postAttachCommand": {
-    "server": "streamlit run app/item_manager_app.py --server.enableCORS false --server.enableXsrfProtection false"
+    "server": "python manage.py runserver 0.0.0.0:8000"
   },
   "portsAttributes": {
-    "8501": {
+    "8000": {
       "label": "Application",
       "onAutoForward": "openPreview"
     }
   },
   "forwardPorts": [
-    8501
+    8000
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-# Streamlit secrets
-.streamlit/secrets.toml
-
-# Django environment variables
+# Environment-based configuration
 .env
 
 # Python virtual environment

--- a/README.md
+++ b/README.md
@@ -1,24 +1,47 @@
 # Inventory-App
 
-Inventory-App is a Streamlit application for managing restaurant inventory. It helps track items, suppliers, stock movements and more using a PostgreSQL database.
+Inventory-App is a Django application for managing restaurant inventory with a PostgreSQL database.
 
 ## Features
 
 - Item and supplier management
 - Stock movement logging and history reports
-- Indents and purchase order tracking
+- Indent and purchase order tracking
 - Dashboard showing key metrics such as low-stock items
-- Unified sidebar navigation for quick access to all pages
 - Automatic unit inference so new items get sensible base and purchase units
 - Bulk upload items and stock transactions from CSV files
 
-## Changelog
+## Installation
 
-- Recipes editor now reuses the Indents item selector and supports selecting stock items or sub-recipes with automatic unit and category population.
+Install dependencies using `pip`:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Configuration is controlled via environment variables. Copy `.env.example` to `.env` and set values for your database and other settings:
+
+```bash
+cp .env.example .env
+# edit .env with your configuration
+```
+
+You can also set these values directly in the environment instead of using a `.env` file.
+
+## Running
+
+Apply database migrations and launch the Django development server:
+
+```bash
+python manage.py migrate
+python manage.py runserver
+```
 
 ## Unit Inference
 
-The app includes a lightweight **unit inference module** that guesses an item's base unit (e.g. `kg`, `ltr`, `pcs`) and optional purchase unit from its name or category. This removes the need for a separate database table of units – when a new item is added, the service automatically assigns sensible defaults so users don't have to enter them manually.
+The project includes a lightweight **unit inference module** that guesses an item's base unit (e.g. `kg`, `ltr`, `pcs`) and optional purchase unit from its name or category. This removes the need for a separate database table of units – when a new item is added, the service automatically assigns sensible defaults so users don't have to enter them manually.
 
 You can override or extend these heuristics without touching the code by creating a `units.yaml` file in the project root. The file accepts two sections – `name_keywords` and `categories` – whose entries override the default mappings:
 
@@ -29,7 +52,7 @@ categories:
   spices: ["g", "jar"]
 ```
 
-To extend the behaviour programmatically, edit `app/core/unit_inference.py`:
+To extend the behaviour programmatically, edit `inventory/unit_inference.py`:
 
 * Add keywords to the `_NAME_KEYWORD_MAP` for name-based matches.
 * Add categories to `_CATEGORY_DEFAULT_MAP` for category-based defaults.
@@ -44,122 +67,3 @@ from inventory.services.item_service import add_new_item
 success, msg = add_new_item(engine, {"name": "Whole Milk", "category": "Dairy"})
 ```
 
-## Installation
-
-Install dependencies using `pip`:
-
-```bash
-pip install -r requirements.txt
-```
-
-## Running
-
-Launch the Streamlit app from the repository root:
-
-```bash
-streamlit run app/item_manager_app.py
-```
-
-### Django development server
-
-```bash
-pip install -r requirements.txt
-cp .env.example .env  # set your values
-python manage.py migrate
-python manage.py runserver
-```
-
-## Configuration
-
-Before running the app, create a `.streamlit/secrets.toml` file containing your database credentials. An example file can be found at `.streamlit/secrets.toml` in this repository—copy it and replace the placeholder values with your own. The committed sample uses obvious placeholders so you must supply real values.
-
-Alternatively you can provide the database settings via environment variables. If the following variables are set, they will be used instead of the values in `secrets.toml`:
-
-```
-DB_ENGINE
-DB_USER
-DB_PASSWORD
-DB_HOST
-DB_PORT
-DB_NAME
-```
-
-### Logging
-
-Logging output is written to a rotating file handler (`app.log` by default).
-You can control verbosity, log file location, and retention with environment variables:
-
-- `LOG_LEVEL` – set the minimum log level (`DEBUG`, `INFO`, etc.). Defaults to
-  `INFO`.
-- `LOG_FILE` – path to the log file. Defaults to `app.log` in the project root.
-- `LOG_RETENTION_DAYS` – number of days to keep rotated log files. Defaults to
-  `30`.
-
-Example `.env` entries:
-
-```
-LOG_LEVEL=INFO
-LOG_FILE=app.log
-LOG_RETENTION_DAYS=30
-```
-
-Rotated logs older than the retention period are removed when logging is configured.
-Call `flush_logs()` from `app.core.logging` to truncate the current log file when
-needed.
-
-## Customizing the Sidebar Logo
-
-The sidebar image displayed in the app is defined in `app/ui/logo.py` as a base64 encoded PNG. To use your own logo:
-
-1. Convert your PNG image to a base64 string:
-
-   ```python
-   import base64
-
-   with open("my_logo.png", "rb") as f:
-       print(base64.b64encode(f.read()).decode())
-   ```
-
-2. Replace the `LOGO_BASE64` value in `app/ui/logo.py` with the string printed above.
-
-Restart the application and your logo will appear in the sidebar.
-
-## Bulk Uploading Data
-
-The app supports uploading multiple records at once using CSV files.
-
-### Items
-
-On the **Item Master Management** page open the *Bulk Upload Items* expander and
-upload a CSV containing columns such as:
-
-```
-name,base_unit,purchase_unit,category,sub_category,permitted_departments,reorder_point,current_stock,notes,is_active
-```
-
-Example:
-
-```csv
-name,base_unit,purchase_unit,category,sub_category,permitted_departments,reorder_point,current_stock,notes,is_active
-Tomato,kg,,Vegetables,Fresh,KITCHEN,10,0,Fresh tomatoes,True
-```
-
-### Stock Transactions
-
-On the **Stock Movements Log** page use the *Bulk Upload Stock Transactions*
-expander and provide a CSV with columns:
-
-```
-item_id,quantity_change,transaction_type,user_id,notes
-```
-
-Example:
-
-```csv
-item_id,quantity_change,transaction_type,user_id,notes
-1,5,RECEIVING,manager,Initial stock
-2,-2,WASTAGE,chef,Expired batch
-```
-
-After the upload the app reports how many rows succeeded and lists any errors
-for rows that could not be processed.


### PR DESCRIPTION
## Summary
- Rewrote README to describe Django app usage, documenting environment-based configuration and `python manage.py runserver`.
- Simplified devcontainer to install Django requirements and launch the development server on port 8000.
- Dropped `.streamlit/secrets.toml` from `.gitignore` in favor of `.env`-driven configuration.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f7d28dfb88326b0c2c4f53d7c29ac