### PR TITLE
feat: add responsive padding classes

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,17 +1,17 @@
 <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
-  <div class="rounded-xl shadow p-4 flex items-center justify-between bg-white border-l-4 border-secondary">
+  <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
     <h2 class="text-sm font-medium text-primary">Stock Value</h2>
     <span class="text-2xl font-bold">{{ stock_value }}</span>
   </div>
-  <div class="rounded-xl shadow p-4 flex items-center justify-between bg-white border-l-4 border-secondary">
+  <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
     <h2 class="text-sm font-medium text-primary">7-day Receipts</h2>
     <span class="text-2xl font-bold">{{ receipts }}</span>
   </div>
-  <div class="rounded-xl shadow p-4 flex items-center justify-between bg-white border-l-4 border-secondary">
+  <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
     <h2 class="text-sm font-medium text-primary">7-day Issues</h2>
     <span class="text-2xl font-bold">{{ issues }}</span>
   </div>
-  <div class="rounded-xl shadow p-4 flex items-center justify-between bg-white border-l-4 border-secondary">
+  <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
     <h2 class="text-sm font-medium text-primary">Low-stock Count</h2>
     <span class="text-2xl font-bold">{{ low_stock }}</span>
   </div>

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -2,7 +2,7 @@
 
 {% block content %}
   <div class="flex items-center justify-center">
-    <div class="bg-white p-6 rounded shadow text-center">
+    <div class="bg-white py-6 px-8 max-md:px-6 max-sm:px-4 rounded shadow text-center">
       <p class="text-xl">Django is running</p>
       <div class="mt-4 flex flex-wrap justify-center gap-2">
         <a href="{% url 'dashboard' %}" class="px-4 py-2 bg-blue-600 text-white rounded">Dashboard</a>

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -11,7 +11,7 @@
   </head>
   <body class="min-h-screen">
     <nav class="bg-primary">
-      <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="container mx-auto px-8 max-md:px-6 max-sm:px-4">
         <div class="flex items-center justify-between h-16">
           <div class="flex-shrink-0">
             <a href="{% url 'root' %}" class="text-white font-bold">Inventory App</a>
@@ -69,7 +69,7 @@
     <div id="htmx-spinner" class="hidden fixed inset-0 flex items-center justify-center bg-black/25">
       <div class="h-12 w-12 border-4 border-primary border-t-transparent rounded-full animate-spin"></div>
     </div>
-    <div class="container mx-auto p-4">
+    <div class="container mx-auto px-8 max-md:px-6 max-sm:px-4 py-4">
       {% if messages %}
         {% include "components/alert.html" %}
       {% endif %}

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -1,19 +1,19 @@
 {% for message in messages %}
   {% if 'error' in message.tags %}
     {% with bg='bg-red-100' border='border-red-500' text='text-red-700' %}
-      <div class="{{ bg }} {{ text }} p-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
+      <div class="{{ bg }} {{ text }} px-8 max-md:px-6 max-sm:px-4 py-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
     {% endwith %}
   {% elif 'warning' in message.tags %}
     {% with bg='bg-yellow-100' border='border-yellow-500' text='text-yellow-700' %}
-      <div class="{{ bg }} {{ text }} p-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
+      <div class="{{ bg }} {{ text }} px-8 max-md:px-6 max-sm:px-4 py-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
     {% endwith %}
   {% elif 'success' in message.tags %}
     {% with bg='bg-green-100' border='border-green-500' text='text-green-700' %}
-      <div class="{{ bg }} {{ text }} p-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
+      <div class="{{ bg }} {{ text }} px-8 max-md:px-6 max-sm:px-4 py-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
     {% endwith %}
   {% else %}
     {% with bg='bg-blue-100' border='border-blue-500' text='text-blue-700' %}
-      <div class="{{ bg }} {{ text }} p-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
+      <div class="{{ bg }} {{ text }} px-8 max-md:px-6 max-sm:px-4 py-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
     {% endwith %}
   {% endif %}
 {% endfor %}

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -1,4 +1,4 @@
-<div class="p-6 text-center border rounded bg-white">
+<div class="py-6 px-8 max-md:px-6 max-sm:px-4 text-center border rounded bg-white">
   <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
   <h2 class="mt-4 mb-2 text-lg font-semibold">{{ title }}</h2>
   <p class="mb-4 text-gray-600">{{ message }}</p>


### PR DESCRIPTION
## Summary
- add responsive padding utilities for navigation and content containers
- adjust component padding for alerts, empty states, KPI cards, and home page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a88b65e23883268c64e004cba16d6f