### PR TITLE
Use template filter for form field CSS classes

### DIFF
--- a/inventory/templatetags/form_tags.py
+++ b/inventory/templatetags/form_tags.py
@@ -1,0 +1,11 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def add_class(field, css_class: str) -> str:
+    """Add CSS classes to a form field's widget."""
+    existing = field.field.widget.attrs.get("class", "")
+    classes = f"{existing} {css_class}".strip()
+    return field.as_widget(attrs={"class": classes})

--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -1,12 +1,13 @@
+{% load form_tags %}
 {% with input_class="w-full px-3 py-2 border rounded" checkbox_class="h-4 w-4 text-blue-600" %}
 <div class="mb-4">
   <label for="{{ field.id_for_label }}" class="block mb-1 font-medium">{{ field.label }}</label>
   {% if field.field.widget.attrs.class %}
     {{ field }}
   {% elif field.field.widget.input_type == "checkbox" %}
-    {{ field.as_widget(attrs={"class": checkbox_class}) }}
+    {{ field|add_class:checkbox_class }}
   {% else %}
-    {{ field.as_widget(attrs={"class": input_class}) }}
+    {{ field|add_class:input_class }}
   {% endif %}
   {% if field.help_text %}
     <p class="text-sm text-gray-500">{{ field.help_text }}</p>


### PR DESCRIPTION
## Summary
- add `add_class` template filter to inject classes into form widgets
- update form field component to use filter instead of `as_widget` with attr dict

## Testing
- `python manage.py shell <<'PY'
from django.test import Client
from django.urls import reverse
from django.conf import settings
from inventory.models import Item

settings.ALLOWED_HOSTS.append('testserver')
client = Client()
item = Item.objects.create(name='Test', base_unit='pcs', purchase_unit='box', category='cat')
print('item_create status:', client.get(reverse('item_create')).status_code)
print('item_edit status:', client.get(reverse('item_edit', args=[item.pk])).status_code)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a855683f608326bb146d20fe233f02