### PR TITLE
Surface unit suggestions via messages

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -142,13 +142,13 @@ class ItemCreateView(View):
 
     def get(self, request):
         suggest_url = reverse("item_suggest")
-        form = ItemForm(suggest_url=suggest_url)
+        form = ItemForm(suggest_url=suggest_url, request=request)
         ctx = {"form": form, "is_edit": False, "excluded_fields": EXCLUDED_FIELDS}
         return render(request, self.template_name, ctx)
 
     def post(self, request):
         suggest_url = reverse("item_suggest")
-        form = ItemForm(request.POST, suggest_url=suggest_url)
+        form = ItemForm(request.POST, suggest_url=suggest_url, request=request)
         if form.is_valid():
             form.save()
             messages.success(request, "Item created")
@@ -171,7 +171,7 @@ class ItemEditView(View):
         item = self.get_object(pk)
         try:
             suggest_url = reverse("item_suggest")
-            form = ItemForm(instance=item, suggest_url=suggest_url)
+            form = ItemForm(instance=item, suggest_url=suggest_url, request=request)
         except (DatabaseError, ValueError):
             logger.exception("Error loading form for item %s", pk)
             messages.error(request, "Unable to load item")
@@ -188,7 +188,12 @@ class ItemEditView(View):
         item = self.get_object(pk)
         try:
             suggest_url = reverse("item_suggest")
-            form = ItemForm(request.POST, instance=item, suggest_url=suggest_url)
+            form = ItemForm(
+                request.POST,
+                instance=item,
+                suggest_url=suggest_url,
+                request=request,
+            )
         except (DatabaseError, ValueError):
             logger.exception("Error loading form for item %s", pk)
             messages.error(request, "Unable to load item")

--- a/tests/test_item_form_units.py
+++ b/tests/test_item_form_units.py
@@ -1,5 +1,8 @@
 import pytest
 from django.urls import reverse
+from django.test import RequestFactory
+from django.contrib.messages import get_messages
+from django.contrib.messages.storage.fallback import FallbackStorage
 
 from inventory.forms import ItemForm
 from inventory.services import supabase_units, unit_suggestions
@@ -26,3 +29,46 @@ def test_item_suggest_view_returns_message(client, monkeypatch):
     resp = client.get(url, {"name": "milk"})
     html = resp.content.decode()
     assert "Base: kg, Purchase: g" in html
+
+
+def _add_messages(request):
+    request.session = {}
+    storage = FallbackStorage(request)
+    setattr(request, "_messages", storage)
+
+
+def test_item_form_adds_unit_suggestion_message(monkeypatch):
+    mapping = {"kg": ["g"]}
+    monkeypatch.setattr(supabase_units, "get_units", lambda force=False: mapping)
+    monkeypatch.setattr("inventory.forms.get_units", lambda force=False: mapping)
+    monkeypatch.setattr(unit_suggestions, "suggest_units", lambda name: ("kg", "g"))
+    rf = RequestFactory()
+    request = rf.post("/items/add/", {"name": "Flour"})
+    _add_messages(request)
+    form = ItemForm(request.POST, request=request)
+    assert not form.is_valid()
+    msgs = [str(m) for m in get_messages(request)]
+    assert any("Base: kg" in m and "Purchase: g" in m for m in msgs)
+    assert "base_unit" in form.errors
+    assert "purchase_unit" in form.errors
+    assert "base_unit" not in form.cleaned_data
+    assert "purchase_unit" not in form.cleaned_data
+
+
+def test_item_form_suggests_missing_purchase_unit(monkeypatch):
+    mapping = {"kg": ["g"]}
+    monkeypatch.setattr(supabase_units, "get_units", lambda force=False: mapping)
+    monkeypatch.setattr("inventory.forms.get_units", lambda force=False: mapping)
+    monkeypatch.setattr(unit_suggestions, "suggest_units", lambda name: ("kg", "g"))
+    rf = RequestFactory()
+    request = rf.post("/items/add/", {"name": "Flour", "base_unit": "kg"})
+    _add_messages(request)
+    form = ItemForm(request.POST, request=request)
+    assert not form.is_valid()
+    msgs = [str(m) for m in get_messages(request)]
+    assert any("Purchase: g" in m for m in msgs)
+    assert all("Base: kg" not in m for m in msgs)
+    assert "purchase_unit" in form.errors
+    assert "base_unit" not in form.errors
+    assert form.cleaned_data.get("base_unit") == "kg"
+    assert "purchase_unit" not in form.cleaned_data


### PR DESCRIPTION
## Summary
- invoke unit suggestion helper in `ItemForm.clean` and report hints via Django messages without altering form data
- allow item views to pass the request so suggestions can be surfaced as toast notifications
- add tests ensuring suggestions appear in messages and validation still requires explicit unit choices

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8a76868588326a92f7fc9c0f3ad2c