### PR TITLE
refactor: drop pandas-based returns

### DIFF
--- a/inventory/services/recipe_service.py
+++ b/inventory/services/recipe_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from django.db import IntegrityError, transaction
 
@@ -82,9 +82,10 @@ def _creates_cycle(parent_id: int, child_id: int) -> bool:
 
 
 def build_components_from_editor(
-    df, choice_map: Dict[str, Dict[str, Any]]
+    rows: Iterable[Dict[str, Any]],
+    choice_map: Dict[str, Dict[str, Any]],
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
-    """Convert a data-editor DataFrame into component payload.
+    """Convert an iterable of editor rows into component payload.
 
     ``choice_map`` is expected to map the label from the UI to metadata about
     the component (kind, id, unit information etc.).
@@ -94,7 +95,7 @@ def build_components_from_editor(
 
     components: List[Dict[str, Any]] = []
     errors: List[str] = []
-    for idx, row in df.iterrows():
+    for idx, row in enumerate(rows):
         label = row.get("component")
         if not label or label == PLACEHOLDER_SELECT_COMPONENT:
             continue

--- a/inventory/services/supplier_service.py
+++ b/inventory/services/supplier_service.py
@@ -1,7 +1,6 @@
 import logging
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
-import pandas as pd
 from django.db import IntegrityError, transaction
 
 from inventory.models import Supplier
@@ -38,11 +37,11 @@ def add_supplier(details: Dict[str, Any]) -> Tuple[bool, str]:
         return False, "A database error occurred while adding the supplier."
 
 
-def get_all_suppliers(include_inactive: bool = False) -> pd.DataFrame:
+def get_all_suppliers(include_inactive: bool = False) -> List[Dict[str, Any]]:
     qs = Supplier.objects.all()
     if not include_inactive:
         qs = qs.filter(is_active=True)
-    data = list(
+    return list(
         qs.values(
             "supplier_id",
             "name",
@@ -54,7 +53,6 @@ def get_all_suppliers(include_inactive: bool = False) -> pd.DataFrame:
             "is_active",
         )
     )
-    return pd.DataFrame(data)
 
 
 def get_supplier_details(supplier_id: int) -> Optional[Dict[str, Any]]:

--- a/inventory/services/ui_service.py
+++ b/inventory/services/ui_service.py
@@ -6,8 +6,6 @@ used in tests and Django views."""
 
 from typing import Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Any
 
-import pandas as pd
-
 __all__ = [
     "build_item_choice_label",
     "build_recipe_choice_label",
@@ -112,23 +110,23 @@ def build_component_options(
 
 
 def autofill_component_meta(
-    df: pd.DataFrame, choice_map: Dict[str, Dict[str, Any]]
-) -> pd.DataFrame:
-    """Fill the ``unit`` and ``category`` columns using ``choice_map``.
+    rows: Iterable[Dict[str, Any]], choice_map: Dict[str, Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Fill the ``unit`` and ``category`` fields using ``choice_map``.
 
-    Any row whose component label exists in ``choice_map`` receives the
-    corresponding unit and category; others are set to ``None``. The
-    dataframe is modified in place and returned for convenience.
+    The passed ``rows`` iterable is converted to a list, updated in place,
+    and returned. Any row whose component label exists in ``choice_map``
+    receives the corresponding unit and category; others are set to
+    ``None``.
     """
 
-    if df is None or "component" not in df:
-        return df
-    for idx, comp in df["component"].items():
-        meta = choice_map.get(comp)
+    result = [dict(row) for row in rows or []]
+    for row in result:
+        meta = choice_map.get(row.get("component"))
         if meta:
-            df.at[idx, "unit"] = meta.get("base_unit")
-            df.at[idx, "category"] = meta.get("category")
+            row["unit"] = meta.get("base_unit")
+            row["category"] = meta.get("category")
         else:
-            df.at[idx, "unit"] = None
-            df.at[idx, "category"] = None
-    return df
+            row["unit"] = None
+            row["category"] = None
+    return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ whitenoise==6.9.0
 gunicorn
 psycopg[binary]==3.2.9
 fpdf2
-pandas
 sqlalchemy
 pyyaml

--- a/tests/test_autofill_component_meta.py
+++ b/tests/test_autofill_component_meta.py
@@ -1,19 +1,15 @@
-import pandas as pd
 from inventory.services.ui_service import autofill_component_meta
 
 
 def test_autofill_component_meta_populates_unit_and_category():
-    df = pd.DataFrame(
-        {
-            "component": ["Flour (1) | kg | Baking | 10.00", "Unknown"],
-            "unit": [None, None],
-            "category": [None, None],
-        }
-    )
+    rows = [
+        {"component": "Flour (1) | kg | Baking | 10.00", "unit": None, "category": None},
+        {"component": "Unknown", "unit": None, "category": None},
+    ]
     choice_map = {
         "Flour (1) | kg | Baking | 10.00": {"base_unit": "kg", "category": "Baking"}
     }
-    result = autofill_component_meta(df, choice_map)
-    assert result.loc[0, "unit"] == "kg"
-    assert result.loc[0, "category"] == "Baking"
-    assert pd.isna(result.loc[1, "unit"]) and pd.isna(result.loc[1, "category"])
+    result = autofill_component_meta(rows, choice_map)
+    assert result[0]["unit"] == "kg"
+    assert result[0]["category"] == "Baking"
+    assert result[1]["unit"] is None and result[1]["category"] is None

--- a/tests/test_recipes_components.py
+++ b/tests/test_recipes_components.py
@@ -1,9 +1,8 @@
-import pandas as pd
 from inventory.services.recipe_service import build_components_from_editor
 from inventory.constants import PLACEHOLDER_SELECT_COMPONENT
 
 def test_build_components_autofill_and_validation():
-    df = pd.DataFrame([
+    rows = [
         {
             "component": "Flour (1) | kg | Baking | 10.00",  # label; irrelevant
             "quantity": 2,
@@ -20,7 +19,7 @@ def test_build_components_autofill_and_validation():
             "sort_order": 2,
             "notes": None,
         },
-    ])
+    ]
     choice_map = {
         "Flour (1) | kg | Baking | 10.00": {
             "kind": "ITEM",
@@ -38,13 +37,13 @@ def test_build_components_autofill_and_validation():
             "name": "Dough",
         },
     }
-    comps, errs = build_components_from_editor(df, choice_map)
+    comps, errs = build_components_from_editor(rows, choice_map)
     assert not errs
     assert comps[0]["unit"] == "kg" and comps[0]["component_id"] == 1
     assert comps[1]["unit"] == "kg" and comps[1]["component_id"] == 2
 
 def test_build_components_detects_unit_mismatch():
-    df = pd.DataFrame([
+    rows = [
         {
             "component": "Flour (1) | kg | Baking | 10.00",
             "quantity": 1,
@@ -53,7 +52,7 @@ def test_build_components_detects_unit_mismatch():
             "sort_order": 1,
             "notes": None,
         }
-    ])
+    ]
     choice_map = {
         "Flour (1) | kg | Baking | 10.00": {
             "kind": "ITEM",
@@ -64,13 +63,13 @@ def test_build_components_detects_unit_mismatch():
             "name": "Flour",
         }
     }
-    comps, errs = build_components_from_editor(df, choice_map)
+    comps, errs = build_components_from_editor(rows, choice_map)
     assert errs and "Unit mismatch" in errs[0]
     assert not comps
 
 
 def test_build_components_allows_purchase_unit():
-    df = pd.DataFrame([
+    rows = [
         {
             "component": "Flour (1) | kg | Baking | 10.00",
             "quantity": 3,
@@ -79,7 +78,7 @@ def test_build_components_allows_purchase_unit():
             "sort_order": 1,
             "notes": None,
         }
-    ])
+    ]
     choice_map = {
         "Flour (1) | kg | Baking | 10.00": {
             "kind": "ITEM",
@@ -90,13 +89,13 @@ def test_build_components_allows_purchase_unit():
             "name": "Flour",
         }
     }
-    comps, errs = build_components_from_editor(df, choice_map)
+    comps, errs = build_components_from_editor(rows, choice_map)
     assert not errs
     assert comps and comps[0]["unit"] == "bag"
 
 
 def test_build_components_skips_placeholder():
-    df = pd.DataFrame([
+    rows = [
         {
             "component": PLACEHOLDER_SELECT_COMPONENT,
             "quantity": 1,
@@ -105,7 +104,7 @@ def test_build_components_skips_placeholder():
             "sort_order": 1,
             "notes": None,
         }
-    ])
-    comps, errs = build_components_from_editor(df, {})
+    ]
+    comps, errs = build_components_from_editor(rows, {})
     assert not comps
     assert not errs

--- a/tests/test_supplier_service.py
+++ b/tests/test_supplier_service.py
@@ -65,3 +65,16 @@ def test_deactivate_and_reactivate_supplier():
     supplier.refresh_from_db()
     assert supplier.is_active is True
 
+
+def test_get_all_suppliers_returns_list_of_dicts():
+    Supplier.objects.create(name="Vendor D", is_active=True)
+    Supplier.objects.create(name="Vendor E", is_active=False)
+    active_only = supplier_service.get_all_suppliers()
+    assert isinstance(active_only, list)
+    assert all(isinstance(row, dict) for row in active_only)
+    names = {row["name"] for row in active_only}
+    assert "Vendor D" in names and "Vendor E" not in names
+    all_suppliers = supplier_service.get_all_suppliers(include_inactive=True)
+    names_all = {row["name"] for row in all_suppliers}
+    assert {"Vendor D", "Vendor E"}.issubset(names_all)
+

--- a/tests/test_supplier_service_django.py
+++ b/tests/test_supplier_service_django.py
@@ -43,3 +43,17 @@ def test_deactivate_and_reactivate_supplier():
     assert ok
     supplier.refresh_from_db()
     assert supplier.is_active is True
+
+
+@pytest.mark.django_db
+def test_get_all_suppliers_returns_list_of_dicts():
+    Supplier.objects.create(name="Vendor D", is_active=True)
+    Supplier.objects.create(name="Vendor E", is_active=False)
+    active_only = supplier_service.get_all_suppliers()
+    assert isinstance(active_only, list)
+    assert all(isinstance(row, dict) for row in active_only)
+    names = {row["name"] for row in active_only}
+    assert "Vendor D" in names and "Vendor E" not in names
+    all_suppliers = supplier_service.get_all_suppliers(include_inactive=True)
+    names_all = {row["name"] for row in all_suppliers}
+    assert {"Vendor D", "Vendor E"}.issubset(names_all)


### PR DESCRIPTION
## Summary
- replace supplier service DataFrame responses with plain lists of dicts
- convert UI helper and recipe component builder to work on iterables instead of pandas
- remove pandas dependency and adjust tests accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2fc120c3c83269d0f2c02642364db