### PR TITLE
Increase stock transaction retries with backoff

### DIFF
--- a/inventory/services/stock_service.py
+++ b/inventory/services/stock_service.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
@@ -20,7 +21,7 @@ def record_stock_transaction(
     notes: Optional[str] = None,
 ) -> bool:
     quantity_change = Decimal(str(quantity_change))
-    for _ in range(3):
+    for attempt in range(5):
         try:
             with transaction.atomic():
                 updated = Item.objects.filter(pk=item_id).update(
@@ -41,6 +42,7 @@ def record_stock_transaction(
             return True
         except OperationalError as exc:  # pragma: no cover - retry on lock
             logger.error("Error recording stock transaction: %s", exc)
+            time.sleep(0.1 * attempt)
             continue
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("Error recording stock transaction: %s", exc)


### PR DESCRIPTION
## Summary
- expand stock transaction retry loop to five attempts
- add short incremental sleep on OperationalError

## Testing
- `pytest tests/test_stock_service.py::test_concurrent_stock_updates -q`


------
https://chatgpt.com/codex/tasks/task_e_68a877e1649c8326bf6739778465844d