### PR TITLE
Display recent stock transactions

### DIFF
--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -51,5 +51,48 @@
       {% endfor %}
     </ul>
   {% endif %}
+  <hr class="my-4"/>
+  <h2 class="text-xl font-semibold mb-2">Recent Transactions</h2>
+  <div class="overflow-x-auto">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Item</th>
+          <th>Type</th>
+          <th>Qty</th>
+          <th>User</th>
+          <th>Date</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for tx in page_obj %}
+        <tr>
+          <td>{{ tx.transaction_id }}</td>
+          <td>{{ tx.item.name }}</td>
+          <td>{{ tx.transaction_type }}</td>
+          <td>{{ tx.quantity_change }}</td>
+          <td>{{ tx.user_id }}</td>
+          <td>{{ tx.transaction_date }}</td>
+          <td>{{ tx.notes }}</td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="7" class="p-2">No transactions found.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="flex items-center gap-3 mt-3">
+    {% if page_obj.has_previous %}
+    <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.previous_page_number }}" class="px-3 py-1 border rounded">Prev</a>
+    {% endif %}
+    <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+    {% if page_obj.has_next %}
+    <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.next_page_number }}" class="px-3 py-1 border rounded">Next</a>
+    {% endif %}
+  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- paginate recent `StockTransaction` entries in `stock_movements` view
- show a table of recent stock transactions with pagination on stock movements page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a847fda08c8326ab65d4bad0ab054a