### PR TITLE
Use shared field component across templates

### DIFF
--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -4,7 +4,14 @@
   <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
-    {{ form.as_p }}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
     <div class="flex gap-2">
       <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Delete</button>
       <a href="{% url back_url %}" class="px-4 py-2 border rounded">Back</a>

--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -4,7 +4,14 @@
   <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
-    {{ form.as_p }}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
     <div class="flex gap-2">
       <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Upload</button>
       <a href="{% url back_url %}" class="px-4 py-2 border rounded">Back</a>

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -14,17 +14,7 @@
     {% endif %}
     <div class="mb-4 space-y-4">
       {% for field in form %}
-      <div>
-        {{ field.label_tag }}
-        {{ field }}
-        {% if field.errors %}
-        <ul class="text-red-600 list-disc pl-5">
-          {% for error in field.errors %}
-          <li>{{ error }}</li>
-          {% endfor %}
-        </ul>
-        {% endif %}
-      </div>
+        {% include "components/form_field.html" with field=field %}
       {% endfor %}
     </div>
     {{ formset.management_form }}
@@ -47,30 +37,9 @@
       <tbody>
       {% for item_form in formset %}
         <tr class="form-row">
-          <td>
-            {{ item_form.item }}
-            {% if item_form.item.errors %}
-            <ul class="text-red-600 list-disc pl-5">
-              {% for error in item_form.item.errors %}<li>{{ error }}</li>{% endfor %}
-            </ul>
-            {% endif %}
-          </td>
-          <td>
-            {{ item_form.requested_qty }}
-            {% if item_form.requested_qty.errors %}
-            <ul class="text-red-600 list-disc pl-5">
-              {% for error in item_form.requested_qty.errors %}<li>{{ error }}</li>{% endfor %}
-            </ul>
-            {% endif %}
-          </td>
-          <td>
-            {{ item_form.notes }}
-            {% if item_form.notes.errors %}
-            <ul class="text-red-600 list-disc pl-5">
-              {% for error in item_form.notes.errors %}<li>{{ error }}</li>{% endfor %}
-            </ul>
-            {% endif %}
-          </td>
+          <td>{% include "components/form_field.html" with field=item_form.item %}</td>
+          <td>{% include "components/form_field.html" with field=item_form.requested_qty %}</td>
+          <td>{% include "components/form_field.html" with field=item_form.notes %}</td>
           <td><button type="button" class="remove-row text-red-600">Remove</button></td>
         </tr>
       {% endfor %}

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -4,11 +4,36 @@
   <h1 class="text-2xl font-semibold mb-4">{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order</h1>
   <form method="post" class="space-y-4" id="po-form">
     {% csrf_token %}
-    {{ form.as_p }}
+    {% if form.non_field_errors %}
+      <ul class="text-red-600 list-disc pl-5">
+        {% for error in form.non_field_errors %}
+          <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
     <div id="items-formset">
       {{ formset.management_form }}
+      {% if formset.non_form_errors %}
+        <ul class="text-red-600 list-disc pl-5">
+          {% for error in formset.non_form_errors %}
+            <li>{{ error }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
       {% for f in formset %}
-      <div class="border p-2 item-form">{{ f.as_p }}</div>
+      <div class="border p-2 item-form">
+        {% if f.non_field_errors %}
+          <ul class="text-red-600 list-disc pl-5">
+            {% for error in f.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+          </ul>
+        {% endif %}
+        {% for field in f %}
+          {% include "components/form_field.html" with field=field %}
+        {% endfor %}
+      </div>
       {% endfor %}
     </div>
     <div class="flex space-x-2">
@@ -17,7 +42,11 @@
     </div>
   </form>
   <template id="item-empty-form">
-    <div class="border p-2 item-form">{{ formset.empty_form.as_p }}</div>
+    <div class="border p-2 item-form">
+      {% for field in formset.empty_form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
+    </div>
   </template>
   <script>
     (function () {

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -4,7 +4,14 @@
   <h1 class="text-2xl font-semibold mb-4">Receive Goods for PO {{ po.pk }}</h1>
   <form method="post" class="space-y-4">
     {% csrf_token %}
-    {{ form.as_p }}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
     <table class="table">
       <thead><tr><th>Item</th><th>Ordered</th><th>Received</th><th>Receive Now</th></tr></thead>
       <tbody>

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -13,17 +13,7 @@
     {% endif %}
     <div class="mb-4 space-y-4">
       {% for field in form %}
-      <div>
-        {{ field.label_tag }}
-        {{ field }}
-        {% if field.errors %}
-        <ul class="text-red-600 list-disc pl-5">
-          {% for error in field.errors %}
-          <li>{{ error }}</li>
-          {% endfor %}
-        </ul>
-        {% endif %}
-      </div>
+        {% include "components/form_field.html" with field=field %}
       {% endfor %}
     </div>
     {{ formset.management_form }}
@@ -48,36 +38,11 @@
       <tbody>
       {% for cform in formset %}
         <tr class="form-row">
-          <td>
-            {{ cform.component_kind }}
-            {% for error in cform.component_kind.errors %}
-            <div class="text-red-600">{{ error }}</div>
-            {% endfor %}
-          </td>
-          <td>
-            {{ cform.component_id }}
-            {% for error in cform.component_id.errors %}
-            <div class="text-red-600">{{ error }}</div>
-            {% endfor %}
-          </td>
-          <td>
-            {{ cform.quantity }}
-            {% for error in cform.quantity.errors %}
-            <div class="text-red-600">{{ error }}</div>
-            {% endfor %}
-          </td>
-          <td>
-            {{ cform.unit }}
-            {% for error in cform.unit.errors %}
-            <div class="text-red-600">{{ error }}</div>
-            {% endfor %}
-          </td>
-          <td>
-            {{ cform.loss_pct }}
-            {% for error in cform.loss_pct.errors %}
-            <div class="text-red-600">{{ error }}</div>
-            {% endfor %}
-          </td>
+          <td>{% include "components/form_field.html" with field=cform.component_kind %}</td>
+          <td>{% include "components/form_field.html" with field=cform.component_id %}</td>
+          <td>{% include "components/form_field.html" with field=cform.quantity %}</td>
+          <td>{% include "components/form_field.html" with field=cform.unit %}</td>
+          <td>{% include "components/form_field.html" with field=cform.loss_pct %}</td>
           <td>
             {{ cform.DELETE }}<button type="button" class="remove-row text-red-600">Remove</button>
           </td>

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -17,21 +17,48 @@
     <h2 class="text-xl font-semibold mb-2">Goods Received</h2>
     <form method="post" class="mb-4">
       {% csrf_token %}
-      {{ receive_form.as_p }}
+      {% if receive_form.non_field_errors %}
+      <ul class="text-red-600 list-disc pl-5">
+        {% for error in receive_form.non_field_errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% for field in receive_form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
       <button type="submit" name="submit_receive" class="px-4 py-2 bg-green-600 text-white rounded">Record</button>
     </form>
   {% elif active_section == 'adjust' %}
     <h2 class="text-xl font-semibold mb-2">Stock Adjustment</h2>
     <form method="post" class="mb-4">
       {% csrf_token %}
-      {{ adjust_form.as_p }}
+      {% if adjust_form.non_field_errors %}
+      <ul class="text-red-600 list-disc pl-5">
+        {% for error in adjust_form.non_field_errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% for field in adjust_form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
       <button type="submit" name="submit_adjust" class="px-4 py-2 bg-green-600 text-white rounded">Record</button>
     </form>
   {% elif active_section == 'waste' %}
     <h2 class="text-xl font-semibold mb-2">Wastage/Spoilage</h2>
     <form method="post" class="mb-4">
       {% csrf_token %}
-      {{ waste_form.as_p }}
+      {% if waste_form.non_field_errors %}
+      <ul class="text-red-600 list-disc pl-5">
+        {% for error in waste_form.non_field_errors %}
+        <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% for field in waste_form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
       <button type="submit" name="submit_waste" class="px-4 py-2 bg-green-600 text-white rounded">Record</button>
     </form>
   {% endif %}
@@ -40,7 +67,16 @@
   <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-blue-600 underline">Download sample CSV</a></p>
   <form method="post" enctype="multipart/form-data" class="mb-4">
     {% csrf_token %}
-    {{ bulk_form.as_p }}
+    {% if bulk_form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in bulk_form.non_field_errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    {% for field in bulk_form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
     <button type="submit" name="bulk_upload" class="px-4 py-2 bg-blue-600 text-white rounded">Upload</button>
   </form>
   {% if bulk_success_count is not None %}

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -14,17 +14,7 @@
     </ul>
     {% endif %}
     {% for field in form %}
-    <div>
-      {{ field.label_tag }}
-        {{ field }}
-      {% if field.errors %}
-      <ul class="text-red-600 list-disc pl-5">
-        {% for error in field.errors %}
-        <li>{{ error }}</li>
-        {% endfor %}
-      </ul>
-      {% endif %}
-    </div>
+      {% include "components/form_field.html" with field=field %}
     {% endfor %}
     <div class="flex gap-2">
       <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -3,7 +3,14 @@
 <h1>Login</h1>
 <form method="post">
   {% csrf_token %}
-  {{ form.as_p }}
+  {% if form.non_field_errors %}
+  <ul class="text-red-600 list-disc pl-5">
+    {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+  </ul>
+  {% endif %}
+  {% for field in form %}
+    {% include "components/form_field.html" with field=field %}
+  {% endfor %}
   <button type="submit">Login</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Render supplier, indent, purchase order, stock movement and other forms with the `components/form_field.html` include
- Update inline formsets to display each field with the shared component for consistent errors and help text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a85133e9b48326a33c299e955ff1e9