### PR TITLE
Style buttons with Tailwind variants

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -78,21 +78,45 @@ body {
 /* Button styles */
 .btn-primary {
   background-color: var(--color-primary);
-  color: #ffffff;
-  padding: 0.5rem 1rem;
-  border-radius: 0.25rem;
+  @apply text-white px-4 py-2 rounded transition-colors;
+}
+.btn-primary:hover {
+  @apply opacity-90;
+}
+.btn-primary:focus {
+  @apply outline-none ring-2 ring-offset-2;
+  --tw-ring-color: var(--color-primary);
+}
+.btn-primary:disabled {
+  @apply opacity-50 cursor-not-allowed;
 }
 
 .btn-secondary {
   background-color: var(--color-secondary);
-  color: #ffffff;
-  padding: 0.5rem 1rem;
-  border-radius: 0.25rem;
+  @apply text-white px-4 py-2 rounded transition-colors;
+}
+.btn-secondary:hover {
+  @apply opacity-90;
+}
+.btn-secondary:focus {
+  @apply outline-none ring-2 ring-offset-2;
+  --tw-ring-color: var(--color-secondary);
+}
+.btn-secondary:disabled {
+  @apply opacity-50 cursor-not-allowed;
 }
 
 .btn-danger {
   background-color: var(--color-danger);
-  color: #ffffff;
-  padding: 0.5rem 1rem;
-  border-radius: 0.25rem;
+  @apply text-white px-4 py-2 rounded transition-colors;
+}
+.btn-danger:hover {
+  @apply opacity-90;
+}
+.btn-danger:focus {
+  @apply outline-none ring-2 ring-offset-2;
+  --tw-ring-color: var(--color-danger);
+}
+.btn-danger:disabled {
+  @apply opacity-50 cursor-not-allowed;
 }

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -24,7 +24,7 @@
       <tr>
         <td colspan="6" class="p-4 text-center">
           0 indents yet.
-          <a href="{% url 'indent_create' %}" class="px-3 py-1 ml-2 text-white bg-primary rounded">New Indent</a>
+          <a href="{% url 'indent_create' %}" class="btn-primary ml-2">New Indent</a>
         </td>
       </tr>
       {% endfor %}

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -44,7 +44,7 @@
       <tr>
         <td colspan="7" class="p-4 text-center">
           0 suppliers yet.
-          <a href="{% url 'supplier_create' %}" class="px-3 py-1 ml-2 text-white bg-primary rounded">Add Supplier</a>
+          <a href="{% url 'supplier_create' %}" class="btn-primary ml-2">Add Supplier</a>
         </td>
       </tr>
       {% endfor %}

--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -13,7 +13,7 @@
       {% include "components/form_field.html" with field=field %}
     {% endfor %}
     <div class="flex gap-2">
-      <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Delete</button>
+      <button type="submit" class="btn-danger">Delete</button>
       <a href="{% url back_url %}" class="px-4 py-2 border rounded">Back</a>
     </div>
   </form>

--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -13,7 +13,7 @@
       {% include "components/form_field.html" with field=field %}
     {% endfor %}
     <div class="flex gap-2">
-      <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Upload</button>
+      <button type="submit" class="btn-primary">Upload</button>
       <a href="{% url back_url %}" class="px-4 py-2 border rounded">Back</a>
     </div>
   </form>

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -21,7 +21,7 @@
       <input type="date" name="end_date" value="{{ end_date }}" class="border rounded px-2 py-1" />
     </div>
     <div>
-      <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Filter</button>
+      <button type="submit" class="btn-primary">Filter</button>
     </div>
   </form>
   <table class="table">

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -28,7 +28,7 @@
       <input type="date" name="end_date" value="{{ end_date }}" class="form-control" />
       <input type="hidden" name="sort" value="{{ sort|default:'date' }}" />
       <input type="hidden" name="direction" value="{{ direction|default:'desc' }}" />
-      <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Filter</button>
+      <button type="submit" class="btn-primary">Filter</button>
       <a href="?{% if query_string %}{{ query_string }}&{% endif %}export=csv" class="px-4 py-2 border rounded">Export CSV</a>
     </form>
     <div id="history_table">

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -50,7 +50,7 @@
       <button type="button" id="add-row" class="px-4 py-2 border rounded">Add Item</button>
     </div>
     <div class="mt-4">
-      <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Submit</button>
+      <button type="submit" class="btn-primary">Submit</button>
     </div>
   </form>
 </div>

--- a/templates/inventory/item_confirm_delete.html
+++ b/templates/inventory/item_confirm_delete.html
@@ -5,7 +5,7 @@
   <p class="mb-4">Are you sure you want to delete or deactivate "{{ item.name }}"?</p>
   <form method="post" class="flex gap-2">
     {% csrf_token %}
-    <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded">Confirm</button>
+    <button type="submit" class="btn-danger">Confirm</button>
     <a href="{% url 'items_list' %}" class="px-4 py-2 border rounded">Cancel</a>
   </form>
 </div>

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -26,7 +26,7 @@
       {% endfor %}
     </div>
     <div class="flex gap-2">
-      <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Save</button>
+      <button type="submit" class="btn-primary">Save</button>
       <a href="{% url 'items_list' %}" class="px-4 py-2 border rounded">Cancel</a>
     </div>
   </form>

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -19,9 +19,9 @@
     </tbody>
   </table>
   <div class="flex gap-2">
-    <a href="{% url 'purchase_order_edit' po.pk %}" class="px-4 py-2 text-white rounded bg-primary">Edit</a>
-    <a href="{% url 'purchase_order_receive' po.pk %}" class="px-4 py-2 text-white rounded bg-primary">Receive Goods</a>
-    <a href="{% url 'grn_list' %}" class="px-4 py-2 text-white rounded bg-primary">View GRNs</a>
+    <a href="{% url 'purchase_order_edit' po.pk %}" class="btn-primary">Edit</a>
+    <a href="{% url 'purchase_order_receive' po.pk %}" class="btn-primary">Receive Goods</a>
+    <a href="{% url 'grn_list' %}" class="btn-primary">View GRNs</a>
   </div>
 </div>
 {% endblock %}

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -39,8 +39,8 @@
     </div>
     <datalist id="item-options"></datalist>
     <div class="flex space-x-2">
-      <button type="button" id="add-item" class="px-3 py-1 text-white rounded bg-primary">Add Item</button>
-      <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Save</button>
+      <button type="button" id="add-item" class="btn-secondary">Add Item</button>
+      <button type="submit" class="btn-primary">Save</button>
     </div>
   </form>
   <template id="item-empty-form">

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -25,7 +25,7 @@
       {% endfor %}
       </tbody>
     </table>
-    <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Submit GRN</button>
+    <button type="submit" class="btn-primary">Submit GRN</button>
   </form>
 </div>
 {% endblock %}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -54,7 +54,7 @@
       <button type="button" id="add-row" class="px-4 py-2 border rounded">Add Component</button>
     </div>
     <div class="mt-4">
-      <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Save</button>
+      <button type="submit" class="btn-primary">Save</button>
     </div>
   </form>
 </div>

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -27,7 +27,7 @@
       {% for field in receive_form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}
-      <button type="submit" name="submit_receive" class="px-4 py-2 text-white rounded bg-primary">Record</button>
+      <button type="submit" name="submit_receive" class="btn-primary">Record</button>
     </form>
   {% elif active_section == 'adjust' %}
     <h2 class="text-xl font-semibold mb-2">Stock Adjustment</h2>
@@ -43,7 +43,7 @@
       {% for field in adjust_form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}
-      <button type="submit" name="submit_adjust" class="px-4 py-2 text-white rounded bg-primary">Record</button>
+      <button type="submit" name="submit_adjust" class="btn-primary">Record</button>
     </form>
   {% elif active_section == 'waste' %}
     <h2 class="text-xl font-semibold mb-2">Wastage/Spoilage</h2>
@@ -59,7 +59,7 @@
       {% for field in waste_form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}
-      <button type="submit" name="submit_waste" class="px-4 py-2 text-white rounded bg-primary">Record</button>
+      <button type="submit" name="submit_waste" class="btn-primary">Record</button>
     </form>
   {% endif %}
   <hr class="my-4"/>
@@ -77,7 +77,7 @@
     {% for field in bulk_form %}
       {% include "components/form_field.html" with field=field %}
     {% endfor %}
-    <button type="submit" name="bulk_upload" class="px-4 py-2 text-white rounded bg-primary">Upload</button>
+    <button type="submit" name="bulk_upload" class="btn-primary">Upload</button>
   </form>
   {% if bulk_success_count is not None %}
     <p>{{ bulk_success_count }} transaction(s) recorded successfully.</p>

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -19,7 +19,7 @@
       {% endfor %}
     </div>
     <div class="flex gap-2">
-      <button type="submit" class="px-4 py-2 text-white rounded bg-primary">Save</button>
+      <button type="submit" class="btn-primary">Save</button>
       <a href="{% url 'suppliers_list' %}" class="px-4 py-2 border rounded">Cancel</a>
     </div>
   </form>


### PR DESCRIPTION
## Summary
- add Tailwind-powered `.btn-primary`, `.btn-secondary`, and `.btn-danger` with hover, focus, and disabled states
- refactor inventory templates to use the new button classes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a87d51961c8326a6092d3fcbfab62a