### PR TITLE
feat: add recipe management service and API

### DIFF
--- a/inventory/models.py
+++ b/inventory/models.py
@@ -71,6 +71,51 @@ class StockTransaction(models.Model):
         db_table = "stock_transactions"
 
 
+class Recipe(models.Model):
+    recipe_id = models.AutoField(primary_key=True)
+    name = models.TextField(unique=True, blank=True, null=True)
+    description = models.TextField(blank=True, null=True)
+    is_active = models.BooleanField(blank=True, null=True)
+    type = models.TextField(blank=True, null=True)
+    default_yield_qty = CoerceFloatField(blank=True, null=True)
+    default_yield_unit = models.TextField(blank=True, null=True)
+    plating_notes = models.TextField(blank=True, null=True)
+    tags = models.TextField(blank=True, null=True)
+    version = models.IntegerField(blank=True, null=True)
+    effective_from = models.TextField(blank=True, null=True)
+    effective_to = models.TextField(blank=True, null=True)
+    created_at = models.TextField(blank=True, null=True)
+    updated_at = models.TextField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = "recipes"
+
+
+class RecipeComponent(models.Model):
+    id = models.AutoField(primary_key=True)
+    parent_recipe = models.ForeignKey(
+        Recipe,
+        models.DO_NOTHING,
+        db_column="parent_recipe_id",
+        related_name="components",
+    )
+    component_kind = models.TextField(blank=True, null=True)
+    component_id = models.IntegerField(blank=True, null=True)
+    quantity = CoerceFloatField(blank=True, null=True)
+    unit = models.TextField(blank=True, null=True)
+    loss_pct = CoerceFloatField(blank=True, null=True)
+    sort_order = models.IntegerField(blank=True, null=True)
+    notes = models.TextField(blank=True, null=True)
+    created_at = models.TextField(blank=True, null=True)
+    updated_at = models.TextField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = "recipe_components"
+        unique_together = ("parent_recipe", "component_kind", "component_id")
+
+
 class Indent(models.Model):
     indent_id = models.AutoField(primary_key=True)
     mrn = models.TextField(unique=True, blank=True, null=True)

--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -1,6 +1,14 @@
 from rest_framework import serializers
 
-from .models import Indent, IndentItem, Item, StockTransaction, Supplier
+from .models import (
+    Indent,
+    IndentItem,
+    Item,
+    StockTransaction,
+    Supplier,
+    Recipe,
+    RecipeComponent,
+)
 
 
 class ItemSerializer(serializers.ModelSerializer):
@@ -30,4 +38,18 @@ class IndentSerializer(serializers.ModelSerializer):
 class IndentItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = IndentItem
+        fields = "__all__"
+
+
+class RecipeComponentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RecipeComponent
+        fields = "__all__"
+
+
+class RecipeSerializer(serializers.ModelSerializer):
+    components = RecipeComponentSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Recipe
         fields = "__all__"

--- a/inventory/services/recipe_service.py
+++ b/inventory/services/recipe_service.py
@@ -1,11 +1,413 @@
-"""Compatibility wrapper for legacy recipe service.
+"""Service layer for recipe management.
 
-This module re-exports the legacy ``recipe_service`` functions from the
-Streamlit codebase so tests can import them via the Django application's
-namespace.  The actual implementation still lives in the legacy module and
-continues to rely on SQLAlchemy; migrating it to Django ORM is tracked
-separately.
+This module provides a light-weight port of the legacy Streamlit
+``recipe_service``.  It operates directly on the ``recipes`` and
+``recipe_components`` tables using SQLAlchemy connections so it can be used
+from the Django app and in tests without depending on the legacy codebase.
 """
 
-from legacy_streamlit.app.services.recipe_service import *  # noqa: F401,F403
+from __future__ import annotations
 
+import logging
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
+logger = logging.getLogger(__name__)
+
+TX_SALE = "SALE"
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+
+def _strip_or_none(val: Any) -> Optional[str]:
+    """Return a stripped string or ``None``."""
+    if isinstance(val, str):
+        val = val.strip()
+        return val or None
+    return None
+
+
+def _component_unit(conn: Connection, kind: str, cid: int, unit: Optional[str]) -> Optional[str]:
+    """Validate and resolve a component's unit.
+
+    For ``ITEM`` components the unit must match the item's ``base_unit``.
+    For ``RECIPE`` components the unit must match the child recipe's
+    ``default_yield_unit``.
+    """
+
+    if kind == "ITEM":
+        row = conn.execute(
+            text("SELECT base_unit FROM items WHERE item_id=:i"), {"i": cid}
+        ).mappings().fetchone()
+        if not row:
+            raise ValueError(f"Item {cid} not found")
+        base = row["base_unit"]
+        if unit is None:
+            return base
+        if unit != base:
+            raise ValueError("Unit mismatch for item component")
+        return unit
+    if kind == "RECIPE":
+        row = conn.execute(
+            text("SELECT default_yield_unit FROM recipes WHERE recipe_id=:r"),
+            {"r": cid},
+        ).mappings().fetchone()
+        db_unit = row["default_yield_unit"] if row else None
+        if unit is not None and db_unit and unit != db_unit:
+            raise ValueError("Unit mismatch for recipe component")
+        return unit if unit is not None else db_unit
+    raise ValueError("Invalid component_kind")
+
+
+def _has_path(conn: Connection, start: int, target: int) -> bool:
+    """Return True if ``start`` recipe references ``target`` recursively."""
+    if start == target:
+        return True
+    rows = conn.execute(
+        text(
+            "SELECT component_id FROM recipe_components "
+            "WHERE parent_recipe_id=:r AND component_kind='RECIPE'"
+        ),
+        {"r": start},
+    ).fetchall()
+    for (cid,) in rows:
+        if _has_path(conn, cid, target):
+            return True
+    return False
+
+
+def _creates_cycle(conn: Connection, parent_id: int, child_id: int) -> bool:
+    """Check whether linking ``parent_id`` -> ``child_id`` creates a cycle."""
+    if parent_id == child_id:
+        return True
+    return _has_path(conn, child_id, parent_id)
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def build_components_from_editor(
+    df, choice_map: Dict[str, Dict[str, Any]]
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Convert a data-editor DataFrame into component payload.
+
+    ``choice_map`` is expected to map the label from the UI to metadata about
+    the component (kind, id, unit information etc.).
+    """
+
+    from inventory.constants import PLACEHOLDER_SELECT_COMPONENT
+
+    components: List[Dict[str, Any]] = []
+    errors: List[str] = []
+    for idx, row in df.iterrows():
+        label = row.get("component")
+        if not label or label == PLACEHOLDER_SELECT_COMPONENT:
+            continue
+        meta = choice_map.get(label)
+        if not meta:
+            continue
+        qty = row.get("quantity")
+        if qty is None or float(qty) <= 0:
+            errors.append(f"Quantity must be greater than 0 for {label}.")
+            continue
+        unit = row.get("unit") or meta.get("base_unit") or meta.get("unit")
+        if meta["kind"] == "ITEM":
+            base_unit = meta.get("base_unit")
+            purchase_unit = meta.get("purchase_unit")
+            allowed = {u for u in [base_unit, purchase_unit] if u}
+            if unit not in allowed:
+                if purchase_unit:
+                    errors.append(
+                        f"Unit mismatch for {meta.get('name')}. Use {base_unit} or {purchase_unit}."
+                    )
+                else:
+                    errors.append(
+                        f"Unit mismatch for {meta.get('name')}. Use {base_unit}."
+                    )
+                continue
+        components.append(
+            {
+                "component_kind": meta["kind"],
+                "component_id": meta["id"],
+                "quantity": float(qty),
+                "unit": unit,
+                "loss_pct": float(row.get("loss_pct") or 0),
+                "sort_order": int(row.get("sort_order") or idx + 1),
+                "notes": row.get("notes") or None,
+            }
+        )
+    return components, errors
+
+
+# ---------------------------------------------------------------------------
+# CRUD operations
+# ---------------------------------------------------------------------------
+
+
+def create_recipe(
+    engine: Engine, data: Dict[str, Any], components: List[Dict[str, Any]]
+) -> Tuple[bool, str, Optional[int]]:
+    """Create a recipe and associated components."""
+    if engine is None:
+        return False, "Database engine not available.", None
+    try:
+        with engine.begin() as conn:
+            fields = [
+                "name",
+                "description",
+                "is_active",
+                "type",
+                "default_yield_qty",
+                "default_yield_unit",
+                "plating_notes",
+                "tags",
+            ]
+            ins = text(
+                f"INSERT INTO recipes ({', '.join(fields)}) "
+                f"VALUES ({', '.join(':'+f for f in fields)})"
+            )
+            params = {f: data.get(f) for f in fields}
+            result = conn.execute(ins, params)
+            rid = result.lastrowid
+            for comp in components:
+                unit = _component_unit(
+                    conn,
+                    comp["component_kind"],
+                    comp["component_id"],
+                    comp.get("unit"),
+                )
+                if comp["component_kind"] == "RECIPE" and _creates_cycle(
+                    conn, rid, comp["component_id"]
+                ):
+                    raise ValueError("Adding this component creates a cycle")
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO recipe_components
+                        (parent_recipe_id, component_kind, component_id, quantity, unit, loss_pct, sort_order, notes)
+                        VALUES
+                        (:r, :k, :cid, :q, :u, :loss, :sort, :notes)
+                        """
+                    ),
+                    {
+                        "r": rid,
+                        "k": comp["component_kind"],
+                        "cid": comp["component_id"],
+                        "q": comp["quantity"],
+                        "u": unit,
+                        "loss": comp.get("loss_pct") or 0,
+                        "sort": comp.get("sort_order") or 0,
+                        "notes": _strip_or_none(comp.get("notes")),
+                    },
+                )
+        return True, "Recipe created.", rid
+    except (IntegrityError, ValueError) as exc:
+        logger.error("Error creating recipe: %s", exc)
+        return False, str(exc), None
+    except SQLAlchemyError as exc:  # pragma: no cover - defensive
+        logger.error("DB error creating recipe: %s", exc)
+        return False, "A database error occurred.", None
+
+
+def update_recipe(
+    engine: Engine,
+    recipe_id: int,
+    data: Dict[str, Any],
+    components: List[Dict[str, Any]],
+) -> Tuple[bool, str]:
+    """Update a recipe and replace its components."""
+    if engine is None:
+        return False, "Database engine not available."
+    try:
+        with engine.begin() as conn:
+            if data:
+                fields = ", ".join(f"{k}=:{k}" for k in data.keys())
+                conn.execute(
+                    text(f"UPDATE recipes SET {fields} WHERE recipe_id=:rid"),
+                    {**data, "rid": recipe_id},
+                )
+            conn.execute(
+                text("DELETE FROM recipe_components WHERE parent_recipe_id=:r"),
+                {"r": recipe_id},
+            )
+            for comp in components:
+                unit = _component_unit(
+                    conn,
+                    comp["component_kind"],
+                    comp["component_id"],
+                    comp.get("unit"),
+                )
+                if comp["component_kind"] == "RECIPE" and _creates_cycle(
+                    conn, recipe_id, comp["component_id"]
+                ):
+                    raise ValueError("Adding this component creates a cycle")
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO recipe_components
+                        (parent_recipe_id, component_kind, component_id, quantity, unit, loss_pct, sort_order, notes)
+                        VALUES
+                        (:r, :k, :cid, :q, :u, :loss, :sort, :notes)
+                        """
+                    ),
+                    {
+                        "r": recipe_id,
+                        "k": comp["component_kind"],
+                        "cid": comp["component_id"],
+                        "q": comp["quantity"],
+                        "u": unit,
+                        "loss": comp.get("loss_pct") or 0,
+                        "sort": comp.get("sort_order") or 0,
+                        "notes": _strip_or_none(comp.get("notes")),
+                    },
+                )
+        return True, "Recipe updated."
+    except (IntegrityError, ValueError) as exc:
+        logger.error("Error updating recipe: %s", exc)
+        return False, str(exc)
+    except SQLAlchemyError as exc:  # pragma: no cover - defensive
+        logger.error("DB error updating recipe: %s", exc)
+        return False, "A database error occurred."
+
+
+# ---------------------------------------------------------------------------
+# Sale handling
+# ---------------------------------------------------------------------------
+
+
+def _expand_requirements(
+    conn: Connection,
+    recipe_id: int,
+    multiplier: float,
+    totals: Dict[int, float],
+    visited: Set[int],
+) -> None:
+    if recipe_id in visited:
+        raise ValueError("Circular reference detected during expansion")
+    visited.add(recipe_id)
+    rows = conn.execute(
+        text(
+            "SELECT component_kind, component_id, quantity, unit, loss_pct "
+            "FROM recipe_components WHERE parent_recipe_id=:r"
+        ),
+        {"r": recipe_id},
+    ).mappings().all()
+    for row in rows:
+        qty = multiplier * float(row["quantity"]) / (
+            1 - float(row.get("loss_pct") or 0) / 100.0
+        )
+        if row["component_kind"] == "ITEM":
+            item = conn.execute(
+                text(
+                    "SELECT base_unit, is_active FROM items WHERE item_id=:i"
+                ),
+                {"i": row["component_id"]},
+            ).mappings().fetchone()
+            if not item:
+                raise ValueError(f"Item {row['component_id']} not found")
+            if not item["is_active"]:
+                raise ValueError("Inactive item component encountered")
+            if item["base_unit"] != row["unit"]:
+                raise ValueError("Unit mismatch for item component")
+            totals[row["component_id"]] = totals.get(row["component_id"], 0) + qty
+        elif row["component_kind"] == "RECIPE":
+            sub = conn.execute(
+                text(
+                    "SELECT default_yield_unit, is_active FROM recipes WHERE recipe_id=:r"
+                ),
+                {"r": row["component_id"]},
+            ).mappings().fetchone()
+            if not sub:
+                raise ValueError(f"Recipe {row['component_id']} not found")
+            if not sub["is_active"]:
+                raise ValueError("Inactive sub-recipe encountered")
+            if not sub["default_yield_unit"]:
+                raise ValueError("Missing unit for recipe component")
+            if sub["default_yield_unit"] != row["unit"]:
+                raise ValueError("Unit mismatch for recipe component")
+            _expand_requirements(conn, row["component_id"], qty, totals, visited)
+        else:
+            raise ValueError("Invalid component_kind")
+    visited.remove(recipe_id)
+
+
+def _resolve_item_requirements(
+    conn: Connection, recipe_id: int, quantity: float
+) -> Dict[int, float]:
+    totals: Dict[int, float] = {}
+    _expand_requirements(conn, recipe_id, quantity, totals, set())
+    return totals
+
+
+def record_sale(
+    engine: Engine,
+    recipe_id: int,
+    quantity: float,
+    user_id: str,
+    notes: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """Record sale of a recipe and reduce ingredient stock."""
+    if engine is None:
+        return False, "Database engine not available."
+    if not recipe_id or quantity <= 0:
+        return False, "Invalid recipe or quantity."
+    user_id_clean = user_id.strip() if user_id else "System"
+    notes_clean = _strip_or_none(notes)
+    sale_ins = text(
+        "INSERT INTO sales_transactions (recipe_id, quantity, user_id, notes) "
+        "VALUES (:r, :q, :u, :n);"
+    )
+    try:
+        with engine.connect() as conn:
+            with conn.begin():
+                is_active = conn.execute(
+                    text("SELECT is_active FROM recipes WHERE recipe_id=:r"),
+                    {"r": recipe_id},
+                ).scalar_one_or_none()
+                if is_active is None:
+                    return False, "Recipe not found."
+                if not is_active:
+                    return False, "Recipe is inactive."
+                totals = _resolve_item_requirements(conn, recipe_id, quantity)
+                conn.execute(
+                    sale_ins,
+                    {"r": recipe_id, "q": quantity, "u": user_id_clean, "n": notes_clean},
+                )
+                for iid, qty in totals.items():
+                    conn.execute(
+                        text(
+                            "UPDATE items SET current_stock = COALESCE(current_stock,0) - :q WHERE item_id=:i"
+                        ),
+                        {"q": qty, "i": iid},
+                    )
+                    conn.execute(
+                        text(
+                            """
+                            INSERT INTO stock_transactions
+                            (item_id, quantity_change, transaction_type, user_id, notes, transaction_date)
+                            VALUES (:i, :q, :t, :u, :n, NOW())
+                            """
+                        ),
+                        {
+                            "i": iid,
+                            "q": -qty,
+                            "t": TX_SALE,
+                            "u": user_id_clean,
+                            "n": f"Recipe {recipe_id} sale",
+                        },
+                    )
+        return True, "Sale recorded."
+    except ValueError as ve:
+        logger.error("Error recording sale: %s", ve)
+        return False, str(ve)
+    except SQLAlchemyError as exc:  # pragma: no cover - defensive
+        logger.error("DB error recording sale: %s", exc)
+        return False, "A database error occurred during sale recording."

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -63,4 +63,13 @@ urlpatterns = [
         views_ui.purchase_order_receive,
         name="purchase_order_receive",
     ),
+
+    # Recipe pages
+    path("recipes/", views_ui.recipes_list, name="recipes_list"),
+    path("recipes/<int:pk>/", views_ui.recipe_detail, name="recipe_detail"),
+    path(
+        "recipes/<int:pk>/component-row/",
+        views_ui.recipe_component_row,
+        name="recipe_component_row",
+    ),
 ]

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -8,6 +8,8 @@ from .views import (
     StockTransactionViewSet,
     IndentViewSet,
     IndentItemViewSet,
+    RecipeViewSet,
+    RecipeComponentViewSet,
 )
 
 router = DefaultRouter()
@@ -16,5 +18,7 @@ router.register(r"suppliers", SupplierViewSet)
 router.register(r"stock-transactions", StockTransactionViewSet)
 router.register(r"indents", IndentViewSet)
 router.register(r"indent-items", IndentItemViewSet)
+router.register(r"recipes", RecipeViewSet)
+router.register(r"recipe-components", RecipeComponentViewSet)
 
 urlpatterns = router.urls

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -1,12 +1,22 @@
 from rest_framework import viewsets
 
-from .models import Item, Supplier, StockTransaction, Indent, IndentItem
+from .models import (
+    Item,
+    Supplier,
+    StockTransaction,
+    Indent,
+    IndentItem,
+    Recipe,
+    RecipeComponent,
+)
 from .serializers import (
     ItemSerializer,
     SupplierSerializer,
     StockTransactionSerializer,
     IndentSerializer,
     IndentItemSerializer,
+    RecipeSerializer,
+    RecipeComponentSerializer,
 )
 
 
@@ -50,3 +60,13 @@ class IndentViewSet(viewsets.ModelViewSet):
 class IndentItemViewSet(viewsets.ModelViewSet):
     queryset = IndentItem.objects.all().select_related("indent", "item")
     serializer_class = IndentItemSerializer
+
+
+class RecipeViewSet(viewsets.ModelViewSet):
+    queryset = Recipe.objects.all()
+    serializer_class = RecipeSerializer
+
+
+class RecipeComponentViewSet(viewsets.ModelViewSet):
+    queryset = RecipeComponent.objects.all().select_related("parent_recipe")
+    serializer_class = RecipeComponentSerializer

--- a/inventory/views_ui.py
+++ b/inventory/views_ui.py
@@ -13,6 +13,7 @@ from inventory.services import (
     stock_service,
     purchase_order_service,
     goods_receiving_service,
+    recipe_service,
 )
 from sqlalchemy import create_engine
 from sqlalchemy.engine import URL
@@ -22,6 +23,8 @@ from .models import (
     Supplier,
     StockTransaction,
     Indent,
+    Recipe,
+    RecipeComponent,
     PurchaseOrder,
     PurchaseOrderItem,
     GoodsReceivedNote,
@@ -774,4 +777,36 @@ def purchase_order_receive(request, pk: int):
         request,
         "inventory/purchase_orders/receive.html",
         {"form": form, "po": po, "items": items},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Recipe UI views
+# ---------------------------------------------------------------------------
+
+
+def recipes_list(request):
+    recipes = Recipe.objects.all().order_by("name")
+    return render(request, "inventory/recipes/list.html", {"recipes": recipes})
+
+
+def recipe_detail(request, pk: int):
+    recipe = get_object_or_404(Recipe, pk=pk)
+    components = RecipeComponent.objects.filter(parent_recipe=recipe).order_by(
+        "sort_order", "id"
+    )
+    return render(
+        request,
+        "inventory/recipes/detail.html",
+        {"recipe": recipe, "components": components},
+    )
+
+
+def recipe_component_row(request, pk: int):
+    recipe = get_object_or_404(Recipe, pk=pk)
+    index = int(request.GET.get("index", 0))
+    return render(
+        request,
+        "inventory/recipes/_component_row.html",
+        {"recipe": recipe, "index": index, "comp": None},
     )

--- a/templates/inventory/recipes/_component_row.html
+++ b/templates/inventory/recipes/_component_row.html
@@ -1,0 +1,7 @@
+<tr>
+  <td class="px-2"><input type="text" name="kind-{{ index }}" value="{{ comp.component_kind if comp }}" class="border p-1" /></td>
+  <td class="px-2"><input type="number" name="id-{{ index }}" value="{{ comp.component_id if comp }}" class="border p-1 w-20" /></td>
+  <td class="px-2"><input type="number" step="any" name="qty-{{ index }}" value="{{ comp.quantity if comp }}" class="border p-1 w-24" /></td>
+  <td class="px-2"><input type="text" name="unit-{{ index }}" value="{{ comp.unit if comp }}" class="border p-1 w-16" /></td>
+  <td class="px-2"><input type="number" step="any" name="loss-{{ index }}" value="{{ comp.loss_pct if comp }}" class="border p-1 w-16" /></td>
+</tr>

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -1,0 +1,21 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1 class="text-xl font-bold mb-4">{{ recipe.name }}</h1>
+<table class="table-auto w-full" id="components">
+  <thead>
+    <tr>
+      <th class="px-2">Kind</th>
+      <th class="px-2">ID</th>
+      <th class="px-2">Qty</th>
+      <th class="px-2">Unit</th>
+      <th class="px-2">Loss %</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for comp in components %}
+    {% include "inventory/recipes/_component_row.html" with comp=comp index=forloop.counter0 %}
+  {% endfor %}
+  </tbody>
+</table>
+<button class="mt-4 px-3 py-1 bg-gray-200" hx-get="{% url 'recipe_component_row' recipe.recipe_id %}?index={{ components|length }}" hx-target="#components tbody" hx-swap="beforeend">Add Component</button>
+{% endblock %}

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -1,0 +1,11 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1 class="text-xl font-bold mb-4">Recipes</h1>
+<ul class="list-disc pl-5">
+  {% for r in recipes %}
+    <li><a class="text-blue-600 underline" href="{% url 'recipe_detail' r.recipe_id %}">{{ r.name }}</a></li>
+  {% empty %}
+    <li>No recipes available.</li>
+  {% endfor %}
+</ul>
+{% endblock %}

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -3,7 +3,11 @@
 import pytest
 from sqlalchemy import text
 
-from inventory.services import recipe_service
+from inventory.services.recipe_service import (
+    create_recipe,
+    update_recipe,
+    record_sale,
+)
 
 
 def _create_item(conn, name="Flour", base_unit="kg", purchase_unit="bag", stock=20):
@@ -43,7 +47,7 @@ def test_create_and_update_components(sqlite_engine):
         }
     ]
 
-    ok, _, rid = recipe_service.create_recipe(sqlite_engine, data, components)
+    ok, _, rid = create_recipe(sqlite_engine, data, components)
     assert ok and rid
 
     with sqlite_engine.connect() as conn:
@@ -62,7 +66,7 @@ def test_create_and_update_components(sqlite_engine):
     # update component quantity and loss percentage
     components[0]["quantity"] = 3
     components[0]["loss_pct"] = 10
-    ok, _ = recipe_service.update_recipe(sqlite_engine, rid, data, components)
+    ok, _ = update_recipe(sqlite_engine, rid, data, components)
     assert ok
 
     with sqlite_engine.connect() as conn:
@@ -97,7 +101,7 @@ def test_nested_recipes_and_cycle_prevention(sqlite_engine):
             "unit": "kg",
         }
     ]
-    ok, _, dough_id = recipe_service.create_recipe(
+    ok, _, dough_id = create_recipe(
         sqlite_engine, dough_data, dough_components
     )
     assert ok and dough_id
@@ -115,7 +119,7 @@ def test_nested_recipes_and_cycle_prevention(sqlite_engine):
             "unit": "kg",
         }
     ]
-    ok, _, bread_id = recipe_service.create_recipe(
+    ok, _, bread_id = create_recipe(
         sqlite_engine, bread_data, bread_components
     )
     assert ok and bread_id
@@ -129,7 +133,7 @@ def test_nested_recipes_and_cycle_prevention(sqlite_engine):
             "unit": "kg",
         }
     )
-    ok, _ = recipe_service.update_recipe(
+    ok, _ = update_recipe(
         sqlite_engine, dough_id, dough_data, dough_components
     )
     assert not ok
@@ -178,7 +182,7 @@ def test_record_sale_reduces_nested_stock(sqlite_engine):
             {"r": bread_id, "c": premix_id},
         )
 
-    ok, msg = recipe_service.record_sale(sqlite_engine, bread_id, 2, "tester")
+    ok, msg = record_sale(sqlite_engine, bread_id, 2, "tester")
     assert ok, msg
 
     with sqlite_engine.connect() as conn:
@@ -213,7 +217,7 @@ def test_recipe_metadata_fields(sqlite_engine):
         }
     ]
 
-    ok, _, rid = recipe_service.create_recipe(sqlite_engine, data, components)
+    ok, _, rid = create_recipe(sqlite_engine, data, components)
     assert ok and rid
 
     with sqlite_engine.connect() as conn:

--- a/tests/test_recipes_components.py
+++ b/tests/test_recipes_components.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from inventory.services import recipe_service
+from inventory.services.recipe_service import build_components_from_editor
 from inventory.constants import PLACEHOLDER_SELECT_COMPONENT
 
 def test_build_components_autofill_and_validation():
@@ -38,7 +38,7 @@ def test_build_components_autofill_and_validation():
             "name": "Dough",
         },
     }
-    comps, errs = recipe_service.build_components_from_editor(df, choice_map)
+    comps, errs = build_components_from_editor(df, choice_map)
     assert not errs
     assert comps[0]["unit"] == "kg" and comps[0]["component_id"] == 1
     assert comps[1]["unit"] == "kg" and comps[1]["component_id"] == 2
@@ -64,7 +64,7 @@ def test_build_components_detects_unit_mismatch():
             "name": "Flour",
         }
     }
-    comps, errs = recipe_service.build_components_from_editor(df, choice_map)
+    comps, errs = build_components_from_editor(df, choice_map)
     assert errs and "Unit mismatch" in errs[0]
     assert not comps
 
@@ -90,7 +90,7 @@ def test_build_components_allows_purchase_unit():
             "name": "Flour",
         }
     }
-    comps, errs = recipe_service.build_components_from_editor(df, choice_map)
+    comps, errs = build_components_from_editor(df, choice_map)
     assert not errs
     assert comps and comps[0]["unit"] == "bag"
 
@@ -106,6 +106,6 @@ def test_build_components_skips_placeholder():
             "notes": None,
         }
     ])
-    comps, errs = recipe_service.build_components_from_editor(df, {})
+    comps, errs = build_components_from_editor(df, {})
     assert not comps
     assert not errs


### PR DESCRIPTION
## Summary
- port legacy recipe service to Django app with SQLAlchemy operations
- expose recipes via new models, DRF serializers and viewsets
- add basic HTMX-driven templates for editing recipe components

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ff57248948326ba607c220daa21bf