### PR TITLE
Use Django modules in tests

### DIFF
--- a/inventory/constants.py
+++ b/inventory/constants.py
@@ -1,0 +1,6 @@
+"""Constants used across the inventory application."""
+
+from legacy_streamlit.app.core.constants import PLACEHOLDER_SELECT_COMPONENT
+
+__all__ = ["PLACEHOLDER_SELECT_COMPONENT"]
+

--- a/inventory/services/__init__.py
+++ b/inventory/services/__init__.py
@@ -1,6 +1,13 @@
 """Service layer for the inventory app."""
 
-from . import item_service, supplier_service, stock_service, purchase_order_service, goods_receiving_service
+from . import (
+    item_service,
+    supplier_service,
+    stock_service,
+    purchase_order_service,
+    goods_receiving_service,
+    recipe_service,
+)
 
 __all__ = [
     "item_service",
@@ -8,4 +15,5 @@ __all__ = [
     "stock_service",
     "purchase_order_service",
     "goods_receiving_service",
+    "recipe_service",
 ]

--- a/inventory/services/recipe_service.py
+++ b/inventory/services/recipe_service.py
@@ -1,0 +1,11 @@
+"""Compatibility wrapper for legacy recipe service.
+
+This module re-exports the legacy ``recipe_service`` functions from the
+Streamlit codebase so tests can import them via the Django application's
+namespace.  The actual implementation still lives in the legacy module and
+continues to rely on SQLAlchemy; migrating it to Django ORM is tracked
+separately.
+"""
+
+from legacy_streamlit.app.services.recipe_service import *  # noqa: F401,F403
+

--- a/inventory/ui/__init__.py
+++ b/inventory/ui/__init__.py
@@ -1,0 +1,2 @@
+"""UI helper compatibility package."""
+

--- a/inventory/ui/choices.py
+++ b/inventory/ui/choices.py
@@ -1,0 +1,6 @@
+"""Compatibility wrapper for UI choice helpers."""
+
+from legacy_streamlit.app.ui.choices import build_component_options
+
+__all__ = ["build_component_options"]
+

--- a/inventory/ui/helpers.py
+++ b/inventory/ui/helpers.py
@@ -1,0 +1,6 @@
+"""Compatibility wrappers for miscellaneous UI helpers."""
+
+from legacy_streamlit.app.ui.helpers import autofill_component_meta
+
+__all__ = ["autofill_component_meta"]
+

--- a/inventory_app/logging.py
+++ b/inventory_app/logging.py
@@ -1,0 +1,27 @@
+"""Django project logging helpers.
+
+This module exposes the logging utilities originally implemented for the
+Streamlit application.  They are re-exported here so test code can import them
+via the ``inventory_app`` namespace, reflecting the Django project's structure.
+"""
+
+import importlib
+
+_legacy = importlib.reload(
+    importlib.import_module("legacy_streamlit.app.core.logging")
+)
+
+LOG_FILE = _legacy.LOG_FILE  # noqa: F401
+LOG_RETENTION_DAYS = _legacy.LOG_RETENTION_DAYS  # noqa: F401
+configure_logging = _legacy.configure_logging  # noqa: F401
+flush_logs = _legacy.flush_logs  # noqa: F401
+get_logger = _legacy.get_logger  # noqa: F401
+
+__all__ = [
+    "LOG_FILE",
+    "LOG_RETENTION_DAYS",
+    "configure_logging",
+    "flush_logs",
+    "get_logger",
+]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,17 @@ import os
 import sys
 import pytest
 from sqlalchemy import create_engine, event, text
+import django
 
 # Ensure project root is on sys.path
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
-from legacy_streamlit.app.core.logging import configure_logging
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inventory_app.settings")
+django.setup()
+
+from inventory_app.logging import configure_logging
 
 # Configure logging for tests once before other modules import loggers
 configure_logging()

--- a/tests/test_autofill_component_meta.py
+++ b/tests/test_autofill_component_meta.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from legacy_streamlit.app.ui.helpers import autofill_component_meta
+from inventory.ui.helpers import autofill_component_meta
 
 
 def test_autofill_component_meta_populates_unit_and_category():

--- a/tests/test_logging_retention.py
+++ b/tests/test_logging_retention.py
@@ -19,7 +19,7 @@ def test_purge_old_logs(tmp_path, monkeypatch):
     monkeypatch.setenv("LOG_FILE", str(log_file))
     monkeypatch.setenv("LOG_RETENTION_DAYS", "7")
 
-    import legacy_streamlit.app.core.logging as logging_mod
+    import inventory_app.logging as logging_mod
     importlib.reload(logging_mod)
 
     logging_mod.configure_logging()

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -3,7 +3,7 @@
 import pytest
 from sqlalchemy import text
 
-from legacy_streamlit.app.services import recipe_service
+from inventory.services import recipe_service
 
 
 def _create_item(conn, name="Flour", base_unit="kg", purchase_unit="bag", stock=20):

--- a/tests/test_recipes_components.py
+++ b/tests/test_recipes_components.py
@@ -1,6 +1,6 @@
 import pandas as pd
-from legacy_streamlit.app.services import recipe_service
-from legacy_streamlit.app.core.constants import PLACEHOLDER_SELECT_COMPONENT
+from inventory.services import recipe_service
+from inventory.constants import PLACEHOLDER_SELECT_COMPONENT
 
 def test_build_components_autofill_and_validation():
     df = pd.DataFrame([

--- a/tests/test_stock_service.py
+++ b/tests/test_stock_service.py
@@ -1,149 +1,98 @@
-from sqlalchemy import text
+from django.db import connection
+from inventory.models import Item, StockTransaction
+from inventory.services import stock_service
 
-from legacy_streamlit.app.services import stock_service
+
+def setup_module(module):
+    with connection.schema_editor() as editor:
+        editor.create_model(Item)
+        editor.create_model(StockTransaction)
 
 
-def test_record_stock_transaction_updates_stock_and_logs(sqlite_engine):
-    # Insert a sample item with initial stock 10
-    with sqlite_engine.begin() as conn:
-        conn.execute(
-            text(
-                "INSERT INTO items (name, base_unit, purchase_unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) "
-                "VALUES ('Sample', 'pcs', 'box', 'cat', 'sub', 'dept', 0, 10, 'n', 1)"
-            )
-        )
-        item_id = conn.execute(text("SELECT item_id FROM items LIMIT 1")).scalar_one()
+def teardown_module(module):
+    with connection.schema_editor() as editor:
+        editor.delete_model(StockTransaction)
+        editor.delete_model(Item)
 
+
+def test_record_stock_transaction_updates_stock_and_logs():
+    StockTransaction.objects.all().delete()
+    Item.objects.all().delete()
+    item = Item.objects.create(name="Sample", current_stock=10)
     success = stock_service.record_stock_transaction(
-        item_id=item_id,
+        item_id=item.item_id,
         quantity_change=5,
         transaction_type="RECEIVING",
         user_id="tester",
-        db_engine_param=sqlite_engine,
     )
     assert success
-
-    with sqlite_engine.connect() as conn:
-        current = conn.execute(text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item_id}).scalar_one()
-        assert current == 15
-        count = conn.execute(text("SELECT COUNT(*) FROM stock_transactions WHERE item_id=:i"), {"i": item_id}).scalar_one()
-        assert count == 1
+    item.refresh_from_db()
+    assert item.current_stock == 15
+    assert StockTransaction.objects.filter(item=item).count() == 1
 
 
-def test_record_stock_transactions_bulk(sqlite_engine):
-    with sqlite_engine.begin() as conn:
-        conn.execute(
-            text(
-                "INSERT INTO items (name, base_unit, purchase_unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) VALUES"
-                " ('Item1', 'pcs', 'box', 'cat', 'sub', 'dept', 0, 10, 'n', 1),"
-                " ('Item2', 'pcs', 'box', 'cat', 'sub', 'dept', 0, 10, 'n', 1)"
-            )
-        )
-        ids = conn.execute(text("SELECT item_id FROM items ORDER BY item_id"))
-        item1_id, item2_id = [row[0] for row in ids.fetchall()]
-
-    transactions = [
-        {"item_id": item1_id, "quantity_change": 5, "transaction_type": "RECEIVING", "user_id": "u1"},
-        {"item_id": item2_id, "quantity_change": -3, "transaction_type": "ISSUE", "user_id": "u2"},
+def test_record_stock_transactions_bulk():
+    StockTransaction.objects.all().delete()
+    Item.objects.all().delete()
+    item1 = Item.objects.create(name="Item1", current_stock=10)
+    item2 = Item.objects.create(name="Item2", current_stock=10)
+    txs = [
+        {"item_id": item1.item_id, "quantity_change": 5, "transaction_type": "RECEIVING", "user_id": "u1"},
+        {"item_id": item2.item_id, "quantity_change": -3, "transaction_type": "ISSUE", "user_id": "u2"},
     ]
-    assert stock_service.record_stock_transactions_bulk(sqlite_engine, transactions)
-
-    with sqlite_engine.connect() as conn:
-        stock1 = conn.execute(text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item1_id}).scalar_one()
-        stock2 = conn.execute(text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item2_id}).scalar_one()
-        assert stock1 == 15
-        assert stock2 == 7
-        count = conn.execute(text("SELECT COUNT(*) FROM stock_transactions"))
-        assert count.scalar_one() == 2
+    assert stock_service.record_stock_transactions_bulk(txs)
+    item1.refresh_from_db()
+    item2.refresh_from_db()
+    assert item1.current_stock == 15
+    assert item2.current_stock == 7
+    assert StockTransaction.objects.count() == 2
 
 
-def test_remove_stock_transactions_bulk(sqlite_engine):
-    with sqlite_engine.begin() as conn:
-        conn.execute(
-            text(
-                "INSERT INTO items (name, base_unit, purchase_unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) VALUES ('Item', 'pcs', 'box', 'cat', 'sub', 'dept', 0, 20, 'n', 1)"
-            )
-        )
-        item_id = conn.execute(text("SELECT item_id FROM items LIMIT 1")).scalar_one()
-
-    transactions = [
-        {"item_id": item_id, "quantity_change": 5, "transaction_type": "RECEIVING"},
-        {"item_id": item_id, "quantity_change": -2, "transaction_type": "ISSUE"},
+def test_remove_stock_transactions_bulk():
+    StockTransaction.objects.all().delete()
+    Item.objects.all().delete()
+    item = Item.objects.create(name="Item", current_stock=20)
+    txs = [
+        {"item_id": item.item_id, "quantity_change": 5, "transaction_type": "RECEIVING"},
+        {"item_id": item.item_id, "quantity_change": -2, "transaction_type": "ISSUE"},
     ]
-    assert stock_service.record_stock_transactions_bulk(sqlite_engine, transactions)
-
-    with sqlite_engine.connect() as conn:
-        ids = conn.execute(
-            text("SELECT transaction_id FROM stock_transactions ORDER BY transaction_id")
-        ).fetchall()
-        t_ids = [row[0] for row in ids]
-
-    assert stock_service.remove_stock_transactions_bulk(sqlite_engine, t_ids)
-
-    with sqlite_engine.connect() as conn:
-        stock = conn.execute(
-            text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item_id}
-        ).scalar_one()
-        assert stock == 20
-        count = conn.execute(text("SELECT COUNT(*) FROM stock_transactions"))
-        assert count.scalar_one() == 0
+    assert stock_service.record_stock_transactions_bulk(txs)
+    ids = list(StockTransaction.objects.values_list("transaction_id", flat=True))
+    assert stock_service.remove_stock_transactions_bulk(ids)
+    item.refresh_from_db()
+    assert item.current_stock == 20
+    assert StockTransaction.objects.count() == 0
 
 
-def test_record_stock_transactions_bulk_rollback_on_error(sqlite_engine):
-    with sqlite_engine.begin() as conn:
-        conn.execute(
-            text(
-                "INSERT INTO items (name, base_unit, purchase_unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) VALUES ('Item', 'pcs', 'box', 'cat', 'sub', 'dept', 0, 10, 'n', 1)"
-            )
-        )
-        item_id = conn.execute(text("SELECT item_id FROM items LIMIT 1")).scalar_one()
-
-    transactions = [
-        {"item_id": item_id, "quantity_change": 5, "transaction_type": "RECEIVING"},
+def test_record_stock_transactions_bulk_rollback_on_error():
+    StockTransaction.objects.all().delete()
+    Item.objects.all().delete()
+    item = Item.objects.create(name="Item", current_stock=10)
+    txs = [
+        {"item_id": item.item_id, "quantity_change": 5, "transaction_type": "RECEIVING"},
         {"item_id": 9999, "quantity_change": 3, "transaction_type": "RECEIVING"},
     ]
-    assert not stock_service.record_stock_transactions_bulk(sqlite_engine, transactions)
-
-    with sqlite_engine.connect() as conn:
-        stock = conn.execute(text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item_id}).scalar_one()
-        assert stock == 10
-        count = conn.execute(text("SELECT COUNT(*) FROM stock_transactions"))
-        assert count.scalar_one() == 0
+    assert not stock_service.record_stock_transactions_bulk(txs)
+    item.refresh_from_db()
+    assert item.current_stock == 10
+    assert StockTransaction.objects.count() == 0
 
 
-def test_remove_stock_transactions_bulk_rollback_on_error(sqlite_engine):
-    with sqlite_engine.begin() as conn:
-        conn.execute(
-            text(
-                "INSERT INTO items (name, base_unit, purchase_unit, category, sub_category, permitted_departments, reorder_point, current_stock, notes, is_active) VALUES ('Item', 'pcs', 'box', 'cat', 'sub', 'dept', 0, 10, 'n', 1)"
-            )
-        )
-        item_id = conn.execute(text("SELECT item_id FROM items LIMIT 1")).scalar_one()
-
-    transactions = [
-        {"item_id": item_id, "quantity_change": 5, "transaction_type": "RECEIVING"},
-        {"item_id": item_id, "quantity_change": -2, "transaction_type": "ISSUE"},
+def test_remove_stock_transactions_bulk_rollback_on_error():
+    StockTransaction.objects.all().delete()
+    Item.objects.all().delete()
+    item = Item.objects.create(name="Item", current_stock=10)
+    txs = [
+        {"item_id": item.item_id, "quantity_change": 5, "transaction_type": "RECEIVING"},
+        {"item_id": item.item_id, "quantity_change": -2, "transaction_type": "ISSUE"},
     ]
-    assert stock_service.record_stock_transactions_bulk(sqlite_engine, transactions)
-
-    with sqlite_engine.connect() as conn:
-        ids = conn.execute(
-            text("SELECT transaction_id FROM stock_transactions ORDER BY transaction_id")
-        ).fetchall()
-        valid_id = ids[0][0]
-        current_stock = conn.execute(
-            text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item_id}
-        ).scalar_one()
-
-    assert not stock_service.remove_stock_transactions_bulk(
-        sqlite_engine, [valid_id, 9999]
-    )
-
-    with sqlite_engine.connect() as conn:
-        stock = conn.execute(
-            text("SELECT current_stock FROM items WHERE item_id=:i"), {"i": item_id}
-        ).scalar_one()
-        assert stock == current_stock
-        count = conn.execute(text("SELECT COUNT(*) FROM stock_transactions"))
-        assert count.scalar_one() == 2
+    assert stock_service.record_stock_transactions_bulk(txs)
+    ids = list(StockTransaction.objects.values_list("transaction_id", flat=True))
+    valid_id = ids[0]
+    item.refresh_from_db()
+    current_stock = item.current_stock
+    assert not stock_service.remove_stock_transactions_bulk([valid_id, 9999])
+    item.refresh_from_db()
+    assert item.current_stock == current_stock
+    assert StockTransaction.objects.count() == 2
 

--- a/tests/test_supplier_service.py
+++ b/tests/test_supplier_service.py
@@ -1,10 +1,19 @@
-from sqlalchemy import text
+from django.db import connection
+from inventory.models import Supplier
+from inventory.services import supplier_service
 
-from legacy_streamlit.app.services import supplier_service
+
+def setup_module(module):
+    with connection.schema_editor() as editor:
+        editor.create_model(Supplier)
 
 
+def teardown_module(module):
+    with connection.schema_editor() as editor:
+        editor.delete_model(Supplier)
 
-def test_add_supplier_inserts_row(sqlite_engine):
+
+def test_add_supplier_inserts_row():
     details = {
         "name": "Vendor A",
         "contact_person": "John",
@@ -14,72 +23,45 @@ def test_add_supplier_inserts_row(sqlite_engine):
         "notes": "Note",
         "is_active": True,
     }
-    success, msg = supplier_service.add_supplier(sqlite_engine, details)
+    success, _ = supplier_service.add_supplier(details)
     assert success
-
-    with sqlite_engine.connect() as conn:
-        row = conn.execute(text("SELECT name FROM suppliers WHERE name='Vendor A'"))
-        assert row.fetchone() is not None
+    assert Supplier.objects.filter(name="Vendor A").exists()
 
 
-def test_add_supplier_duplicate_name_fails(sqlite_engine):
+def test_add_supplier_duplicate_name_fails():
     details = {"name": "Dup", "is_active": True}
-    supplier_service.add_supplier(sqlite_engine, details)
-    success, msg = supplier_service.add_supplier(sqlite_engine, details)
+    supplier_service.add_supplier(details)
+    success, _ = supplier_service.add_supplier(details)
     assert not success
 
 
-def test_add_supplier_requires_name(sqlite_engine):
-    details = {
-        "name": "  ",
-        "contact_person": "x",
-    }
-    success, msg = supplier_service.add_supplier(sqlite_engine, details)
+def test_add_supplier_requires_name():
+    details = {"name": "  ", "contact_person": "x"}
+    success, _ = supplier_service.add_supplier(details)
     assert not success
 
 
-def test_update_supplier_changes_fields(sqlite_engine):
-    with sqlite_engine.begin() as conn:
-        conn.execute(
-            text(
-                "INSERT INTO suppliers (name, is_active) VALUES ('Vendor B', 1)"
-            )
-        )
-        supplier_id = conn.execute(text("SELECT supplier_id FROM suppliers WHERE name='Vendor B'"))
-        supplier_id = supplier_id.scalar_one()
-
-    success, msg = supplier_service.update_supplier(sqlite_engine, supplier_id, {"phone": "999"})
+def test_update_supplier_changes_fields():
+    supplier = Supplier.objects.create(name="Vendor B", is_active=True)
+    success, _ = supplier_service.update_supplier(supplier.pk, {"phone": "999"})
     assert success
-
-    with sqlite_engine.connect() as conn:
-        phone = conn.execute(text("SELECT phone FROM suppliers WHERE supplier_id=:i"), {"i": supplier_id}).scalar_one()
-        assert phone == "999"
+    supplier.refresh_from_db()
+    assert supplier.phone == "999"
 
 
-def test_update_supplier_invalid_id(sqlite_engine):
-    success, msg = supplier_service.update_supplier(sqlite_engine, 999, {"phone": "000"})
+def test_update_supplier_invalid_id():
+    success, _ = supplier_service.update_supplier(999, {"phone": "000"})
     assert not success
 
 
-def test_deactivate_and_reactivate_supplier(sqlite_engine):
-    with sqlite_engine.begin() as conn:
-        conn.execute(
-            text(
-                "INSERT INTO suppliers (name, is_active) VALUES ('Vendor C', 1)"
-            )
-        )
-        supplier_id = conn.execute(text("SELECT supplier_id FROM suppliers WHERE name='Vendor C'"))
-        supplier_id = supplier_id.scalar_one()
-
-    success, _ = supplier_service.deactivate_supplier(sqlite_engine, supplier_id)
+def test_deactivate_and_reactivate_supplier():
+    supplier = Supplier.objects.create(name="Vendor C", is_active=True)
+    success, _ = supplier_service.deactivate_supplier(supplier.pk)
     assert success
-    with sqlite_engine.connect() as conn:
-        active = conn.execute(text("SELECT is_active FROM suppliers WHERE supplier_id=:i"), {"i": supplier_id}).scalar_one()
-        assert active == 0
-
-    success, _ = supplier_service.reactivate_supplier(sqlite_engine, supplier_id)
+    supplier.refresh_from_db()
+    assert supplier.is_active is False
+    success, _ = supplier_service.reactivate_supplier(supplier.pk)
     assert success
-    with sqlite_engine.connect() as conn:
-        active = conn.execute(text("SELECT is_active FROM suppliers WHERE supplier_id=:i"), {"i": supplier_id}).scalar_one()
-        assert active == 1
+    supplier.refresh_from_db()
+    assert supplier.is_active is True
 

--- a/tests/test_ui_choices.py
+++ b/tests/test_ui_choices.py
@@ -1,4 +1,4 @@
-from legacy_streamlit.app.ui.choices import build_component_options
+from inventory.ui.choices import build_component_options
 
 
 def test_build_component_options_basic():


### PR DESCRIPTION
## Summary
- add compatibility wrappers exposing legacy services, constants, and UI helpers through Django package paths
- configure Django and logging in tests and switch imports to inventory_* modules
- rewrite stock and supplier service tests to use Django ORM

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ff00569948326959c01c266d361e7