### PR TITLE
Add Docker deployment configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Dockerfile for Django application using Gunicorn
+FROM python:3.11-slim
+
+# Disable Python buffering and writing pyc files
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+# Copy project
+COPY . .
+
+# Expose the port Gunicorn will listen on
+EXPOSE 8000
+
+# Default command to run the Gunicorn application server
+CMD ["gunicorn", "inventory_app.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,39 @@ python manage.py migrate
 python manage.py runserver
 ```
 
+## Docker Deployment
+
+The project includes a production-ready deployment using Docker and
+Docker Compose. It sets up three services:
+
+- **web** – the Django application served by Gunicorn
+- **nginx** – reverse proxy serving static files
+- **db** – PostgreSQL database
+
+### Setup
+
+1. Ensure Docker and Docker Compose are installed.
+2. Copy `.env.example` to `.env` and provide values, including a
+   `DATABASE_URL` that points to the `db` service and credentials for the
+   Postgres container:
+
+   ```env
+   DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
+   POSTGRES_DB=postgres
+   POSTGRES_USER=postgres
+   POSTGRES_PASSWORD=postgres
+   ```
+
+3. Build and start the stack:
+
+   ```bash
+   docker-compose up --build
+   ```
+
+   The web container automatically applies database migrations and
+   collects static files before launching Gunicorn. Visit
+   `http://localhost/` to access the application.
+
 ## Purchase Order Tables
 
 The project defines four tables used for purchasing and goods receiving workflows:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.9'
+
+services:
+  web:
+    build: .
+    command: >
+      sh -c "python manage.py migrate && \
+             python manage.py collectstatic --noinput && \
+             gunicorn inventory_app.wsgi:application --bind 0.0.0.0:8000"
+    volumes:
+      - static_volume:/app/staticfiles
+    env_file:
+      - .env
+    depends_on:
+      - db
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - static_volume:/app/staticfiles
+    depends_on:
+      - web
+
+  db:
+    image: postgres:15-alpine
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    env_file:
+      - .env
+
+volumes:
+  postgres_data:
+  static_volume:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+
+    location /static/ {
+        alias /app/staticfiles/;
+    }
+
+    location / {
+        proxy_pass http://web:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- containerize the Django app with a production-ready Dockerfile using Gunicorn
- orchestrate web, nginx, and Postgres services via docker-compose
- document Docker deployment steps in the README

## Testing
- `pytest` *(fails: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it)*
- `flake8` *(fails: various lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f646a5fc8326acddf6914e53219e