### PR TITLE
feat: drop dataframe usage from ui helpers

### DIFF
--- a/inventory/services/ui_service.py
+++ b/inventory/services/ui_service.py
@@ -14,13 +14,32 @@ __all__ = [
 ]
 
 
-def build_item_choice_label(item: Mapping) -> str:
+def _to_dict(obj: Any) -> Dict[str, Any]:
+    """Return a dictionary representation of ``obj``.
+
+    Supports plain mappings, objects with ``model_dump``/``dict`` methods
+    (e.g., pydantic models) and simple attribute containers. The function is
+    intentionally lightweight to avoid adding hard dependencies.
+    """
+
+    if isinstance(obj, Mapping):
+        return dict(obj)
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump()  # type: ignore[no-any-return]
+    if hasattr(obj, "dict"):
+        return obj.dict()  # type: ignore[no-any-return]
+    return {k: getattr(obj, k) for k in dir(obj) if not k.startswith("_")}
+
+
+def build_item_choice_label(item: Any) -> str:
     """Return standardized label for item choices.
 
     Displays ``Name (ID) | Unit | Category | On-hand``. SKU is approximated
-    by ``item_id`` if an explicit SKU is unavailable.
+    by ``item_id`` if an explicit SKU is unavailable. ``item`` may be a plain
+    mapping, a Pydantic model, or any object with compatible attributes.
     """
 
+    item = _to_dict(item)
     name = item.get("name", "")
     sku = item.get("sku") or item.get("item_id")
     unit = item.get("base_unit", "")
@@ -30,12 +49,14 @@ def build_item_choice_label(item: Mapping) -> str:
     return f"{name} ({sku}) | {unit} | {category} | {stock_part}"
 
 
-def build_recipe_choice_label(recipe: Mapping) -> str:
+def build_recipe_choice_label(recipe: Any) -> str:
     """Return standardized label for sub-recipe choices.
 
-    Displays ``Recipe Name | Default Unit | Tags``.
+    Displays ``Recipe Name | Default Unit | Tags``. ``recipe`` may be a plain
+    mapping, a Pydantic model, or any object with compatible attributes.
     """
 
+    recipe = _to_dict(recipe)
     name = recipe.get("name", "")
     unit = recipe.get("default_yield_unit") or ""
     tags = recipe.get("tags") or ""
@@ -43,8 +64,8 @@ def build_recipe_choice_label(recipe: Mapping) -> str:
 
 
 def build_component_options(
-    items: Iterable[Mapping] = (),
-    sub_recipes: Iterable[Mapping] = (),
+    items: Iterable[Any] = (),
+    sub_recipes: Iterable[Any] = (),
     *,
     placeholder: Optional[str] = None,
     item_filter: Optional[Callable[[Mapping], bool]] = None,
@@ -52,18 +73,9 @@ def build_component_options(
 ) -> Tuple[List[str], Dict[str, Dict]]:
     """Return option labels and metadata map for items and sub-recipes.
 
-    Parameters
-    ----------
-    items : Iterable[Mapping]
-        Iterable of item-like mappings.
-    sub_recipes : Iterable[Mapping]
-        Iterable of sub-recipe mappings.
-    placeholder : str, optional
-        If provided, inserted at the start of the options list.
-    item_filter : Callable[[Mapping], bool], optional
-        Function returning True for items to include.
-    recipe_filter : Callable[[Mapping], bool], optional
-        Function returning True for recipes to include.
+    ``items`` and ``sub_recipes`` may contain dicts, Pydantic models or other
+    attribute-based objects. Filters receive a plain dict representation of
+    each object if provided.
 
     Returns
     -------
@@ -78,31 +90,33 @@ def build_component_options(
         options.append(placeholder)
 
     for item in items or []:
-        if item_filter and not item_filter(item):
+        item_dict = _to_dict(item)
+        if item_filter and not item_filter(item_dict):
             continue
-        label = build_item_choice_label(item)
+        label = build_item_choice_label(item_dict)
         meta_map[label] = {
             "kind": "ITEM",
-            "id": int(item.get("item_id")),
-            "base_unit": item.get("base_unit"),
+            "id": int(item_dict.get("item_id")),
+            "base_unit": item_dict.get("base_unit"),
             # include purchase_unit so downstream UIs can offer a choice
             # between base and purchase units when selecting component quantities
-            "purchase_unit": item.get("purchase_unit"),
-            "category": item.get("category"),
-            "name": item.get("name"),
+            "purchase_unit": item_dict.get("purchase_unit"),
+            "category": item_dict.get("category"),
+            "name": item_dict.get("name"),
         }
         options.append(label)
 
     for recipe in sub_recipes or []:
-        if recipe_filter and not recipe_filter(recipe):
+        recipe_dict = _to_dict(recipe)
+        if recipe_filter and not recipe_filter(recipe_dict):
             continue
-        label = build_recipe_choice_label(recipe)
+        label = build_recipe_choice_label(recipe_dict)
         meta_map[label] = {
             "kind": "RECIPE",
-            "id": int(recipe.get("recipe_id")),
-            "unit": recipe.get("default_yield_unit"),
+            "id": int(recipe_dict.get("recipe_id")),
+            "unit": recipe_dict.get("default_yield_unit"),
             "category": "Sub-recipe",
-            "name": recipe.get("name"),
+            "name": recipe_dict.get("name"),
         }
         options.append(label)
 
@@ -110,17 +124,17 @@ def build_component_options(
 
 
 def autofill_component_meta(
-    rows: Iterable[Dict[str, Any]], choice_map: Dict[str, Dict[str, Any]]
+    rows: Iterable[Any], choice_map: Dict[str, Dict[str, Any]]
 ) -> List[Dict[str, Any]]:
     """Fill the ``unit`` and ``category`` fields using ``choice_map``.
 
-    The passed ``rows`` iterable is converted to a list, updated in place,
-    and returned. Any row whose component label exists in ``choice_map``
-    receives the corresponding unit and category; others are set to
-    ``None``.
+    ``rows`` may contain dictionaries, Pydantic models or simple objects.
+    Each row is converted to a dict, updated in place, and returned. Any row
+    whose component label exists in ``choice_map`` receives the corresponding
+    unit and category; others are set to ``None``.
     """
 
-    result = [dict(row) for row in rows or []]
+    result = [_to_dict(row) for row in rows or []]
     for row in result:
         meta = choice_map.get(row.get("component"))
         if meta:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psycopg[binary]==3.2.9
 fpdf2
 sqlalchemy
 pyyaml
+pydantic

--- a/tests/test_autofill_component_meta.py
+++ b/tests/test_autofill_component_meta.py
@@ -1,10 +1,31 @@
 from inventory.services.ui_service import autofill_component_meta
+from pydantic import BaseModel
 
 
 def test_autofill_component_meta_populates_unit_and_category():
     rows = [
         {"component": "Flour (1) | kg | Baking | 10.00", "unit": None, "category": None},
         {"component": "Unknown", "unit": None, "category": None},
+    ]
+    choice_map = {
+        "Flour (1) | kg | Baking | 10.00": {"base_unit": "kg", "category": "Baking"}
+    }
+    result = autofill_component_meta(rows, choice_map)
+    assert result[0]["unit"] == "kg"
+    assert result[0]["category"] == "Baking"
+    assert result[1]["unit"] is None and result[1]["category"] is None
+
+
+class RowModel(BaseModel):
+    component: str
+    unit: str | None = None
+    category: str | None = None
+
+
+def test_autofill_component_meta_accepts_models():
+    rows = [
+        RowModel(component="Flour (1) | kg | Baking | 10.00"),
+        RowModel(component="Unknown"),
     ]
     choice_map = {
         "Flour (1) | kg | Baking | 10.00": {"base_unit": "kg", "category": "Baking"}


### PR DESCRIPTION
## Summary
- support dicts and pydantic models in UI helper metadata functions
- remove pandas dependency from legacy UI helper
- test helpers against missing components and pydantic models

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2ff58c4a48326acca51996ed7d76a