### PR TITLE
Fix navigation menu visibility on desktop

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -20,7 +20,7 @@
             <button id="nav-toggle" class="hidden max-sm:block text-gray-300 hover:text-white focus:outline-none" aria-label="Toggle navigation">
               <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
             </button>
-            <div id="nav-menu" class="hidden flex space-x-4 ml-4">
+            <div id="nav-menu" class="flex space-x-4 ml-4 max-sm:hidden">
               <div class="relative nav-group">
                 <button data-dropdown="overview-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Overview</button>
                 <div id="overview-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
@@ -77,7 +77,7 @@
     </div>
     <script>
       document.getElementById('nav-toggle').addEventListener('click', function () {
-        document.getElementById('nav-menu').classList.toggle('hidden');
+        document.getElementById('nav-menu').classList.toggle('max-sm:hidden');
       });
       document.querySelectorAll('[data-dropdown]').forEach(function (btn) {
         btn.addEventListener('click', function () {


### PR DESCRIPTION
## Summary
- show navigation menu by default on desktop
- toggle responsive nav using `max-sm:hidden`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a896005ff88326a7f4e91caf5a8b12