### PR TITLE
refactor: modularize styles and remove streamlit css

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,38 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
-/* General layout */
-:root {
-    /* Increase the default sidebar width to prevent text wrapping */
-    --sidebar-width: 12rem;
-}
 
 body { font-family: 'Roboto', sans-serif; }
-
-.sidebar .sidebar-content {
-    background-color: #f0f2f6;
-}
-
-/* Compact sidebar layout */
-[data-testid="stSidebar"] {
-    width: var(--sidebar-width);
-    min-width: var(--sidebar-width); /* keep navigation items on one line */
-}
-[data-testid="stSidebar"] .sidebar-content {
-    padding: 0.5rem;
-}
-[data-testid="stSidebar"] img {
-    margin-top: -0.5rem;
-    margin-bottom: 0.5rem;
-}
 
 /* Status badge classes */
 .badge-success { background: #21ba45; color: white; padding: 2px 6px; border-radius: 4px; }
 .badge-warning { background: #f2c037; color: black; padding: 2px 6px; border-radius: 4px; }
 .badge-error   { background: #db2828; color: white; padding: 2px 6px; border-radius: 4px; }
-
-/* Hide Streamlit's built-in page navigation so only custom links show */
-[data-testid="stSidebarNav"] {
-    display: none;
-}
 
 /* Responsive typography */
 @media (max-width: 768px) {
@@ -50,47 +23,7 @@ body { font-family: 'Roboto', sans-serif; }
         color: #ffffff;
     }
 
-    .sidebar .sidebar-content {
-        background-color: #0e1117;
-    }
-
     .badge-success { background: #27963c; color: white; }
     .badge-warning { background: #e0b437; color: black; }
     .badge-error   { background: #cc0000; color: white; }
-}
-
-/* Tighten spacing for sidebar navigation items */
-[data-testid="stSidebarNav"] li,
-[data-testid="stSidebarNavLink"] {
-    margin: 0.125rem 0;
-    padding: 0.125rem 0.5rem;
-}
-
-/* High contrast styling for dropdowns in data editors */
-div[data-testid="stDataEditor"] select {
-    background-color: #004085;
-    color: #ffffff;
-}
-
-/* Global form styling */
-label {
-  display: block;
-  margin-bottom: 0.5rem;
-}
-
-input,
-select,
-textarea {
-  font-family: 'Roboto', sans-serif;
-  border: 1px solid #cbd5e0;
-  padding: 0.5rem;
-  border-radius: 0.25rem;
-}
-
-input:focus,
-select:focus,
-textarea:focus {
-  outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.4);
 }

--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -1,0 +1,30 @@
+/* Form component styles */
+form label {
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+form input:not([type="checkbox"]):not([type="radio"]),
+form select,
+form textarea,
+.form-control {
+    font-family: 'Roboto', sans-serif;
+    border: 1px solid #cbd5e0;
+    padding: 0.5rem;
+    border-radius: 0.25rem;
+    width: 100%;
+}
+
+form input:not([type="checkbox"]):not([type="radio"]):focus,
+form select:focus,
+form textarea:focus,
+.form-control:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.4);
+}
+
+.form-checkbox {
+    border: 1px solid #cbd5e0;
+    border-radius: 0.25rem;
+}

--- a/static/css/tables.css
+++ b/static/css/tables.css
@@ -1,0 +1,16 @@
+/* Table component styles */
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    border: 1px solid #e5e7eb;
+    padding: 0.5rem 1rem;
+    text-align: left;
+}
+
+.table thead {
+    background-color: #f9fafb;
+}

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Inventory App</title>
     <link href="{% static 'css/app.css' %}" rel="stylesheet">
+    <link href="{% static 'css/forms.css' %}" rel="stylesheet">
+    <link href="{% static 'css/tables.css' %}" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
   </head>

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -1,27 +1,27 @@
 <div class="overflow-x-auto">
-  <table class="min-w-full border divide-y">
+  <table class="table">
     <thead>
-      <tr class="bg-gray-50">
-        <th class="px-3 py-2 text-left">ID</th>
-        <th class="px-3 py-2 text-left">MRN</th>
-        <th class="px-3 py-2 text-left">Requested By</th>
-        <th class="px-3 py-2 text-left">Department</th>
-        <th class="px-3 py-2 text-left">Status</th>
-        <th class="px-3 py-2 text-left">Actions</th>
+      <tr>
+        <th>ID</th>
+        <th>MRN</th>
+        <th>Requested By</th>
+        <th>Department</th>
+        <th>Status</th>
+        <th>Actions</th>
       </tr>
     </thead>
-    <tbody class="divide-y">
+    <tbody>
       {% for row in page_obj %}
       <tr>
-        <td class="px-3 py-2">{{ row.indent_id }}</td>
-        <td class="px-3 py-2">{{ row.mrn }}</td>
-        <td class="px-3 py-2">{{ row.requested_by }}</td>
-        <td class="px-3 py-2">{{ row.department }}</td>
-        <td class="px-3 py-2"><span class="px-2 py-1 rounded {{ badges[row.status|upper] }}">{{ row.status }}</span></td>
-        <td class="px-3 py-2"><a href="{% url 'indent_detail' row.indent_id %}" class="text-blue-600">View</a></td>
+        <td>{{ row.indent_id }}</td>
+        <td>{{ row.mrn }}</td>
+        <td>{{ row.requested_by }}</td>
+        <td>{{ row.department }}</td>
+        <td><span class="px-2 py-1 rounded {{ badges[row.status|upper] }}">{{ row.status }}</span></td>
+        <td><a href="{% url 'indent_detail' row.indent_id %}" class="text-blue-600">View</a></td>
       </tr>
       {% empty %}
-      <tr><td class="px-3 py-4" colspan="6">No indents found.</td></tr>
+      <tr><td colspan="6" class="p-2">No indents found.</td></tr>
       {% endfor %}
     </tbody>
   </table>

--- a/templates/inventory/_item_suggest_fields.html
+++ b/templates/inventory/_item_suggest_fields.html
@@ -1,3 +1,3 @@
-<input type="text" name="base_unit" value="{{ base }}" id="id_base_unit" class="block w-full rounded border-gray-300 p-2" hx-swap-oob="true">
-<input type="text" name="purchase_unit" value="{{ purchase }}" id="id_purchase_unit" class="block w-full rounded border-gray-300 p-2" hx-swap-oob="true">
-<input type="text" name="category" value="{{ category }}" id="id_category" class="block w-full rounded border-gray-300 p-2" hx-swap-oob="true">
+<input type="text" name="base_unit" value="{{ base }}" id="id_base_unit" class="form-control" hx-swap-oob="true">
+<input type="text" name="purchase_unit" value="{{ purchase }}" id="id_purchase_unit" class="form-control" hx-swap-oob="true">
+<input type="text" name="category" value="{{ category }}" id="id_category" class="form-control" hx-swap-oob="true">

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,33 +1,33 @@
 <div class="overflow-x-auto">
-  <table class="min-w-full border divide-y">
+  <table class="table">
     <thead>
-      <tr class="bg-gray-50">
-        <th class="px-3 py-2 text-left">ID</th>
-        <th class="px-3 py-2 text-left">Name</th>
-        <th class="px-3 py-2 text-left">Base Unit</th>
-        <th class="px-3 py-2 text-left">Category</th>
-        <th class="px-3 py-2 text-left">Subcategory</th>
-        <th class="px-3 py-2 text-right">Current Stock</th>
-        <th class="px-3 py-2 text-right">Reorder Point</th>
-        <th class="px-3 py-2 text-left">Active</th>
-        <th class="px-3 py-2 text-left">Actions</th>
+      <tr>
+        <th>ID</th>
+        <th>Name</th>
+        <th>Base Unit</th>
+        <th>Category</th>
+        <th>Subcategory</th>
+        <th>Current Stock</th>
+        <th>Reorder Point</th>
+        <th>Active</th>
+        <th>Actions</th>
       </tr>
     </thead>
-    <tbody class="divide-y">
+    <tbody>
       {% for row in page_obj %}
       <tr>
-        <td class="px-3 py-2">{{ row.item_id }}</td>
-        <td class="px-3 py-2">{{ row.name }}</td>
-        <td class="px-3 py-2">{{ row.base_unit }}</td>
-        <td class="px-3 py-2">{{ row.category }}</td>
-        <td class="px-3 py-2">{{ row.sub_category }}</td>
-        <td class="px-3 py-2 text-right">{{ row.current_stock }}</td>
-        <td class="px-3 py-2 text-right">{{ row.reorder_point }}</td>
-        <td class="px-3 py-2">{{ row.is_active }}</td>
-        <td class="px-3 py-2"><a href="{% url 'item_edit' row.item_id %}" class="text-blue-600">Edit</a></td>
+        <td>{{ row.item_id }}</td>
+        <td>{{ row.name }}</td>
+        <td>{{ row.base_unit }}</td>
+        <td>{{ row.category }}</td>
+        <td>{{ row.sub_category }}</td>
+        <td class="text-right">{{ row.current_stock }}</td>
+        <td class="text-right">{{ row.reorder_point }}</td>
+        <td>{{ row.is_active }}</td>
+        <td><a href="{% url 'item_edit' row.item_id %}" class="text-blue-600">Edit</a></td>
       </tr>
       {% empty %}
-      <tr><td class="px-3 py-4" colspan="8">No items found.</td></tr>
+      <tr><td colspan="8" class="p-2">No items found.</td></tr>
       {% endfor %}
     </tbody>
   </table>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -1,33 +1,33 @@
 <div class="overflow-x-auto">
-  <table class="min-w-full border divide-y">
+  <table class="table">
     <thead>
-      <tr class="bg-gray-50">
-        <th class="px-3 py-2 text-left">ID</th>
-        <th class="px-3 py-2 text-left">Name</th>
-        <th class="px-3 py-2 text-left">Contact</th>
-        <th class="px-3 py-2 text-left">Email</th>
-        <th class="px-3 py-2 text-left">Phone</th>
-        <th class="px-3 py-2 text-left">Active</th>
-        <th class="px-3 py-2 text-left">Actions</th>
+      <tr>
+        <th>ID</th>
+        <th>Name</th>
+        <th>Contact</th>
+        <th>Email</th>
+        <th>Phone</th>
+        <th>Active</th>
+        <th>Actions</th>
       </tr>
     </thead>
-    <tbody class="divide-y">
+    <tbody>
       {% for row in page_obj %}
       <tr>
-        <td class="px-3 py-2">{{ row.supplier_id }}</td>
-        <td class="px-3 py-2">{{ row.name }}</td>
-        <td class="px-3 py-2">{{ row.contact_person }}</td>
-        <td class="px-3 py-2">{{ row.email }}</td>
-        <td class="px-3 py-2">{{ row.phone }}</td>
-        <td class="px-3 py-2">{{ row.is_active }}</td>
-        <td class="px-3 py-2">
+        <td>{{ row.supplier_id }}</td>
+        <td>{{ row.name }}</td>
+        <td>{{ row.contact_person }}</td>
+        <td>{{ row.email }}</td>
+        <td>{{ row.phone }}</td>
+        <td>{{ row.is_active }}</td>
+        <td>
           <a href="{% url 'supplier_edit' row.supplier_id %}" class="text-blue-600 mr-2">Edit</a>
           <a hx-get="{% url 'supplier_toggle_active' row.supplier_id %}?q={{ q|urlencode }}&page={{ page_obj.number }}&show_inactive={{ show_inactive|urlencode }}"
              hx-target="#suppliers_table" class="text-blue-600">Toggle</a>
         </td>
       </tr>
       {% empty %}
-      <tr><td class="px-3 py-4" colspan="7">No suppliers found.</td></tr>
+      <tr><td colspan="7" class="p-2">No suppliers found.</td></tr>
       {% endfor %}
     </tbody>
   </table>

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -2,62 +2,62 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">History Reports</h1>
-  <form method="get" class="flex flex-wrap gap-2 mb-4">
-    <select name="item" class="border rounded p-2">
-      <option value="">All Items</option>
+    <form method="get" class="flex flex-wrap gap-2 mb-4">
+      <select name="item" class="form-control">
+        <option value="">All Items</option>
       {% for it in items %}
       <option value="{{ it.item_id }}" {% if item|default:'' == it.item_id|stringformat:"s" %}selected{% endif %}>{{ it.name }}</option>
       {% endfor %}
-    </select>
-    <select name="type" class="border rounded p-2">
+      </select>
+      <select name="type" class="form-control">
       <option value="">All Types</option>
       {% for t in transaction_types %}
       <option value="{{ t }}" {% if type == t %}selected{% endif %}>{{ t }}</option>
       {% endfor %}
-    </select>
-    <select name="user" class="border rounded p-2">
+      </select>
+      <select name="user" class="form-control">
       <option value="">All Users</option>
       {% for u in users %}
       <option value="{{ u }}" {% if user == u %}selected{% endif %}>{{ u }}</option>
       {% endfor %}
-    </select>
-    <input type="date" name="start_date" value="{{ start_date }}" class="border rounded p-2" />
-    <input type="date" name="end_date" value="{{ end_date }}" class="border rounded p-2" />
+      </select>
+      <input type="date" name="start_date" value="{{ start_date }}" class="form-control" />
+      <input type="date" name="end_date" value="{{ end_date }}" class="form-control" />
     <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Filter</button>
     <a href="?{% if query_string %}{{ query_string }}&{% endif %}export=csv" class="px-4 py-2 border rounded">Export CSV</a>
   </form>
-  <div class="overflow-x-auto">
-    <table class="min-w-full border divide-y">
-      <thead>
-        <tr class="bg-gray-50">
-          <th class="px-3 py-2 text-left">ID</th>
-          <th class="px-3 py-2 text-left">Item</th>
-          <th class="px-3 py-2 text-left">Type</th>
-          <th class="px-3 py-2 text-left">Qty</th>
-          <th class="px-3 py-2 text-left">User</th>
-          <th class="px-3 py-2 text-left">Date</th>
-          <th class="px-3 py-2 text-left">Notes</th>
-        </tr>
-      </thead>
-      <tbody class="divide-y">
-        {% for row in page_obj %}
-        <tr>
-          <td class="px-3 py-2">{{ row.transaction_id }}</td>
-          <td class="px-3 py-2">{{ row.item.name }}</td>
-          <td class="px-3 py-2">{{ row.transaction_type }}</td>
-          <td class="px-3 py-2">{{ row.quantity_change }}</td>
-          <td class="px-3 py-2">{{ row.user_id }}</td>
-          <td class="px-3 py-2">{{ row.transaction_date }}</td>
-          <td class="px-3 py-2">{{ row.notes }}</td>
-        </tr>
-        {% empty %}
-        <tr>
-          <td class="px-3 py-4" colspan="7">No transactions found.</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+    <div class="overflow-x-auto">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Item</th>
+            <th>Type</th>
+            <th>Qty</th>
+            <th>User</th>
+            <th>Date</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in page_obj %}
+          <tr>
+            <td>{{ row.transaction_id }}</td>
+            <td>{{ row.item.name }}</td>
+            <td>{{ row.transaction_type }}</td>
+            <td>{{ row.quantity_change }}</td>
+            <td>{{ row.user_id }}</td>
+            <td>{{ row.transaction_date }}</td>
+            <td>{{ row.notes }}</td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="7" class="p-2">No transactions found.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   <div class="flex items-center gap-3 mt-3">
     {% if page_obj.has_previous %}
     <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.previous_page_number }}" class="px-3 py-1 border rounded">Prev</a>

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -9,11 +9,11 @@
     <a href="{% url 'indent_pdf' indent.indent_id %}" class="text-blue-600">Download PDF</a>
   </div>
   <h2 class="text-xl font-semibold mb-2">Items</h2>
-  <table class="min-w-full border divide-y">
-    <thead><tr class="bg-gray-50"><th class="px-3 py-2 text-left">Item</th><th class="px-3 py-2 text-left">Qty</th></tr></thead>
-    <tbody class="divide-y">
+  <table class="table">
+    <thead><tr><th>Item</th><th>Qty</th></tr></thead>
+    <tbody>
     {% for row in items %}
-      <tr><td class="px-3 py-2">{{ row.item.name }}</td><td class="px-3 py-2">{{ row.requested_qty }}</td></tr>
+      <tr><td>{{ row.item.name }}</td><td>{{ row.requested_qty }}</td></tr>
     {% endfor %}
     </tbody>
   </table>

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -17,9 +17,9 @@
       <div>
         {{ field.label_tag }}
         {% if field.field.widget.input_type == "checkbox" %}
-        {{ field.as_widget(attrs={'class': 'rounded border-gray-300'}) }}
+        {{ field.as_widget(attrs={'class': 'form-checkbox'}) }}
         {% else %}
-        {{ field.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
+        {{ field.as_widget(attrs={'class': 'form-control'}) }}
         {% endif %}
         {% if field.errors %}
         <ul class="text-red-600 list-disc pl-5">
@@ -39,43 +39,43 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <table class="min-w-full border divide-y" id="items-table">
+    <table id="items-table" class="table">
       <thead>
-        <tr class="bg-gray-50">
-          <th class="px-3 py-2 text-left">Item</th>
-          <th class="px-3 py-2 text-left">Qty</th>
-          <th class="px-3 py-2 text-left">Notes</th>
-          <th class="px-3 py-2"></th>
+        <tr>
+          <th>Item</th>
+          <th>Qty</th>
+          <th>Notes</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
       {% for item_form in formset %}
         <tr class="form-row">
-          <td class="px-3 py-2">
-            {{ item_form.item.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
+          <td>
+            {{ item_form.item.as_widget(attrs={'class': 'form-control'}) }}
             {% if item_form.item.errors %}
             <ul class="text-red-600 list-disc pl-5">
               {% for error in item_form.item.errors %}<li>{{ error }}</li>{% endfor %}
             </ul>
             {% endif %}
           </td>
-          <td class="px-3 py-2">
-            {{ item_form.requested_qty.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
+          <td>
+            {{ item_form.requested_qty.as_widget(attrs={'class': 'form-control'}) }}
             {% if item_form.requested_qty.errors %}
             <ul class="text-red-600 list-disc pl-5">
               {% for error in item_form.requested_qty.errors %}<li>{{ error }}</li>{% endfor %}
             </ul>
             {% endif %}
           </td>
-          <td class="px-3 py-2">
-            {{ item_form.notes.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
+          <td>
+            {{ item_form.notes.as_widget(attrs={'class': 'form-control'}) }}
             {% if item_form.notes.errors %}
             <ul class="text-red-600 list-disc pl-5">
               {% for error in item_form.notes.errors %}<li>{{ error }}</li>{% endfor %}
             </ul>
             {% endif %}
           </td>
-          <td class="px-3 py-2"><button type="button" class="remove-row text-red-600">Remove</button></td>
+          <td><button type="button" class="remove-row text-red-600">Remove</button></td>
         </tr>
       {% endfor %}
       </tbody>

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -5,9 +5,9 @@
   <div class="mb-4 flex gap-2">
     <a href="{% url 'indent_create' %}" class="px-4 py-2 bg-green-600 text-white rounded">New Indent</a>
   </div>
-  <form id="filters" class="flex flex-wrap gap-2 mb-4">
-    <select name="status" class="border rounded p-2"
-            hx-get="{% url 'indents_table' %}" hx-target="#indents_table" hx-trigger="change" hx-include="#filters">
+    <form id="filters" class="flex flex-wrap gap-2 mb-4">
+      <select name="status" class="form-control"
+              hx-get="{% url 'indents_table' %}" hx-target="#indents_table" hx-trigger="change" hx-include="#filters">
       <option value="">All Statuses</option>
       <option value="SUBMITTED" {% if status == 'SUBMITTED' %}selected{% endif %}>Submitted</option>
       <option value="PROCESSING" {% if status == 'PROCESSING' %}selected{% endif %}>Processing</option>

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -16,10 +16,10 @@
     <div>
       {{ form.name.label_tag }}
       {% url 'item_suggest' as suggest_url %}
-      {{ form.name.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2',
-                                   'hx-get': suggest_url,
-                                   'hx-trigger': 'keyup changed delay:500ms',
-                                   'hx-swap': 'none'}) }}
+        {{ form.name.as_widget(attrs={'class': 'form-control',
+                                     'hx-get': suggest_url,
+                                     'hx-trigger': 'keyup changed delay:500ms',
+                                     'hx-swap': 'none'}) }}
       {% if form.name.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in form.name.errors %}
@@ -30,7 +30,7 @@
     </div>
     <div>
       {{ form.base_unit.label_tag }}
-      {{ form.base_unit.as_widget(attrs={'id': 'id_base_unit', 'class': 'block w-full rounded border-gray-300 p-2'}) }}
+        {{ form.base_unit.as_widget(attrs={'id': 'id_base_unit', 'class': 'form-control'}) }}
       {% if form.base_unit.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in form.base_unit.errors %}
@@ -41,7 +41,7 @@
     </div>
     <div>
       {{ form.purchase_unit.label_tag }}
-      {{ form.purchase_unit.as_widget(attrs={'id': 'id_purchase_unit', 'class': 'block w-full rounded border-gray-300 p-2'}) }}
+        {{ form.purchase_unit.as_widget(attrs={'id': 'id_purchase_unit', 'class': 'form-control'}) }}
       {% if form.purchase_unit.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in form.purchase_unit.errors %}
@@ -52,7 +52,7 @@
     </div>
     <div>
       {{ form.category.label_tag }}
-      {{ form.category.as_widget(attrs={'id': 'id_category', 'class': 'block w-full rounded border-gray-300 p-2'}) }}
+        {{ form.category.as_widget(attrs={'id': 'id_category', 'class': 'form-control'}) }}
       {% if form.category.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in form.category.errors %}
@@ -65,11 +65,11 @@
     {% if field.name not in ['name', 'base_unit', 'purchase_unit', 'category'] %}
     <div>
       {{ field.label_tag }}
-      {% if field.field.widget.input_type == "checkbox" %}
-      {{ field.as_widget(attrs={'class': 'rounded border-gray-300'}) }}
-      {% else %}
-      {{ field.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
-      {% endif %}
+        {% if field.field.widget.input_type == "checkbox" %}
+        {{ field.as_widget(attrs={'class': 'form-checkbox'}) }}
+        {% else %}
+        {{ field.as_widget(attrs={'class': 'form-control'}) }}
+        {% endif %}
       {% if field.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in field.errors %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -7,33 +7,33 @@
     <a href="{% url 'items_bulk_upload' %}" class="px-4 py-2 border rounded">Bulk Upload</a>
   </div>
   <form id="filters" class="flex flex-wrap gap-2 mb-4">
-    <input
-      type="text"
-      name="q"
-      placeholder="Search items..."
-      class="border rounded p-2 flex-grow"
-      value="{{ q }}"
-      hx-get="{% url 'items_table' %}"
-      hx-target="#items_table"
-      hx-trigger="keyup changed delay:300ms"
-      hx-include="#filters"
-    />
-    <select name="category" class="border rounded p-2"
-            hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters">
+      <input
+        type="text"
+        name="q"
+        placeholder="Search items..."
+        class="form-control flex-grow"
+        value="{{ q }}"
+        hx-get="{% url 'items_table' %}"
+        hx-target="#items_table"
+        hx-trigger="keyup changed delay:300ms"
+        hx-include="#filters"
+      />
+      <select name="category" class="form-control"
+              hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters">
       <option value="">All Categories</option>
       {% for cat in categories %}
       <option value="{{ cat }}" {% if cat == category %}selected{% endif %}>{{ cat }}</option>
       {% endfor %}
     </select>
-    <select name="subcategory" class="border rounded p-2"
-            hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters">
+      <select name="subcategory" class="form-control"
+              hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters">
       <option value="">All Subcategories</option>
       {% for sub in subcategories %}
       <option value="{{ sub }}" {% if sub == subcategory %}selected{% endif %}>{{ sub }}</option>
       {% endfor %}
     </select>
-    <select name="active" class="border rounded p-2"
-            hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters">
+      <select name="active" class="form-control"
+              hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters">
       <option value="">All</option>
       <option value="1" {% if active == '1' %}selected{% endif %}>Active</option>
       <option value="0" {% if active == '0' %}selected{% endif %}>Inactive</option>

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -6,14 +6,14 @@
   <p class="mb-2"><strong>Order Date:</strong> {{ po.order_date }}</p>
   <p class="mb-4"><span class="px-2 py-1 rounded text-xs {{ badge_class }}">{{ po.get_status_display }}</span></p>
   <h2 class="text-xl mb-2">Items</h2>
-  <table class="min-w-full border mb-4">
-    <thead><tr class="border-b"><th class="p-2 text-left">Item</th><th class="p-2 text-left">Ordered</th><th class="p-2 text-left">Received</th></tr></thead>
+  <table class="table mb-4">
+    <thead><tr><th>Item</th><th>Ordered</th><th>Received</th></tr></thead>
     <tbody>
     {% for item in items %}
-      <tr class="border-b">
-        <td class="p-2">{{ item.item.name }}</td>
-        <td class="p-2">{{ item.quantity_ordered }}</td>
-        <td class="p-2">{{ item.quantity_received }}</td>
+      <tr>
+        <td>{{ item.item.name }}</td>
+        <td>{{ item.quantity_ordered }}</td>
+        <td>{{ item.quantity_received }}</td>
       </tr>
     {% endfor %}
     </tbody>

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -5,22 +5,22 @@
   <div class="mb-4">
     <a href="{% url 'purchase_order_create' %}" class="px-4 py-2 bg-green-600 text-white rounded">New PO</a>
   </div>
-  <table class="min-w-full border">
+  <table class="table">
     <thead>
-      <tr class="border-b">
-        <th class="p-2 text-left">PO #</th>
-        <th class="p-2 text-left">Supplier</th>
-        <th class="p-2 text-left">Order Date</th>
-        <th class="p-2 text-left">Status</th>
+      <tr>
+        <th>PO #</th>
+        <th>Supplier</th>
+        <th>Order Date</th>
+        <th>Status</th>
       </tr>
     </thead>
     <tbody>
       {% for po in orders %}
-      <tr class="border-b">
-        <td class="p-2"><a class="text-blue-600" href="{% url 'purchase_order_detail' po.pk %}">{{ po.pk }}</a></td>
-        <td class="p-2">{{ po.supplier.name }}</td>
-        <td class="p-2">{{ po.order_date }}</td>
-        <td class="p-2"><span class="px-2 py-1 rounded text-xs {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
+      <tr>
+        <td><a class="text-blue-600" href="{% url 'purchase_order_detail' po.pk %}">{{ po.pk }}</a></td>
+        <td>{{ po.supplier.name }}</td>
+        <td>{{ po.order_date }}</td>
+        <td><span class="px-2 py-1 rounded text-xs {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
       </tr>
       {% empty %}
       <tr><td colspan="4" class="p-2">No purchase orders.</td></tr>

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -5,15 +5,15 @@
   <form method="post" class="space-y-4">
     {% csrf_token %}
     {{ form.as_p }}
-    <table class="min-w-full border">
-      <thead><tr class="border-b"><th class="p-2 text-left">Item</th><th class="p-2 text-left">Ordered</th><th class="p-2 text-left">Received</th><th class="p-2 text-left">Receive Now</th></tr></thead>
+    <table class="table">
+      <thead><tr><th>Item</th><th>Ordered</th><th>Received</th><th>Receive Now</th></tr></thead>
       <tbody>
       {% for item in items %}
-        <tr class="border-b">
-          <td class="p-2">{{ item.item.name }}</td>
-          <td class="p-2">{{ item.quantity_ordered }}</td>
-          <td class="p-2">{{ item.quantity_received }}</td>
-          <td class="p-2"><input type="number" step="any" name="item_{{ item.pk }}" class="border p-1 w-24" /></td>
+        <tr>
+          <td>{{ item.item.name }}</td>
+          <td>{{ item.quantity_ordered }}</td>
+          <td>{{ item.quantity_received }}</td>
+          <td><input type="number" step="any" name="item_{{ item.pk }}" class="form-control w-24" /></td>
         </tr>
       {% endfor %}
       </tbody>

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -4,10 +4,10 @@
   <h1 class="text-2xl font-semibold mb-4">Stock Movements</h1>
   <form method="get" id="section-form" class="mb-4">
     {% for key, label in sections.items %}
-      <label class="mr-4">
-        <input type="radio" name="section" value="{{ key }}" {% if key == active_section %}checked{% endif %} onchange="document.getElementById('section-form').submit();"> {{ label }}
-      </label>
-    {% endfor %}
+        <label class="mr-4">
+          <input type="radio" name="section" value="{{ key }}" class="form-checkbox" {% if key == active_section %}checked{% endif %} onchange="document.getElementById('section-form').submit();"> {{ label }}
+        </label>
+      {% endfor %}
   </form>
   {% if messages %}
     <ul class="mb-4">

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -16,11 +16,11 @@
     {% for field in form %}
     <div>
       {{ field.label_tag }}
-      {% if field.field.widget.input_type == "checkbox" %}
-      {{ field.as_widget(attrs={'class': 'rounded border-gray-300'}) }}
-      {% else %}
-      {{ field.as_widget(attrs={'class': 'block w-full rounded border-gray-300 p-2'}) }}
-      {% endif %}
+        {% if field.field.widget.input_type == "checkbox" %}
+        {{ field.as_widget(attrs={'class': 'form-checkbox'}) }}
+        {% else %}
+        {{ field.as_widget(attrs={'class': 'form-control'}) }}
+        {% endif %}
       {% if field.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in field.errors %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -8,22 +8,22 @@
     <a href="{% url 'suppliers_bulk_delete' %}" class="px-4 py-2 border rounded">Bulk Delete</a>
   </div>
   <form id="filters" class="flex flex-wrap gap-2 mb-4">
-    <input
-      type="text"
-      name="q"
-      placeholder="Search suppliers..."
-      class="border rounded p-2 flex-grow"
-      value="{{ q }}"
-      hx-get="{% url 'suppliers_table' %}"
-      hx-target="#suppliers_table"
-      hx-trigger="keyup changed delay:300ms"
-      hx-include="#filters"
-    />
-    <label class="flex items-center gap-2">
-      <input type="checkbox" name="show_inactive" value="1" {% if show_inactive %}checked{% endif %}
-             hx-get="{% url 'suppliers_table' %}" hx-target="#suppliers_table" hx-trigger="change" hx-include="#filters" />
-      Show Inactive
-    </label>
+      <input
+        type="text"
+        name="q"
+        placeholder="Search suppliers..."
+        class="form-control flex-grow"
+        value="{{ q }}"
+        hx-get="{% url 'suppliers_table' %}"
+        hx-target="#suppliers_table"
+        hx-trigger="keyup changed delay:300ms"
+        hx-include="#filters"
+      />
+      <label class="flex items-center gap-2">
+        <input type="checkbox" name="show_inactive" value="1" class="form-checkbox" {% if show_inactive %}checked{% endif %}
+               hx-get="{% url 'suppliers_table' %}" hx-target="#suppliers_table" hx-trigger="change" hx-include="#filters" />
+        Show Inactive
+      </label>
   </form>
   <div id="suppliers_table"
        hx-get="{% url 'suppliers_table' %}"


### PR DESCRIPTION
## Summary
- remove Streamlit-specific rules from main stylesheet
- extract reusable form and table styles into their own CSS modules
- update templates to use new form-control, form-checkbox, and table classes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f7eb4ac648326a536c0520fd1a7fc