### PR TITLE
Display Django messages in base layout

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -31,6 +31,13 @@
       </div>
     </nav>
     <div class="max-w-7xl mx-auto p-4">
+      {% if messages %}
+        <ul class="mb-4">
+          {% for message in messages %}
+            <li class="text-{{ message.tags }}">{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
       {% block content %}{% endblock %}
     </div>
   </body>


### PR DESCRIPTION
## Summary
- Surface Django message flashes in the base template before content blocks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4102027408326b42f0a6f6170e7e0