### PR TITLE
Add item export and sorting functionality

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views.items import (
     ItemsListView,
     ItemsTableView,
+    ItemsExportView,
     ItemCreateView,
     ItemEditView,
     ItemSuggestView,
@@ -46,6 +47,7 @@ from .views.goods_received import (
 urlpatterns = [
     path("items/", ItemsListView.as_view(), name="items_list"),
     path("items/table/", ItemsTableView.as_view(), name="items_table"),
+    path("items/export/", ItemsExportView.as_view(), name="items_export"),
     path("items/create/", ItemCreateView.as_view(), name="item_create"),
     path("items/<int:pk>/edit/", ItemEditView.as_view(), name="item_edit"),
     path("items/suggest/", ItemSuggestView.as_view(), name="item_suggest"),

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -1,5 +1,6 @@
 """API routes for the inventory app."""
 
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from .views import (
@@ -16,6 +17,7 @@ from .views import (
     GRNItemViewSet,
     SaleTransactionViewSet,
 )
+from .views.items import ItemsExportView
 
 router = DefaultRouter()
 router.register(r"items", ItemViewSet)
@@ -31,4 +33,6 @@ router.register(r"goods-received-notes", GoodsReceivedNoteViewSet)
 router.register(r"grn-items", GRNItemViewSet)
 router.register(r"sale-transactions", SaleTransactionViewSet)
 
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path("items/export/", ItemsExportView.as_view(), name="items_export_api"),
+]

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -2,14 +2,62 @@
   <table class="table">
     <thead>
       <tr>
-        <th>ID</th>
-        <th>Name</th>
-        <th>Base Unit</th>
-        <th>Category</th>
-        <th>Subcategory</th>
-        <th>Current Stock</th>
-        <th>Reorder Point</th>
-        <th>Active</th>
+        <th>
+          <a hx-get="{% url 'items_table' %}?sort=item_id&direction={% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#items_table" hx-include="#filters"
+             hx-on:click="document.querySelector('#filters input[name=sort]').value='item_id';document.querySelector('#filters input[name=direction]').value='{% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+            ID{% if sort == 'item_id' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+          </a>
+        </th>
+        <th>
+          <a hx-get="{% url 'items_table' %}?sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#items_table" hx-include="#filters"
+             hx-on:click="document.querySelector('#filters input[name=sort]').value='name';document.querySelector('#filters input[name=direction]').value='{% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+            Name{% if sort == 'name' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+          </a>
+        </th>
+        <th>
+          <a hx-get="{% url 'items_table' %}?sort=base_unit&direction={% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#items_table" hx-include="#filters"
+             hx-on:click="document.querySelector('#filters input[name=sort]').value='base_unit';document.querySelector('#filters input[name=direction]').value='{% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+            Base Unit{% if sort == 'base_unit' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+          </a>
+        </th>
+        <th>
+          <a hx-get="{% url 'items_table' %}?sort=category&direction={% if sort == 'category' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#items_table" hx-include="#filters"
+             hx-on:click="document.querySelector('#filters input[name=sort]').value='category';document.querySelector('#filters input[name=direction]').value='{% if sort == 'category' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+            Category{% if sort == 'category' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+          </a>
+        </th>
+        <th>
+          <a hx-get="{% url 'items_table' %}?sort=sub_category&direction={% if sort == 'sub_category' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#items_table" hx-include="#filters"
+             hx-on:click="document.querySelector('#filters input[name=sort]').value='sub_category';document.querySelector('#filters input[name=direction]').value='{% if sort == 'sub_category' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+            Subcategory{% if sort == 'sub_category' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+          </a>
+        </th>
+        <th class="text-right">
+          <a hx-get="{% url 'items_table' %}?sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#items_table" hx-include="#filters"
+             hx-on:click="document.querySelector('#filters input[name=sort]').value='current_stock';document.querySelector('#filters input[name=direction]').value='{% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+            Current Stock{% if sort == 'current_stock' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+          </a>
+        </th>
+        <th class="text-right">
+          <a hx-get="{% url 'items_table' %}?sort=reorder_point&direction={% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#items_table" hx-include="#filters"
+             hx-on:click="document.querySelector('#filters input[name=sort]').value='reorder_point';document.querySelector('#filters input[name=direction]').value='{% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+            Reorder Point{% if sort == 'reorder_point' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+          </a>
+        </th>
+        <th>
+          <a hx-get="{% url 'items_table' %}?sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#items_table" hx-include="#filters"
+             hx-on:click="document.querySelector('#filters input[name=sort]').value='is_active';document.querySelector('#filters input[name=direction]').value='{% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+            Active{% if sort == 'is_active' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+          </a>
+        </th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -43,17 +91,17 @@
 <div class="flex items-center gap-3 mt-3 flex-wrap">
   <div class="flex items-center gap-1">
     {% if page_obj.has_previous %}
-      <a hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}" hx-target="#items_table" class="px-3 py-1 border rounded">Prev</a>
+      <a hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">Prev</a>
     {% endif %}
     {% for num in page_obj.paginator.page_range %}
       {% if num == page_obj.number %}
         <span class="px-3 py-1 border rounded bg-gray-200">{{ num }}</span>
       {% else %}
-        <a hx-get="{% url 'items_table' %}?page={{ num }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}" hx-target="#items_table" class="px-3 py-1 border rounded">{{ num }}</a>
+        <a hx-get="{% url 'items_table' %}?page={{ num }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">{{ num }}</a>
       {% endif %}
     {% endfor %}
     {% if page_obj.has_next %}
-      <a hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}" hx-target="#items_table" class="px-3 py-1 border rounded">Next</a>
+      <a hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">Next</a>
     {% endif %}
   </div>
   <div class="ml-auto flex items-center gap-2">

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -40,6 +40,9 @@
       <option value="0" {% if active == '0' %}selected{% endif %}>Inactive</option>
       </select>
       <input type="hidden" name="page_size" value="{{ page_size|default:25 }}">
+      <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
+      <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">
+      <button type="submit" formaction="{% url 'items_export' %}" formmethod="get" class="px-4 py-2 border rounded">Export</button>
   </form>
   <div id="items_table"
        hx-get="{% url 'items_table' %}"


### PR DESCRIPTION
## Summary
- enable CSV export of filtered items
- allow sorting items table via query params and sortable headers
- register export endpoint in UI and API routes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a82ce74bf88326ad0b630272ab31f7