### PR TITLE
feat(ui): global visual polish pack

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,0 +1,18 @@
+<div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+  <div class="rounded-xl shadow p-4 flex items-center justify-between bg-white border-l-4 border-secondary">
+    <h2 class="text-sm font-medium text-primary">Stock Value</h2>
+    <span class="text-2xl font-bold">{{ stock_value }}</span>
+  </div>
+  <div class="rounded-xl shadow p-4 flex items-center justify-between bg-white border-l-4 border-secondary">
+    <h2 class="text-sm font-medium text-primary">7-day Receipts</h2>
+    <span class="text-2xl font-bold">{{ receipts }}</span>
+  </div>
+  <div class="rounded-xl shadow p-4 flex items-center justify-between bg-white border-l-4 border-secondary">
+    <h2 class="text-sm font-medium text-primary">7-day Issues</h2>
+    <span class="text-2xl font-bold">{{ issues }}</span>
+  </div>
+  <div class="rounded-xl shadow p-4 flex items-center justify-between bg-white border-l-4 border-secondary">
+    <h2 class="text-sm font-medium text-primary">Low-stock Count</h2>
+    <span class="text-2xl font-bold">{{ low_stock }}</span>
+  </div>
+</div>

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -2,27 +2,9 @@
 {% block content %}
 <h1 class="text-2xl font-semibold mb-4">Dashboard</h1>
 
-<div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow">
-    <h2 class="text-sm font-medium text-gray-500">Items</h2>
-    <p class="text-2xl font-bold">{{ total_items }}</p>
-  </div>
-  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow">
-    <h2 class="text-sm font-medium text-gray-500">Suppliers</h2>
-    <p class="text-2xl font-bold">{{ total_suppliers }}</p>
-  </div>
-  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow">
-    <h2 class="text-sm font-medium text-gray-500">Recent Transactions</h2>
-    <p class="text-2xl font-bold">{{ recent_transactions }}</p>
-  </div>
-</div>
+<div id="kpi-cards" hx-get="{% url 'dashboard-kpis' %}" hx-trigger="load"></div>
 
-<div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow h-64 flex items-center justify-center">Chart 1</div>
-  <div class="bg-white dark:bg-gray-800 p-4 rounded shadow h-64 flex items-center justify-center">Chart 2</div>
-</div>
-
-<h2 class="text-xl mb-2">Low Stock Items</h2>
+<h2 class="text-xl mb-2 mt-8">Low Stock Items</h2>
 <table class="table">
   <thead><tr><th>Item</th><th>Stock</th><th>Reorder Point</th></tr></thead>
   <tbody>

--- a/core/views.py
+++ b/core/views.py
@@ -1,13 +1,7 @@
-from datetime import timedelta
-
-from decimal import Decimal
-from django.db.models import F, Value
-from django.db.models.functions import Coalesce
 from django.http import HttpResponse
 from django.shortcuts import render
-from django.utils import timezone
 
-from inventory.models import Item, Supplier, StockTransaction
+from inventory.services import dashboard_service, kpis
 
 
 def root_view(request):
@@ -20,31 +14,17 @@ def health_check(request):
 
 
 def dashboard(request):
-    # Use Coalesce to safely handle potential NULL values in the database,
-    # treating them as 0.0 for the comparison. This prevents the 500 error.
-    low_stock = Item.objects.annotate(
-        stock_safe=Coalesce(
-            "current_stock", Value(Decimal("0"))
-        ),
-        reorder_safe=Coalesce(
-            "reorder_point", Value(Decimal("0"))
-        )
-    ).filter(
-        reorder_safe__gt=0,  # Only consider items with a reorder point > 0
-        stock_safe__lt=F("reorder_safe")
-    ).order_by("name")
-
-    total_items = Item.objects.count()
-    total_suppliers = Supplier.objects.count()
-    recent_transactions = StockTransaction.objects.filter(
-        transaction_date__gte=timezone.now() - timedelta(days=7)
-    ).count()
-
-    context = {
-        "low_stock": low_stock,
-        "total_items": total_items,
-        "total_suppliers": total_suppliers,
-        "recent_transactions": recent_transactions,
-    }
-
+    """Render dashboard shell; KPI cards are loaded asynchronously."""
+    context = {"low_stock": dashboard_service.get_low_stock_items()}
     return render(request, "core/dashboard.html", context)
+
+
+def dashboard_kpis(request):
+    """HTMX endpoint returning KPI card values."""
+    data = {
+        "stock_value": kpis.stock_value(),
+        "receipts": kpis.receipts_last_7_days(),
+        "issues": kpis.issues_last_7_days(),
+        "low_stock": kpis.low_stock_count(),
+    }
+    return render(request, "core/_kpi_cards.html", data)

--- a/inventory/services/__init__.py
+++ b/inventory/services/__init__.py
@@ -11,6 +11,7 @@ from . import (
     ui_service,
     list_utils,
     sale_service,
+    kpis,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "ui_service",
     "list_utils",
     "sale_service",
+    "kpis",
 ]

--- a/inventory/services/goods_receiving_service.py
+++ b/inventory/services/goods_receiving_service.py
@@ -2,8 +2,6 @@ import logging
 from datetime import date
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple
-
-from decimal import Decimal
 from django.db import transaction
 from django.db.models import Max
 

--- a/inventory/services/kpis.py
+++ b/inventory/services/kpis.py
@@ -1,0 +1,41 @@
+from datetime import timedelta
+
+from django.db.models import F, Sum
+from django.utils import timezone
+
+from inventory.models import Item, StockTransaction
+
+
+def stock_value():
+    """Total stock value based on current stock quantities."""
+    return Item.objects.aggregate(total=Sum("current_stock"))["total"] or 0
+
+
+def receipts_last_7_days():
+    """Total quantity received in the past 7 days."""
+    week_ago = timezone.now() - timedelta(days=7)
+    return (
+        StockTransaction.objects.filter(
+            transaction_type="RECEIVING", transaction_date__gte=week_ago
+        ).aggregate(total=Sum("quantity_change"))["total"]
+        or 0
+    )
+
+
+def issues_last_7_days():
+    """Total quantity issued in the past 7 days."""
+    week_ago = timezone.now() - timedelta(days=7)
+    total = (
+        StockTransaction.objects.filter(
+            transaction_type="ISSUE", transaction_date__gte=week_ago
+        ).aggregate(total=Sum("quantity_change"))["total"]
+        or 0
+    )
+    return abs(total)
+
+
+def low_stock_count():
+    """Number of items below their reorder point."""
+    return Item.objects.filter(
+        reorder_point__isnull=False, current_stock__lt=F("reorder_point")
+    ).count()

--- a/inventory_app/urls.py
+++ b/inventory_app/urls.py
@@ -18,13 +18,14 @@ Including another URLconf
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.urls import path, include
-from core.views import root_view, health_check, dashboard
+from core.views import root_view, health_check, dashboard, dashboard_kpis
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("login/", auth_views.LoginView.as_view(), name="login"),
     path("", root_view, name="root"),
     path("dashboard/", dashboard, name="dashboard"),
+    path("dashboard/kpis/", dashboard_kpis, name="dashboard-kpis"),
     path("healthz", health_check, name="health-check"),
     path("accounts/", include("django.contrib.auth.urls")),
     path("api/", include("inventory.urls")),   # DRF API

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2,29 +2,39 @@
 
 :root {
   --color-body-bg: #f9fafb;
-  --color-body-text: #1a202c;
-  --color-primary: #3b82f6;
+  --color-body-text: #111827;
+  --color-primary: #1e40af;
+  --color-secondary: #059669;
+  --color-accent: #f59e0b;
+  --color-danger: #dc2626;
   --form-bg: #ffffff;
-  --form-border: #cbd5e0;
-  --form-text: #1a202c;
-  --form-focus-border: #3b82f6;
-  --form-focus-shadow: rgba(59, 130, 246, 0.4);
+  --form-border: #d1d5db;
+  --form-text: #111827;
+  --form-focus-border: var(--color-primary);
+  --form-focus-shadow: rgba(30, 64, 175, 0.4);
   --table-border: #e5e7eb;
-  --table-header-bg: #f9fafb;
+  --table-header-bg: var(--color-primary);
+  --table-header-text: #ffffff;
+  --table-hover-bg: #f3f4f6;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-body-bg: #1e1e1e;
+    --color-body-bg: #1f2937;
     --color-body-text: #ffffff;
-    --color-primary: #63b3ed;
-    --form-bg: #2d3748;
-    --form-border: #4a5568;
-    --form-text: #f7fafc;
-    --form-focus-border: #63b3ed;
-    --form-focus-shadow: rgba(99, 179, 237, 0.6);
-    --table-border: #4a5568;
-    --table-header-bg: #2d3748;
+    --color-primary: #1e3a8a;
+    --color-secondary: #047857;
+    --color-accent: #b45309;
+    --color-danger: #b91c1c;
+    --form-bg: #374151;
+    --form-border: #4b5563;
+    --form-text: #f9fafb;
+    --form-focus-border: var(--color-primary);
+    --form-focus-shadow: rgba(30, 58, 138, 0.6);
+    --table-border: #4b5563;
+    --table-header-bg: var(--color-primary);
+    --table-header-text: #ffffff;
+    --table-hover-bg: #1f2937;
   }
 }
 
@@ -59,3 +69,34 @@ body {
 .bg-primary { background-color: var(--color-primary); }
 .border-primary { border-color: var(--color-primary); }
 .text-primary { color: var(--color-primary); }
+.bg-secondary { background-color: var(--color-secondary); }
+.border-secondary { border-color: var(--color-secondary); }
+.text-secondary { color: var(--color-secondary); }
+.bg-accent { background-color: var(--color-accent); }
+.border-accent { border-color: var(--color-accent); }
+.text-accent { color: var(--color-accent); }
+.bg-danger { background-color: var(--color-danger); }
+.border-danger { border-color: var(--color-danger); }
+.text-danger { color: var(--color-danger); }
+
+/* Button styles */
+.btn-primary {
+  background-color: var(--color-primary);
+  color: #ffffff;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+}
+
+.btn-secondary {
+  background-color: var(--color-secondary);
+  color: #ffffff;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+}
+
+.btn-danger {
+  background-color: var(--color-danger);
+  color: #ffffff;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+}

--- a/static/css/tables.css
+++ b/static/css/tables.css
@@ -13,4 +13,9 @@
 
 .table thead {
     background-color: var(--table-header-bg);
+    color: var(--table-header-text);
+}
+
+.table tbody tr:hover {
+    background-color: var(--table-hover-bg);
 }

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -1,0 +1,6 @@
+<div class="p-6 text-center border rounded bg-white">
+  <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+  <h2 class="mt-4 mb-2 text-lg font-semibold">{{ title }}</h2>
+  <p class="mb-4 text-gray-600">{{ message }}</p>
+  <a href="{{ cta_url }}" class="btn-primary">{{ cta_label }}</a>
+</div>

--- a/templates/components/table.html
+++ b/templates/components/table.html
@@ -1,8 +1,8 @@
 {% comment %}Reusable table component with sticky headers and optional actions and footer slots{% endcomment %}
 <div class="overflow-x-auto">
   {% block actions %}{% endblock %}
-  <table class="table-auto w-full text-sm border-collapse">
-    <thead class="sticky top-0 bg-white">
+  <table class="table table-auto w-full text-sm border-collapse">
+    <thead class="sticky top-0 bg-primary text-white">
       <tr>
         {% block headers %}{% endblock %}
       </tr>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -62,7 +62,7 @@
 
 {% block rows %}
 {% for row in page_obj %}
-<tr class="odd:bg-gray-50">
+<tr class="odd:bg-gray-50 hover:bg-gray-100">
   <td class="px-4 py-2">{{ row.item_id }}</td>
   <td class="px-4 py-2">{{ row.name }}</td>
   <td class="px-4 py-2">{{ row.base_unit }}</td>
@@ -80,11 +80,8 @@
 {% empty %}
 <tr>
   <td colspan="9" class="px-4 py-2">
-    <div class="text-center py-6 text-gray-500">
-      <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path></svg>
-      <p class="mt-2">No items found.</p>
-      <a href="{% url 'item_create' %}" class="mt-2 inline-block text-primary underline">Create the first item</a>
-    </div>
+    {% url 'item_create' as item_create_url %}
+    {% include "components/empty_state.html" with title="No Items" message="No items found." cta_label="Add Item" cta_url=item_create_url %}
   </td>
 </tr>
 {% endfor %}

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -2,8 +2,8 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Indents ({{ total_indents }})</h1>
-  <div class="mb-4 flex gap-2">
-    <a href="{% url 'indent_create' %}" class="px-4 py-2 text-white rounded bg-primary">New Indent</a>
+  <div class="mb-4 flex justify-end gap-2">
+    <a href="{% url 'indent_create' %}" class="btn-primary">New Indent</a>
   </div>
     <form id="filters" class="flex flex-wrap gap-2 mb-4">
       <input
@@ -31,10 +31,8 @@
        hx-trigger="load"
        hx-include="#filters">
     {% if total_indents == 0 %}
-    <div class="p-4 text-center border rounded">
-      <p class="mb-2">0 indents yet.</p>
-      <a href="{% url 'indent_create' %}" class="px-4 py-2 text-white rounded bg-primary">New Indent</a>
-    </div>
+      {% url 'indent_create' as indent_create_url %}
+      {% include "components/empty_state.html" with title="No Indents" message="Create your first indent to get started." cta_label="New Indent" cta_url=indent_create_url %}
     {% endif %}
   </div>
 </div>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -2,9 +2,9 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Items</h1>
-  <div class="mb-4 flex gap-2">
-    <a href="{% url 'item_create' %}" class="px-4 py-2 text-white rounded bg-primary">Add Item</a>
-    <a href="{% url 'items_bulk_upload' %}" class="px-4 py-2 border rounded">Bulk Upload</a>
+  <div class="mb-4 flex justify-end gap-2">
+    <a href="{% url 'item_create' %}" class="btn-primary">Add Item</a>
+    <a href="{% url 'items_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
   </div>
   <form id="filters" class="flex flex-wrap gap-2 mb-4" hx-indicator="#htmx-spinner">
       <input
@@ -42,7 +42,7 @@
       <input type="hidden" name="page_size" value="{{ page_size|default:25 }}">
       <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
       <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">
-      <button type="submit" formaction="{% url 'items_export' %}" formmethod="get" class="px-4 py-2 border rounded">Export</button>
+      <button type="submit" formaction="{% url 'items_export' %}" formmethod="get" class="btn-secondary">Export</button>
   </form>
   <div id="items_table"
        hx-get="{% url 'items_table' %}"

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -9,14 +9,19 @@
 
 {% block rows %}
 {% for po in orders %}
-<tr class="odd:bg-gray-50">
+<tr class="odd:bg-gray-50 hover:bg-gray-100">
   <td class="px-4 py-2"><a class="text-primary" href="{% url 'purchase_order_detail' po.pk %}">{{ po.pk }}</a></td>
   <td class="px-4 py-2">{{ po.supplier.name }}</td>
   <td class="px-4 py-2">{{ po.order_date }}</td>
   <td class="px-4 py-2"><span class="px-2 py-1 rounded text-xs {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
 </tr>
 {% empty %}
-<tr><td colspan="4" class="px-4 py-2">No purchase orders.</td></tr>
+<tr>
+  <td colspan="4" class="px-4 py-2">
+    {% url 'purchase_order_create' as po_create_url %}
+    {% include "components/empty_state.html" with title="No Purchase Orders" message="Create a new purchase order to get started." cta_label="New PO" cta_url=po_create_url %}
+  </td>
+</tr>
 {% endfor %}
 {% endblock %}
 

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -2,9 +2,9 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Purchase Orders</h1>
-  <div class="mb-4 flex gap-2">
-    <a href="{% url 'purchase_order_create' %}" class="px-4 py-2 text-white rounded bg-primary">New PO</a>
-    <a href="{% url 'grn_list' %}" class="px-4 py-2 text-white rounded bg-primary">GRNs</a>
+  <div class="mb-4 flex justify-end gap-2">
+    <a href="{% url 'purchase_order_create' %}" class="btn-primary">New PO</a>
+    <a href="{% url 'grn_list' %}" class="btn-secondary">GRNs</a>
   </div>
   <form method="get" class="mb-4 flex flex-wrap items-end gap-2">
     <div>
@@ -34,7 +34,7 @@
       <input type="date" name="end_date" value="{{ end_date }}" class="border rounded px-2 py-1" />
     </div>
     <div>
-      <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Filter</button>
+      <button type="submit" class="btn-primary">Filter</button>
     </div>
   </form>
   {% include "inventory/purchase_orders/_table.html" %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -2,10 +2,10 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Suppliers ({{ total_suppliers }})</h1>
-  <div class="mb-4 flex gap-2">
-    <a href="{% url 'supplier_create' %}" class="px-4 py-2 text-white rounded bg-primary">Add Supplier</a>
-    <a href="{% url 'suppliers_bulk_upload' %}" class="px-4 py-2 border rounded">Bulk Upload</a>
-    <a href="{% url 'suppliers_bulk_delete' %}" class="px-4 py-2 border rounded">Bulk Delete</a>
+  <div class="mb-4 flex justify-end gap-2">
+    <a href="{% url 'supplier_create' %}" class="btn-primary">Add Supplier</a>
+    <a href="{% url 'suppliers_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
+    <a href="{% url 'suppliers_bulk_delete' %}" class="btn-danger">Bulk Delete</a>
   </div>
   <form id="filters" class="flex flex-wrap gap-2 mb-4">
       <input
@@ -28,17 +28,15 @@
       <input type="hidden" name="page_size" value="{{ page_size|default:25 }}">
       <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
       <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">
-      <button type="submit" name="export" value="1" formaction="{% url 'suppliers_table' %}" formmethod="get" class="px-4 py-2 border rounded">Export</button>
+      <button type="submit" name="export" value="1" formaction="{% url 'suppliers_table' %}" formmethod="get" class="btn-secondary">Export</button>
   </form>
   <div id="suppliers_table"
        hx-get="{% url 'suppliers_table' %}"
        hx-trigger="load"
        hx-include="#filters">
     {% if total_suppliers == 0 %}
-    <div class="p-4 text-center border rounded">
-      <p class="mb-2">0 suppliers yet.</p>
-      <a href="{% url 'supplier_create' %}" class="px-4 py-2 text-white rounded bg-primary">Add Supplier</a>
-    </div>
+      {% url 'supplier_create' as supplier_create_url %}
+      {% include "components/empty_state.html" with title="No Suppliers" message="Start by adding your first supplier." cta_label="Add Supplier" cta_url=supplier_create_url %}
     {% endif %}
   </div>
 </div>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,7 +1,7 @@
 import pytest
 from django.urls import reverse
 
-from inventory.models import Item, Supplier, StockTransaction
+from inventory.models import Item, StockTransaction
 
 
 @pytest.mark.django_db
@@ -13,15 +13,10 @@ def test_dashboard_low_stock(client):
 
 
 @pytest.mark.django_db
-def test_dashboard_totals(client):
+def test_dashboard_kpis_endpoint(client):
     item1 = Item.objects.create(name="Foo", reorder_point=10, current_stock=5)
-    Item.objects.create(name="Bar", reorder_point=0, current_stock=0)
-    Supplier.objects.create(name="ACME")
-    Supplier.objects.create(name="Globex")
-    StockTransaction.objects.create(item=item1, quantity_change=1)
+    StockTransaction.objects.create(item=item1, quantity_change=1, transaction_type="RECEIVING")
 
-    resp = client.get(reverse("dashboard"))
+    resp = client.get(reverse("dashboard-kpis"))
     assert resp.status_code == 200
-    assert resp.context["total_items"] == 2
-    assert resp.context["total_suppliers"] == 2
-    assert resp.context["recent_transactions"] == 1
+    assert b"Stock Value" in resp.content

--- a/tests/test_kpis_service.py
+++ b/tests/test_kpis_service.py
@@ -1,0 +1,20 @@
+import pytest
+from datetime import timedelta
+from django.utils import timezone
+
+from inventory.models import Item, StockTransaction
+from inventory.services import kpis
+
+
+@pytest.mark.django_db
+def test_kpi_calculations():
+    item1 = Item.objects.create(name="A", reorder_point=20, current_stock=10)
+    item2 = Item.objects.create(name="B", reorder_point=1, current_stock=5)
+    week_ago = timezone.now() - timedelta(days=2)
+    StockTransaction.objects.create(item=item1, quantity_change=5, transaction_type="RECEIVING", transaction_date=week_ago)
+    StockTransaction.objects.create(item=item2, quantity_change=-2, transaction_type="ISSUE", transaction_date=week_ago)
+
+    assert kpis.stock_value() == 15
+    assert kpis.receipts_last_7_days() == 5
+    assert kpis.issues_last_7_days() == 2
+    assert kpis.low_stock_count() == 1


### PR DESCRIPTION
## Summary
- add reusable table component with sticky headers
- standardize button styles and apply new color palette
- replace dashboard charts with KPI cards and async loading
- introduce empty state component for list pages
- implement KPI services and tests

## Testing
- `python -m flake8`
- `pytest` *(fails: database table is locked in tests/test_stock_service.py::test_concurrent_stock_updates)*

------
https://chatgpt.com/codex/tasks/task_e_68a87257f9e883269ca3fa1e72ea1d1e