### PR TITLE
Add login route and homepage navigation links

### DIFF
--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -4,7 +4,12 @@
   <div class="flex items-center justify-center">
     <div class="bg-white p-6 rounded shadow text-center">
       <p class="text-xl">Django is running</p>
-      <p class="mt-4"><a href="{% url 'dashboard' %}" class="text-blue-600 underline">Go to Dashboard</a></p>
+      <div class="mt-4 flex flex-wrap justify-center gap-2">
+        <a href="{% url 'dashboard' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Dashboard</a>
+        <a href="{% url 'items_list' %}" class="px-4 py-2 bg-green-600 text-white rounded">Items</a>
+        <a href="{% url 'suppliers_list' %}" class="px-4 py-2 bg-purple-600 text-white rounded">Suppliers</a>
+        <a href="{% url 'login' %}" class="px-4 py-2 bg-gray-600 text-white rounded">Login</a>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/inventory_app/urls.py
+++ b/inventory_app/urls.py
@@ -16,11 +16,13 @@ Including another URLconf
 """
 
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
 from django.urls import path, include
 from core.views import root_view, health_check, dashboard
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("login/", auth_views.LoginView.as_view(), name="login"),
     path("", root_view, name="root"),
     path("dashboard/", dashboard, name="dashboard"),
     path("healthz", health_check, name="health-check"),

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -33,6 +33,11 @@
               <a href="{% url 'stock_movements' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock Movements</a>
               <a href="{% url 'history_reports' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
               <a href="{% url 'recipes_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Recipes</a>
+              {% if user.is_authenticated %}
+                <a href="{% url 'logout' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Logout</a>
+              {% else %}
+                <a href="{% url 'login' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Login</a>
+              {% endif %}
             </div>
             <button id="theme-toggle" class="ml-4 text-gray-300 hover:text-white dark:text-gray-200" aria-label="Toggle theme">🌓</button>
           </div>


### PR DESCRIPTION
## Summary
- add explicit login path to project urls
- show login/logout options in main navigation
- add homepage buttons linking to dashboard, items, suppliers, and login

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a82afe70448326a5d565fca03b4f4d