### PR TITLE
Secure API, add sales endpoint and dashboard

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -1,0 +1,19 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1 class="text-2xl font-semibold mb-4">Dashboard</h1>
+<h2 class="text-xl mb-2">Low Stock Items</h2>
+<table class="table">
+  <thead><tr><th>Item</th><th>Stock</th><th>Reorder Point</th></tr></thead>
+  <tbody>
+  {% for item in low_stock %}
+    <tr>
+      <td>{{ item.name }}</td>
+      <td>{{ item.current_stock }}</td>
+      <td>{{ item.reorder_point }}</td>
+    </tr>
+  {% empty %}
+    <tr><td colspan="3">No low stock items.</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -4,6 +4,7 @@
   <div class="flex items-center justify-center">
     <div class="bg-white p-6 rounded shadow text-center">
       <p class="text-xl">Django is running</p>
+      <p class="mt-4"><a href="{% url 'dashboard' %}" class="text-blue-600 underline">Go to Dashboard</a></p>
     </div>
   </div>
 {% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -1,8 +1,21 @@
+from django.contrib.auth.decorators import login_required
+from django.db.models import F
 from django.http import HttpResponse
 from django.shortcuts import render
+
+from inventory.models import Item
 
 def root_view(request):
     return render(request, "core/home.html")
 
 def health_check(request):
     return HttpResponse("ok")
+
+
+@login_required
+def dashboard(request):
+    low_stock = Item.objects.filter(
+        reorder_point__isnull=False,
+        current_stock__lt=F("reorder_point"),
+    ).order_by("name")
+    return render(request, "core/dashboard.html", {"low_stock": low_stock})

--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -1,3 +1,33 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import (
+    GRNItem,
+    GoodsReceivedNote,
+    Indent,
+    IndentItem,
+    Item,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    Recipe,
+    RecipeComponent,
+    SaleTransaction,
+    StockTransaction,
+    Supplier,
+)
+
+
+for model in [
+    Item,
+    Supplier,
+    StockTransaction,
+    Recipe,
+    RecipeComponent,
+    SaleTransaction,
+    Indent,
+    IndentItem,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    GoodsReceivedNote,
+    GRNItem,
+]:
+    admin.site.register(model)

--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -12,6 +12,7 @@ from .models import (
     PurchaseOrderItem,
     GoodsReceivedNote,
     GRNItem,
+    SaleTransaction,
 )
 
 
@@ -66,6 +67,12 @@ class GoodsReceivedNoteSerializer(serializers.ModelSerializer):
 class GRNItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = GRNItem
+        fields = "__all__"
+
+
+class SaleTransactionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = SaleTransaction
         fields = "__all__"
 
 

--- a/inventory/services/__init__.py
+++ b/inventory/services/__init__.py
@@ -8,6 +8,7 @@ from . import (
     goods_receiving_service,
     recipe_service,
     ui_service,
+    sale_service,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "goods_receiving_service",
     "recipe_service",
     "ui_service",
+    "sale_service",
 ]

--- a/inventory/services/sale_service.py
+++ b/inventory/services/sale_service.py
@@ -1,0 +1,9 @@
+"""Services for recording sales transactions."""
+from typing import Tuple, Optional
+
+from . import recipe_service
+
+
+def record_sale(recipe_id: int, quantity: float, user_id: str, notes: Optional[str] = None) -> Tuple[bool, str]:
+    """Record a sale via :mod:`recipe_service` and adjust stock."""
+    return recipe_service.record_sale(recipe_id, quantity, user_id, notes)

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -38,6 +38,10 @@ from .views.recipes import (
     RecipeDetailView,
     RecipeComponentRowView,
 )
+from .views.goods_received import (
+    GRNListView,
+    GRNDetailView,
+)
 
 urlpatterns = [
     path("items/", ItemsListView.as_view(), name="items_list"),
@@ -70,6 +74,9 @@ urlpatterns = [
     path("purchase-orders/<int:pk>/edit/", purchase_order_edit, name="purchase_order_edit"),
     path("purchase-orders/<int:pk>/", purchase_order_detail, name="purchase_order_detail"),
     path("purchase-orders/<int:pk>/receive/", purchase_order_receive, name="purchase_order_receive"),
+
+    path("grns/", GRNListView.as_view(), name="grn_list"),
+    path("grns/<int:pk>/", GRNDetailView.as_view(), name="grn_detail"),
 
     path("recipes/", RecipesListView.as_view(), name="recipes_list"),
     path("recipes/<int:pk>/", RecipeDetailView.as_view(), name="recipe_detail"),

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -14,6 +14,7 @@ from .views import (
     PurchaseOrderItemViewSet,
     GoodsReceivedNoteViewSet,
     GRNItemViewSet,
+    SaleTransactionViewSet,
 )
 
 router = DefaultRouter()
@@ -28,5 +29,6 @@ router.register(r"purchase-orders", PurchaseOrderViewSet)
 router.register(r"purchase-order-items", PurchaseOrderItemViewSet)
 router.register(r"goods-received-notes", GoodsReceivedNoteViewSet)
 router.register(r"grn-items", GRNItemViewSet)
+router.register(r"sale-transactions", SaleTransactionViewSet)
 
 urlpatterns = router.urls

--- a/inventory/views/__init__.py
+++ b/inventory/views/__init__.py
@@ -10,6 +10,7 @@ from .api import (
     PurchaseOrderItemViewSet,
     GoodsReceivedNoteViewSet,
     GRNItemViewSet,
+    SaleTransactionViewSet,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     'PurchaseOrderItemViewSet',
     'GoodsReceivedNoteViewSet',
     'GRNItemViewSet',
+    'SaleTransactionViewSet',
 ]

--- a/inventory/views/api.py
+++ b/inventory/views/api.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets
+from rest_framework import permissions, viewsets
 
 from ..models import (
     Item,
@@ -12,6 +12,7 @@ from ..models import (
     PurchaseOrderItem,
     GoodsReceivedNote,
     GRNItem,
+    SaleTransaction,
 )
 from ..serializers import (
     ItemSerializer,
@@ -25,12 +26,14 @@ from ..serializers import (
     PurchaseOrderItemSerializer,
     GoodsReceivedNoteSerializer,
     GRNItemSerializer,
+    SaleTransactionSerializer,
 )
 
 
 class ItemViewSet(viewsets.ModelViewSet):
     queryset = Item.objects.all()
     serializer_class = ItemSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -43,16 +46,19 @@ class ItemViewSet(viewsets.ModelViewSet):
 class SupplierViewSet(viewsets.ModelViewSet):
     queryset = Supplier.objects.all()
     serializer_class = SupplierSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
 
 class StockTransactionViewSet(viewsets.ModelViewSet):
     queryset = StockTransaction.objects.all().select_related("item")
     serializer_class = StockTransactionSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
 
 class IndentViewSet(viewsets.ModelViewSet):
     queryset = Indent.objects.all()
     serializer_class = IndentSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
         queryset = super().get_queryset()
@@ -68,33 +74,46 @@ class IndentViewSet(viewsets.ModelViewSet):
 class IndentItemViewSet(viewsets.ModelViewSet):
     queryset = IndentItem.objects.all().select_related("indent", "item")
     serializer_class = IndentItemSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
 
 class PurchaseOrderViewSet(viewsets.ModelViewSet):
     queryset = PurchaseOrder.objects.all().select_related("supplier")
     serializer_class = PurchaseOrderSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
 
 class PurchaseOrderItemViewSet(viewsets.ModelViewSet):
     queryset = PurchaseOrderItem.objects.all().select_related("purchase_order", "item")
     serializer_class = PurchaseOrderItemSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
 
 class GoodsReceivedNoteViewSet(viewsets.ModelViewSet):
     queryset = GoodsReceivedNote.objects.all().select_related("purchase_order", "supplier")
     serializer_class = GoodsReceivedNoteSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
 
 class GRNItemViewSet(viewsets.ModelViewSet):
     queryset = GRNItem.objects.all().select_related("grn", "po_item")
     serializer_class = GRNItemSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
 
 class RecipeViewSet(viewsets.ModelViewSet):
     queryset = Recipe.objects.all()
     serializer_class = RecipeSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
 
 class RecipeComponentViewSet(viewsets.ModelViewSet):
     queryset = RecipeComponent.objects.all().select_related("parent_recipe")
     serializer_class = RecipeComponentSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+
+class SaleTransactionViewSet(viewsets.ModelViewSet):
+    queryset = SaleTransaction.objects.all().select_related("recipe")
+    serializer_class = SaleTransactionSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/inventory/views/goods_received.py
+++ b/inventory/views/goods_received.py
@@ -1,0 +1,29 @@
+import logging
+
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import get_object_or_404
+from django.views.generic import TemplateView
+
+from ..models import GoodsReceivedNote
+
+logger = logging.getLogger(__name__)
+
+
+class GRNListView(LoginRequiredMixin, TemplateView):
+    template_name = "inventory/grns/list.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["grns"] = GoodsReceivedNote.objects.select_related("purchase_order", "supplier").order_by("-received_date")
+        return ctx
+
+
+class GRNDetailView(LoginRequiredMixin, TemplateView):
+    template_name = "inventory/grns/detail.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        grn = get_object_or_404(GoodsReceivedNote, pk=self.kwargs["pk"])
+        items = grn.grnitem_set.select_related("po_item", "po_item__item")
+        ctx.update({"grn": grn, "items": items})
+        return ctx

--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -2,6 +2,11 @@ import logging
 
 
 from django.contrib import messages
+import logging
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.paginator import Paginator
 from django.db import DatabaseError, transaction
 from django.http import HttpResponse
@@ -23,7 +28,7 @@ INDENT_STATUS_BADGES = {
 }
 
 
-class IndentsListView(TemplateView):
+class IndentsListView(LoginRequiredMixin, TemplateView):
     template_name = "inventory/indents_list.html"
 
     def get_context_data(self, **kwargs):
@@ -33,7 +38,7 @@ class IndentsListView(TemplateView):
         return ctx
 
 
-class IndentsTableView(TemplateView):
+class IndentsTableView(LoginRequiredMixin, TemplateView):
     template_name = "inventory/_indents_table.html"
 
     def get_context_data(self, **kwargs):
@@ -50,7 +55,7 @@ class IndentsTableView(TemplateView):
         return ctx
 
 
-class IndentCreateView(View):
+class IndentCreateView(LoginRequiredMixin, View):
     template_name = "inventory/indent_form.html"
 
     def get(self, request):
@@ -73,6 +78,7 @@ class IndentCreateView(View):
         return render(request, self.template_name, {"form": form, "formset": formset})
 
 
+@login_required
 def indent_detail(request, pk: int):
     indent = get_object_or_404(Indent, pk=pk)
     items = indent.indentitem_set.select_related("item").all()
@@ -83,6 +89,7 @@ def indent_detail(request, pk: int):
     )
 
 
+@login_required
 def indent_update_status(request, pk: int, status: str):
     indent = get_object_or_404(Indent, pk=pk)
     indent.status = status.upper()
@@ -90,6 +97,7 @@ def indent_update_status(request, pk: int, status: str):
     return redirect("indent_detail", pk=pk)
 
 
+@login_required
 def indent_pdf(request, pk: int):
     indent = get_object_or_404(Indent, pk=pk)
     items = indent.indentitem_set.select_related("item").all()

--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -3,6 +3,7 @@ import io
 import logging
 
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db import DatabaseError
@@ -18,7 +19,7 @@ from ..services import item_service
 logger = logging.getLogger(__name__)
 
 
-class ItemsListView(TemplateView):
+class ItemsListView(LoginRequiredMixin, TemplateView):
     template_name = "inventory/items_list.html"
 
     def get_context_data(self, **kwargs):
@@ -55,7 +56,7 @@ class ItemsListView(TemplateView):
         return ctx
 
 
-class ItemsTableView(TemplateView):
+class ItemsTableView(LoginRequiredMixin, TemplateView):
     template_name = "inventory/_items_table.html"
 
     def get_context_data(self, **kwargs):
@@ -93,7 +94,7 @@ class ItemsTableView(TemplateView):
         return ctx
 
 
-class ItemCreateView(View):
+class ItemCreateView(LoginRequiredMixin, View):
     template_name = "inventory/item_form.html"
 
     def get(self, request):
@@ -108,7 +109,7 @@ class ItemCreateView(View):
         return render(request, self.template_name, {"form": form, "is_edit": False})
 
 
-class ItemEditView(View):
+class ItemEditView(LoginRequiredMixin, View):
     template_name = "inventory/item_form.html"
 
     def get_object(self, pk: int):
@@ -155,7 +156,7 @@ class ItemEditView(View):
         return render(request, self.template_name, ctx)
 
 
-class ItemSuggestView(TemplateView):
+class ItemSuggestView(LoginRequiredMixin, TemplateView):
     template_name = "inventory/_item_suggest_fields.html"
 
     def get_context_data(self, **kwargs):
@@ -168,7 +169,7 @@ class ItemSuggestView(TemplateView):
         return ctx
 
 
-class ItemsBulkUploadView(View):
+class ItemsBulkUploadView(LoginRequiredMixin, View):
     template_name = "inventory/bulk_upload.html"
 
     def get(self, request):

--- a/inventory/views/purchase_orders.py
+++ b/inventory/views/purchase_orders.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 
 from ..forms import (
@@ -23,6 +24,7 @@ PO_STATUS_BADGES = {
 }
 
 
+@login_required
 def purchase_orders_list(request):
     orders = PurchaseOrder.objects.select_related("supplier").order_by("-order_date")
     for o in orders:
@@ -34,6 +36,7 @@ def purchase_orders_list(request):
     )
 
 
+@login_required
 def purchase_order_create(request):
     if request.method == "POST":
         form = PurchaseOrderForm(request.POST)
@@ -70,6 +73,7 @@ def purchase_order_create(request):
     )
 
 
+@login_required
 def purchase_order_edit(request, pk: int):
     po = get_object_or_404(PurchaseOrder, pk=pk)
     if request.method == "POST":
@@ -89,6 +93,7 @@ def purchase_order_edit(request, pk: int):
     )
 
 
+@login_required
 def purchase_order_detail(request, pk: int):
     po = get_object_or_404(PurchaseOrder, pk=pk)
     items = po.purchaseorderitem_set.select_related("item").all()
@@ -100,6 +105,7 @@ def purchase_order_detail(request, pk: int):
     )
 
 
+@login_required
 def purchase_order_receive(request, pk: int):
     po = get_object_or_404(PurchaseOrder, pk=pk)
     items = po.purchaseorderitem_set.select_related("item").all()

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -1,11 +1,14 @@
 from django.shortcuts import get_object_or_404, render
 from django.views import View
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import get_object_or_404, render
+from django.views import View
 from django.views.generic import TemplateView
 
 from ..models import Recipe, RecipeComponent
 
 
-class RecipesListView(TemplateView):
+class RecipesListView(LoginRequiredMixin, TemplateView):
     template_name = "inventory/recipes/list.html"
 
     def get_context_data(self, **kwargs):
@@ -14,7 +17,7 @@ class RecipesListView(TemplateView):
         return ctx
 
 
-class RecipeDetailView(View):
+class RecipeDetailView(LoginRequiredMixin, View):
     template_name = "inventory/recipes/detail.html"
 
     def get(self, request, pk: int):
@@ -29,7 +32,7 @@ class RecipeDetailView(View):
         )
 
 
-class RecipeComponentRowView(View):
+class RecipeComponentRowView(LoginRequiredMixin, View):
     template_name = "inventory/recipes/_component_row.html"
 
     def get(self, request, pk: int):

--- a/inventory/views/stock.py
+++ b/inventory/views/stock.py
@@ -2,6 +2,7 @@ import csv
 import io
 
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
@@ -16,6 +17,7 @@ from ..models import StockTransaction, Item
 from ..services import stock_service
 
 
+@login_required
 def stock_movements(request):
     sections = {
         "receive": "Goods Received",
@@ -129,6 +131,7 @@ def stock_movements(request):
     return render(request, "inventory/stock_movements.html", ctx)
 
 
+@login_required
 def history_reports(request):
     item = (request.GET.get("item") or "").strip()
     tx_type = (request.GET.get("type") or "").strip()

--- a/inventory/views/suppliers.py
+++ b/inventory/views/suppliers.py
@@ -3,6 +3,7 @@ import io
 import logging
 
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
@@ -16,7 +17,7 @@ from ..services import supplier_service
 logger = logging.getLogger(__name__)
 
 
-class SuppliersListView(TemplateView):
+class SuppliersListView(LoginRequiredMixin, TemplateView):
     template_name = "inventory/suppliers_list.html"
 
     def get_context_data(self, **kwargs):
@@ -27,7 +28,7 @@ class SuppliersListView(TemplateView):
         return ctx
 
 
-class SuppliersTableView(TemplateView):
+class SuppliersTableView(LoginRequiredMixin, TemplateView):
     template_name = "inventory/_suppliers_table.html"
 
     def get_context_data(self, **kwargs):
@@ -51,7 +52,7 @@ class SuppliersTableView(TemplateView):
         return ctx
 
 
-class SupplierCreateView(View):
+class SupplierCreateView(LoginRequiredMixin, View):
     template_name = "inventory/supplier_form.html"
 
     def get(self, request):
@@ -68,7 +69,7 @@ class SupplierCreateView(View):
         return render(request, self.template_name, {"form": form, "is_edit": False})
 
 
-class SupplierEditView(View):
+class SupplierEditView(LoginRequiredMixin, View):
     template_name = "inventory/supplier_form.html"
 
     def get(self, request, pk: int):
@@ -89,7 +90,7 @@ class SupplierEditView(View):
         return render(request, self.template_name, ctx)
 
 
-class SupplierToggleActiveView(View):
+class SupplierToggleActiveView(LoginRequiredMixin, View):
     def get(self, request, pk: int):
         supplier = get_object_or_404(Supplier, pk=pk)
         if supplier.is_active:
@@ -100,7 +101,7 @@ class SupplierToggleActiveView(View):
         return view(request)
 
 
-class SuppliersBulkUploadView(View):
+class SuppliersBulkUploadView(LoginRequiredMixin, View):
     template_name = "inventory/bulk_upload.html"
 
     def get(self, request):
@@ -142,7 +143,7 @@ class SuppliersBulkUploadView(View):
         return render(request, self.template_name, ctx)
 
 
-class SuppliersBulkDeleteView(View):
+class SuppliersBulkDeleteView(LoginRequiredMixin, View):
     template_name = "inventory/bulk_delete.html"
 
     def get(self, request):

--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -135,6 +135,13 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.BasicAuthentication",
+    ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 25,
 }

--- a/inventory_app/urls.py
+++ b/inventory_app/urls.py
@@ -17,11 +17,12 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
-from core.views import root_view, health_check
+from core.views import root_view, health_check, dashboard
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", root_view, name="root"),
+    path("dashboard/", dashboard, name="dashboard"),
     path("healthz", health_check, name="health-check"),
     path("api/", include("inventory.urls")),   # DRF API
     path("", include("inventory.ui_urls")),    # HTML UI routes

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -19,6 +19,7 @@
             <a href="{% url 'root' %}" class="text-white font-bold">Inventory App</a>
           </div>
           <div class="flex space-x-4">
+            <a href="{% url 'dashboard' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Dashboard</a>
             <a href="{% url 'root' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Home</a>
             <a href="{% url 'items_list' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
             <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>

--- a/templates/inventory/grns/detail.html
+++ b/templates/inventory/grns/detail.html
@@ -1,0 +1,21 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-5xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">GRN {{ grn.pk }}</h1>
+  <p class="mb-2"><strong>PO:</strong> {{ grn.purchase_order_id }}</p>
+  <p class="mb-2"><strong>Supplier:</strong> {{ grn.supplier.name }}</p>
+  <p class="mb-4"><strong>Date:</strong> {{ grn.received_date }}</p>
+  <table class="table">
+    <thead><tr><th>Item</th><th>Ordered</th><th>Received</th></tr></thead>
+    <tbody>
+    {% for item in items %}
+      <tr>
+        <td>{{ item.po_item.item.name }}</td>
+        <td>{{ item.po_item.quantity_ordered }}</td>
+        <td>{{ item.quantity_received }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -1,0 +1,21 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-5xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">Goods Received Notes</h1>
+  <table class="table">
+    <thead><tr><th>ID</th><th>PO</th><th>Supplier</th><th>Date</th></tr></thead>
+    <tbody>
+    {% for grn in grns %}
+      <tr>
+        <td><a class="text-blue-600" href="{% url 'grn_detail' grn.pk %}">{{ grn.pk }}</a></td>
+        <td>{{ grn.purchase_order_id }}</td>
+        <td>{{ grn.supplier.name }}</td>
+        <td>{{ grn.received_date }}</td>
+      </tr>
+    {% empty %}
+      <tr><td colspan="4">No goods received notes.</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -21,6 +21,7 @@
   <div class="flex gap-2">
     <a href="{% url 'purchase_order_edit' po.pk %}" class="px-4 py-2 bg-blue-600 text-white rounded">Edit</a>
     <a href="{% url 'purchase_order_receive' po.pk %}" class="px-4 py-2 bg-green-600 text-white rounded">Receive Goods</a>
+    <a href="{% url 'grn_list' %}" class="px-4 py-2 bg-gray-600 text-white rounded">View GRNs</a>
   </div>
 </div>
 {% endblock %}

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -2,8 +2,9 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Purchase Orders</h1>
-  <div class="mb-4">
+  <div class="mb-4 flex gap-2">
     <a href="{% url 'purchase_order_create' %}" class="px-4 py-2 bg-green-600 text-white rounded">New PO</a>
+    <a href="{% url 'grn_list' %}" class="px-4 py-2 bg-blue-600 text-white rounded">GRNs</a>
   </div>
   <table class="table">
     <thead>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,15 @@
+import pytest
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+from inventory.models import Item
+
+
+@pytest.mark.django_db
+def test_dashboard_low_stock(client):
+    user = User.objects.create_user(username="u", password="p")
+    Item.objects.create(name="Foo", reorder_point=10, current_stock=5)
+    client.login(username="u", password="p")
+    resp = client.get(reverse("dashboard"))
+    assert resp.status_code == 200
+    assert b"Foo" in resp.content


### PR DESCRIPTION
## Summary
- require authentication for all API endpoints and register a SaleTransaction API
- add dashboard view for low stock items with navigation and admin registrations
- expose Goods Received Notes in the UI and register models in admin

## Testing
- `pytest` *(fails: FOREIGN KEY constraint failed in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ff0c4f748326a823aad2b577604b