### PR TITLE
Use database categories for item form dropdowns

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -10,11 +10,10 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.views import View
 from django.views.generic import TemplateView
 
-from ..models import Item, StockTransaction
+from ..models import Item, StockTransaction, Category
 from ..forms.item_forms import ItemForm
 from ..forms.bulk_forms import BulkUploadForm
 from ..services import item_service, list_utils
-from ..services.supabase_categories import get_categories
 
 logger = logging.getLogger(__name__)
 
@@ -324,24 +323,19 @@ class ItemSearchView(TemplateView):
 
 
 class SubCategoryOptionsView(TemplateView):
-    """Return ``<option>`` tags for subcategories of a category.
-
-    GET param `category` specifies the parent category ID.
-    Template: inventory/_subcategory_options.html.
-    """
+    """Return ``<option>`` tags for subcategories of a category."""
 
     template_name = "inventory/_subcategory_options.html"
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         cat_id = self.request.GET.get("category")
-        categories_map = get_categories()
-        subcats = []
+        subcats = Category.objects.none()
         if cat_id:
             try:
-                subcats = categories_map.get(int(cat_id), [])
+                subcats = Category.objects.filter(parent_id=int(cat_id)).order_by("name")
             except (ValueError, TypeError):
-                subcats = []
+                subcats = Category.objects.none()
         ctx["subcategories"] = subcats
         return ctx
 

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -2,7 +2,7 @@ import pytest
 from django.urls import reverse
 
 from inventory.models import Item, StockTransaction, Category
-from inventory.services import item_service, supabase_categories
+from inventory.services import item_service
 
 pytestmark = pytest.mark.django_db
 
@@ -59,15 +59,6 @@ def test_item_edit_view_updates_and_clears_cache(client, monkeypatch):
     from inventory.forms import item_forms as forms_module
 
     monkeypatch.setattr(forms_module, "get_units", lambda: {"pcs": ["box"]})
-    categories_map = {
-        None: [{"id": 1, "name": "Food"}, {"id": 2, "name": "Drink"}],
-        1: [{"id": 3, "name": "Fruit"}],
-        2: [{"id": 4, "name": "Soda"}],
-    }
-    monkeypatch.setattr(forms_module, "get_categories", lambda: categories_map)
-    monkeypatch.setattr(
-        supabase_categories, "get_categories", lambda: categories_map
-    )
     item_service.get_all_items_with_stock.clear()
     item_service.get_distinct_departments_from_items.clear()
 


### PR DESCRIPTION
## Summary
- load category and subcategory options from local `Category` model
- query database in subcategory AJAX view
- update tests to match new category lookup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8f305073883268ac4432293939787