### PR TITLE
Add purchase order and GRN APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,19 @@ from inventory.services.item_service import add_new_item
 success, msg = add_new_item(engine, {"name": "Whole Milk", "category": "Dairy"})
 ```
 
+## API Endpoints
+
+The application exposes the following REST endpoints under `/api/`:
+
+- `/api/items/` – manage items.
+- `/api/suppliers/` – manage suppliers.
+- `/api/stock-transactions/` – record stock movements.
+- `/api/indents/` – manage indents.
+- `/api/indent-items/` – manage indent items.
+- `/api/recipes/` – manage recipes.
+- `/api/recipe-components/` – manage recipe components.
+- `/api/purchase-orders/` – create and track purchase orders.
+- `/api/purchase-order-items/` – line items within a purchase order.
+- `/api/goods-received-notes/` – log received goods.
+- `/api/grn-items/` – items contained in a goods received note.
+

--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -8,6 +8,10 @@ from .models import (
     Supplier,
     Recipe,
     RecipeComponent,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    GoodsReceivedNote,
+    GRNItem,
 )
 
 
@@ -38,6 +42,30 @@ class IndentSerializer(serializers.ModelSerializer):
 class IndentItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = IndentItem
+        fields = "__all__"
+
+
+class PurchaseOrderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PurchaseOrder
+        fields = "__all__"
+
+
+class PurchaseOrderItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PurchaseOrderItem
+        fields = "__all__"
+
+
+class GoodsReceivedNoteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GoodsReceivedNote
+        fields = "__all__"
+
+
+class GRNItemSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GRNItem
         fields = "__all__"
 
 

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -10,6 +10,10 @@ from .views import (
     IndentItemViewSet,
     RecipeViewSet,
     RecipeComponentViewSet,
+    PurchaseOrderViewSet,
+    PurchaseOrderItemViewSet,
+    GoodsReceivedNoteViewSet,
+    GRNItemViewSet,
 )
 
 router = DefaultRouter()
@@ -20,5 +24,9 @@ router.register(r"indents", IndentViewSet)
 router.register(r"indent-items", IndentItemViewSet)
 router.register(r"recipes", RecipeViewSet)
 router.register(r"recipe-components", RecipeComponentViewSet)
+router.register(r"purchase-orders", PurchaseOrderViewSet)
+router.register(r"purchase-order-items", PurchaseOrderItemViewSet)
+router.register(r"goods-received-notes", GoodsReceivedNoteViewSet)
+router.register(r"grn-items", GRNItemViewSet)
 
 urlpatterns = router.urls

--- a/inventory/views.py
+++ b/inventory/views.py
@@ -8,6 +8,10 @@ from .models import (
     IndentItem,
     Recipe,
     RecipeComponent,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    GoodsReceivedNote,
+    GRNItem,
 )
 from .serializers import (
     ItemSerializer,
@@ -17,6 +21,10 @@ from .serializers import (
     IndentItemSerializer,
     RecipeSerializer,
     RecipeComponentSerializer,
+    PurchaseOrderSerializer,
+    PurchaseOrderItemSerializer,
+    GoodsReceivedNoteSerializer,
+    GRNItemSerializer,
 )
 
 
@@ -60,6 +68,26 @@ class IndentViewSet(viewsets.ModelViewSet):
 class IndentItemViewSet(viewsets.ModelViewSet):
     queryset = IndentItem.objects.all().select_related("indent", "item")
     serializer_class = IndentItemSerializer
+
+
+class PurchaseOrderViewSet(viewsets.ModelViewSet):
+    queryset = PurchaseOrder.objects.all().select_related("supplier")
+    serializer_class = PurchaseOrderSerializer
+
+
+class PurchaseOrderItemViewSet(viewsets.ModelViewSet):
+    queryset = PurchaseOrderItem.objects.all().select_related("purchase_order", "item")
+    serializer_class = PurchaseOrderItemSerializer
+
+
+class GoodsReceivedNoteViewSet(viewsets.ModelViewSet):
+    queryset = GoodsReceivedNote.objects.all().select_related("purchase_order", "supplier")
+    serializer_class = GoodsReceivedNoteSerializer
+
+
+class GRNItemViewSet(viewsets.ModelViewSet):
+    queryset = GRNItem.objects.all().select_related("grn", "po_item")
+    serializer_class = GRNItemSerializer
 
 
 class RecipeViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary
- add serializers and viewsets for purchase orders and goods received notes
- register routes for purchase order and GRN endpoints
- document new API endpoints in README

## Testing
- `flake8 inventory/serializers.py inventory/views.py inventory/urls.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ff9d6488c8326907cecf6f862c5ff