### PR TITLE
Delay navigation dropdown hide to improve accessibility

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -126,8 +126,10 @@
       document.querySelectorAll('.nav-group').forEach(function (group) {
         const btn = group.querySelector('[data-dropdown]');
         const menu = document.getElementById(btn.dataset.dropdown);
+        let hideTimer;
 
         group.addEventListener('mouseenter', function () {
+          clearTimeout(hideTimer);
           if (window.matchMedia('(min-width: 641px)').matches) {
             menu.classList.remove('hidden');
           }
@@ -135,11 +137,14 @@
 
         group.addEventListener('mouseleave', function () {
           if (window.matchMedia('(min-width: 641px)').matches) {
-            menu.classList.add('hidden');
+            hideTimer = setTimeout(function () {
+              menu.classList.add('hidden');
+            }, 200);
           }
         });
 
         group.addEventListener('focusin', function () {
+          clearTimeout(hideTimer);
           if (window.matchMedia('(min-width: 641px)').matches) {
             menu.classList.remove('hidden');
           }
@@ -147,7 +152,9 @@
 
         group.addEventListener('focusout', function (e) {
           if (window.matchMedia('(min-width: 641px)').matches && !group.contains(e.relatedTarget)) {
-            menu.classList.add('hidden');
+            hideTimer = setTimeout(function () {
+              menu.classList.add('hidden');
+            }, 200);
           }
         });
 


### PR DESCRIPTION
## Summary
- add per-group hide timers to prevent flicker when cursor quickly leaves navigation menus
- clear timers on re-entry and focus to keep dropdowns accessible

## Testing
- `pytest`
- `node test (desktop)`
- `node test (mobile)`

------
https://chatgpt.com/codex/tasks/task_e_68a8c25cbb208326bcd5b5e399b3c200