### PR TITLE
Enable search for indents list

### DIFF
--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -28,10 +28,10 @@
 </div>
 <div class="flex items-center gap-3 mt-3">
   {% if page_obj.has_previous %}
-    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.previous_page_number }}&status={{ status|urlencode }}" hx-target="#indents_table" class="px-3 py-1 border rounded">Prev</a>
+    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.previous_page_number }}&status={{ status|urlencode }}&q={{ q|urlencode }}" hx-target="#indents_table" class="px-3 py-1 border rounded">Prev</a>
   {% endif %}
   <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
   {% if page_obj.has_next %}
-    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.next_page_number }}&status={{ status|urlencode }}" hx-target="#indents_table" class="px-3 py-1 border rounded">Next</a>
+    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.next_page_number }}&status={{ status|urlencode }}&q={{ q|urlencode }}" hx-target="#indents_table" class="px-3 py-1 border rounded">Next</a>
   {% endif %}
 </div>

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -6,6 +6,17 @@
     <a href="{% url 'indent_create' %}" class="px-4 py-2 bg-green-600 text-white rounded">New Indent</a>
   </div>
     <form id="filters" class="flex flex-wrap gap-2 mb-4">
+      <input
+        type="text"
+        name="q"
+        placeholder="Search indents..."
+        class="form-control flex-grow"
+        value="{{ q }}"
+        hx-get="{% url 'indents_table' %}"
+        hx-target="#indents_table"
+        hx-trigger="keyup changed delay:300ms"
+        hx-include="#filters"
+      />
       <select name="status" class="form-control"
               hx-get="{% url 'indents_table' %}" hx-target="#indents_table" hx-trigger="change" hx-include="#filters">
       <option value="">All Statuses</option>


### PR DESCRIPTION
## Summary
- allow searching indents by MRN, requester or department
- add search box to indents list and propagate query in HTMX calls

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a840527074832680ed19f55ad52f65