### PR TITLE
Use shared container for layout

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -11,7 +11,7 @@
   </head>
   <body class="min-h-screen">
     <nav class="bg-primary">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="container mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between h-16">
           <div class="flex-shrink-0">
             <a href="{% url 'root' %}" class="text-white font-bold">Inventory App</a>
@@ -69,7 +69,7 @@
     <div id="htmx-spinner" class="hidden fixed inset-0 flex items-center justify-center bg-black/25">
       <div class="h-12 w-12 border-4 border-primary border-t-transparent rounded-full animate-spin"></div>
     </div>
-    <div class="max-w-7xl mx-auto p-4">
+    <div class="container mx-auto p-4">
       {% if messages %}
         {% include "components/alert.html" %}
       {% endif %}

--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-xl mx-auto p-4">
+<div class="max-w-xl mx-auto">
   <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}

--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-xl mx-auto p-4">
+<div class="max-w-xl mx-auto">
   <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}

--- a/templates/inventory/grns/detail.html
+++ b/templates/inventory/grns/detail.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">GRN {{ grn.pk }}</h1>
   <p class="mb-2"><strong>PO:</strong> <a class="text-primary" href="{% url 'purchase_order_detail' grn.purchase_order_id %}">{{ grn.purchase_order_id }}</a></p>
   <p class="mb-2"><strong>Supplier:</strong> {{ grn.supplier.name }}</p>
@@ -17,5 +16,4 @@
     {% endfor %}
     </tbody>
   </table>
-</div>
 {% endblock %}

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Goods Received Notes</h1>
   <form method="get" class="mb-4 grid gap-2 sm:grid-cols-2 md:grid-cols-4 items-end">
     <div class="space-y-1">
@@ -48,5 +47,4 @@
     <a href="?page={{ page_obj.next_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-primary">Next</a>
     {% endif %}
   </div>
-</div>
 {% endblock %}

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">History Reports</h1>
     <form id="filters" method="get" class="grid gap-2 mb-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7"
           hx-get="{% url 'history_reports' %}"
@@ -34,5 +33,4 @@
     <div id="history_table">
       {% include "inventory/_history_table.html" %}
     </div>
-</div>
 {% endblock %}

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-3xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Indent {{ indent.indent_id }}</h1>
   <div class="mb-2">Status: <span class="px-2 py-1 rounded {{ badges[indent.status|upper] }}">{{ indent.status }}</span></div>
   <div class="mb-2">Requested By: {{ indent.requested_by }}</div>
@@ -31,5 +30,4 @@
       <button type="submit" class="px-3 py-2 border rounded">Cancel</button>
     </form>
   </div>
-</div>
 {% endblock %}

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% load static %}
 {% block content %}
-<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto p-4 max-h-screen overflow-y-auto">
+<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto max-h-screen overflow-y-auto">
   <h1 class="text-2xl font-semibold mb-4">New Indent</h1>
   <form method="post" id="indent-form" class="space-y-4">
     {% csrf_token %}

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Indents ({{ total_indents }})</h1>
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'indent_create' %}" class="btn-primary">New Indent</a>
@@ -35,5 +34,4 @@
       {% include "components/empty_state.html" with title="No Indents" message="Create your first indent to get started." cta_label="New Indent" cta_url=indent_create_url %}
     {% endif %}
   </div>
-</div>
 {% endblock %}

--- a/templates/inventory/item_confirm_delete.html
+++ b/templates/inventory/item_confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-xl mx-auto p-4">
+<div class="max-w-xl mx-auto">
   <h1 class="text-2xl font-semibold mb-4">Delete/Deactivate Item</h1>
   <p class="mb-4">Are you sure you want to delete or deactivate "{{ item.name }}"?</p>
   <form method="post" class="flex gap-2">

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-3xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">{{ item.name }}</h1>
   <table class="table">
     <tbody>
@@ -18,5 +17,4 @@
   <div class="mt-4">
     <a href="{% url 'items_list' %}" class="text-primary">Back to list</a>
   </div>
-</div>
 {% endblock %}

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto p-4 max-h-screen overflow-y-auto">
+<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto max-h-screen overflow-y-auto">
   <h1 class="text-2xl font-semibold mb-4">
     {% if is_edit %}Edit Item{% else %}Add Item{% endif %}
   </h1>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Items</h1>
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'item_create' %}" class="btn-primary">Add Item</a>
@@ -50,5 +49,4 @@
        hx-include="#filters"
        hx-indicator="#htmx-spinner">
   </div>
-</div>
 {% endblock %}

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Purchase Order {{ po.pk }}</h1>
   <p class="mb-2"><strong>Supplier:</strong> {{ po.supplier.name }}</p>
   <p class="mb-2"><strong>Order Date:</strong> {{ po.order_date }}</p>
@@ -23,5 +22,4 @@
     <a href="{% url 'purchase_order_receive' po.pk %}" class="btn-primary">Receive Goods</a>
     <a href="{% url 'grn_list' %}" class="btn-primary">View GRNs</a>
   </div>
-</div>
 {% endblock %}

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order</h1>
   <form method="post" class="space-y-4" id="po-form">
     {% csrf_token %}
@@ -85,5 +84,4 @@
       });
     })();
   </script>
-</div>
 {% endblock %}

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Purchase Orders</h1>
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'purchase_order_create' %}" class="btn-primary">New PO</a>
@@ -38,5 +37,4 @@
     </div>
   </form>
   {% include "inventory/purchase_orders/_table.html" %}
-</div>
 {% endblock %}

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Receive Goods for PO {{ po.pk }}</h1>
   <form method="post" class="space-y-4">
     {% csrf_token %}
@@ -29,5 +28,4 @@
     </table>
     <button type="submit" class="btn-primary">Submit GRN</button>
   </form>
-</div>
 {% endblock %}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="w-full max-w-2xl mx-auto p-4">
+<div class="w-full max-w-2xl mx-auto">
   <h1 class="text-xl font-bold mb-4">{% if recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}</h1>
   <form method="post" id="recipe-form">
     {% csrf_token %}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -1,7 +1,6 @@
 {% extends "_base.html" %}
 {% load static %}
 {% block content %}
-<div class="max-w-4xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Stock Movements</h1>
   <form method="get" id="section-form" class="mb-4">
     {% for key, label in sections.items %}
@@ -132,5 +131,4 @@
     <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.next_page_number }}" class="px-3 py-1 border rounded">Next</a>
     {% endif %}
   </div>
-</div>
 {% endblock %}

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto p-4 max-h-screen overflow-y-auto">
+<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto max-h-screen overflow-y-auto">
   <h1 class="text-2xl font-semibold mb-4">
     {% if is_edit %}Edit Supplier{% else %}Add Supplier{% endif %}
   </h1>

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -1,6 +1,5 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-5xl mx-auto p-4">
   <h1 class="text-2xl font-semibold mb-4">Suppliers ({{ total_suppliers }})</h1>
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'supplier_create' %}" class="btn-primary">Add Supplier</a>
@@ -39,6 +38,5 @@
       {% include "components/empty_state.html" with title="No Suppliers" message="Start by adding your first supplier." cta_label="Add Supplier" cta_url=supplier_create_url %}
     {% endif %}
   </div>
-</div>
 {% endblock %}
 

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-sm mx-auto p-4 space-y-4">
+<div class="max-w-sm mx-auto space-y-4">
   <h1 class="text-2xl font-semibold">Login</h1>
   <form method="post" class="space-y-4">
     {% csrf_token %}


### PR DESCRIPTION
## Summary
- define a shared `container mx-auto` in base template
- drop page-specific `max-w-*` wrappers and rely on shared container

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a886f783f083268785a51bb145b838