### PR TITLE
Add suggest URL and success messaging to item creation

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -100,14 +100,19 @@ class ItemCreateView(LoginRequiredMixin, View):
 
     def get(self, request):
         form = ItemForm()
-        return render(request, self.template_name, {"form": form, "is_edit": False})
+        suggest_url = reverse("item_suggest")
+        ctx = {"form": form, "is_edit": False, "suggest_url": suggest_url}
+        return render(request, self.template_name, ctx)
 
     def post(self, request):
         form = ItemForm(request.POST)
+        suggest_url = reverse("item_suggest")
         if form.is_valid():
             form.save()
+            messages.success(request, "Item created")
             return redirect("items_list")
-        return render(request, self.template_name, {"form": form, "is_edit": False})
+        ctx = {"form": form, "is_edit": False, "suggest_url": suggest_url}
+        return render(request, self.template_name, ctx)
 
 
 class ItemEditView(LoginRequiredMixin, View):

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -15,7 +15,6 @@
     {% endif %}
     <div>
       {{ form.name.label_tag }}
-      {% url 'item_suggest' as suggest_url %}
         {{ form.name.as_widget(attrs={'class': 'form-control',
                                      'hx-get': suggest_url,
                                      'hx-trigger': 'keyup changed delay:500ms',


### PR DESCRIPTION
## Summary
- compute `suggest_url` in `ItemCreateView` and pass to template
- show success message after creating items
- rely on view-provided `suggest_url` in item form template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a40d18c4f48326a82b9d4d4c799b35