### PR TITLE
Improve responsive grid layouts

### DIFF
--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block content %}
   <h1 class="text-2xl font-semibold mb-4">Goods Received Notes</h1>
-  <form method="get" class="mb-4 grid gap-2 sm:grid-cols-2 md:grid-cols-4 items-end">
+  <form method="get" class="mb-4 grid gap-2 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
       <label class="block text-sm">Supplier</label>
       <select name="supplier" class="border rounded px-2 py-1 w-full">

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block content %}
   <h1 class="text-2xl font-semibold mb-4">History Reports</h1>
-    <form id="filters" method="get" class="grid gap-2 mb-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-7"
+    <form id="filters" method="get" class="grid gap-2 mb-4 grid-cols-7 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1"
           hx-get="{% url 'history_reports' %}"
           hx-target="#history_table"
           hx-indicator="#htmx-spinner">

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -12,7 +12,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <div class="grid gap-4 sm:grid-cols-2">
+    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
       {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -4,7 +4,7 @@
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'indent_create' %}" class="btn-primary">New Indent</a>
   </div>
-    <form id="filters" class="grid gap-2 mb-4 sm:grid-cols-2">
+    <form id="filters" class="grid gap-2 mb-4 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1">
       <input
         type="text"
         name="q"

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -14,7 +14,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="grid gap-4 grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
       {% include "components/form_field.html" with field=form.name %}
       {% include "components/form_field.html" with field=form.base_unit %}
       {% include "components/form_field.html" with field=form.purchase_unit %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -5,7 +5,7 @@
     <a href="{% url 'item_create' %}" class="btn-primary">Add Item</a>
     <a href="{% url 'items_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
   </div>
-  <form id="filters" class="grid gap-2 mb-4 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-5" hx-indicator="#htmx-spinner">
+  <form id="filters" class="grid gap-2 mb-4 grid-cols-5 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1" hx-indicator="#htmx-spinner">
       <input
         type="text"
         name="q"

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -10,7 +10,7 @@
         {% endfor %}
       </ul>
     {% endif %}
-    <div class="grid gap-4 sm:grid-cols-2">
+    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
       {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -5,7 +5,7 @@
     <a href="{% url 'purchase_order_create' %}" class="btn-primary">New PO</a>
     <a href="{% url 'grn_list' %}" class="btn-secondary">GRNs</a>
   </div>
-  <form method="get" class="mb-4 grid gap-2 sm:grid-cols-2 md:grid-cols-5 items-end">
+  <form method="get" class="mb-4 grid gap-2 grid-cols-5 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
       <label class="block text-sm">Status</label>
       <select name="status" class="border rounded px-2 py-1 w-full">

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -8,7 +8,7 @@
       {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
     </ul>
     {% endif %}
-    <div class="grid gap-4 sm:grid-cols-2">
+    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
       {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -13,7 +13,7 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="grid gap-4 grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
       {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -6,7 +6,7 @@
     <a href="{% url 'suppliers_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
     <a href="{% url 'suppliers_bulk_delete' %}" class="btn-danger">Bulk Delete</a>
   </div>
-  <form id="filters" class="grid gap-2 mb-4 sm:grid-cols-2 md:grid-cols-4">
+  <form id="filters" class="grid gap-2 mb-4 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1">
       <input
         type="text"
         name="q"


### PR DESCRIPTION
## Summary
- adopt desktop-first grid definitions for filter forms with responsive max breakpoints
- collapse general form grids progressively on smaller screens

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a88cfec3108326ad8b96de415fa4ab