### PR TITLE
Add default master superuser

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -1,6 +1,34 @@
+"""Core application configuration."""
+
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+
+
+def _create_master_user(sender, **kwargs):
+    """Ensure a default superuser exists.
+
+    This creates a ``master`` user with password ``admin`` so the
+    application always has a default login available. The function is
+    attached to Django's ``post_migrate`` signal so it runs after the
+    database schema has been created.
+    """
+
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+    if not User.objects.filter(username="master").exists():
+        User.objects.create_superuser("master", email="", password="admin")
 
 
 class CoreConfig(AppConfig):
+    """Configuration for the core app."""
+
     default_auto_field = "django.db.models.BigAutoField"
     name = "core"
+
+    def ready(self):  # pragma: no cover - executed via Django startup
+        """Connect signal handlers when the app is ready."""
+
+        post_migrate.connect(
+            _create_master_user, dispatch_uid="core.create_master_user"
+        )

--- a/tests/test_master_user.py
+++ b/tests/test_master_user.py
@@ -1,0 +1,9 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+
+@pytest.mark.django_db
+def test_master_user_exists_and_can_login(client):
+    User = get_user_model()
+    assert User.objects.filter(username="master").exists()
+    assert client.login(username="master", password="admin")


### PR DESCRIPTION
## Summary
- ensure a default `master` superuser with password `admin` is created after migrations
- add regression test verifying master login exists and works

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a456b9352c8326a0d120e543fe8765