### PR TITLE
feat: add empty states for suppliers and indents

### DIFF
--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -33,7 +33,8 @@ class IndentsListView(TemplateView):
         ctx = super().get_context_data(**kwargs)
         status = (self.request.GET.get("status") or "").strip()
         q = (self.request.GET.get("q") or "").strip()
-        ctx.update({"status": status, "q": q})
+        total_indents = Indent.objects.count()
+        ctx.update({"status": status, "q": q, "total_indents": total_indents})
         return ctx
 
 

--- a/inventory/views/suppliers.py
+++ b/inventory/views/suppliers.py
@@ -26,6 +26,7 @@ class SuppliersListView(TemplateView):
         page_size = (self.request.GET.get("page_size") or "25").strip()
         sort = (self.request.GET.get("sort") or "name").strip()
         direction = (self.request.GET.get("direction") or "asc").strip()
+        total_suppliers = Supplier.objects.count()
         ctx.update(
             {
                 "q": q,
@@ -33,6 +34,7 @@ class SuppliersListView(TemplateView):
                 "page_size": page_size,
                 "sort": sort,
                 "direction": direction,
+                "total_suppliers": total_suppliers,
             }
         )
         return ctx

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -21,7 +21,12 @@
         <td><a href="{% url 'indent_detail' row.indent_id %}" class="text-primary">View</a></td>
       </tr>
       {% empty %}
-      <tr><td colspan="6" class="p-2">No indents found.</td></tr>
+      <tr>
+        <td colspan="6" class="p-4 text-center">
+          0 indents yet.
+          <a href="{% url 'indent_create' %}" class="px-3 py-1 ml-2 text-white bg-primary rounded">New Indent</a>
+        </td>
+      </tr>
       {% endfor %}
     </tbody>
   </table>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -41,7 +41,12 @@
         </td>
       </tr>
       {% empty %}
-      <tr><td colspan="7" class="p-2">No suppliers found.</td></tr>
+      <tr>
+        <td colspan="7" class="p-4 text-center">
+          0 suppliers yet.
+          <a href="{% url 'supplier_create' %}" class="px-3 py-1 ml-2 text-white bg-primary rounded">Add Supplier</a>
+        </td>
+      </tr>
       {% endfor %}
     </tbody>
   </table>

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
-  <h1 class="text-2xl font-semibold mb-4">Indents</h1>
+  <h1 class="text-2xl font-semibold mb-4">Indents ({{ total_indents }})</h1>
   <div class="mb-4 flex gap-2">
     <a href="{% url 'indent_create' %}" class="px-4 py-2 text-white rounded bg-primary">New Indent</a>
   </div>
@@ -30,6 +30,12 @@
        hx-get="{% url 'indents_table' %}"
        hx-trigger="load"
        hx-include="#filters">
+    {% if total_indents == 0 %}
+    <div class="p-4 text-center border rounded">
+      <p class="mb-2">0 indents yet.</p>
+      <a href="{% url 'indent_create' %}" class="px-4 py-2 text-white rounded bg-primary">New Indent</a>
+    </div>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
-  <h1 class="text-2xl font-semibold mb-4">Suppliers</h1>
+  <h1 class="text-2xl font-semibold mb-4">Suppliers ({{ total_suppliers }})</h1>
   <div class="mb-4 flex gap-2">
     <a href="{% url 'supplier_create' %}" class="px-4 py-2 text-white rounded bg-primary">Add Supplier</a>
     <a href="{% url 'suppliers_bulk_upload' %}" class="px-4 py-2 border rounded">Bulk Upload</a>
@@ -34,6 +34,12 @@
        hx-get="{% url 'suppliers_table' %}"
        hx-trigger="load"
        hx-include="#filters">
+    {% if total_suppliers == 0 %}
+    <div class="p-4 text-center border rounded">
+      <p class="mb-2">0 suppliers yet.</p>
+      <a href="{% url 'supplier_create' %}" class="px-4 py-2 text-white rounded bg-primary">Add Supplier</a>
+    </div>
+    {% endif %}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show item counts and placeholders on supplier and indent list views
- provide friendly empty state messages with action buttons for suppliers and indents

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a86cbbcfec83269713b6a9886fd264