### PR TITLE
Add supplier filtering and CSV export

### DIFF
--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -22,7 +22,7 @@
         <td>{{ row.is_active }}</td>
         <td>
           <a href="{% url 'supplier_edit' row.supplier_id %}" class="text-blue-600 mr-2">Edit</a>
-          <a hx-get="{% url 'supplier_toggle_active' row.supplier_id %}?q={{ q|urlencode }}&page={{ page_obj.number }}&show_inactive={{ show_inactive|urlencode }}"
+          <a hx-get="{% url 'supplier_toggle_active' row.supplier_id %}?q={{ q|urlencode }}&page={{ page_obj.number }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
              hx-target="#suppliers_table" class="text-blue-600">Toggle</a>
         </td>
       </tr>
@@ -34,12 +34,12 @@
 </div>
 <div class="flex items-center gap-3 mt-3">
   {% if page_obj.has_previous %}
-    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&show_inactive={{ show_inactive|urlencode }}"
+    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
        hx-target="#suppliers_table" class="px-3 py-1 border rounded">Prev</a>
   {% endif %}
   <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
   {% if page_obj.has_next %}
-    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&show_inactive={{ show_inactive|urlencode }}"
+    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
        hx-target="#suppliers_table" class="px-3 py-1 border rounded">Next</a>
   {% endif %}
 </div>

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -19,11 +19,16 @@
         hx-trigger="keyup changed delay:300ms"
         hx-include="#filters"
       />
-      <label class="flex items-center gap-2">
-        <input type="checkbox" name="show_inactive" value="1" class="form-checkbox" {% if show_inactive %}checked{% endif %}
-               hx-get="{% url 'suppliers_table' %}" hx-target="#suppliers_table" hx-trigger="change" hx-include="#filters" />
-        Show Inactive
-      </label>
+      <select name="active" class="form-control"
+              hx-get="{% url 'suppliers_table' %}" hx-target="#suppliers_table" hx-trigger="change" hx-include="#filters">
+        <option value="">All</option>
+        <option value="1" {% if active == '1' %}selected{% endif %}>Active</option>
+        <option value="0" {% if active == '0' %}selected{% endif %}>Inactive</option>
+      </select>
+      <input type="hidden" name="page_size" value="{{ page_size|default:25 }}">
+      <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
+      <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">
+      <button type="submit" name="export" value="1" formaction="{% url 'suppliers_table' %}" formmethod="get" class="px-4 py-2 border rounded">Export</button>
   </form>
   <div id="suppliers_table"
        hx-get="{% url 'suppliers_table' %}"


### PR DESCRIPTION
## Summary
- allow filtering suppliers by status, sorting and exporting to CSV
- add filter controls and export button on suppliers list page
- cover supplier filtering and export with tests

## Testing
- `pytest tests/test_supplier_service_django.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a830cf6e1c83268de96a9d9df7f2fd