### PR TITLE
Fix units dropdown to load Supabase units

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -11,6 +11,8 @@ from django.urls import reverse
 from django.views import View
 from django.views.generic import TemplateView
 
+from ..services.supabase_units import get_units
+
 from ..models import Item, StockTransaction
 from ..forms import ItemForm, BulkUploadForm
 from ..services import item_service, list_utils
@@ -270,8 +272,15 @@ class ItemSuggestView(TemplateView):
         ctx = super().get_context_data(**kwargs)
         name = (self.request.GET.get("name") or "").strip()
         base, purchase, category = item_service.suggest_category_and_units(name)
+        units_map = get_units()
         ctx.update(
-            {"base": base or "", "purchase": purchase or "", "category": category or ""}
+            {
+                "base": base or "",
+                "purchase": purchase or "",
+                "category": category or "",
+                "units_map": units_map,
+                "purchase_options": units_map.get(base or "", []),
+            }
         )
         return ctx
 

--- a/templates/inventory/_item_suggest_fields.html
+++ b/templates/inventory/_item_suggest_fields.html
@@ -1,3 +1,37 @@
-<input type="text" name="base_unit" value="{{ base }}" id="id_base_unit" class="form-control" hx-swap-oob="true">
-<input type="text" name="purchase_unit" value="{{ purchase }}" id="id_purchase_unit" class="form-control" hx-swap-oob="true">
+<select name="base_unit" id="id_base_unit" class="form-control" hx-swap-oob="true">
+  <option value="">---------</option>
+  {% for unit in units_map %}
+    <option value="{{ unit }}"{% if unit == base %} selected{% endif %}>{{ unit }}</option>
+  {% endfor %}
+</select>
+<select name="purchase_unit" id="id_purchase_unit" class="form-control" hx-swap-oob="true">
+  <option value="">---------</option>
+  {% for unit in purchase_options %}
+    <option value="{{ unit }}"{% if unit == purchase %} selected{% endif %}>{{ unit }}</option>
+  {% endfor %}
+</select>
 <input type="text" name="category" value="{{ category }}" id="id_category" class="form-control" hx-swap-oob="true">
+<script hx-swap-oob="true">
+  (function() {
+    const units = JSON.parse(document.getElementById('units-data').textContent);
+    const baseSelect = document.getElementById('id_base_unit');
+    const purchaseSelect = document.getElementById('id_purchase_unit');
+    function refresh(selected) {
+      const base = baseSelect.value;
+      const options = units[base] || [];
+      purchaseSelect.innerHTML = '<option value="">---------</option>';
+      options.forEach(function(opt) {
+        const o = document.createElement('option');
+        o.value = opt;
+        o.textContent = opt;
+        purchaseSelect.appendChild(o);
+      });
+      if (selected && options.includes(selected)) {
+        purchaseSelect.value = selected;
+      }
+    }
+    const initial = purchaseSelect.value;
+    refresh(initial);
+    baseSelect.addEventListener('change', function() { refresh(); });
+  })();
+</script>

--- a/tests/test_item_form_units.py
+++ b/tests/test_item_form_units.py
@@ -1,0 +1,38 @@
+import pytest
+from django.urls import reverse
+
+from inventory.forms import ItemForm
+from inventory.services import supabase_units, item_service
+
+pytestmark = pytest.mark.django_db
+
+def test_item_form_uses_supabase_units(monkeypatch):
+    mapping = {"kg": ["g", "lb"], "ltr": ["ml"]}
+    monkeypatch.setattr(supabase_units, "get_units", lambda force=False: mapping)
+    monkeypatch.setattr("inventory.forms.get_units", lambda force=False: mapping)
+
+    form = ItemForm()
+    base_choices = [c[0] for c in form.fields["base_unit"].choices]
+    assert "kg" in base_choices and "ltr" in base_choices
+
+    form = ItemForm(data={"base_unit": "kg"})
+    purchase_choices = [c[0] for c in form.fields["purchase_unit"].choices]
+    assert "g" in purchase_choices and "lb" in purchase_choices
+    assert "ml" not in purchase_choices
+
+def test_item_suggest_view_returns_filtered_units(client, monkeypatch):
+    mapping = {"kg": ["g", "lb"], "ltr": ["ml"]}
+    monkeypatch.setattr(supabase_units, "get_units", lambda force=False: mapping)
+    monkeypatch.setattr("inventory.views.items.get_units", lambda force=False: mapping)
+    monkeypatch.setattr(
+        item_service,
+        "suggest_category_and_units",
+        lambda name: ("kg", "g", "food"),
+    )
+    url = reverse("item_suggest")
+    resp = client.get(url, {"name": "milk"})
+    html = resp.content.decode()
+    assert '<select name="base_unit"' in html
+    assert '<option value="kg"' in html
+    assert '<option value="g"' in html
+    assert '<option value="ml"' not in html


### PR DESCRIPTION
## Summary
- populate item form unit dropdowns from Supabase and filter purchase units by selected base unit
- update unit suggestion partial to render dropdowns and refresh purchase options client-side
- add tests for Supabase-provided unit choices

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a89a73c0c08326a3dd428973792800