### PR TITLE
Switch inventory API to ModelViewSet

### DIFF
--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -1,3 +1,5 @@
+"""API routes for the inventory app."""
+
 from rest_framework.routers import DefaultRouter
 
 from .views import (

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -10,7 +10,7 @@ from .serializers import (
 )
 
 
-class ItemViewSet(viewsets.ReadOnlyModelViewSet):
+class ItemViewSet(viewsets.ModelViewSet):
     queryset = Item.objects.all()
     serializer_class = ItemSerializer
 
@@ -22,17 +22,17 @@ class ItemViewSet(viewsets.ReadOnlyModelViewSet):
         return queryset
 
 
-class SupplierViewSet(viewsets.ReadOnlyModelViewSet):
+class SupplierViewSet(viewsets.ModelViewSet):
     queryset = Supplier.objects.all()
     serializer_class = SupplierSerializer
 
 
-class StockTransactionViewSet(viewsets.ReadOnlyModelViewSet):
+class StockTransactionViewSet(viewsets.ModelViewSet):
     queryset = StockTransaction.objects.all().select_related("item")
     serializer_class = StockTransactionSerializer
 
 
-class IndentViewSet(viewsets.ReadOnlyModelViewSet):
+class IndentViewSet(viewsets.ModelViewSet):
     queryset = Indent.objects.all()
     serializer_class = IndentSerializer
 
@@ -47,6 +47,6 @@ class IndentViewSet(viewsets.ReadOnlyModelViewSet):
         return queryset
 
 
-class IndentItemViewSet(viewsets.ReadOnlyModelViewSet):
+class IndentItemViewSet(viewsets.ModelViewSet):
     queryset = IndentItem.objects.all().select_related("indent", "item")
     serializer_class = IndentItemSerializer


### PR DESCRIPTION
## Summary
- convert inventory API ViewSets to use `ModelViewSet`
- retain queryset filtering for items and indents
- document router-based API registration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689feee21668832694863a826f90e71c