### PR TITLE
Add supplier/date filtering and pagination for GRN list

### DIFF
--- a/inventory/views/goods_received.py
+++ b/inventory/views/goods_received.py
@@ -1,9 +1,10 @@
 import logging
 
+from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView
 
-from ..models import GoodsReceivedNote
+from ..models import GoodsReceivedNote, Supplier
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,41 @@ class GRNListView(TemplateView):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
-        ctx["grns"] = GoodsReceivedNote.objects.select_related("purchase_order", "supplier").order_by("-received_date")
+        request = self.request
+        grns = GoodsReceivedNote.objects.select_related("purchase_order", "supplier").order_by("-received_date")
+
+        supplier_id = request.GET.get("supplier")
+        start_date = request.GET.get("start_date")
+        end_date = request.GET.get("end_date")
+
+        if supplier_id:
+            grns = grns.filter(supplier_id=supplier_id)
+        if start_date:
+            grns = grns.filter(received_date__gte=start_date)
+        if end_date:
+            grns = grns.filter(received_date__lte=end_date)
+
+        paginator = Paginator(grns, 20)
+        page_number = request.GET.get("page")
+        page_obj = paginator.get_page(page_number)
+
+        suppliers = Supplier.objects.all()
+        query_params = request.GET.copy()
+        if "page" in query_params:
+            query_params.pop("page")
+        querystring = query_params.urlencode()
+
+        ctx.update(
+            {
+                "grns": page_obj,
+                "page_obj": page_obj,
+                "suppliers": suppliers,
+                "current_supplier": supplier_id,
+                "start_date": start_date,
+                "end_date": end_date,
+                "querystring": querystring,
+            }
+        )
         return ctx
 
 

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -2,6 +2,28 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Goods Received Notes</h1>
+  <form method="get" class="mb-4 flex flex-wrap items-end gap-2">
+    <div>
+      <label class="block text-sm">Supplier</label>
+      <select name="supplier" class="border rounded px-2 py-1">
+        <option value="">All</option>
+        {% for s in suppliers %}
+        <option value="{{ s.pk }}" {% if current_supplier == s.pk|stringformat:'s' %}selected{% endif %}>{{ s.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label class="block text-sm">Start Date</label>
+      <input type="date" name="start_date" value="{{ start_date }}" class="border rounded px-2 py-1" />
+    </div>
+    <div>
+      <label class="block text-sm">End Date</label>
+      <input type="date" name="end_date" value="{{ end_date }}" class="border rounded px-2 py-1" />
+    </div>
+    <div>
+      <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Filter</button>
+    </div>
+  </form>
   <table class="table">
     <thead><tr><th>ID</th><th>PO</th><th>Supplier</th><th>Date</th></tr></thead>
     <tbody>
@@ -17,5 +39,14 @@
     {% endfor %}
     </tbody>
   </table>
+  <div class="mt-4 flex justify-between">
+    {% if page_obj.has_previous %}
+    <a href="?page={{ page_obj.previous_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-blue-600">Previous</a>
+    {% endif %}
+    <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+    {% if page_obj.has_next %}
+    <a href="?page={{ page_obj.next_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-blue-600">Next</a>
+    {% endif %}
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add supplier and date filter form to GRN list template
- paginate and filter GRNs by supplier and date in view

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a84571d65883268700a80782862b5c