### PR TITLE
Expose procurement and recipe pages in navbar

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -23,9 +23,12 @@
             <a href="{% url 'items_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
             <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
             <a href="{% url 'indents_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Indents</a>
+            <a href="{% url 'purchase_orders_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Purchase Orders</a>
+            <a href="{% url 'grn_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">GRNs</a>
             <a href="{% url 'stock_movements' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock Movements</a>
             <a href="{% url 'history_reports' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
-          </div>
+            <a href="{% url 'recipes_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Recipes</a>
+            </div>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- add purchase orders, GRNs, and recipes links to the main navigation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8232cfe8c8326823516acb138d5e9