### PR TITLE
Handle unit load failures in ItemForm

### DIFF
--- a/inventory/forms/item_forms.py
+++ b/inventory/forms/item_forms.py
@@ -46,9 +46,12 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        units_map = get_units()
-        logger.debug("Units map loaded: %s", units_map)
+        try:
+            units_map = get_units()
+            logger.debug("Units map loaded: %s", units_map)
+        except Exception:
+            units_map = {}
+            logger.error("Failed to load units map", exc_info=True)
         self.units_map = units_map
 
         for field in ("name", "base_unit", "purchase_unit", "category"):

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -7,6 +7,9 @@
   {% if form %}
   <form method="post" class="space-y-4">
     {% csrf_token %}
+    {% if not form.units_map %}
+    <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
+    {% endif %}
     {% if form.non_field_errors %}
     <ul class="text-red-600 list-disc pl-5">
       {% for error in form.non_field_errors %}

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -1,5 +1,7 @@
 import pytest
 from django import forms
+from django.template.loader import render_to_string
+from django.test import RequestFactory
 
 from django.urls import reverse
 
@@ -29,6 +31,25 @@ def test_purchase_unit_includes_base(monkeypatch):
     form = ItemForm(data={"base_unit": "kg"})
     purchase_choices = [c[0] for c in form.fields["purchase_unit"].choices]
     assert "kg" in purchase_choices
+
+
+@pytest.mark.django_db
+def test_item_form_units_fallback(monkeypatch, caplog):
+    def fail():
+        raise Exception("boom")
+
+    monkeypatch.setattr(forms_module, "get_units", fail)
+    with caplog.at_level("ERROR"):
+        form = ItemForm()
+    assert form.units_map == {}
+    request = RequestFactory().get("/")
+    content = render_to_string(
+        "inventory/item_form.html",
+        {"form": form, "is_edit": False, "excluded_fields": []},
+        request=request,
+    )
+    assert "Could not load unit options" in content
+    assert "Failed to load units map" in caplog.text
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Guard `get_units` in `ItemForm` and log errors when unit loading fails
- Show a user-friendly notice when unit options cannot be retrieved
- Test fallback behaviour for missing units

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8d5c5579c8326b553ff5cdd5bf8ed