### PR TITLE
feat: switch to desktop-first responsive utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Inventory-App is a Django application for managing restaurant inventory with a P
 - Automatic unit inference so new items get sensible base and purchase units
 - Bulk upload items and stock transactions from CSV files
 
+## Responsive Breakpoints
+
+This project uses a desktop-first Tailwind CSS strategy. Base styles target larger screens, while `max-*` variants provide overrides for smaller viewports. Custom `max-sm`, `max-md`, `max-lg`, and `max-xl` screens are defined in `tailwind.config.js`. Use these utilities when building templates so mobile adjustments are explicit:
+
+```html
+<div class="grid grid-cols-4 max-md:grid-cols-1"></div>
+```
+
 ## Installation
 
 Install dependencies using `pip`:

--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+<div class="grid grid-cols-4 max-md:grid-cols-1 gap-4">
   <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
     <h2 class="text-sm font-medium text-primary">Stock Value</h2>
     <span class="text-2xl font-bold">{{ stock_value }}</span>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,18 @@
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 module.exports = {
   content: [
     "./templates/**/*.{html,js}",
     "./static/js/**/*.js",
   ],
   theme: {
+    screens: {
+      ...defaultTheme.screens,
+      'max-sm': { max: '639px' },
+      'max-md': { max: '767px' },
+      'max-lg': { max: '1023px' },
+      'max-xl': { max: '1279px' },
+    },
     extend: {
       colors: {
         body: {

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -17,27 +17,27 @@
             <a href="{% url 'root' %}" class="text-white font-bold">Inventory App</a>
           </div>
           <div class="flex items-center">
-            <button id="nav-toggle" class="hidden max-sm:block lg:hidden text-gray-300 hover:text-white focus:outline-none" aria-label="Toggle navigation">
+            <button id="nav-toggle" class="hidden max-sm:block text-gray-300 hover:text-white focus:outline-none" aria-label="Toggle navigation">
               <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
             </button>
             <div id="nav-menu" class="hidden flex space-x-4 ml-4">
               <div class="relative nav-group">
                 <button data-dropdown="overview-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Overview</button>
-                <div id="overview-menu" class="max-sm:hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
+                <div id="overview-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
                   <a href="{% url 'dashboard' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Dashboard</a>
                   <a href="{% url 'history_reports' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>
                 </div>
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="inventory-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Inventory</button>
-                <div id="inventory-menu" class="max-sm:hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
+                <div id="inventory-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
                   <a href="{% url 'items_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Items</a>
                   <a href="{% url 'stock_movements' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Stock Movements</a>
                 </div>
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="procurement-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Procurement</button>
-                <div id="procurement-menu" class="max-sm:hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
+                <div id="procurement-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
                   <a href="{% url 'suppliers_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Suppliers</a>
                   <a href="{% url 'indents_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Indents</a>
                   <a href="{% url 'purchase_orders_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Purchase Orders</a>
@@ -46,13 +46,13 @@
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="production-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Production</button>
-                <div id="production-menu" class="max-sm:hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
+                <div id="production-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
                   <a href="{% url 'recipes_list' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Recipes</a>
                 </div>
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="account-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Account</button>
-                <div id="account-menu" class="max-sm:hidden flex-col sm:absolute sm:bg-primary sm:mt-2 sm:rounded-md">
+                <div id="account-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
                   {% if user.is_authenticated %}
                     <a href="{% url 'logout' %}" class="text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Logout</a>
                   {% else %}


### PR DESCRIPTION
## Summary
- add max-* screen definitions to Tailwind config for desktop-first utilities
- refactor layout templates to use downward-scaling responsive classes
- document new breakpoint strategy in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a890ea6de08326a06b327c9ce84c58