### PR TITLE
feat: unify table styling with reusable component

### DIFF
--- a/templates/components/table.html
+++ b/templates/components/table.html
@@ -1,0 +1,15 @@
+{% comment %}Reusable table component with sticky headers and optional actions and footer slots{% endcomment %}
+<div class="overflow-x-auto">
+  {% block actions %}{% endblock %}
+  <table class="table-auto w-full text-sm border-collapse">
+    <thead class="sticky top-0 bg-white">
+      <tr>
+        {% block headers %}{% endblock %}
+      </tr>
+    </thead>
+    <tbody>
+      {% block rows %}{% endblock %}
+    </tbody>
+  </table>
+</div>
+{% block footer %}{% endblock %}

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,97 +1,96 @@
-<div class="overflow-x-auto">
-  <table class="table">
-    <thead>
-      <tr>
-        <th>
-          <a hx-get="{% url 'items_table' %}?sort=item_id&direction={% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#items_table" hx-include="#filters"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='item_id';document.querySelector('#filters input[name=direction]').value='{% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            ID{% if sort == 'item_id' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th>
-          <a hx-get="{% url 'items_table' %}?sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#items_table" hx-include="#filters"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='name';document.querySelector('#filters input[name=direction]').value='{% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Name{% if sort == 'name' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th>
-          <a hx-get="{% url 'items_table' %}?sort=base_unit&direction={% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#items_table" hx-include="#filters"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='base_unit';document.querySelector('#filters input[name=direction]').value='{% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Base Unit{% if sort == 'base_unit' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th>
-          <a hx-get="{% url 'items_table' %}?sort=category&direction={% if sort == 'category' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#items_table" hx-include="#filters"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='category';document.querySelector('#filters input[name=direction]').value='{% if sort == 'category' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Category{% if sort == 'category' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th>
-          <a hx-get="{% url 'items_table' %}?sort=sub_category&direction={% if sort == 'sub_category' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#items_table" hx-include="#filters"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='sub_category';document.querySelector('#filters input[name=direction]').value='{% if sort == 'sub_category' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Subcategory{% if sort == 'sub_category' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="text-right">
-          <a hx-get="{% url 'items_table' %}?sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#items_table" hx-include="#filters"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='current_stock';document.querySelector('#filters input[name=direction]').value='{% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Current Stock{% if sort == 'current_stock' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="text-right">
-          <a hx-get="{% url 'items_table' %}?sort=reorder_point&direction={% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#items_table" hx-include="#filters"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='reorder_point';document.querySelector('#filters input[name=direction]').value='{% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Reorder Point{% if sort == 'reorder_point' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th>
-          <a hx-get="{% url 'items_table' %}?sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#items_table" hx-include="#filters"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='is_active';document.querySelector('#filters input[name=direction]').value='{% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Active{% if sort == 'is_active' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for row in page_obj %}
-      <tr>
-        <td>{{ row.item_id }}</td>
-        <td>{{ row.name }}</td>
-        <td>{{ row.base_unit }}</td>
-        <td>{{ row.category }}</td>
-        <td>{{ row.sub_category }}</td>
-        <td class="text-right">{{ row.current_stock }}</td>
-        <td class="text-right">{{ row.reorder_point }}</td>
-        <td>{{ row.is_active }}</td>
-        <td>
-          <a href="{% url 'item_detail' row.item_id %}" class="text-primary mr-2">View</a>
-          <a href="{% url 'item_edit' row.item_id %}" class="text-primary mr-2">Edit</a>
-          <a href="{% url 'item_delete' row.item_id %}" class="text-primary">Delete/Deactivate</a>
-        </td>
-      </tr>
-      {% empty %}
-      <tr>
-        <td colspan="9">
-          <div class="text-center py-6 text-gray-500">
-            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
-            <p class="mt-2">No items found.</p>
-            <a href="{% url 'item_create' %}" class="mt-2 inline-block text-primary underline">Create the first item</a>
-          </div>
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
+{% extends "components/table.html" %}
+
+{% block headers %}
+<th class="px-4 py-2">
+  <a hx-get="{% url 'items_table' %}?sort=item_id&direction={% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#items_table" hx-include="#filters"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='item_id';document.querySelector('#filters input[name=direction]').value='{% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    ID{% if sort == 'item_id' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2">
+  <a hx-get="{% url 'items_table' %}?sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#items_table" hx-include="#filters"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='name';document.querySelector('#filters input[name=direction]').value='{% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Name{% if sort == 'name' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2">
+  <a hx-get="{% url 'items_table' %}?sort=base_unit&direction={% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#items_table" hx-include="#filters"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='base_unit';document.querySelector('#filters input[name=direction]').value='{% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Base Unit{% if sort == 'base_unit' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2">
+  <a hx-get="{% url 'items_table' %}?sort=category&direction={% if sort == 'category' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#items_table" hx-include="#filters"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='category';document.querySelector('#filters input[name=direction]').value='{% if sort == 'category' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Category{% if sort == 'category' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2">
+  <a hx-get="{% url 'items_table' %}?sort=sub_category&direction={% if sort == 'sub_category' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#items_table" hx-include="#filters"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='sub_category';document.querySelector('#filters input[name=direction]').value='{% if sort == 'sub_category' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Subcategory{% if sort == 'sub_category' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2 text-right">
+  <a hx-get="{% url 'items_table' %}?sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#items_table" hx-include="#filters"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='current_stock';document.querySelector('#filters input[name=direction]').value='{% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Current Stock{% if sort == 'current_stock' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2 text-right">
+  <a hx-get="{% url 'items_table' %}?sort=reorder_point&direction={% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#items_table" hx-include="#filters"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='reorder_point';document.querySelector('#filters input[name=direction]').value='{% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Reorder Point{% if sort == 'reorder_point' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2">
+  <a hx-get="{% url 'items_table' %}?sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#items_table" hx-include="#filters"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='is_active';document.querySelector('#filters input[name=direction]').value='{% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Active{% if sort == 'is_active' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2">Actions</th>
+{% endblock %}
+
+{% block rows %}
+{% for row in page_obj %}
+<tr class="odd:bg-gray-50">
+  <td class="px-4 py-2">{{ row.item_id }}</td>
+  <td class="px-4 py-2">{{ row.name }}</td>
+  <td class="px-4 py-2">{{ row.base_unit }}</td>
+  <td class="px-4 py-2">{{ row.category }}</td>
+  <td class="px-4 py-2">{{ row.sub_category }}</td>
+  <td class="px-4 py-2 text-right">{{ row.current_stock }}</td>
+  <td class="px-4 py-2 text-right">{{ row.reorder_point }}</td>
+  <td class="px-4 py-2">{{ row.is_active }}</td>
+  <td class="px-4 py-2">
+    <a href="{% url 'item_detail' row.item_id %}" class="text-primary mr-2">View</a>
+    <a href="{% url 'item_edit' row.item_id %}" class="text-primary mr-2">Edit</a>
+    <a href="{% url 'item_delete' row.item_id %}" class="text-primary">Delete/Deactivate</a>
+  </td>
+</tr>
+{% empty %}
+<tr>
+  <td colspan="9" class="px-4 py-2">
+    <div class="text-center py-6 text-gray-500">
+      <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
+      <p class="mt-2">No items found.</p>
+      <a href="{% url 'item_create' %}" class="mt-2 inline-block text-primary underline">Create the first item</a>
+    </div>
+  </td>
+</tr>
+{% endfor %}
+{% endblock %}
+
+{% block footer %}
 <div class="flex items-center gap-3 mt-3 flex-wrap">
   <div class="flex items-center gap-1">
     {% if page_obj.has_previous %}
@@ -118,3 +117,4 @@
     </select>
   </div>
 </div>
+{% endblock %}

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -1,0 +1,33 @@
+{% extends "components/table.html" %}
+
+{% block headers %}
+<th class="px-4 py-2">PO #</th>
+<th class="px-4 py-2">Supplier</th>
+<th class="px-4 py-2">Order Date</th>
+<th class="px-4 py-2">Status</th>
+{% endblock %}
+
+{% block rows %}
+{% for po in orders %}
+<tr class="odd:bg-gray-50">
+  <td class="px-4 py-2"><a class="text-primary" href="{% url 'purchase_order_detail' po.pk %}">{{ po.pk }}</a></td>
+  <td class="px-4 py-2">{{ po.supplier.name }}</td>
+  <td class="px-4 py-2">{{ po.order_date }}</td>
+  <td class="px-4 py-2"><span class="px-2 py-1 rounded text-xs {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
+</tr>
+{% empty %}
+<tr><td colspan="4" class="px-4 py-2">No purchase orders.</td></tr>
+{% endfor %}
+{% endblock %}
+
+{% block footer %}
+<div class="mt-4 flex justify-between">
+  {% if page_obj.has_previous %}
+  <a href="?page={{ page_obj.previous_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-primary">Previous</a>
+  {% endif %}
+  <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+  {% if page_obj.has_next %}
+  <a href="?page={{ page_obj.next_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-primary">Next</a>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -37,36 +37,6 @@
       <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Filter</button>
     </div>
   </form>
-  <table class="table">
-    <thead>
-      <tr>
-        <th>PO #</th>
-        <th>Supplier</th>
-        <th>Order Date</th>
-        <th>Status</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for po in orders %}
-      <tr>
-        <td><a class="text-primary" href="{% url 'purchase_order_detail' po.pk %}">{{ po.pk }}</a></td>
-        <td>{{ po.supplier.name }}</td>
-        <td>{{ po.order_date }}</td>
-        <td><span class="px-2 py-1 rounded text-xs {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
-      </tr>
-      {% empty %}
-      <tr><td colspan="4" class="p-2">No purchase orders.</td></tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  <div class="mt-4 flex justify-between">
-    {% if page_obj.has_previous %}
-    <a href="?page={{ page_obj.previous_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-primary">Previous</a>
-    {% endif %}
-    <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-    <a href="?page={{ page_obj.next_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-primary">Next</a>
-    {% endif %}
-  </div>
+  {% include "inventory/purchase_orders/_table.html" %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add Tailwind table component with sticky headers
- use component for items and purchase order lists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a86dfa711c8326829f7dc5441a153d