### PR TITLE
Use Tailwind utilities for form layout

### DIFF
--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -14,26 +14,7 @@ form textarea,
     color: var(--form-text);
     padding: 0.5rem;
     border-radius: 0.25rem;
-    max-width: 100%;
-}
-
-@media (min-width: 641px) {
-    form input:not([type="checkbox"]):not([type="radio"]),
-    form select,
-    form textarea,
-    .form-control {
-        width: 50%;
-        max-width: 32rem;
-    }
-}
-
-@media (max-width: 640px) {
-    form input:not([type="checkbox"]):not([type="radio"]),
-    form select,
-    form textarea,
-    .form-control {
-        width: 100%;
-    }
+    width: 100%;
 }
 
 form input:not([type="checkbox"]):not([type="radio"]):focus,

--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -1,6 +1,6 @@
 {% load form_tags %}
-{% with input_class="w-full sm:w-1/2 lg:w-1/3 px-3 py-2 border rounded" checkbox_class="h-4 w-4 text-primary" %}
-<div class="mb-4">
+{% with input_class="w-full px-3 py-2 border rounded" checkbox_class="h-4 w-4 text-primary" %}
+<div class="space-y-1">
   <label for="{{ field.id_for_label }}" class="block mb-1 font-medium">{{ field.label }}</label>
   {% if field.field.widget.attrs.class %}
     {{ field }}

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -2,26 +2,26 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Goods Received Notes</h1>
-  <form method="get" class="mb-4 flex flex-wrap items-end gap-2">
-    <div>
+  <form method="get" class="mb-4 grid gap-2 sm:grid-cols-2 md:grid-cols-4 items-end">
+    <div class="space-y-1">
       <label class="block text-sm">Supplier</label>
-      <select name="supplier" class="border rounded px-2 py-1">
+      <select name="supplier" class="border rounded px-2 py-1 w-full">
         <option value="">All</option>
         {% for s in suppliers %}
         <option value="{{ s.pk }}" {% if current_supplier == s.pk|stringformat:'s' %}selected{% endif %}>{{ s.name }}</option>
         {% endfor %}
       </select>
     </div>
-    <div>
+    <div class="space-y-1">
       <label class="block text-sm">Start Date</label>
-      <input type="date" name="start_date" value="{{ start_date }}" class="border rounded px-2 py-1" />
+      <input type="date" name="start_date" value="{{ start_date }}" class="border rounded px-2 py-1 w-full" />
     </div>
-    <div>
+    <div class="space-y-1">
       <label class="block text-sm">End Date</label>
-      <input type="date" name="end_date" value="{{ end_date }}" class="border rounded px-2 py-1" />
+      <input type="date" name="end_date" value="{{ end_date }}" class="border rounded px-2 py-1 w-full" />
     </div>
-    <div>
-      <button type="submit" class="btn-primary">Filter</button>
+    <div class="space-y-1">
+      <button type="submit" class="btn-primary w-full">Filter</button>
     </div>
   </form>
   <table class="table">

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -2,34 +2,34 @@
 {% block content %}
 <div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">History Reports</h1>
-    <form id="filters" method="get" class="flex flex-wrap gap-2 mb-4"
+    <form id="filters" method="get" class="grid gap-2 mb-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7"
           hx-get="{% url 'history_reports' %}"
           hx-target="#history_table"
           hx-indicator="#htmx-spinner">
-      <select name="item" class="form-control">
+      <select name="item" class="form-control w-full">
         <option value="">All Items</option>
       {% for it in items %}
       <option value="{{ it.item_id }}" {% if item|default:'' == it.item_id|stringformat:"s" %}selected{% endif %}>{{ it.name }}</option>
       {% endfor %}
       </select>
-      <select name="type" class="form-control">
+      <select name="type" class="form-control w-full">
       <option value="">All Types</option>
       {% for t in transaction_types %}
       <option value="{{ t }}" {% if type == t %}selected{% endif %}>{{ t }}</option>
       {% endfor %}
       </select>
-      <select name="user" class="form-control">
+      <select name="user" class="form-control w-full">
       <option value="">All Users</option>
       {% for u in users %}
       <option value="{{ u }}" {% if user == u %}selected{% endif %}>{{ u }}</option>
       {% endfor %}
       </select>
-      <input type="date" name="start_date" value="{{ start_date }}" class="form-control" />
-      <input type="date" name="end_date" value="{{ end_date }}" class="form-control" />
+      <input type="date" name="start_date" value="{{ start_date }}" class="form-control w-full" />
+      <input type="date" name="end_date" value="{{ end_date }}" class="form-control w-full" />
       <input type="hidden" name="sort" value="{{ sort|default:'date' }}" />
       <input type="hidden" name="direction" value="{{ direction|default:'desc' }}" />
-      <button type="submit" class="btn-primary">Filter</button>
-      <a href="?{% if query_string %}{{ query_string }}&{% endif %}export=csv" class="px-4 py-2 border rounded">Export CSV</a>
+      <button type="submit" class="btn-primary w-full">Filter</button>
+      <a href="?{% if query_string %}{{ query_string }}&{% endif %}export=csv" class="px-4 py-2 border rounded w-full">Export CSV</a>
     </form>
     <div id="history_table">
       {% include "inventory/_history_table.html" %}

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto p-4 max-h-screen overflow-y-auto">
   <h1 class="text-2xl font-semibold mb-4">New Indent</h1>
-  <form method="post" id="indent-form">
+  <form method="post" id="indent-form" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}
     <ul class="text-red-600 list-disc pl-5">
@@ -12,7 +12,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <div class="mb-4 flex flex-wrap gap-4">
+    <div class="grid gap-4 sm:grid-cols-2">
       {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -5,19 +5,19 @@
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'indent_create' %}" class="btn-primary">New Indent</a>
   </div>
-    <form id="filters" class="flex flex-wrap gap-2 mb-4">
+    <form id="filters" class="grid gap-2 mb-4 sm:grid-cols-2">
       <input
         type="text"
         name="q"
         placeholder="Search indents..."
-        class="form-control flex-grow"
+        class="form-control w-full"
         value="{{ q }}"
         hx-get="{% url 'indents_table' %}"
         hx-target="#indents_table"
         hx-trigger="keyup changed delay:300ms"
         hx-include="#filters"
       />
-      <select name="status" class="form-control"
+      <select name="status" class="form-control w-full"
               hx-get="{% url 'indents_table' %}" hx-target="#indents_table" hx-trigger="change" hx-include="#filters">
       <option value="">All Statuses</option>
       <option value="SUBMITTED" {% if status == 'SUBMITTED' %}selected{% endif %}>Submitted</option>

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -14,7 +14,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <div class="flex flex-wrap gap-4">
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {% include "components/form_field.html" with field=form.name %}
       {% include "components/form_field.html" with field=form.base_unit %}
       {% include "components/form_field.html" with field=form.purchase_unit %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -6,12 +6,12 @@
     <a href="{% url 'item_create' %}" class="btn-primary">Add Item</a>
     <a href="{% url 'items_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
   </div>
-  <form id="filters" class="flex flex-wrap gap-2 mb-4" hx-indicator="#htmx-spinner">
+  <form id="filters" class="grid gap-2 mb-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-5" hx-indicator="#htmx-spinner">
       <input
         type="text"
         name="q"
         placeholder="Search items..."
-        class="form-control flex-grow"
+        class="form-control w-full"
         value="{{ q }}"
         hx-get="{% url 'items_table' %}"
         hx-target="#items_table"
@@ -19,21 +19,21 @@
         hx-include="#filters"
         hx-indicator="#htmx-spinner"
       />
-      <select name="category" class="form-control"
+      <select name="category" class="form-control w-full"
               hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters" hx-indicator="#htmx-spinner">
       <option value="">All Categories</option>
       {% for cat in categories %}
       <option value="{{ cat }}" {% if cat == category %}selected{% endif %}>{{ cat }}</option>
       {% endfor %}
       </select>
-      <select name="subcategory" class="form-control"
+      <select name="subcategory" class="form-control w-full"
               hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters" hx-indicator="#htmx-spinner">
       <option value="">All Subcategories</option>
       {% for sub in subcategories %}
       <option value="{{ sub }}" {% if sub == subcategory %}selected{% endif %}>{{ sub }}</option>
       {% endfor %}
       </select>
-      <select name="active" class="form-control"
+      <select name="active" class="form-control w-full"
               hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters" hx-indicator="#htmx-spinner">
       <option value="">All</option>
       <option value="1" {% if active == '1' %}selected{% endif %}>Active</option>
@@ -42,7 +42,7 @@
       <input type="hidden" name="page_size" value="{{ page_size|default:25 }}">
       <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
       <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">
-      <button type="submit" formaction="{% url 'items_export' %}" formmethod="get" class="btn-secondary">Export</button>
+      <button type="submit" formaction="{% url 'items_export' %}" formmethod="get" class="btn-secondary w-full">Export</button>
   </form>
   <div id="items_table"
        hx-get="{% url 'items_table' %}"

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -11,9 +11,11 @@
         {% endfor %}
       </ul>
     {% endif %}
-    {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
-    {% endfor %}
+    <div class="grid gap-4 sm:grid-cols-2">
+      {% for field in form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
+    </div>
     <datalist id="supplier-options"></datalist>
     <div id="items-formset">
       {{ formset.management_form }}

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -6,35 +6,35 @@
     <a href="{% url 'purchase_order_create' %}" class="btn-primary">New PO</a>
     <a href="{% url 'grn_list' %}" class="btn-secondary">GRNs</a>
   </div>
-  <form method="get" class="mb-4 flex flex-wrap items-end gap-2">
-    <div>
+  <form method="get" class="mb-4 grid gap-2 sm:grid-cols-2 md:grid-cols-5 items-end">
+    <div class="space-y-1">
       <label class="block text-sm">Status</label>
-      <select name="status" class="border rounded px-2 py-1">
+      <select name="status" class="border rounded px-2 py-1 w-full">
         <option value="">All</option>
         {% for value, label in statuses %}
         <option value="{{ value }}" {% if current_status == value %}selected{% endif %}>{{ label }}</option>
         {% endfor %}
       </select>
     </div>
-    <div>
+    <div class="space-y-1">
       <label class="block text-sm">Supplier</label>
-      <select name="supplier" class="border rounded px-2 py-1">
+      <select name="supplier" class="border rounded px-2 py-1 w-full">
         <option value="">All</option>
         {% for s in suppliers %}
         <option value="{{ s.pk }}" {% if current_supplier == s.pk|stringformat:'s' %}selected{% endif %}>{{ s.name }}</option>
         {% endfor %}
       </select>
     </div>
-    <div>
+    <div class="space-y-1">
       <label class="block text-sm">Start Date</label>
-      <input type="date" name="start_date" value="{{ start_date }}" class="border rounded px-2 py-1" />
+      <input type="date" name="start_date" value="{{ start_date }}" class="border rounded px-2 py-1 w-full" />
     </div>
-    <div>
+    <div class="space-y-1">
       <label class="block text-sm">End Date</label>
-      <input type="date" name="end_date" value="{{ end_date }}" class="border rounded px-2 py-1" />
+      <input type="date" name="end_date" value="{{ end_date }}" class="border rounded px-2 py-1 w-full" />
     </div>
-    <div>
-      <button type="submit" class="btn-primary">Filter</button>
+    <div class="space-y-1">
+      <button type="submit" class="btn-primary w-full">Filter</button>
     </div>
   </form>
   {% include "inventory/purchase_orders/_table.html" %}

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -9,9 +9,11 @@
       {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
     </ul>
     {% endif %}
-    {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
-    {% endfor %}
+    <div class="grid gap-4 sm:grid-cols-2">
+      {% for field in form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
+    </div>
     <table class="table">
       <thead><tr><th>Item</th><th>Ordered</th><th>Received</th><th>Receive Now</th></tr></thead>
       <tbody>

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -13,7 +13,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <div class="flex flex-wrap gap-4">
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -7,19 +7,19 @@
     <a href="{% url 'suppliers_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
     <a href="{% url 'suppliers_bulk_delete' %}" class="btn-danger">Bulk Delete</a>
   </div>
-  <form id="filters" class="flex flex-wrap gap-2 mb-4">
+  <form id="filters" class="grid gap-2 mb-4 sm:grid-cols-2 md:grid-cols-4">
       <input
         type="text"
         name="q"
         placeholder="Search suppliers..."
-        class="form-control flex-grow"
+        class="form-control w-full"
         value="{{ q }}"
         hx-get="{% url 'suppliers_table' %}"
         hx-target="#suppliers_table"
         hx-trigger="keyup changed delay:300ms"
         hx-include="#filters"
       />
-      <select name="active" class="form-control"
+      <select name="active" class="form-control w-full"
               hx-get="{% url 'suppliers_table' %}" hx-target="#suppliers_table" hx-trigger="change" hx-include="#filters">
         <option value="">All</option>
         <option value="1" {% if active == '1' %}selected{% endif %}>Active</option>
@@ -28,7 +28,7 @@
       <input type="hidden" name="page_size" value="{{ page_size|default:25 }}">
       <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
       <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">
-      <button type="submit" name="export" value="1" formaction="{% url 'suppliers_table' %}" formmethod="get" class="btn-secondary">Export</button>
+      <button type="submit" name="export" value="1" formaction="{% url 'suppliers_table' %}" formmethod="get" class="btn-secondary w-full">Export</button>
   </form>
   <div id="suppliers_table"
        hx-get="{% url 'suppliers_table' %}"

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,16 +1,18 @@
 {% extends "_base.html" %}
 {% block content %}
-<h1>Login</h1>
-<form method="post">
-  {% csrf_token %}
-  {% if form.non_field_errors %}
-  <ul class="text-red-600 list-disc pl-5">
-    {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-  </ul>
-  {% endif %}
-  {% for field in form %}
-    {% include "components/form_field.html" with field=field %}
-  {% endfor %}
-  <button type="submit">Login</button>
-</form>
+<div class="max-w-sm mx-auto p-4 space-y-4">
+  <h1 class="text-2xl font-semibold">Login</h1>
+  <form method="post" class="space-y-4">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
+    <button type="submit" class="btn-primary">Login</button>
+  </form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove fixed width form styling so inputs stretch full width
- apply Tailwind grid utilities in forms and filter templates for responsive columns and gaps
- ensure templates use consistent `gap-*`/`space-y-*` spacing

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a87f402eb48326a404d69f78cc8bfe