### PR TITLE
Improve form responsiveness

### DIFF
--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -14,7 +14,16 @@ form textarea,
     color: var(--form-text);
     padding: 0.5rem;
     border-radius: 0.25rem;
-    width: 100%;
+    max-width: 100%;
+}
+
+@media (max-width: 640px) {
+    form input:not([type="checkbox"]):not([type="radio"]),
+    form select,
+    form textarea,
+    .form-control {
+        width: 100%;
+    }
 }
 
 form input:not([type="checkbox"]):not([type="radio"]):focus,

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% load static %}
 {% block content %}
-<div class="max-w-3xl mx-auto p-4">
+<div class="w-full max-w-md sm:max-w-2xl lg:max-w-3xl mx-auto p-4 max-h-screen overflow-y-auto">
   <h1 class="text-2xl font-semibold mb-4">New Indent</h1>
   <form method="post" id="indent-form">
     {% csrf_token %}

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-xl mx-auto p-4">
+<div class="w-full max-w-md sm:max-w-lg mx-auto p-4 max-h-screen overflow-y-auto">
   <h1 class="text-2xl font-semibold mb-4">
     {% if is_edit %}Edit Item{% else %}Add Item{% endif %}
   </h1>

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-xl mx-auto p-4">
+<div class="w-full max-w-md sm:max-w-lg mx-auto p-4 max-h-screen overflow-y-auto">
   <h1 class="text-2xl font-semibold mb-4">
     {% if is_edit %}Edit Supplier{% else %}Add Supplier{% endif %}
   </h1>


### PR DESCRIPTION
## Summary
- Replace global form-control width with max-width and mobile-specific width rule
- Constrain form templates with breakpoint-aware containers and scrollable height

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a824742b4c8326a6cae228ad12c071