### PR TITLE
Fetch categories from Supabase for item form

### DIFF
--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -10,6 +10,9 @@
     {% if not form.units_map %}
     <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
     {% endif %}
+    {% if form.supabase_categories_failed %}
+    <p class="text-sm text-red-600">Could not load category options. Please try again later.</p>
+    {% endif %}
     {% if form.non_field_errors %}
     <ul class="text-red-600 list-disc pl-5">
       {% for error in form.non_field_errors %}

--- a/tests/test_aa_views.py
+++ b/tests/test_aa_views.py
@@ -35,9 +35,11 @@ def test_item_edit_handles_save_error(item_factory):
     )
     _add_messages(request)
     # Simulate DB error on save
-    with patch("inventory.forms.item_forms.ItemForm.save", side_effect=DatabaseError):
-        with patch("inventory.views.items.render", return_value=HttpResponse()):
-            resp = ItemEditView.as_view()(request, pk=item.pk)
+    with patch("inventory.forms.item_forms.get_units", return_value={}), \
+        patch("inventory.forms.item_forms.get_categories", return_value={}), \
+        patch("inventory.forms.item_forms.ItemForm.save", side_effect=DatabaseError), \
+        patch("inventory.views.items.render", return_value=HttpResponse()):
+        resp = ItemEditView.as_view()(request, pk=item.pk)
     assert resp.status_code == 200
 
 
@@ -58,7 +60,9 @@ def test_item_edit_handles_non_numeric_values(item_factory):
     rf = RequestFactory()
     request = rf.get(f"/items/{item.pk}/edit/")
     _add_messages(request)
-    with patch("inventory.views.items.render", return_value=HttpResponse()):
+    with patch("inventory.forms.item_forms.get_units", return_value={}), \
+        patch("inventory.forms.item_forms.get_categories", return_value={}), \
+        patch("inventory.views.items.render", return_value=HttpResponse()):
         resp = ItemEditView.as_view()(request, pk=item.pk)
     assert resp.status_code == 200
 
@@ -72,7 +76,9 @@ def test_item_edit_db_error_returns_404():
     request = rf.get("/items/1/edit/")
     _add_messages(request)
     # Simulate DB error when fetching the object
-    with patch("inventory.views.items.get_object_or_404", side_effect=DatabaseError):
+    with patch("inventory.forms.item_forms.get_units", return_value={}), \
+        patch("inventory.forms.item_forms.get_categories", return_value={}), \
+        patch("inventory.views.items.get_object_or_404", side_effect=DatabaseError):
         with pytest.raises(Http404):
             ItemEditView.as_view()(request, pk=1)
 

--- a/tests/test_supabase_categories.py
+++ b/tests/test_supabase_categories.py
@@ -1,0 +1,76 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from inventory.services import supabase_categories
+
+
+class DummyResp:
+    def __init__(self, data):
+        self.data = data
+
+
+class DummyClient:
+    def table(self, name):
+        assert name == "category"
+        return self
+
+    def select(self, fields):
+        assert fields == "id,name,parent_id"
+        return self
+
+    def execute(self):
+        return DummyResp([
+            {"id": 1, "name": "Food", "parent_id": None},
+            {"id": 2, "name": "Tools", "parent_id": None},
+            {"id": 3, "name": "Fruit", "parent_id": 1},
+            {"id": None, "name": "Bad", "parent_id": None},
+            {"id": 4, "name": None, "parent_id": None},
+        ])
+
+
+def test_load_categories_from_supabase(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "url")
+    monkeypatch.setenv("SUPABASE_KEY", "key")
+    monkeypatch.setattr(
+        supabase_categories, "create_client", lambda url, key: DummyClient()
+    )
+    cats = supabase_categories._load_categories_from_supabase()
+    assert cats == {
+        None: [{"id": 1, "name": "Food"}, {"id": 2, "name": "Tools"}],
+        1: [{"id": 3, "name": "Fruit"}],
+    }
+
+
+def test_load_categories_supabase_exception(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "url")
+    monkeypatch.setenv("SUPABASE_KEY", "key")
+
+    class FailingClient(DummyClient):
+        def table(self, name):
+            raise supabase_categories.SupabaseException("fail")
+
+    monkeypatch.setattr(
+        supabase_categories, "create_client", lambda u, k: FailingClient()
+    )
+    cats = supabase_categories._load_categories_from_supabase()
+    assert cats == {}
+
+
+def test_get_categories_thread_safe(monkeypatch):
+    monkeypatch.setattr(supabase_categories, "_cache", None)
+    monkeypatch.setattr(supabase_categories, "_cache_time", None)
+
+    def slow_load():
+        time.sleep(0.01)
+        return {None: [{"id": 1, "name": "Food"}]}
+
+    monkeypatch.setattr(
+        supabase_categories, "_load_categories_from_supabase", slow_load
+    )
+
+    with ThreadPoolExecutor(max_workers=5) as ex:
+        list(ex.map(lambda _: supabase_categories.get_categories(force=True), range(5)))
+
+    assert supabase_categories._cache == {None: [{"id": 1, "name": "Food"}]}


### PR DESCRIPTION
## Summary
- populate category choices from Supabase during ItemForm initialization
- warn users when Supabase categories cannot be loaded
- add tests for Supabase-backed category loading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8f7f3d608832690a5e4e2ad388ad3