### PR TITLE
Gracefully handle ItemForm initialization failures

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -199,8 +199,8 @@ class ItemEditView(View):
         item = self.get_object(pk)
         try:
             form = ItemForm(instance=item)
-        except (DatabaseError, ValueError):
-            logger.exception("Error loading form for item %s", pk)
+        except Exception:
+            logger.exception("Error loading form for item %s", item.pk)
             messages.error(request, "Unable to load item")
             return redirect("items_list")
         ctx = {
@@ -215,8 +215,8 @@ class ItemEditView(View):
         item = self.get_object(pk)
         try:
             form = ItemForm(request.POST, instance=item)
-        except (DatabaseError, ValueError):
-            logger.exception("Error loading form for item %s", pk)
+        except Exception:
+            logger.exception("Error loading form for item %s", item.pk)
             messages.error(request, "Unable to load item")
             return redirect("items_list")
         if form.is_valid():

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -39,7 +39,7 @@ def test_item_form_units_fallback(monkeypatch, caplog):
         raise Exception("boom")
 
     monkeypatch.setattr(forms_module, "get_units", fail)
-    with caplog.at_level("ERROR"):
+    with caplog.at_level("WARNING"):
         form = ItemForm()
     assert form.units_map == {}
     request = RequestFactory().get("/")


### PR DESCRIPTION
## Summary
- Log item ID and stack trace when ItemForm instantiation fails in ItemEditView
- Tolerate exceptions during unit and category lookups in ItemForm, defaulting to empty choices
- Update ItemForm tests to expect warning logs

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8d6b2c9bc8326aa4dcab008932bc8