### PR TITLE
Add dark mode toast styling and utility class

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -437,14 +437,14 @@ video {
 }
 
 body {
-  background-color: #f9fafb;
+  background-color: #ffffff;
   color: #111827;
   font-family: Roboto, sans-serif;
 }
 
 .dark body {
-  background-color: #1f2937;
-  color: #ffffff;
+  background-color: #0f172a;
+  color: #f8fafc;
 }
 
 *, ::before, ::after{
@@ -597,9 +597,9 @@ body {
 
 .dark .badge-warning{
   --tw-bg-opacity: 1;
-  background-color: rgb(202 138 4 / var(--tw-bg-opacity));
+  background-color: rgb(217 119 6 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
-  color: rgb(0 0 0 / var(--tw-text-opacity));
+  color: rgb(17 24 39 / var(--tw-text-opacity));
 }
 
 .dark .badge-error{
@@ -609,10 +609,20 @@ body {
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+/* Toast component styles */
+
+.toast{
+  position: absolute;
+  left: 0px;
+  top: 100%;
+  z-index: 10;
+  margin-top: 0.25rem;
+}
+
 /* Button styles */
 
 .btn-primary {
-  background-color: #1e40af;
+  background-color: #1d4ed8;
   border-radius: 0.25rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -636,7 +646,7 @@ body {
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
   --tw-ring-offset-width: 2px;
-  --tw-ring-color: #1e40af;
+  --tw-ring-color: #1d4ed8;
 }
 
 .btn-primary:disabled{
@@ -645,7 +655,7 @@ body {
 }
 
 .btn-secondary {
-  background-color: #047857;
+  background-color: #065f46;
   border-radius: 0.25rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -669,7 +679,7 @@ body {
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
   --tw-ring-offset-width: 2px;
-  --tw-ring-color: #047857;
+  --tw-ring-color: #065f46;
 }
 
 .btn-secondary:disabled{
@@ -678,7 +688,7 @@ body {
 }
 
 .btn-danger {
-  background-color: #dc2626;
+  background-color: #b91c1c;
   border-radius: 0.25rem;
   padding-left: 1rem;
   padding-right: 1rem;
@@ -702,7 +712,7 @@ body {
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
   --tw-ring-offset-width: 2px;
-  --tw-ring-color: #dc2626;
+  --tw-ring-color: #b91c1c;
 }
 
 .btn-danger:disabled{
@@ -735,8 +745,8 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   form textarea:focus,
   .form-control:focus {
   outline: none;
-  border-color: #1e40af;
-  --tw-shadow: 0 0 0 2px rgba(30, 64, 175, 0.4);
+  border-color: #1d4ed8;
+  --tw-shadow: 0 0 0 2px rgba(29, 78, 216, 0.4);
   --tw-shadow-colored: 0 0 0 2px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
@@ -752,9 +762,9 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   .dark form select,
   .dark form textarea,
   .dark .form-control {
-  border: 1px solid #4b5563;
-  background-color: #374151;
-  color: #f9fafb;
+  border: 1px solid #334155;
+  background-color: #1e293b;
+  color: #f8fafc;
 }
 
 .dark form input:not([type='checkbox']):not([type='radio']):focus,
@@ -762,16 +772,16 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   .dark form textarea:focus,
   .dark .form-control:focus {
   outline: none;
-  border-color: #1e40af;
-  --tw-shadow: 0 0 0 2px rgba(30, 58, 138, 0.6);
+  border-color: #1d4ed8;
+  --tw-shadow: 0 0 0 2px rgba(29, 78, 216, 0.6);
   --tw-shadow-colored: 0 0 0 2px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .dark .form-checkbox {
-  border: 1px solid #4b5563;
-  background-color: #374151;
-  color: #f9fafb;
+  border: 1px solid #334155;
+  background-color: #1e293b;
+  color: #f8fafc;
 }
 
 /* Table component styles */
@@ -783,27 +793,39 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 
 .table th,
   .table td {
-  border: 1px solid #e5e7eb;
+  border: 1px solid #d1d5db;
   padding: 0.5rem 1rem;
   text-align: left;
 }
 
 .table thead {
-  background-color: #1e40af;
+  background-color: #1d4ed8;
   color: #ffffff;
 }
 
 .table tbody tr:hover {
-  background-color: #f3f4f6;
+  background-color: #e5e7eb;
 }
 
 .dark .table th,
   .dark .table td {
-  border: 1px solid #4b5563;
+  border: 1px solid #334155;
 }
 
 .dark .table tbody tr:hover {
-  background-color: #1f2937;
+  background-color: #1e293b;
+}
+
+.sr-only{
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }
 
 .static{
@@ -960,12 +982,25 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   width: 100%;
 }
 
+.w-max{
+  width: -moz-max-content;
+  width: max-content;
+}
+
 .max-w-2xl{
   max-width: 42rem;
 }
 
 .max-w-sm{
   max-width: 24rem;
+}
+
+.max-w-xs{
+  max-width: 20rem;
+}
+
+.flex-1{
+  flex: 1 1 0%;
 }
 
 .flex-shrink-0{
@@ -1016,6 +1051,10 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 
 .flex-wrap{
   flex-wrap: wrap;
+}
+
+.items-start{
+  align-items: flex-start;
 }
 
 .items-end{
@@ -1122,6 +1161,11 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   border-color: rgb(59 130 246 / var(--tw-border-opacity));
 }
 
+.border-form-border{
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity));
+}
+
 .border-green-500{
   --tw-border-opacity: 1;
   border-color: rgb(34 197 94 / var(--tw-border-opacity));
@@ -1129,7 +1173,7 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 
 .border-primary{
   --tw-border-opacity: 1;
-  border-color: rgb(30 64 175 / var(--tw-border-opacity));
+  border-color: rgb(29 78 216 / var(--tw-border-opacity));
 }
 
 .border-red-500{
@@ -1155,6 +1199,11 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   background-color: rgb(219 234 254 / var(--tw-bg-opacity));
 }
 
+.bg-form-bg{
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
 .bg-gray-200{
   --tw-bg-opacity: 1;
   background-color: rgb(229 231 235 / var(--tw-bg-opacity));
@@ -1167,17 +1216,12 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 
 .bg-primary{
   --tw-bg-opacity: 1;
-  background-color: rgb(30 64 175 / var(--tw-bg-opacity));
+  background-color: rgb(29 78 216 / var(--tw-bg-opacity));
 }
 
 .bg-red-100{
   --tw-bg-opacity: 1;
   background-color: rgb(254 226 226 / var(--tw-bg-opacity));
-}
-
-.bg-white{
-  --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
 
 .bg-yellow-100{
@@ -1299,6 +1343,16 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   color: rgb(29 78 216 / var(--tw-text-opacity));
 }
 
+.text-blue-800{
+  --tw-text-opacity: 1;
+  color: rgb(30 64 175 / var(--tw-text-opacity));
+}
+
+.text-form-text{
+  --tw-text-opacity: 1;
+  color: rgb(17 24 39 / var(--tw-text-opacity));
+}
+
 .text-gray-300{
   --tw-text-opacity: 1;
   color: rgb(209 213 219 / var(--tw-text-opacity));
@@ -1314,11 +1368,6 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   color: rgb(107 114 128 / var(--tw-text-opacity));
 }
 
-.text-gray-600{
-  --tw-text-opacity: 1;
-  color: rgb(75 85 99 / var(--tw-text-opacity));
-}
-
 .text-green-700{
   --tw-text-opacity: 1;
   color: rgb(21 128 61 / var(--tw-text-opacity));
@@ -1326,7 +1375,7 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 
 .text-primary{
   --tw-text-opacity: 1;
-  color: rgb(30 64 175 / var(--tw-text-opacity));
+  color: rgb(29 78 216 / var(--tw-text-opacity));
 }
 
 .text-red-600{
@@ -1351,6 +1400,12 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 
 .underline{
   text-decoration-line: underline;
+}
+
+.shadow{
+  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .dark .text-primary {
@@ -1392,6 +1447,31 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 .focus\:outline-none:focus{
   outline: 2px solid transparent;
   outline-offset: 2px;
+}
+
+:is(.dark .dark\:border-form-darkBorder){
+  --tw-border-opacity: 1;
+  border-color: rgb(51 65 85 / var(--tw-border-opacity));
+}
+
+:is(.dark .dark\:bg-blue-900){
+  --tw-bg-opacity: 1;
+  background-color: rgb(30 58 138 / var(--tw-bg-opacity));
+}
+
+:is(.dark .dark\:bg-form-darkBg){
+  --tw-bg-opacity: 1;
+  background-color: rgb(30 41 59 / var(--tw-bg-opacity));
+}
+
+:is(.dark .dark\:text-blue-100){
+  --tw-text-opacity: 1;
+  color: rgb(219 234 254 / var(--tw-text-opacity));
+}
+
+:is(.dark .dark\:text-form-darkText){
+  --tw-text-opacity: 1;
+  color: rgb(248 250 252 / var(--tw-text-opacity));
 }
 
 :is(.dark .dark\:text-gray-200){

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -27,6 +27,9 @@
   .dark .badge-warning { @apply bg-amber-600 text-gray-900; }
   .dark .badge-error { @apply bg-red-700 text-white; }
 
+  /* Toast component styles */
+  .toast { @apply absolute left-0 top-full mt-1 z-10; }
+
   /* Button styles */
   .btn-primary {
     background-color: theme('colors.primary.DEFAULT');

--- a/templates/components/toast.html
+++ b/templates/components/toast.html
@@ -1,7 +1,7 @@
 {% if message %}
-<div id="{{ toast_id|default:'toast' }}" class="toast absolute left-0 top-full mt-1 z-10 w-max max-w-xs bg-blue-100 text-blue-800 text-sm px-3 py-2 rounded shadow flex items-start gap-2" role="status" aria-live="polite">
+<div id="{{ toast_id|default:'toast' }}" class="toast w-max max-w-xs bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100 text-sm px-3 py-2 rounded shadow flex items-start gap-2" role="status" aria-live="polite">
   <span class="flex-1">{{ message }}</span>
-  <button type="button" class="text-blue-800" aria-label="Dismiss" onclick="this.parentElement.remove()">&times;</button>
+  <button type="button" class="text-blue-800 dark:bg-blue-900 dark:text-blue-100" aria-label="Dismiss" onclick="this.parentElement.remove()">&times;</button>
 </div>
 <script>
   setTimeout(() => document.getElementById('{{ toast_id|default:'toast' }}')?.remove(), 5000);


### PR DESCRIPTION
## Summary
- add dark mode colors to toast container and dismiss button
- extract absolute positioning into reusable `toast` utility class

## Testing
- `flake8` *(fails: W391, E303, E302)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8e3b236d88326810ebd834626eb59