### PR TITLE
Avoid querying missing category_id for low-stock dashboard items

### DIFF
--- a/inventory/services/dashboard_service.py
+++ b/inventory/services/dashboard_service.py
@@ -5,7 +5,8 @@ from inventory.models import Item
 
 def get_low_stock_items():
     """Return items whose current stock is below their reorder point."""
-    return Item.objects.filter(
-        reorder_point__isnull=False,
-        current_stock__lt=F("reorder_point"),
-    ).order_by("name")
+    return (
+        Item.objects.only("name", "current_stock", "reorder_point")
+        .filter(reorder_point__isnull=False, current_stock__lt=F("reorder_point"))
+        .order_by("name")
+    )


### PR DESCRIPTION
## Summary
- limit low-stock query to essential fields to avoid selecting missing `category_id`

## Testing
- `flake8 inventory/services/dashboard_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8e26c35748326803f7b96073b3072