### PR TITLE
Configure static files directory

### DIFF
--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -127,6 +127,7 @@ USE_TZ = True
 
 STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
+STATICFILES_DIRS = [BASE_DIR / "static"]
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # Default primary key field type


### PR DESCRIPTION
## Summary
- add `STATICFILES_DIRS` to include project `static` folder

## Testing
- `python manage.py collectstatic --no-input`
- `pytest` *(fails: no such table: stock_transactions)*

------
https://chatgpt.com/codex/tasks/task_e_68a403c3337c8326a8dcb0f79c0013cc