### PR TITLE
Enable user login and redirects

### DIFF
--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -146,3 +146,6 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 25,
 }
+
+LOGIN_REDIRECT_URL = "/dashboard/"
+LOGOUT_REDIRECT_URL = "/"

--- a/inventory_app/urls.py
+++ b/inventory_app/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path("", root_view, name="root"),
     path("dashboard/", dashboard, name="dashboard"),
     path("healthz", health_check, name="health-check"),
+    path("accounts/", include("django.contrib.auth.urls")),
     path("api/", include("inventory.urls")),   # DRF API
     path("", include("inventory.ui_urls")),    # HTML UI routes
 ]

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,9 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1>Login</h1>
+<form method="post">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <button type="submit">Login</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- expose Django's built-in auth views under /accounts/
- add simple login form template
- configure login/logout redirects

## Testing
- `python manage.py check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a40a66f3008326968274ab03e64535