### PR TITLE
Move widget attrs to forms and simplify templates

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -98,19 +98,19 @@ class ItemCreateView(View):
     template_name = "inventory/item_form.html"
 
     def get(self, request):
-        form = ItemForm()
         suggest_url = reverse("item_suggest")
-        ctx = {"form": form, "is_edit": False, "suggest_url": suggest_url}
+        form = ItemForm(suggest_url=suggest_url)
+        ctx = {"form": form, "is_edit": False}
         return render(request, self.template_name, ctx)
 
     def post(self, request):
-        form = ItemForm(request.POST)
         suggest_url = reverse("item_suggest")
+        form = ItemForm(request.POST, suggest_url=suggest_url)
         if form.is_valid():
             form.save()
             messages.success(request, "Item created")
             return redirect("items_list")
-        ctx = {"form": form, "is_edit": False, "suggest_url": suggest_url}
+        ctx = {"form": form, "is_edit": False}
         return render(request, self.template_name, ctx)
 
 
@@ -127,24 +127,24 @@ class ItemEditView(View):
     def get(self, request, pk: int):
         item = self.get_object(pk)
         try:
-            form = ItemForm(instance=item)
+            suggest_url = reverse("item_suggest")
+            form = ItemForm(instance=item, suggest_url=suggest_url)
         except (DatabaseError, ValueError):
             logger.exception("Error loading form for item %s", pk)
             messages.error(request, "Unable to load item")
             return redirect("items_list")
-        suggest_url = reverse("item_suggest")
         ctx = {
             "form": form,
             "is_edit": True,
             "item": item,
-            "suggest_url": suggest_url,
         }
         return render(request, self.template_name, ctx)
 
     def post(self, request, pk: int):
         item = self.get_object(pk)
         try:
-            form = ItemForm(request.POST, instance=item)
+            suggest_url = reverse("item_suggest")
+            form = ItemForm(request.POST, instance=item, suggest_url=suggest_url)
         except (DatabaseError, ValueError):
             logger.exception("Error loading form for item %s", pk)
             messages.error(request, "Unable to load item")
@@ -156,12 +156,10 @@ class ItemEditView(View):
                 return redirect("items_list")
             except (ValidationError, DatabaseError):
                 messages.error(request, "Unable to save item")
-        suggest_url = reverse("item_suggest")
         ctx = {
             "form": form,
             "is_edit": True,
             "item": item,
-            "suggest_url": suggest_url,
         }
         return render(request, self.template_name, ctx)
 

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -16,11 +16,7 @@
       {% for field in form %}
       <div>
         {{ field.label_tag }}
-        {% if field.field.widget.input_type == "checkbox" %}
-        {{ field.as_widget(attrs={'class': 'form-checkbox'}) }}
-        {% else %}
-        {{ field.as_widget(attrs={'class': 'form-control'}) }}
-        {% endif %}
+        {{ field }}
         {% if field.errors %}
         <ul class="text-red-600 list-disc pl-5">
           {% for error in field.errors %}
@@ -52,7 +48,7 @@
       {% for item_form in formset %}
         <tr class="form-row">
           <td>
-            {{ item_form.item.as_widget(attrs={'class': 'form-control'}) }}
+            {{ item_form.item }}
             {% if item_form.item.errors %}
             <ul class="text-red-600 list-disc pl-5">
               {% for error in item_form.item.errors %}<li>{{ error }}</li>{% endfor %}
@@ -60,7 +56,7 @@
             {% endif %}
           </td>
           <td>
-            {{ item_form.requested_qty.as_widget(attrs={'class': 'form-control'}) }}
+            {{ item_form.requested_qty }}
             {% if item_form.requested_qty.errors %}
             <ul class="text-red-600 list-disc pl-5">
               {% for error in item_form.requested_qty.errors %}<li>{{ error }}</li>{% endfor %}
@@ -68,7 +64,7 @@
             {% endif %}
           </td>
           <td>
-            {{ item_form.notes.as_widget(attrs={'class': 'form-control'}) }}
+            {{ item_form.notes }}
             {% if item_form.notes.errors %}
             <ul class="text-red-600 list-disc pl-5">
               {% for error in item_form.notes.errors %}<li>{{ error }}</li>{% endfor %}

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -16,10 +16,7 @@
     {% endif %}
     <div>
       {{ form.name.label_tag }}
-        {{ form.name.as_widget(attrs={'class': 'form-control',
-                                     'hx-get': suggest_url,
-                                     'hx-trigger': 'keyup changed delay:500ms',
-                                     'hx-swap': 'none'}) }}
+        {{ form.name }}
       {% if form.name.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in form.name.errors %}
@@ -30,7 +27,7 @@
     </div>
     <div>
       {{ form.base_unit.label_tag }}
-        {{ form.base_unit.as_widget(attrs={'id': 'id_base_unit', 'class': 'form-control'}) }}
+        {{ form.base_unit }}
       {% if form.base_unit.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in form.base_unit.errors %}
@@ -41,7 +38,7 @@
     </div>
     <div>
       {{ form.purchase_unit.label_tag }}
-        {{ form.purchase_unit.as_widget(attrs={'id': 'id_purchase_unit', 'class': 'form-control'}) }}
+        {{ form.purchase_unit }}
       {% if form.purchase_unit.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in form.purchase_unit.errors %}
@@ -52,7 +49,7 @@
     </div>
     <div>
       {{ form.category.label_tag }}
-        {{ form.category.as_widget(attrs={'id': 'id_category', 'class': 'form-control'}) }}
+        {{ form.category }}
       {% if form.category.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in form.category.errors %}
@@ -65,11 +62,7 @@
     {% if field.name not in ['name', 'base_unit', 'purchase_unit', 'category'] %}
     <div>
       {{ field.label_tag }}
-        {% if field.field.widget.input_type == "checkbox" %}
-        {{ field.as_widget(attrs={'class': 'form-checkbox'}) }}
-        {% else %}
-        {{ field.as_widget(attrs={'class': 'form-control'}) }}
-        {% endif %}
+        {{ field }}
       {% if field.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in field.errors %}

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -16,11 +16,7 @@
     {% for field in form %}
     <div>
       {{ field.label_tag }}
-        {% if field.field.widget.input_type == "checkbox" %}
-        {{ field.as_widget(attrs={'class': 'form-checkbox'}) }}
-        {% else %}
-        {{ field.as_widget(attrs={'class': 'form-control'}) }}
-        {% endif %}
+        {{ field }}
       {% if field.errors %}
       <ul class="text-red-600 list-disc pl-5">
         {% for error in field.errors %}


### PR DESCRIPTION
## Summary
- define widget attributes in ItemForm, SupplierForm and IndentForm
- pass item_suggest URL into ItemForm and drop template as_widget calls
- simplify Indent and Supplier templates to render fields directly

## Testing
- `pytest`
- `flake8` *(warnings: blank line contains whitespace, blank line at end of file)*

------
https://chatgpt.com/codex/tasks/task_e_68a81e262f6c8326bba4fce9ad3c8bcb