### PR TITLE
Fix alert template block tags

### DIFF
--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -1,13 +1,19 @@
 {% for message in messages %}
   {% if 'error' in message.tags %}
     {% with bg='bg-red-100' border='border-red-500' text='text-red-700' %}
+      <div class="{{ bg }} {{ text }} p-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
+    {% endwith %}
   {% elif 'warning' in message.tags %}
     {% with bg='bg-yellow-100' border='border-yellow-500' text='text-yellow-700' %}
+      <div class="{{ bg }} {{ text }} p-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
+    {% endwith %}
   {% elif 'success' in message.tags %}
     {% with bg='bg-green-100' border='border-green-500' text='text-green-700' %}
+      <div class="{{ bg }} {{ text }} p-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
+    {% endwith %}
   {% else %}
     {% with bg='bg-blue-100' border='border-blue-500' text='text-blue-700' %}
+      <div class="{{ bg }} {{ text }} p-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
+    {% endwith %}
   {% endif %}
-  <div class="{{ bg }} {{ text }} p-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
-  {% endwith %}
 {% endfor %}


### PR DESCRIPTION
## Summary
- fix invalid block tag usage in alert component to avoid TemplateSyntaxError

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a87cdf00ec8326ba0b470456ddd559