### PR TITLE
Group navigation menu into dropdown sections

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -24,20 +24,45 @@
               <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
             </button>
             <div id="nav-menu" class="hidden sm:flex sm:space-x-4 flex-col sm:flex-row ml-4 sm:ml-0">
-              <a href="{% url 'dashboard' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Dashboard</a>
-              <a href="{% url 'items_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
-              <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
-              <a href="{% url 'indents_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Indents</a>
-              <a href="{% url 'purchase_orders_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Purchase Orders</a>
-              <a href="{% url 'grn_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">GRNs</a>
-              <a href="{% url 'stock_movements' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock Movements</a>
-              <a href="{% url 'history_reports' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
-              <a href="{% url 'recipes_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Recipes</a>
-              {% if user.is_authenticated %}
-                <a href="{% url 'logout' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Logout</a>
-              {% else %}
-                <a href="{% url 'login' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Login</a>
-              {% endif %}
+              <div class="relative nav-group">
+                <button data-dropdown="overview-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Overview</button>
+                <div id="overview-menu" class="hidden flex-col sm:absolute sm:bg-gray-800 sm:dark:bg-gray-950 sm:mt-2 sm:rounded-md">
+                  <a href="{% url 'dashboard' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Dashboard</a>
+                  <a href="{% url 'history_reports' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
+                </div>
+              </div>
+              <div class="relative nav-group">
+                <button data-dropdown="inventory-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Inventory</button>
+                <div id="inventory-menu" class="hidden flex-col sm:absolute sm:bg-gray-800 sm:dark:bg-gray-950 sm:mt-2 sm:rounded-md">
+                  <a href="{% url 'items_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
+                  <a href="{% url 'stock_movements' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock Movements</a>
+                </div>
+              </div>
+              <div class="relative nav-group">
+                <button data-dropdown="procurement-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Procurement</button>
+                <div id="procurement-menu" class="hidden flex-col sm:absolute sm:bg-gray-800 sm:dark:bg-gray-950 sm:mt-2 sm:rounded-md">
+                  <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
+                  <a href="{% url 'indents_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Indents</a>
+                  <a href="{% url 'purchase_orders_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Purchase Orders</a>
+                  <a href="{% url 'grn_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">GRNs</a>
+                </div>
+              </div>
+              <div class="relative nav-group">
+                <button data-dropdown="production-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Production</button>
+                <div id="production-menu" class="hidden flex-col sm:absolute sm:bg-gray-800 sm:dark:bg-gray-950 sm:mt-2 sm:rounded-md">
+                  <a href="{% url 'recipes_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Recipes</a>
+                </div>
+              </div>
+              <div class="relative nav-group">
+                <button data-dropdown="account-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Account</button>
+                <div id="account-menu" class="hidden flex-col sm:absolute sm:bg-gray-800 sm:dark:bg-gray-950 sm:mt-2 sm:rounded-md">
+                  {% if user.is_authenticated %}
+                    <a href="{% url 'logout' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Logout</a>
+                  {% else %}
+                    <a href="{% url 'login' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Login</a>
+                  {% endif %}
+                </div>
+              </div>
             </div>
             <button id="theme-toggle" class="ml-4 text-gray-300 hover:text-white dark:text-gray-200" aria-label="Toggle theme">🌓</button>
           </div>
@@ -56,6 +81,12 @@
     <script>
       document.getElementById('nav-toggle').addEventListener('click', function () {
         document.getElementById('nav-menu').classList.toggle('hidden');
+      });
+      document.querySelectorAll('[data-dropdown]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          const menu = document.getElementById(btn.dataset.dropdown);
+          menu.classList.toggle('hidden');
+        });
       });
       document.body.addEventListener('htmx:request', function () {
         document.getElementById('htmx-spinner').classList.remove('hidden');


### PR DESCRIPTION
## Summary
- Group navigation links into Overview, Inventory, Procurement, Production, and Account dropdowns
- Add JavaScript to toggle each dropdown menu

## Testing
- `pytest`
- `NODE_PATH=/tmp/jsdom/node_modules node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a854d6ebf88326a89b70c71780dcd1