### PR TITLE
Refactor item service to use Django ORM

### DIFF
--- a/inventory/services/item_service.py
+++ b/inventory/services/item_service.py
@@ -1,7 +1,7 @@
 """Database-backed item service utilities for the Django app.
 
 This module extracts a subset of the legacy Streamlit service functions and
-makes them available for the Django codebase.  Any Streamlit-specific caching is
+makes them available for the Django codebase. Any Streamlit-specific caching is
 replaced with :func:`functools.lru_cache` so that callers can clear caches after
 mutating operations.
 """
@@ -13,62 +13,48 @@ import traceback
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-import pandas as pd
-from sqlalchemy import bindparam, text
-from sqlalchemy.engine import Engine
-from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from django.db import IntegrityError, transaction
+from django.db.models import Sum
+from django.db.models.functions import Coalesce
 
+from inventory.models import Item, StockTransaction
 from inventory.unit_inference import infer_units
 
 logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Helper utilities
-# ---------------------------------------------------------------------------
-
-def _fetch_df(
-    engine: Engine, query: str, params: Optional[Dict[str, Any]] = None
-) -> pd.DataFrame:
-    """Execute ``query`` and return the results as a :class:`pandas.DataFrame`."""
-    if engine is None:
-        logger.error("Database engine not available")
-        return pd.DataFrame()
-    try:
-        with engine.connect() as conn:
-            result = conn.execute(text(query), params or {})
-            return pd.DataFrame(result.mappings().all())
-    except Exception as e:  # pragma: no cover - defensive logging
-        logger.error("Error fetching data: %s\n%s", e, traceback.format_exc())
-        return pd.DataFrame()
-
-
-# ---------------------------------------------------------------------------
 # Cached lookup helpers
 # ---------------------------------------------------------------------------
 
-@lru_cache(maxsize=None)
-def get_all_items_with_stock(
-    _engine: Engine, include_inactive: bool = False
-) -> pd.DataFrame:
-    """Return all items with their current stock.
 
-    A convenience ``unit`` column mirroring ``base_unit`` is included so that
-    callers can use a single field for display purposes.
-    """
-    if _engine is None:
-        logger.error("ERROR [item_service.get_all_items_with_stock]: Database engine not available.")
-        return pd.DataFrame()
-    query = (
-        "SELECT item_id, name, base_unit, purchase_unit, category, sub_category, "
-        "permitted_departments, reorder_point, current_stock, notes, is_active FROM items"
-    )
+@lru_cache(maxsize=None)
+def get_all_items_with_stock(include_inactive: bool = False) -> List[Dict[str, Any]]:
+    """Return all items with their current stock as a list of dictionaries."""
+
+    qs = Item.objects.all()
     if not include_inactive:
-        query += " WHERE is_active = TRUE"
-    query += " ORDER BY name;"
-    df = _fetch_df(_engine, query)
-    df["unit"] = df["base_unit"]
-    return df
+        qs = qs.filter(is_active=True)
+    qs = qs.annotate(_stock=Coalesce(Sum("stocktransaction__quantity_change"), 0.0))
+    data = list(
+        qs.values(
+            "item_id",
+            "name",
+            "base_unit",
+            "purchase_unit",
+            "category",
+            "sub_category",
+            "permitted_departments",
+            "reorder_point",
+            "notes",
+            "is_active",
+            "_stock",
+        )
+    )
+    for row in data:
+        row["unit"] = row.get("base_unit")
+        row["current_stock"] = row.pop("_stock")
+    return data
 
 
 # expose a ``clear`` method like the legacy cache decorator
@@ -76,84 +62,61 @@ get_all_items_with_stock.clear = get_all_items_with_stock.cache_clear  # type: i
 
 
 @lru_cache(maxsize=None)
-def suggest_category_and_units(
-    _engine: Engine, item_name: str
-) -> Tuple[Optional[str], Optional[str], Optional[str]]:
-    """Guess base unit, purchase unit and category for ``item_name``.
+def suggest_category_and_units(item_name: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Guess base unit, purchase unit and category for ``item_name``."""
 
-    The first database row whose name contains any token from ``item_name`` is
-    returned.  If no match is found ``(None, None, None)`` is returned so callers
-    may fall back to heuristic inference.
-    """
-    if _engine is None or not item_name:
+    if not item_name:
         return None, None, None
     tokens = [t for t in re.split(r"\W+", item_name.lower()) if t]
     if not tokens:
         return None, None, None
-    query = text(
-        "SELECT base_unit, purchase_unit, category FROM items "
-        "WHERE lower(name) LIKE :pattern LIMIT 1"
-    )
-    with _engine.connect() as conn:
-        for token in tokens:
-            row = conn.execute(query, {"pattern": f"%{token}%"}).mappings().first()
-            if row:
-                return row["base_unit"], row["purchase_unit"], row["category"]
+    for token in tokens:
+        row = (
+            Item.objects.filter(name__icontains=token)
+            .values("base_unit", "purchase_unit", "category")
+            .first()
+        )
+        if row:
+            return row["base_unit"], row["purchase_unit"], row["category"]
     return None, None, None
 
 
-suggest_category_and_units.clear = (  # type: ignore[attr-defined]
+suggest_category_and_units.clear = (
     suggest_category_and_units.cache_clear
-)
+)  # type: ignore[attr-defined]
 
 
 @lru_cache(maxsize=None)
-def get_distinct_departments_from_items(_engine: Engine) -> List[str]:
+def get_distinct_departments_from_items() -> List[str]:
     """Return a sorted list of unique department names from active items."""
-    if _engine is None:
-        logger.error(
-            "ERROR [item_service.get_distinct_departments_from_items]: Database engine not available."
-        )
-        return []
-    query = (
-        "SELECT permitted_departments FROM items "
-        "WHERE is_active = TRUE AND permitted_departments IS NOT NULL "
-        "AND permitted_departments <> '' AND permitted_departments <> ' ';"
+
+    qs = (
+        Item.objects.filter(is_active=True)
+        .exclude(permitted_departments__isnull=True)
+        .exclude(permitted_departments__exact="")
+        .exclude(permitted_departments__exact=" ")
     )
     departments: Set[str] = set()
-    try:
-        with _engine.connect() as conn:
-            result = conn.execute(text(query))
-            for (permitted,) in result.fetchall():
-                if permitted:
-                    departments.update({d.strip() for d in permitted.split(",") if d.strip()})
-        return sorted(departments)
-    except Exception as e:  # pragma: no cover - defensive logging
-        logger.error(
-            "ERROR [item_service.get_distinct_departments_from_items]: %s\n%s",
-            e,
-            traceback.format_exc(),
-        )
-        return []
+    for permitted in qs.values_list("permitted_departments", flat=True):
+        departments.update({d.strip() for d in permitted.split(",") if d.strip()})
+    return sorted(departments)
 
 
-get_distinct_departments_from_items.clear = (  # type: ignore[attr-defined]
+get_distinct_departments_from_items.clear = (
     get_distinct_departments_from_items.cache_clear
-)
+)  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------
 # Mutating helpers
 # ---------------------------------------------------------------------------
 
-def add_new_item(engine: Engine, details: Dict[str, Any]) -> Tuple[bool, str]:
-    """Insert a single item into the database."""
-    if engine is None:
-        return False, "Database engine not available."
 
-    s_base, s_purchase, s_category = suggest_category_and_units(
-        engine, details.get("name", "")
-    )
+@transaction.atomic
+def add_new_item(details: Dict[str, Any]) -> Tuple[bool, str]:
+    """Insert a single item into the database."""
+
+    s_base, s_purchase, s_category = suggest_category_and_units(details.get("name", ""))
     if s_base and not str(details.get("base_unit", "")).strip():
         details["base_unit"] = s_base
     if s_purchase and not str(details.get("purchase_unit", "")).strip():
@@ -194,44 +157,28 @@ def add_new_item(engine: Engine, details: Dict[str, Any]) -> Tuple[bool, str]:
     if isinstance(purchase_unit_val, str):
         purchase_unit_val = purchase_unit_val.strip() or None
 
-    params = {
-        "name": details["name"].strip(),
-        "base_unit": details["base_unit"].strip(),
-        "purchase_unit": purchase_unit_val,
-        "category": (details.get("category", "").strip() or "Uncategorized"),
-        "sub_category": (details.get("sub_category", "").strip() or "General"),
-        "permitted_departments": cleaned_permitted,
-        "reorder_point": details.get("reorder_point", 0.0),
-        "current_stock": details.get("current_stock", 0.0),
-        "notes": cleaned_notes,
-        "is_active": details.get("is_active", True),
-    }
-    query = text(
-        """
-        INSERT INTO items (
-            name, base_unit, purchase_unit, category, sub_category,
-            permitted_departments, reorder_point, current_stock, notes, is_active
-        ) VALUES (
-            :name, :base_unit, :purchase_unit, :category, :sub_category,
-            :permitted_departments, :reorder_point, :current_stock, :notes, :is_active
-        ) RETURNING item_id;
-        """
+    params = dict(
+        name=details["name"].strip(),
+        base_unit=details["base_unit"].strip(),
+        purchase_unit=purchase_unit_val,
+        category=(details.get("category", "").strip() or "Uncategorized"),
+        sub_category=(details.get("sub_category", "").strip() or "General"),
+        permitted_departments=cleaned_permitted,
+        reorder_point=details.get("reorder_point", 0.0),
+        notes=cleaned_notes,
+        is_active=details.get("is_active", True),
     )
     try:
-        with engine.connect() as conn:
-            with conn.begin():
-                new_id = conn.execute(query, params).scalar_one_or_none()
-        if new_id:
-            get_all_items_with_stock.clear()
-            get_distinct_departments_from_items.clear()
-            return True, f"Item '{params['name']}' added with ID {new_id}."
-        return False, "Failed to add item (no ID returned)."
+        item = Item.objects.create(**params)
+        get_all_items_with_stock.clear()
+        get_distinct_departments_from_items.clear()
+        return True, f"Item '{item.name}' added with ID {item.pk}."
     except IntegrityError:
         return (
             False,
             f"Item name '{params['name']}' already exists. Choose a unique name.",
         )
-    except (SQLAlchemyError, Exception) as e:
+    except Exception as e:  # pragma: no cover - defensive logging
         logger.error(
             "ERROR [item_service.add_new_item]: Database error adding item: %s\n%s",
             e,
@@ -240,10 +187,10 @@ def add_new_item(engine: Engine, details: Dict[str, Any]) -> Tuple[bool, str]:
         return False, "A database error occurred while adding the item."
 
 
-def add_items_bulk(engine: Engine, items: List[Dict[str, Any]]) -> Tuple[int, List[str]]:
+@transaction.atomic
+def add_items_bulk(items: List[Dict[str, Any]]) -> Tuple[int, List[str]]:
     """Insert multiple items in a single transaction."""
-    if engine is None:
-        return 0, ["Database engine not available."]
+
     if not items:
         return 0, ["No items provided."]
 
@@ -251,7 +198,7 @@ def add_items_bulk(engine: Engine, items: List[Dict[str, Any]]) -> Tuple[int, Li
     errors: List[str] = []
     for idx, details in enumerate(items):
         s_base, s_purchase, s_category = suggest_category_and_units(
-            engine, details.get("name", "")
+            details.get("name", "")
         )
         if s_base and not str(details.get("base_unit", "")).strip():
             details["base_unit"] = s_base
@@ -295,46 +242,31 @@ def add_items_bulk(engine: Engine, items: List[Dict[str, Any]]) -> Tuple[int, Li
             purchase_unit_val = purchase_unit_val.strip() or None
 
         processed.append(
-            {
-                "name": details["name"].strip(),
-                "base_unit": details["base_unit"].strip(),
-                "purchase_unit": purchase_unit_val,
-                "category": (details.get("category", "").strip() or "Uncategorized"),
-                "sub_category": (details.get("sub_category", "").strip() or "General"),
-                "permitted_departments": cleaned_permitted,
-                "reorder_point": details.get("reorder_point", 0.0),
-                "current_stock": details.get("current_stock", 0.0),
-                "notes": cleaned_notes,
-                "is_active": details.get("is_active", True),
-            }
+            dict(
+                name=details["name"].strip(),
+                base_unit=details["base_unit"].strip(),
+                purchase_unit=purchase_unit_val,
+                category=(details.get("category", "").strip() or "Uncategorized"),
+                sub_category=(details.get("sub_category", "").strip() or "General"),
+                permitted_departments=cleaned_permitted,
+                reorder_point=details.get("reorder_point", 0.0),
+                notes=cleaned_notes,
+                is_active=details.get("is_active", True),
+            )
         )
 
     if errors:
         return 0, errors
 
-    query = text(
-        """
-        INSERT INTO items (
-            name, base_unit, purchase_unit, category, sub_category,
-            permitted_departments, reorder_point, current_stock, notes, is_active
-        ) VALUES (
-            :name, :base_unit, :purchase_unit, :category, :sub_category,
-            :permitted_departments, :reorder_point, :current_stock, :notes, :is_active
-        );
-        """
-    )
     try:
-        with engine.connect() as conn:
-            with conn.begin():
-                result = conn.execute(query, processed)
-                inserted = result.rowcount or 0
-        if inserted:
-            get_all_items_with_stock.clear()
-            get_distinct_departments_from_items.clear()
-        return inserted, []
+        objs = [Item(**p) for p in processed]
+        Item.objects.bulk_create(objs)
+        get_all_items_with_stock.clear()
+        get_distinct_departments_from_items.clear()
+        return len(objs), []
     except IntegrityError as e:
-        return 0, [str(e.orig) if hasattr(e, "orig") else str(e)]
-    except (SQLAlchemyError, Exception) as e:
+        return 0, [str(e)]
+    except Exception as e:  # pragma: no cover - defensive logging
         logger.error(
             "ERROR [item_service.add_items_bulk]: Database error adding items: %s\n%s",
             e,
@@ -343,26 +275,20 @@ def add_items_bulk(engine: Engine, items: List[Dict[str, Any]]) -> Tuple[int, Li
         return 0, ["A database error occurred while adding items."]
 
 
-def remove_items_bulk(engine: Engine, item_ids: List[int]) -> Tuple[int, List[str]]:
+@transaction.atomic
+def remove_items_bulk(item_ids: List[int]) -> Tuple[int, List[str]]:
     """Mark multiple items inactive by ID."""
-    if engine is None:
-        return 0, ["Database engine not available."]
+
     if not item_ids:
         return 0, ["No item IDs provided."]
 
-    query = text("UPDATE items SET is_active = FALSE WHERE item_id IN :ids").bindparams(
-        bindparam("ids", expanding=True)
-    )
     try:
-        with engine.connect() as conn:
-            with conn.begin():
-                result = conn.execute(query, {"ids": item_ids})
-                affected = result.rowcount or 0
+        affected = Item.objects.filter(item_id__in=item_ids).update(is_active=False)
         if affected:
             get_all_items_with_stock.clear()
             get_distinct_departments_from_items.clear()
         return affected, []
-    except (SQLAlchemyError, Exception) as e:
+    except Exception as e:  # pragma: no cover - defensive logging
         logger.error(
             "ERROR [item_service.remove_items_bulk]: Database error removing items: %s\n%s",
             e,
@@ -375,21 +301,30 @@ def remove_items_bulk(engine: Engine, item_ids: List[int]) -> Tuple[int, List[st
 # Non-cached detail lookup
 # ---------------------------------------------------------------------------
 
-def get_item_details(engine: Engine, item_id: int) -> Optional[Dict[str, Any]]:
+
+def get_item_details(item_id: int) -> Optional[Dict[str, Any]]:
     """Return the details for a single item."""
-    if engine is None:
-        logger.error(
-            "ERROR [item_service.get_item_details]: Database engine not available."
+
+    row = (
+        Item.objects.filter(pk=item_id)
+        .annotate(_stock=Coalesce(Sum("stocktransaction__quantity_change"), 0.0))
+        .values(
+            "item_id",
+            "name",
+            "base_unit",
+            "purchase_unit",
+            "category",
+            "sub_category",
+            "permitted_departments",
+            "reorder_point",
+            "notes",
+            "is_active",
+            "_stock",
         )
-        return None
-    query = (
-        "SELECT item_id, name, base_unit, purchase_unit, category, sub_category, "
-        "permitted_departments, reorder_point, current_stock, notes, is_active FROM items "
-        "WHERE item_id = :item_id;"
+        .first()
     )
-    df = _fetch_df(engine, query, {"item_id": item_id})
-    if not df.empty:
-        result = df.iloc[0].to_dict()
-        result["unit"] = result.get("base_unit")
-        return result
+    if row:
+        row["unit"] = row.get("base_unit")
+        row["current_stock"] = row.pop("_stock")
+        return row
     return None

--- a/tests/test_unit_inference.py
+++ b/tests/test_unit_inference.py
@@ -1,32 +1,46 @@
-from sqlalchemy import text
+import pytest
+from django.db import connection
 
+from inventory.models import Item
 from inventory.services import item_service
 
 
-def test_suggest_from_similar_item(sqlite_engine):
-    with sqlite_engine.begin() as conn:
-        conn.execute(
-            text(
-                """
-                INSERT INTO items (
-                    name, base_unit, purchase_unit, category, sub_category,
-                    permitted_departments, reorder_point, current_stock, notes, is_active
-                ) VALUES (
-                    'Whole Milk', 'ltr', 'carton', 'Dairy', 'General', NULL, 0, 0, NULL, 1
-                )
-                """
-            )
-        )
-    base, purchase, category = item_service.suggest_category_and_units(
-        sqlite_engine, "Skim Milk"
+@pytest.fixture(autouse=True)
+def clear_items():
+    Item.objects.all().delete()
+    item_service.suggest_category_and_units.clear()
+
+
+def setup_module(module):
+    with connection.schema_editor() as editor:
+        editor.create_model(Item)
+    item_service.suggest_category_and_units.clear()
+
+
+def teardown_module(module):
+    with connection.schema_editor() as editor:
+        editor.delete_model(Item)
+
+
+def test_suggest_from_similar_item():
+    Item.objects.create(
+        name="Whole Milk",
+        base_unit="ltr",
+        purchase_unit="carton",
+        category="Dairy",
+        sub_category="General",
+        permitted_departments=None,
+        reorder_point=0,
+        notes=None,
+        is_active=True,
     )
+    base, purchase, category = item_service.suggest_category_and_units("Skim Milk")
     assert base == "ltr"
     assert purchase == "carton"
     assert category == "Dairy"
 
 
-def test_suggest_returns_none_if_no_match(sqlite_engine):
-    base, purchase, category = item_service.suggest_category_and_units(
-        sqlite_engine, "Widget"
-    )
+def test_suggest_returns_none_if_no_match():
+    base, purchase, category = item_service.suggest_category_and_units("Widget")
     assert base is None and purchase is None and category is None
+


### PR DESCRIPTION
## Summary
- Replace raw SQL item service with Django ORM queries returning plain dict/list structures and computing stock via annotations
- Implement bulk insert and removal using `bulk_create` and queryset updates with cache clearing
- Simplify item suggestion view and update unit tests to validate dictionary outputs

## Testing
- `pytest tests/test_item_service.py tests/test_unit_inference.py -q`
- `flake8 inventory/services/item_service.py inventory/views/items.py tests/test_item_service.py tests/test_unit_inference.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ec7798e08326be160df656f64a32