### PR TITLE
style: widen form containers and improve responsiveness

### DIFF
--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-xl mx-auto">
+<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
   <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}

--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-xl mx-auto">
+<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
   <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% load static %}
 {% block content %}
-<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto max-h-screen overflow-y-auto">
+<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
   <h1 class="text-2xl font-semibold mb-4">New Indent</h1>
   <form method="post" id="indent-form" class="space-y-4">
     {% csrf_token %}

--- a/templates/inventory/item_confirm_delete.html
+++ b/templates/inventory/item_confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="max-w-xl mx-auto">
+<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
   <h1 class="text-2xl font-semibold mb-4">Delete/Deactivate Item</h1>
   <p class="mb-4">Are you sure you want to delete or deactivate "{{ item.name }}"?</p>
   <form method="post" class="flex gap-2">

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto max-h-screen overflow-y-auto">
+<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
   <h1 class="text-2xl font-semibold mb-4">
     {% if is_edit %}Edit Item{% else %}Add Item{% endif %}
   </h1>

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -1,5 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
+<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
   <h1 class="text-2xl font-semibold mb-4">{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order</h1>
   <form method="post" class="space-y-4" id="po-form">
     {% csrf_token %}
@@ -51,6 +52,7 @@
       {% endfor %}
     </div>
   </template>
+</div>
   <script>
     (function () {
       const formsetPrefix = "{{ formset.prefix }}";

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -1,5 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
+<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
   <h1 class="text-2xl font-semibold mb-4">Receive Goods for PO {{ po.pk }}</h1>
   <form method="post" class="space-y-4">
     {% csrf_token %}
@@ -28,4 +29,5 @@
     </table>
     <button type="submit" class="btn-primary">Submit GRN</button>
   </form>
+</div>
 {% endblock %}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="w-full max-w-2xl mx-auto">
+<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
   <h1 class="text-xl font-bold mb-4">{% if recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}</h1>
   <form method="post" id="recipe-form">
     {% csrf_token %}

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-<div class="w-full max-w-md sm:max-w-xl lg:max-w-2xl mx-auto max-h-screen overflow-y-auto">
+<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
   <h1 class="text-2xl font-semibold mb-4">
     {% if is_edit %}Edit Supplier{% else %}Add Supplier{% endif %}
   </h1>


### PR DESCRIPTION
## Summary
- widen inventory form containers for a more spacious default layout
- add responsive max-width classes for medium and small screens
- apply consistent `p-8 max-sm:p-4` padding across forms

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a88e0cb04883269cbd73fb0864fa88