### PR TITLE
Add test for ItemEditView and ensure caches clear on update

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -222,6 +222,8 @@ class ItemEditView(View):
         if form.is_valid():
             try:
                 form.save()
+                item_service.get_all_items_with_stock.clear()
+                item_service.get_distinct_departments_from_items.clear()
                 messages.success(request, "Item updated")
                 return redirect("items_list")
             except (ValidationError, DatabaseError):

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -1,7 +1,8 @@
 import pytest
 from django.urls import reverse
 
-from inventory.models import Item, StockTransaction
+from inventory.models import Item, StockTransaction, Category
+from inventory.services import item_service
 
 pytestmark = pytest.mark.django_db
 
@@ -48,3 +49,52 @@ def test_item_delete_view_deactivates_with_transactions(client):
     assert resp.status_code == 302
     item.refresh_from_db()
     assert item.is_active is False
+
+
+def test_item_edit_view_updates_and_clears_cache(client, monkeypatch):
+    from inventory.forms import item_forms as forms_module
+
+    monkeypatch.setattr(forms_module, "get_units", lambda: {"pcs": ["box"]})
+    item_service.get_all_items_with_stock.clear()
+    item_service.get_distinct_departments_from_items.clear()
+
+    parent1 = Category.objects.create(name="Food")
+    sub1 = Category.objects.create(name="Fruit", parent=parent1)
+    parent2 = Category.objects.create(name="Drink")
+    sub2 = Category.objects.create(name="Soda", parent=parent2)
+    item = _create_item(category="Food", sub_category="Fruit")
+
+    # Prime caches
+    item_service.get_all_items_with_stock()
+    item_service.get_distinct_departments_from_items()
+    assert item_service.get_all_items_with_stock.cache_info().currsize == 1
+    assert item_service.get_distinct_departments_from_items.cache_info().currsize == 1
+
+    url = reverse("item_edit", args=[item.pk])
+    resp = client.get(url)
+    assert resp.status_code == 200
+    form = resp.context["form"]
+    assert form.fields["category"].initial == parent1.id
+    assert form.fields["sub_category"].initial == sub1.id
+
+    data = {
+        "name": "Gadget",
+        "base_unit": "pcs",
+        "purchase_unit": "box",
+        "category": str(parent2.pk),
+        "sub_category": str(sub2.pk),
+        "permitted_departments": "dept2",
+        "reorder_point": "5",
+        "current_stock": "0",
+        "notes": "updated",
+        "is_active": "on",
+    }
+    resp = client.post(url, data)
+    assert resp.status_code == 302
+    item.refresh_from_db()
+    assert item.name == "Gadget"
+    assert item.category == "Drink"
+    assert item.sub_category == "Soda"
+
+    assert item_service.get_all_items_with_stock.cache_info().currsize == 0
+    assert item_service.get_distinct_departments_from_items.cache_info().currsize == 0


### PR DESCRIPTION
## Summary
- add ItemEditView test verifying category/subcategory handling and cache clearing
- clear cached item queries when an item is edited

## Testing
- `pytest tests/test_item_views.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8d6e4b2d0832694d60efa00752f91