### PR TITLE
Handle new Supabase unit schema

### DIFF
--- a/inventory/services/supabase_units.py
+++ b/inventory/services/supabase_units.py
@@ -32,22 +32,17 @@ def _load_units_from_supabase() -> Dict[str, List[str]]:
         return {}
     try:  # pragma: no cover - network interaction
         client: Client = create_client(url, key)
-        # The ``units`` table contains a ``name`` column for the base unit and
-        # a ``purchase_units`` column with a list of compatible units.
-        resp = client.table("units").select("name,purchase_units").execute()
-        data = resp.data or []
+        resp = client.table("units").select("base_unit,purchase_unit").execute()
     except Exception as exc:
         logger.warning("Failed to fetch units from Supabase: %s", exc)
         return {}
 
     units: Dict[str, List[str]] = {}
-    for row in data:
-        name = row.get("name")
-        purchase = row.get("purchase_units") or []
-        if isinstance(purchase, str):
-            purchase = [purchase]
-        if name:
-            units[name] = purchase
+    for row in resp.data or []:
+        base = row.get("base_unit")
+        purchase = row.get("purchase_unit")
+        if base and purchase:
+            units.setdefault(base, []).append(purchase)
     return units
 
 

--- a/tests/test_supabase_units.py
+++ b/tests/test_supabase_units.py
@@ -1,0 +1,37 @@
+import pytest
+
+from inventory.services import supabase_units
+
+
+class DummyResp:
+    def __init__(self, data):
+        self.data = data
+
+
+class DummyClient:
+    def table(self, name):
+        assert name == "units"
+        return self
+
+    def select(self, fields):
+        # Ensure new schema columns are requested
+        assert fields == "base_unit,purchase_unit"
+        return self
+
+    def execute(self):
+        return DummyResp([
+            {"base_unit": "kg", "purchase_unit": "g"},
+            {"base_unit": "kg", "purchase_unit": "lb"},
+            {"base_unit": "ltr", "purchase_unit": "ml"},
+            {"base_unit": None, "purchase_unit": "x"},
+            {"base_unit": "kg", "purchase_unit": None},
+        ])
+
+
+def test_load_units_from_supabase(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "url")
+    monkeypatch.setenv("SUPABASE_KEY", "key")
+    monkeypatch.setattr(supabase_units, "create_client", lambda url, key: DummyClient())
+
+    units = supabase_units._load_units_from_supabase()
+    assert units == {"kg": ["g", "lb"], "ltr": ["ml"]}


### PR DESCRIPTION
## Summary
- Load units from Supabase using `base_unit` and `purchase_unit` columns
- Group rows by `base_unit` to build mapping
- Test Supabase unit loading with new schema

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8afbcb0dc83268fb61c26f9e4bcc6