### PR TITLE
Add dashboard totals and placeholder charts

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -1,6 +1,27 @@
 {% extends "_base.html" %}
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Dashboard</h1>
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
+  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow">
+    <h2 class="text-sm font-medium text-gray-500">Items</h2>
+    <p class="text-2xl font-bold">{{ total_items }}</p>
+  </div>
+  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow">
+    <h2 class="text-sm font-medium text-gray-500">Suppliers</h2>
+    <p class="text-2xl font-bold">{{ total_suppliers }}</p>
+  </div>
+  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow">
+    <h2 class="text-sm font-medium text-gray-500">Recent Transactions</h2>
+    <p class="text-2xl font-bold">{{ recent_transactions }}</p>
+  </div>
+</div>
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow h-64 flex items-center justify-center">Chart 1</div>
+  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow h-64 flex items-center justify-center">Chart 2</div>
+</div>
+
 <h2 class="text-xl mb-2">Low Stock Items</h2>
 <table class="table">
   <thead><tr><th>Item</th><th>Stock</th><th>Reorder Point</th></tr></thead>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,7 +1,7 @@
 import pytest
 from django.urls import reverse
 
-from inventory.models import Item
+from inventory.models import Item, Supplier, StockTransaction
 
 
 @pytest.mark.django_db
@@ -10,3 +10,18 @@ def test_dashboard_low_stock(client):
     resp = client.get(reverse("dashboard"))
     assert resp.status_code == 200
     assert b"Foo" in resp.content
+
+
+@pytest.mark.django_db
+def test_dashboard_totals(client):
+    item1 = Item.objects.create(name="Foo", reorder_point=10, current_stock=5)
+    Item.objects.create(name="Bar", reorder_point=0, current_stock=0)
+    Supplier.objects.create(name="ACME")
+    Supplier.objects.create(name="Globex")
+    StockTransaction.objects.create(item=item1, quantity_change=1)
+
+    resp = client.get(reverse("dashboard"))
+    assert resp.status_code == 200
+    assert resp.context["total_items"] == 2
+    assert resp.context["total_suppliers"] == 2
+    assert resp.context["recent_transactions"] == 1


### PR DESCRIPTION
## Summary
- extend dashboard view to compute item, supplier, and recent transaction totals
- display summary cards and chart placeholders in dashboard template
- test dashboard context for new totals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a82becde048326a5eca3c1836fe818