### PR TITLE
style: theme empty state

### DIFF
--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -1,6 +1,6 @@
-<div class="py-6 px-8 max-md:px-6 max-sm:px-4 text-center border rounded bg-white">
+<div class="py-6 px-8 max-md:px-6 max-sm:px-4 text-center border border-form-border rounded bg-form-bg dark:bg-form-darkBg dark:border-form-darkBorder">
   <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
   <h2 class="mt-4 mb-2 text-lg font-semibold">{{ title }}</h2>
-  <p class="mb-4 text-gray-600">{{ message }}</p>
+  <p class="mb-4 text-form-text dark:text-form-darkText">{{ message }}</p>
   <a href="{{ cta_url }}" class="btn-primary">{{ cta_label }}</a>
 </div>


### PR DESCRIPTION
## Summary
- theme empty state component with form palette tokens
- add dark mode border, background, and text styles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8e2aebb88832698d75fbfeefe98bc