### PR TITLE
Add csv import for item bulk uploads

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -1,3 +1,4 @@
+import csv
 import io
 import logging
 


### PR DESCRIPTION
## Summary
- import csv module in item views
- ensure bulk upload view uses csv reader

## Testing
- `python - <<'PY'
import os
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'inventory_app.settings')
import django
django.setup()

from django.test import RequestFactory
from django.core.files.uploadedfile import SimpleUploadedFile
from django.contrib.sessions.middleware import SessionMiddleware
from django.contrib.messages.storage.fallback import FallbackStorage

from inventory.views.items import ItemsBulkUploadView

csv_content = 'name\nSample Item\n'
file = SimpleUploadedFile('items.csv', csv_content.encode('utf-8'), content_type='text/csv')
factory = RequestFactory()
request = factory.post('/items/bulk_upload/', {'file': file})
request.FILES['file'] = file
middleware = SessionMiddleware(lambda req: None)
middleware.process_request(request)
# Don't save session to avoid DB
setattr(request, '_messages', FallbackStorage(request))

response = ItemsBulkUploadView.as_view()(request)
print('Status code:', response.status_code)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a85a6d2aec832694a4c8b7c9489ba6