### PR TITLE
Add item detail and delete views

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -6,6 +6,8 @@ from .views.items import (
     ItemsExportView,
     ItemCreateView,
     ItemEditView,
+    ItemDetailView,
+    ItemDeleteView,
     ItemSuggestView,
     ItemsBulkUploadView,
 )
@@ -50,6 +52,8 @@ urlpatterns = [
     path("items/export/", ItemsExportView.as_view(), name="items_export"),
     path("items/create/", ItemCreateView.as_view(), name="item_create"),
     path("items/<int:pk>/edit/", ItemEditView.as_view(), name="item_edit"),
+    path("items/<int:pk>/delete/", ItemDeleteView.as_view(), name="item_delete"),
+    path("items/<int:pk>/", ItemDetailView.as_view(), name="item_detail"),
     path("items/suggest/", ItemSuggestView.as_view(), name="item_suggest"),
     path("items/bulk-upload/", ItemsBulkUploadView.as_view(), name="items_bulk_upload"),
 

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -72,7 +72,11 @@
         <td class="text-right">{{ row.current_stock }}</td>
         <td class="text-right">{{ row.reorder_point }}</td>
         <td>{{ row.is_active }}</td>
-        <td><a href="{% url 'item_edit' row.item_id %}" class="text-blue-600">Edit</a></td>
+        <td>
+          <a href="{% url 'item_detail' row.item_id %}" class="text-blue-600 mr-2">View</a>
+          <a href="{% url 'item_edit' row.item_id %}" class="text-blue-600 mr-2">Edit</a>
+          <a href="{% url 'item_delete' row.item_id %}" class="text-blue-600">Delete/Deactivate</a>
+        </td>
       </tr>
       {% empty %}
       <tr>

--- a/templates/inventory/item_confirm_delete.html
+++ b/templates/inventory/item_confirm_delete.html
@@ -1,0 +1,12 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">Delete/Deactivate Item</h1>
+  <p class="mb-4">Are you sure you want to delete or deactivate "{{ item.name }}"?</p>
+  <form method="post" class="flex gap-2">
+    {% csrf_token %}
+    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Confirm</button>
+    <a href="{% url 'items_list' %}" class="px-4 py-2 border rounded">Cancel</a>
+  </form>
+</div>
+{% endblock %}

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -1,0 +1,22 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="max-w-3xl mx-auto p-4">
+  <h1 class="text-2xl font-semibold mb-4">{{ item.name }}</h1>
+  <table class="table">
+    <tbody>
+      <tr><th class="text-left pr-4">ID</th><td>{{ item.item_id }}</td></tr>
+      <tr><th class="text-left pr-4">Base Unit</th><td>{{ item.base_unit }}</td></tr>
+      <tr><th class="text-left pr-4">Purchase Unit</th><td>{{ item.purchase_unit }}</td></tr>
+      <tr><th class="text-left pr-4">Category</th><td>{{ item.category }}</td></tr>
+      <tr><th class="text-left pr-4">Subcategory</th><td>{{ item.sub_category }}</td></tr>
+      <tr><th class="text-left pr-4">Current Stock</th><td>{{ item.current_stock }}</td></tr>
+      <tr><th class="text-left pr-4">Reorder Point</th><td>{{ item.reorder_point }}</td></tr>
+      <tr><th class="text-left pr-4">Notes</th><td>{{ item.notes }}</td></tr>
+      <tr><th class="text-left pr-4">Active</th><td>{{ item.is_active }}</td></tr>
+    </tbody>
+  </table>
+  <div class="mt-4">
+    <a href="{% url 'items_list' %}" class="text-blue-600">Back to list</a>
+  </div>
+</div>
+{% endblock %}

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -1,0 +1,50 @@
+import pytest
+from django.urls import reverse
+
+from inventory.models import Item, StockTransaction
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_item(**kwargs):
+    defaults = {
+        "name": "Widget",
+        "base_unit": "pcs",
+        "purchase_unit": "box",
+        "category": "cat",
+        "sub_category": "sub",
+        "permitted_departments": "dept",
+        "reorder_point": 1,
+        "notes": "n",
+        "is_active": True,
+    }
+    defaults.update(kwargs)
+    return Item.objects.create(**defaults)
+
+
+def test_item_detail_view(client):
+    item = _create_item()
+    StockTransaction.objects.create(item=item, quantity_change=5)
+    url = reverse("item_detail", args=[item.pk])
+    resp = client.get(url)
+    assert resp.status_code == 200
+    assert b"Widget" in resp.content
+    assert b"Current Stock" in resp.content
+
+
+def test_item_delete_view_deletes_without_transactions(client):
+    item = _create_item()
+    url = reverse("item_delete", args=[item.pk])
+    resp = client.post(url)
+    assert resp.status_code == 302
+    assert Item.objects.count() == 0
+
+
+def test_item_delete_view_deactivates_with_transactions(client):
+    item = _create_item()
+    StockTransaction.objects.create(item=item, quantity_change=2)
+    url = reverse("item_delete", args=[item.pk])
+    resp = client.post(url)
+    assert resp.status_code == 302
+    item.refresh_from_db()
+    assert item.is_active is False


### PR DESCRIPTION
## Summary
- implement ItemDetailView to render item details
- implement ItemDeleteView to delete or deactivate items
- add templates and table links for view and delete/deactivate actions
- cover new views with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a82e73def083268612375941335f1d