### PR TITLE
Replace dropdowns with predictive text fields

### DIFF
--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -106,12 +106,25 @@
   </div>
   <div class="ml-auto flex items-center gap-2">
     <label for="page_size" class="text-sm">Per page:</label>
-    <select id="page_size" name="page_size" class="border rounded p-1" hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters" hx-on:change="document.querySelector('#filters input[name=page_size]').value=this.value">
-      <option value="10" {% if page_size == 10 %}selected{% endif %}>10</option>
-      <option value="25" {% if page_size == 25 %}selected{% endif %}>25</option>
-      <option value="50" {% if page_size == 50 %}selected{% endif %}>50</option>
-      <option value="100" {% if page_size == 100 %}selected{% endif %}>100</option>
-    </select>
+    <input
+      type="text"
+      id="page_size"
+      name="page_size"
+      list="page_size_options"
+      class="border rounded p-1"
+      value="{{ page_size }}"
+      hx-get="{% url 'items_table' %}"
+      hx-target="#items_table"
+      hx-trigger="change"
+      hx-include="#filters"
+      hx-on:change="document.querySelector('#filters input[name=page_size]').value=this.value"
+    />
+    <datalist id="page_size_options">
+      <option value="10"></option>
+      <option value="25"></option>
+      <option value="50"></option>
+      <option value="100"></option>
+    </datalist>
   </div>
 </div>
 {% endblock %}

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -4,12 +4,19 @@
   <form method="get" class="mb-4 grid gap-2 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
       <label class="block text-sm">Supplier</label>
-      <select name="supplier" class="border rounded px-2 py-1 w-full">
-        <option value="">All</option>
+      <input
+        type="text"
+        name="supplier"
+        list="grn-suppliers"
+        class="border rounded px-2 py-1 w-full"
+        value="{{ current_supplier }}"
+      />
+      <datalist id="grn-suppliers">
+        <option value="" label="All"></option>
         {% for s in suppliers %}
-        <option value="{{ s.pk }}" {% if current_supplier == s.pk|stringformat:'s' %}selected{% endif %}>{{ s.name }}</option>
+        <option value="{{ s.pk }}" label="{{ s.name }}"></option>
         {% endfor %}
-      </select>
+      </datalist>
     </div>
     <div class="space-y-1">
       <label class="block text-sm">Start Date</label>

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -5,24 +5,45 @@
           hx-get="{% url 'history_reports' %}"
           hx-target="#history_table"
           hx-indicator="#htmx-spinner">
-      <select name="item" class="form-control w-full">
-        <option value="">All Items</option>
-      {% for it in items %}
-      <option value="{{ it.item_id }}" {% if item|default:'' == it.item_id|stringformat:"s" %}selected{% endif %}>{{ it.name }}</option>
-      {% endfor %}
-      </select>
-      <select name="type" class="form-control w-full">
-      <option value="">All Types</option>
-      {% for t in transaction_types %}
-      <option value="{{ t }}" {% if type == t %}selected{% endif %}>{{ t }}</option>
-      {% endfor %}
-      </select>
-      <select name="user" class="form-control w-full">
-      <option value="">All Users</option>
-      {% for u in users %}
-      <option value="{{ u }}" {% if user == u %}selected{% endif %}>{{ u }}</option>
-      {% endfor %}
-      </select>
+      <input
+        type="text"
+        name="item"
+        list="history-items"
+        class="form-control w-full"
+        value="{{ item|default:'' }}"
+      />
+      <datalist id="history-items">
+        <option value="" label="All Items"></option>
+        {% for it in items %}
+        <option value="{{ it.item_id }}" label="{{ it.name }}"></option>
+        {% endfor %}
+      </datalist>
+      <input
+        type="text"
+        name="type"
+        list="history-types"
+        class="form-control w-full"
+        value="{{ type }}"
+      />
+      <datalist id="history-types">
+        <option value="" label="All Types"></option>
+        {% for t in transaction_types %}
+        <option value="{{ t }}"></option>
+        {% endfor %}
+      </datalist>
+      <input
+        type="text"
+        name="user"
+        list="history-users"
+        class="form-control w-full"
+        value="{{ user }}"
+      />
+      <datalist id="history-users">
+        <option value="" label="All Users"></option>
+        {% for u in users %}
+        <option value="{{ u }}"></option>
+        {% endfor %}
+      </datalist>
       <input type="date" name="start_date" value="{{ start_date }}" class="form-control w-full" />
       <input type="date" name="end_date" value="{{ end_date }}" class="form-control w-full" />
       <input type="hidden" name="sort" value="{{ sort|default:'date' }}" />

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -16,14 +16,24 @@
         hx-trigger="keyup changed delay:300ms"
         hx-include="#filters"
       />
-      <select name="status" class="form-control w-full"
-              hx-get="{% url 'indents_table' %}" hx-target="#indents_table" hx-trigger="change" hx-include="#filters">
-      <option value="">All Statuses</option>
-      <option value="SUBMITTED" {% if status == 'SUBMITTED' %}selected{% endif %}>Submitted</option>
-      <option value="PROCESSING" {% if status == 'PROCESSING' %}selected{% endif %}>Processing</option>
-      <option value="COMPLETED" {% if status == 'COMPLETED' %}selected{% endif %}>Completed</option>
-      <option value="CANCELLED" {% if status == 'CANCELLED' %}selected{% endif %}>Cancelled</option>
-    </select>
+      <input
+        type="text"
+        name="status"
+        list="indent-statuses"
+        class="form-control w-full"
+        value="{{ status }}"
+        hx-get="{% url 'indents_table' %}"
+        hx-target="#indents_table"
+        hx-trigger="change"
+        hx-include="#filters"
+      />
+      <datalist id="indent-statuses">
+        <option value="" label="All Statuses"></option>
+        <option value="SUBMITTED" label="Submitted"></option>
+        <option value="PROCESSING" label="Processing"></option>
+        <option value="COMPLETED" label="Completed"></option>
+        <option value="CANCELLED" label="Cancelled"></option>
+      </datalist>
   </form>
   <div id="indents_table"
        hx-get="{% url 'indents_table' %}"

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -18,26 +18,59 @@
         hx-include="#filters"
         hx-indicator="#htmx-spinner"
       />
-      <select name="category" class="form-control w-full"
-              hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters" hx-indicator="#htmx-spinner">
-      <option value="">All Categories</option>
-      {% for cat in categories %}
-      <option value="{{ cat }}" {% if cat == category %}selected{% endif %}>{{ cat }}</option>
-      {% endfor %}
-      </select>
-      <select name="subcategory" class="form-control w-full"
-              hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters" hx-indicator="#htmx-spinner">
-      <option value="">All Subcategories</option>
-      {% for sub in subcategories %}
-      <option value="{{ sub }}" {% if sub == subcategory %}selected{% endif %}>{{ sub }}</option>
-      {% endfor %}
-      </select>
-      <select name="active" class="form-control w-full"
-              hx-get="{% url 'items_table' %}" hx-target="#items_table" hx-trigger="change" hx-include="#filters" hx-indicator="#htmx-spinner">
-      <option value="">All</option>
-      <option value="1" {% if active == '1' %}selected{% endif %}>Active</option>
-      <option value="0" {% if active == '0' %}selected{% endif %}>Inactive</option>
-      </select>
+      <input
+        type="text"
+        name="category"
+        list="item-categories"
+        class="form-control w-full"
+        value="{{ category }}"
+        hx-get="{% url 'items_table' %}"
+        hx-target="#items_table"
+        hx-trigger="change"
+        hx-include="#filters"
+        hx-indicator="#htmx-spinner"
+      />
+      <datalist id="item-categories">
+        <option value="" label="All Categories"></option>
+        {% for cat in categories %}
+        <option value="{{ cat }}"></option>
+        {% endfor %}
+      </datalist>
+      <input
+        type="text"
+        name="subcategory"
+        list="item-subcategories"
+        class="form-control w-full"
+        value="{{ subcategory }}"
+        hx-get="{% url 'items_table' %}"
+        hx-target="#items_table"
+        hx-trigger="change"
+        hx-include="#filters"
+        hx-indicator="#htmx-spinner"
+      />
+      <datalist id="item-subcategories">
+        <option value="" label="All Subcategories"></option>
+        {% for sub in subcategories %}
+        <option value="{{ sub }}"></option>
+        {% endfor %}
+      </datalist>
+      <input
+        type="text"
+        name="active"
+        list="item-active"
+        class="form-control w-full"
+        value="{{ active }}"
+        hx-get="{% url 'items_table' %}"
+        hx-target="#items_table"
+        hx-trigger="change"
+        hx-include="#filters"
+        hx-indicator="#htmx-spinner"
+      />
+      <datalist id="item-active">
+        <option value="" label="All"></option>
+        <option value="1" label="Active"></option>
+        <option value="0" label="Inactive"></option>
+      </datalist>
       <input type="hidden" name="page_size" value="{{ page_size|default:25 }}">
       <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
       <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -8,21 +8,35 @@
   <form method="get" class="mb-4 grid gap-2 grid-cols-5 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
       <label class="block text-sm">Status</label>
-      <select name="status" class="border rounded px-2 py-1 w-full">
-        <option value="">All</option>
+      <input
+        type="text"
+        name="status"
+        list="po-statuses"
+        class="border rounded px-2 py-1 w-full"
+        value="{{ current_status }}"
+      />
+      <datalist id="po-statuses">
+        <option value="" label="All"></option>
         {% for value, label in statuses %}
-        <option value="{{ value }}" {% if current_status == value %}selected{% endif %}>{{ label }}</option>
+        <option value="{{ value }}" label="{{ label }}"></option>
         {% endfor %}
-      </select>
+      </datalist>
     </div>
     <div class="space-y-1">
       <label class="block text-sm">Supplier</label>
-      <select name="supplier" class="border rounded px-2 py-1 w-full">
-        <option value="">All</option>
+      <input
+        type="text"
+        name="supplier"
+        list="po-suppliers"
+        class="border rounded px-2 py-1 w-full"
+        value="{{ current_supplier }}"
+      />
+      <datalist id="po-suppliers">
+        <option value="" label="All"></option>
         {% for s in suppliers %}
-        <option value="{{ s.pk }}" {% if current_supplier == s.pk|stringformat:'s' %}selected{% endif %}>{{ s.name }}</option>
+        <option value="{{ s.pk }}" label="{{ s.name }}"></option>
         {% endfor %}
-      </select>
+      </datalist>
     </div>
     <div class="space-y-1">
       <label class="block text-sm">Start Date</label>

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -18,12 +18,22 @@
         hx-trigger="keyup changed delay:300ms"
         hx-include="#filters"
       />
-      <select name="active" class="form-control w-full"
-              hx-get="{% url 'suppliers_table' %}" hx-target="#suppliers_table" hx-trigger="change" hx-include="#filters">
-        <option value="">All</option>
-        <option value="1" {% if active == '1' %}selected{% endif %}>Active</option>
-        <option value="0" {% if active == '0' %}selected{% endif %}>Inactive</option>
-      </select>
+      <input
+        type="text"
+        name="active"
+        list="active-statuses"
+        class="form-control w-full"
+        value="{{ active }}"
+        hx-get="{% url 'suppliers_table' %}"
+        hx-target="#suppliers_table"
+        hx-trigger="change"
+        hx-include="#filters"
+      />
+      <datalist id="active-statuses">
+        <option value="" label="All"></option>
+        <option value="1" label="Active"></option>
+        <option value="0" label="Inactive"></option>
+      </datalist>
       <input type="hidden" name="page_size" value="{{ page_size|default:25 }}">
       <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
       <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">


### PR DESCRIPTION
## Summary
- swap dropdown `<select>` elements for predictive text inputs using `<datalist>` across inventory templates
- preserve existing filtering behavior while offering search-as-you-type suggestions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a89b6e44988326b923b3de891d88c4