### PR TITLE
Link GRNs to purchase orders and add export endpoint

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -44,6 +44,7 @@ from .views.recipes import (
 from .views.goods_received import (
     GRNListView,
     GRNDetailView,
+    grn_export,
 )
 
 urlpatterns = [
@@ -82,6 +83,7 @@ urlpatterns = [
     path("purchase-orders/<int:pk>/receive/", purchase_order_receive, name="purchase_order_receive"),
 
     path("grns/", GRNListView.as_view(), name="grn_list"),
+    path("grns/<int:pk>/export/", grn_export, name="grn_export"),
     path("grns/<int:pk>/", GRNDetailView.as_view(), name="grn_detail"),
 
     path("recipes/", RecipesListView.as_view(), name="recipes_list"),

--- a/inventory/views/goods_received.py
+++ b/inventory/views/goods_received.py
@@ -1,8 +1,13 @@
+import csv
 import logging
 
 from django.core.paginator import Paginator
+from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView
+
+from fpdf import FPDF
+from fpdf.enums import XPos, YPos
 
 from ..models import GoodsReceivedNote, Supplier
 
@@ -61,3 +66,63 @@ class GRNDetailView(TemplateView):
         items = grn.grnitem_set.select_related("po_item", "po_item__item")
         ctx.update({"grn": grn, "items": items})
         return ctx
+
+
+def grn_export(request, pk: int):
+    grn = get_object_or_404(GoodsReceivedNote, pk=pk)
+    items = grn.grnitem_set.select_related("po_item", "po_item__item")
+    fmt = (request.GET.get("format") or "pdf").lower()
+    if fmt == "csv":
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = f"attachment; filename=grn_{grn.pk}.csv"
+        writer = csv.writer(response)
+        writer.writerow(["Item", "Ordered", "Received"])
+        for line in items:
+            writer.writerow(
+                [
+                    getattr(line.po_item.item, "name", ""),
+                    line.po_item.quantity_ordered,
+                    line.quantity_received,
+                ]
+            )
+        return response
+
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=12)
+    pdf.cell(0, 10, f"GRN {grn.pk}", new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+    pdf.cell(
+        0,
+        10,
+        f"PO: {grn.purchase_order_id}",
+        new_x=XPos.LMARGIN,
+        new_y=YPos.NEXT,
+    )
+    pdf.cell(
+        0,
+        10,
+        f"Supplier: {getattr(grn.supplier, 'name', '')}",
+        new_x=XPos.LMARGIN,
+        new_y=YPos.NEXT,
+    )
+    pdf.cell(
+        0,
+        10,
+        f"Date: {grn.received_date}",
+        new_x=XPos.LMARGIN,
+        new_y=YPos.NEXT,
+    )
+    pdf.ln(4)
+    pdf.set_font("Helvetica", size=10)
+    pdf.cell(100, 8, "Item", border=1)
+    pdf.cell(30, 8, "Ordered", border=1)
+    pdf.cell(30, 8, "Received", border=1, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+    for line in items:
+        name = getattr(line.po_item.item, "name", "")
+        pdf.cell(100, 8, str(name), border=1)
+        pdf.cell(30, 8, str(line.po_item.quantity_ordered), border=1)
+        pdf.cell(30, 8, str(line.quantity_received), border=1, new_x=XPos.LMARGIN, new_y=YPos.NEXT)
+    pdf_bytes = bytes(pdf.output())
+    response = HttpResponse(pdf_bytes, content_type="application/pdf")
+    response["Content-Disposition"] = f"attachment; filename=grn_{grn.pk}.pdf"
+    return response

--- a/templates/inventory/grns/detail.html
+++ b/templates/inventory/grns/detail.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">GRN {{ grn.pk }}</h1>
-  <p class="mb-2"><strong>PO:</strong> {{ grn.purchase_order_id }}</p>
+  <p class="mb-2"><strong>PO:</strong> <a class="text-blue-600" href="{% url 'purchase_order_detail' grn.purchase_order_id %}">{{ grn.purchase_order_id }}</a></p>
   <p class="mb-2"><strong>Supplier:</strong> {{ grn.supplier.name }}</p>
   <p class="mb-4"><strong>Date:</strong> {{ grn.received_date }}</p>
   <table class="table">


### PR DESCRIPTION
## Summary
- Link GRN detail pages to their originating purchase order
- Add PDF/CSV export endpoint for Goods Received Notes and route to access it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8463f8f088326bb05946414c8d63f