### PR TITLE
Refactor services and modernize PDF generation

### DIFF
--- a/inventory/indent_pdf.py
+++ b/inventory/indent_pdf.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
-from io import BytesIO
 from typing import Iterable
 
 from fpdf import FPDF
+from fpdf.enums import XPos, YPos
 
 from .models import Indent, IndentItem
 
@@ -21,21 +21,29 @@ def generate_indent_pdf(indent: Indent, items: Iterable[IndentItem]) -> bytes:
     """
     pdf = FPDF()
     pdf.add_page()
-    pdf.set_font("Arial", size=12)
+    pdf.set_font("Helvetica", size=12)
     title = f"Indent {indent.mrn or indent.pk}"
-    pdf.cell(0, 10, title, ln=True)
+    pdf.cell(0, 10, title, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
     if getattr(indent, "requested_by", None):
-        pdf.cell(0, 10, f"Requested by: {indent.requested_by}", ln=True)
+        pdf.cell(
+            0,
+            10,
+            f"Requested by: {indent.requested_by}",
+            new_x=XPos.LMARGIN,
+            new_y=YPos.NEXT,
+        )
     pdf.ln(4)
     # Table header
-    pdf.set_font("Arial", size=10)
+    pdf.set_font("Helvetica", size=10)
     pdf.cell(120, 8, "Item", border=1)
-    pdf.cell(30, 8, "Qty", border=1, ln=True)
+    pdf.cell(30, 8, "Qty", border=1, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
     for line in items:
-        name = getattr(getattr(line, "item", None), "name", str(getattr(line, "item", "")))
+        name = getattr(
+            getattr(line, "item", None),
+            "name",
+            str(getattr(line, "item", "")),
+        )
         qty = getattr(line, "requested_qty", "")
         pdf.cell(120, 8, str(name), border=1)
-        pdf.cell(30, 8, str(qty), border=1, ln=True)
-    buffer = BytesIO()
-    pdf.output(buffer)
-    return buffer.getvalue()
+        pdf.cell(30, 8, str(qty), border=1, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+    return bytes(pdf.output())

--- a/inventory/services/goods_receiving_service.py
+++ b/inventory/services/goods_receiving_service.py
@@ -23,63 +23,98 @@ def generate_grn_number() -> str:
     return f"GRN-{next_id:04d}"
 
 
-def create_grn(
+def _validate_inputs(
     grn_data: Dict[str, Any], items_received_data: List[Dict[str, Any]]
-) -> Tuple[bool, str, Optional[int]]:
+) -> Tuple[bool, str]:
     required = ["supplier_id", "received_date", "received_by_user_id"]
     missing = [f for f in required if not grn_data.get(f)]
     if missing:
-        return False, f"Missing GRN fields: {', '.join(missing)}", None
+        return False, f"Missing GRN fields: {', '.join(missing)}"
     if not items_received_data:
-        return False, "GRN must contain at least one received item.", None
+        return False, "GRN must contain at least one received item."
+    return True, ""
+
+
+def _create_grn_header(
+    grn_data: Dict[str, Any],
+) -> Tuple[GoodsReceivedNote, Optional[PurchaseOrder]]:
+    supplier = Supplier.objects.get(pk=grn_data["supplier_id"])
+    po = (
+        PurchaseOrder.objects.get(pk=grn_data.get("po_id"))
+        if grn_data.get("po_id")
+        else None
+    )
+    grn = GoodsReceivedNote.objects.create(
+        purchase_order=po,
+        supplier=supplier,
+        received_date=grn_data["received_date"],
+        notes=grn_data.get("notes"),
+    )
+    return grn, po
+
+
+def _process_items(
+    grn: GoodsReceivedNote,
+    items_received_data: List[Dict[str, Any]],
+    user_id: str,
+    po: Optional[PurchaseOrder],
+) -> None:
+    grn_number = generate_grn_number()
+    for item_d in items_received_data:
+        item = Item.objects.get(pk=item_d["item_id"])
+        po_item = PurchaseOrderItem.objects.get(pk=item_d["po_item_id"])
+        qty = float(item_d["quantity_received"])
+        GRNItem.objects.create(
+            grn=grn,
+            po_item=po_item,
+            quantity_ordered_on_po=item_d.get(
+                "quantity_ordered_on_po", po_item.quantity_ordered
+            ),
+            quantity_received=qty,
+            unit_price_at_receipt=float(item_d["unit_price_at_receipt"]),
+            item_notes=item_d.get("item_notes"),
+        )
+        po_item.quantity_received += qty
+        po_item.save()
+        stock_service.record_stock_transaction(
+            item_id=item.item_id,
+            quantity_change=qty,
+            transaction_type="RECEIVING",
+            user_id=user_id,
+            related_po_id=po.po_id if po else None,
+            notes=f"GRN {grn_number}",
+        )
+    if po:
+        _update_po_status(po)
+
+
+def _update_po_status(po: PurchaseOrder) -> None:
+    fully_received = all(
+        i.quantity_received >= i.quantity_ordered
+        for i in po.purchaseorderitem_set.all()
+    )
+    po.status = "COMPLETE" if fully_received else "PARTIAL"
+    po.save()
+
+
+def create_grn(
+    grn_data: Dict[str, Any], items_received_data: List[Dict[str, Any]]
+) -> Tuple[bool, str, Optional[int]]:
+    valid, msg = _validate_inputs(grn_data, items_received_data)
+    if not valid:
+        return False, msg, None
     try:
         with transaction.atomic():
-            supplier = Supplier.objects.get(pk=grn_data["supplier_id"])
-            po = (
-                PurchaseOrder.objects.get(pk=grn_data.get("po_id"))
-                if grn_data.get("po_id")
-                else None
+            grn, po = _create_grn_header(grn_data)
+            _process_items(
+                grn, items_received_data, grn_data["received_by_user_id"], po
             )
-            grn = GoodsReceivedNote.objects.create(
-                purchase_order=po,
-                supplier=supplier,
-                received_date=grn_data["received_date"],
-                notes=grn_data.get("notes"),
-            )
-            grn_number = generate_grn_number()
-            for item_d in items_received_data:
-                item = Item.objects.get(pk=item_d["item_id"])
-                po_item = PurchaseOrderItem.objects.get(pk=item_d["po_item_id"])
-                qty = float(item_d["quantity_received"])
-                GRNItem.objects.create(
-                    grn=grn,
-                    po_item=po_item,
-                    quantity_ordered_on_po=item_d.get(
-                        "quantity_ordered_on_po", po_item.quantity_ordered
-                    ),
-                    quantity_received=qty,
-                    unit_price_at_receipt=float(item_d["unit_price_at_receipt"]),
-                    item_notes=item_d.get("item_notes"),
-                )
-                po_item.quantity_received += qty
-                po_item.save()
-                stock_service.record_stock_transaction(
-                    item_id=item.item_id,
-                    quantity_change=qty,
-                    transaction_type="RECEIVING",
-                    user_id=grn_data["received_by_user_id"],
-                    related_po_id=po.po_id if po else None,
-                    notes=f"GRN {grn_number}",
-                )
-            if po:
-                fully_received = all(
-                    i.quantity_received >= i.quantity_ordered
-                    for i in po.purchaseorderitem_set.all()
-                )
-                po.status = "COMPLETE" if fully_received else "PARTIAL"
-                po.save()
             return True, "GRN created", grn.grn_id
-    except (Supplier.DoesNotExist, Item.DoesNotExist, PurchaseOrderItem.DoesNotExist) as exc:
+    except (
+        Supplier.DoesNotExist,
+        Item.DoesNotExist,
+        PurchaseOrderItem.DoesNotExist,
+    ) as exc:
         return False, f"Invalid reference: {exc}", None
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("Error creating GRN: %s", exc)


### PR DESCRIPTION
## Summary
- use fpdf2's modern API in indent PDF generation
- split GRN creation logic into smaller helpers
- modularize item creation to simplify unit/category handling

## Testing
- `flake8 inventory/indent_pdf.py`
- `flake8 inventory/services/goods_receiving_service.py`
- `flake8 inventory/services/item_service.py`
- `pytest tests/test_indent_pdf.py tests/test_item_service.py tests/test_goods_receiving_service_django.py -q`
- `pytest -q` *(fails: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f9885d80832688deaa5354122e4c