### PR TITLE
Limit table overflow to small viewports

### DIFF
--- a/templates/components/table.html
+++ b/templates/components/table.html
@@ -1,5 +1,5 @@
 {% comment %}Reusable table component with sticky headers and optional actions and footer slots{% endcomment %}
-<div class="overflow-x-auto">
+<div class="max-md:overflow-x-auto">
   {% block actions %}{% endblock %}
   <table class="w-full table-auto text-sm divide-y divide-gray-200">
     <thead class="sticky top-0 bg-primary text-white">

--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -1,4 +1,4 @@
-<div class="overflow-x-auto">
+<div class="max-md:overflow-x-auto">
   <table class="w-full table-auto text-sm divide-y divide-gray-200">
     <thead class="bg-primary text-white">
       <tr>

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -1,4 +1,4 @@
-<div class="overflow-x-auto">
+<div class="max-md:overflow-x-auto">
   <table class="w-full table-auto text-sm divide-y divide-gray-200">
     <thead class="bg-primary text-white">
       <tr>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -1,4 +1,4 @@
-<div class="overflow-x-auto">
+<div class="max-md:overflow-x-auto">
   <table class="w-full table-auto text-sm divide-y divide-gray-200">
     <thead class="bg-primary text-white">
       <tr>

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -90,7 +90,7 @@
   {% endif %}
   <hr class="my-4"/>
   <h2 class="text-xl font-semibold mb-2">Recent Transactions</h2>
-  <div class="overflow-x-auto">
+  <div class="max-md:overflow-x-auto">
     <table class="table">
       <thead>
         <tr>


### PR DESCRIPTION
## Summary
- remove always-on horizontal scrolling from table component
- apply responsive overflow handling across inventory tables

## Testing
- `pip install -r requirements.txt`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a88f8510e48326ab7589ffb09fb24e