### PR TITLE
Ensure base unit available as purchase option

### DIFF
--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -4,13 +4,14 @@ from django import forms
 from django.urls import reverse
 
 from inventory.forms import ItemForm
+from inventory import forms as forms_module
 from inventory.services import supabase_units
 from inventory.models import Category
 
 
 @pytest.mark.django_db
 def test_item_form_preserves_metadata(monkeypatch):
-    monkeypatch.setattr(supabase_units, "get_units", lambda: {"kg": ["g"]})
+    monkeypatch.setattr(forms_module, "get_units", lambda: {"kg": ["g"]})
     form = ItemForm()
     base_field = form.fields["base_unit"]
     purchase_field = form.fields["purchase_unit"]
@@ -20,6 +21,14 @@ def test_item_form_preserves_metadata(monkeypatch):
     assert purchase_field.label == "Purchase unit"
     assert purchase_field.max_length == 50
     assert isinstance(purchase_field.widget, forms.Select)
+
+
+@pytest.mark.django_db
+def test_purchase_unit_includes_base(monkeypatch):
+    monkeypatch.setattr(forms_module, "get_units", lambda: {"kg": ["kg", "g"]})
+    form = ItemForm(data={"base_unit": "kg"})
+    purchase_choices = [c[0] for c in form.fields["purchase_unit"].choices]
+    assert "kg" in purchase_choices
 
 
 @pytest.mark.django_db

--- a/tests/test_supabase_units.py
+++ b/tests/test_supabase_units.py
@@ -37,7 +37,7 @@ def test_load_units_from_supabase(monkeypatch):
     monkeypatch.setattr(supabase_units, "create_client", lambda url, key: DummyClient())
 
     units = supabase_units._load_units_from_supabase()
-    assert units == {"kg": ["g", "lb"], "ltr": ["ml"]}
+    assert units == {"kg": ["kg", "g", "lb"], "ltr": ["ltr", "ml"]}
 
 
 def test_load_units_supabase_exception(monkeypatch):


### PR DESCRIPTION
## Summary
- Include base unit itself in Supabase unit mappings so purchase dropdown lists the base unit
- Add regression tests for unit mapping and ItemForm purchase options

## Testing
- `pytest tests/test_supabase_units.py::test_load_units_from_supabase -q`
- `pytest tests/test_item_form.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c88b4d308326806e526fac35e225