### PR TITLE
Show nav dropdown only on hover

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -23,7 +23,7 @@
             <div id="nav-menu" class="flex space-x-4 ml-4 max-sm:hidden">
               <div class="relative nav-group">
                 <button data-dropdown="overview-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Overview</button>
-                <div id="overview-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
+                <div id="overview-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
                   {% url 'dashboard' as dashboard_url %}
                   <a href="{{ dashboard_url }}" class="flex items-center text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == dashboard_url %}active{% endif %}">
                     <svg class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
@@ -38,7 +38,7 @@
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="inventory-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Inventory</button>
-                <div id="inventory-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
+                <div id="inventory-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
                   {% url 'items_list' as items_url %}
                   <a href="{{ items_url }}" class="flex items-center text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == items_url %}active{% endif %}">
                     <svg class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/></svg>
@@ -53,7 +53,7 @@
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="procurement-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Procurement</button>
-                <div id="procurement-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
+                <div id="procurement-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
                   {% url 'suppliers_list' as suppliers_url %}
                   <a href="{{ suppliers_url }}" class="flex items-center text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == suppliers_url %}active{% endif %}">
                     <svg class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 0 1-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.213-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"/></svg>
@@ -78,7 +78,7 @@
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="production-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Production</button>
-                <div id="production-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
+                <div id="production-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
                   {% url 'recipes_list' as recipes_url %}
                   <a href="{{ recipes_url }}" class="flex items-center text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == recipes_url %}active{% endif %}">
                     <svg class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/></svg>
@@ -88,7 +88,7 @@
               </div>
               <div class="relative nav-group">
                 <button data-dropdown="account-menu" class="flex items-center justify-between text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Account</button>
-                <div id="account-menu" class="flex-col absolute bg-primary mt-2 rounded-md max-sm:hidden max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
+                <div id="account-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
                   {% if user.is_authenticated %}
                     {% url 'logout' as logout_url %}
                     <a href="{{ logout_url }}" class="flex items-center text-gray-300 hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == logout_url %}active{% endif %}">
@@ -123,10 +123,39 @@
       document.getElementById('nav-toggle').addEventListener('click', function () {
         document.getElementById('nav-menu').classList.toggle('max-sm:hidden');
       });
-      document.querySelectorAll('[data-dropdown]').forEach(function (btn) {
-        btn.addEventListener('click', function () {
-          const menu = document.getElementById(btn.dataset.dropdown);
-          menu.classList.toggle('max-sm:hidden');
+      document.querySelectorAll('.nav-group').forEach(function (group) {
+        const btn = group.querySelector('[data-dropdown]');
+        const menu = document.getElementById(btn.dataset.dropdown);
+
+        group.addEventListener('mouseenter', function () {
+          if (window.matchMedia('(min-width: 641px)').matches) {
+            menu.classList.remove('hidden');
+          }
+        });
+
+        group.addEventListener('mouseleave', function () {
+          if (window.matchMedia('(min-width: 641px)').matches) {
+            menu.classList.add('hidden');
+          }
+        });
+
+        btn.addEventListener('focus', function () {
+          if (window.matchMedia('(min-width: 641px)').matches) {
+            menu.classList.remove('hidden');
+          }
+        });
+
+        btn.addEventListener('blur', function () {
+          if (window.matchMedia('(min-width: 641px)').matches) {
+            menu.classList.add('hidden');
+          }
+        });
+
+        btn.addEventListener('click', function (e) {
+          if (window.matchMedia('(max-width: 640px)').matches) {
+            e.preventDefault();
+            menu.classList.toggle('hidden');
+          }
         });
       });
       document.body.addEventListener('htmx:request', function () {


### PR DESCRIPTION
## Summary
- Hide navigation dropdown menus by default and reveal on hover/focus
- Add mobile-friendly click toggle for dropdowns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b071a9f883268e1ac412d9d1fa2a