### PR TITLE
Improve responsive form layout and styling

### DIFF
--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -17,6 +17,16 @@ form textarea,
     max-width: 100%;
 }
 
+@media (min-width: 641px) {
+    form input:not([type="checkbox"]):not([type="radio"]),
+    form select,
+    form textarea,
+    .form-control {
+        width: 50%;
+        max-width: 32rem;
+    }
+}
+
 @media (max-width: 640px) {
     form input:not([type="checkbox"]):not([type="radio"]),
     form select,

--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -1,5 +1,5 @@
 {% load form_tags %}
-{% with input_class="w-full px-3 py-2 border rounded" checkbox_class="h-4 w-4 text-primary" %}
+{% with input_class="w-full sm:w-1/2 lg:w-1/3 px-3 py-2 border rounded" checkbox_class="h-4 w-4 text-primary" %}
 <div class="mb-4">
   <label for="{{ field.id_for_label }}" class="block mb-1 font-medium">{{ field.label }}</label>
   {% if field.field.widget.attrs.class %}

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% load static %}
 {% block content %}
-<div class="w-full max-w-md sm:max-w-2xl lg:max-w-3xl mx-auto p-4 max-h-screen overflow-y-auto">
+<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto p-4 max-h-screen overflow-y-auto">
   <h1 class="text-2xl font-semibold mb-4">New Indent</h1>
   <form method="post" id="indent-form">
     {% csrf_token %}
@@ -12,7 +12,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <div class="mb-4 space-y-4">
+    <div class="mb-4 flex flex-wrap gap-4">
       {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="w-full max-w-md sm:max-w-lg mx-auto p-4 max-h-screen overflow-y-auto">
+<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto p-4 max-h-screen overflow-y-auto">
   <h1 class="text-2xl font-semibold mb-4">
     {% if is_edit %}Edit Item{% else %}Add Item{% endif %}
   </h1>
@@ -14,15 +14,17 @@
       {% endfor %}
     </ul>
     {% endif %}
-    {% include "components/form_field.html" with field=form.name %}
-    {% include "components/form_field.html" with field=form.base_unit %}
-    {% include "components/form_field.html" with field=form.purchase_unit %}
-    {% include "components/form_field.html" with field=form.category %}
-    {% for field in form %}
-      {% if field.name not in excluded_fields %}
-        {% include "components/form_field.html" with field=field %}
-      {% endif %}
-    {% endfor %}
+    <div class="flex flex-wrap gap-4">
+      {% include "components/form_field.html" with field=form.name %}
+      {% include "components/form_field.html" with field=form.base_unit %}
+      {% include "components/form_field.html" with field=form.purchase_unit %}
+      {% include "components/form_field.html" with field=form.category %}
+      {% for field in form %}
+        {% if field.name not in excluded_fields %}
+          {% include "components/form_field.html" with field=field %}
+        {% endif %}
+      {% endfor %}
+    </div>
     <div class="flex gap-2">
       <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Save</button>
       <a href="{% url 'items_list' %}" class="px-4 py-2 border rounded">Cancel</a>

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="w-full max-w-md sm:max-w-lg mx-auto p-4 max-h-screen overflow-y-auto">
+<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto p-4 max-h-screen overflow-y-auto">
   <h1 class="text-2xl font-semibold mb-4">
     {% if is_edit %}Edit Supplier{% else %}Add Supplier{% endif %}
   </h1>
@@ -13,9 +13,11 @@
       {% endfor %}
     </ul>
     {% endif %}
-    {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
-    {% endfor %}
+    <div class="flex flex-wrap gap-4">
+      {% for field in form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
+    </div>
     <div class="flex gap-2">
       <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Save</button>
       <a href="{% url 'suppliers_list' %}" class="px-4 py-2 border rounded">Cancel</a>


### PR DESCRIPTION
## Summary
- add desktop form control width via media query
- make form fields responsive across breakpoints
- upgrade inventory forms with responsive containers and flex layouts

## Testing
- `pytest`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_68a858b951dc8326b263a2f64f2a45ad