### PR TITLE
Add pytest dependencies for test database setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ fpdf2
 sqlalchemy
 pyyaml
 pydantic
+pytest
+pytest-django


### PR DESCRIPTION
## Summary
- add pytest and pytest-django to project requirements

## Testing
- `pytest --ds=inventory_app.settings`

------
https://chatgpt.com/codex/tasks/task_e_68a405c44aa083269520875f24eaa9de