### PR TITLE
Use POST for indent status updates

### DIFF
--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -8,6 +8,8 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views import View
 from django.views.generic import TemplateView
+from django.views.decorators.http import require_POST
+from django.views.decorators.csrf import csrf_protect
 
 from ..forms import IndentForm, IndentItemFormSet
 from ..indent_pdf import generate_indent_pdf
@@ -98,6 +100,8 @@ def indent_detail(request, pk: int):
     )
 
 
+@require_POST
+@csrf_protect
 def indent_update_status(request, pk: int, status: str):
     indent = get_object_or_404(Indent, pk=pk)
     indent.status = status.upper()

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -18,9 +18,18 @@
     </tbody>
   </table>
   <div class="mt-4 flex gap-2">
-    <a href="{% url 'indent_update_status' indent.indent_id 'PROCESSING' %}" class="px-3 py-2 border rounded">Mark Processing</a>
-    <a href="{% url 'indent_update_status' indent.indent_id 'COMPLETED' %}" class="px-3 py-2 border rounded">Mark Completed</a>
-    <a href="{% url 'indent_update_status' indent.indent_id 'CANCELLED' %}" class="px-3 py-2 border rounded">Cancel</a>
+    <form action="{% url 'indent_update_status' indent.indent_id 'PROCESSING' %}" method="post" class="inline">
+      {% csrf_token %}
+      <button type="submit" class="px-3 py-2 border rounded">Mark Processing</button>
+    </form>
+    <form action="{% url 'indent_update_status' indent.indent_id 'COMPLETED' %}" method="post" class="inline">
+      {% csrf_token %}
+      <button type="submit" class="px-3 py-2 border rounded">Mark Completed</button>
+    </form>
+    <form action="{% url 'indent_update_status' indent.indent_id 'CANCELLED' %}" method="post" class="inline">
+      {% csrf_token %}
+      <button type="submit" class="px-3 py-2 border rounded">Cancel</button>
+    </form>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace status-changing links in indent detail with CSRF-protected POST forms
- Require POST and CSRF validation when updating indent status

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8412860788326a4c00c95adb6485d