### PR TITLE
feat: add dark mode and theme variables

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,6 +1,36 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 
-body { font-family: 'Roboto', sans-serif; }
+:root {
+  --color-body-bg: #f9fafb;
+  --color-body-text: #1a202c;
+  --form-bg: #ffffff;
+  --form-border: #cbd5e0;
+  --form-text: #1a202c;
+  --form-focus-border: #3b82f6;
+  --form-focus-shadow: rgba(59, 130, 246, 0.4);
+  --table-border: #e5e7eb;
+  --table-header-bg: #f9fafb;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-body-bg: #1e1e1e;
+    --color-body-text: #ffffff;
+    --form-bg: #2d3748;
+    --form-border: #4a5568;
+    --form-text: #f7fafc;
+    --form-focus-border: #63b3ed;
+    --form-focus-shadow: rgba(99, 179, 237, 0.6);
+    --table-border: #4a5568;
+    --table-header-bg: #2d3748;
+  }
+}
+
+body {
+  font-family: 'Roboto', sans-serif;
+  background-color: var(--color-body-bg);
+  color: var(--color-body-text);
+}
 
 /* Status badge classes */
 .badge-success { background: #21ba45; color: white; padding: 2px 6px; border-radius: 4px; }
@@ -16,13 +46,8 @@ body { font-family: 'Roboto', sans-serif; }
     .badge-error { font-size: 0.8rem; padding: 2px 4px; }
 }
 
-/* Dark mode support */
+/* Dark mode support for badges */
 @media (prefers-color-scheme: dark) {
-    body {
-        background-color: #1e1e1e;
-        color: #ffffff;
-    }
-
     .badge-success { background: #27963c; color: white; }
     .badge-warning { background: #e0b437; color: black; }
     .badge-error   { background: #cc0000; color: white; }

--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -9,7 +9,9 @@ form select,
 form textarea,
 .form-control {
     font-family: 'Roboto', sans-serif;
-    border: 1px solid #cbd5e0;
+    border: 1px solid var(--form-border);
+    background-color: var(--form-bg);
+    color: var(--form-text);
     padding: 0.5rem;
     border-radius: 0.25rem;
     width: 100%;
@@ -20,11 +22,13 @@ form select:focus,
 form textarea:focus,
 .form-control:focus {
     outline: none;
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.4);
+    border-color: var(--form-focus-border);
+    box-shadow: 0 0 0 2px var(--form-focus-shadow);
 }
 
 .form-checkbox {
-    border: 1px solid #cbd5e0;
+    border: 1px solid var(--form-border);
+    background-color: var(--form-bg);
+    color: var(--form-text);
     border-radius: 0.25rem;
 }

--- a/static/css/tables.css
+++ b/static/css/tables.css
@@ -6,11 +6,11 @@
 
 .table th,
 .table td {
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--table-border);
     padding: 0.5rem 1rem;
     text-align: left;
 }
 
 .table thead {
-    background-color: #f9fafb;
+    background-color: var(--table-header-bg);
 }

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -11,20 +11,20 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
   </head>
-  <body class="bg-gray-100 min-h-screen">
-    <nav class="bg-gray-800">
+  <body class="bg-gray-100 dark:bg-gray-900 min-h-screen">
+    <nav class="bg-gray-800 dark:bg-gray-950">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between h-16">
           <div class="flex-shrink-0">
             <a href="{% url 'root' %}" class="text-white font-bold">Inventory App</a>
           </div>
           <div class="flex space-x-4">
-            <a href="{% url 'dashboard' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Dashboard</a>
-            <a href="{% url 'items_list' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
-            <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
-            <a href="{% url 'indents_list' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Indents</a>
-            <a href="{% url 'stock_movements' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock Movements</a>
-            <a href="{% url 'history_reports' %}" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
+            <a href="{% url 'dashboard' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Dashboard</a>
+            <a href="{% url 'items_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
+            <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
+            <a href="{% url 'indents_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Indents</a>
+            <a href="{% url 'stock_movements' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock Movements</a>
+            <a href="{% url 'history_reports' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
           </div>
         </div>
       </div>

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -17,5 +17,5 @@
   {% endfor %}
   </tbody>
 </table>
-<button class="mt-4 px-3 py-1 bg-gray-200" hx-get="{% url 'recipe_component_row' recipe.recipe_id %}?index={{ components|length }}" hx-target="#components tbody" hx-swap="beforeend">Add Component</button>
+<button class="mt-4 px-3 py-1 bg-gray-200 dark:bg-gray-700 dark:text-white" hx-get="{% url 'recipe_component_row' recipe.recipe_id %}?index={{ components|length }}" hx-target="#components tbody" hx-swap="beforeend">Add Component</button>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add dark-mode classes to layout navigation and buttons
- introduce CSS variables for form and table theming
- support dark theme for buttons in recipe detail

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a81f8e3ee88326a4b71bb6e6a22710