### PR TITLE
Adjust nav responsiveness for small screens

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -17,27 +17,27 @@
             <a href="{% url 'root' %}" class="text-white font-bold">Inventory App</a>
           </div>
           <div class="flex items-center">
-            <button id="nav-toggle" class="sm:hidden text-gray-300 hover:text-white focus:outline-none" aria-label="Toggle navigation">
+            <button id="nav-toggle" class="hidden max-sm:block lg:hidden text-gray-300 hover:text-white focus:outline-none" aria-label="Toggle navigation">
               <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
             </button>
-            <div id="nav-menu" class="hidden sm:flex sm:space-x-4 flex-col sm:flex-row ml-4 sm:ml-0">
+            <div id="nav-menu" class="hidden flex space-x-4 ml-4">
               <div class="relative nav-group">
                 <button data-dropdown="overview-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Overview</button>
-                <div id="overview-menu" class="hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
+                <div id="overview-menu" class="max-sm:hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
                   <a href="{% url 'dashboard' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Dashboard</a>
                   <a href="{% url 'history_reports' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
                 </div>
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="inventory-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Inventory</button>
-                <div id="inventory-menu" class="hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
+                <div id="inventory-menu" class="max-sm:hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
                   <a href="{% url 'items_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
                   <a href="{% url 'stock_movements' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock Movements</a>
                 </div>
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="procurement-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Procurement</button>
-                <div id="procurement-menu" class="hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
+                <div id="procurement-menu" class="max-sm:hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
                   <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
                   <a href="{% url 'indents_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Indents</a>
                   <a href="{% url 'purchase_orders_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Purchase Orders</a>
@@ -46,13 +46,13 @@
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="production-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Production</button>
-                <div id="production-menu" class="hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
+                <div id="production-menu" class="max-sm:hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
                   <a href="{% url 'recipes_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Recipes</a>
                 </div>
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="account-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Account</button>
-                <div id="account-menu" class="hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
+                <div id="account-menu" class="max-sm:hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
                   {% if user.is_authenticated %}
                     <a href="{% url 'logout' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Logout</a>
                   {% else %}
@@ -82,7 +82,7 @@
       document.querySelectorAll('[data-dropdown]').forEach(function (btn) {
         btn.addEventListener('click', function () {
           const menu = document.getElementById(btn.dataset.dropdown);
-          menu.classList.toggle('hidden');
+          menu.classList.toggle('max-sm:hidden');
         });
       });
       document.body.addEventListener('htmx:request', function () {


### PR DESCRIPTION
## Summary
- simplify nav menu layout and remove `sm:` prefixes
- hide hamburger on larger viewports and collapse dropdowns only on small screens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a889b675ec8326bd0045c5be3698af