### PR TITLE
Refactor Supabase category mapping

### DIFF
--- a/inventory/forms/item_forms.py
+++ b/inventory/forms/item_forms.py
@@ -56,13 +56,16 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
         self.categories_map = categories_map
         self.supabase_categories_failed = not categories_map
         if categories_map:
+            top_ids: dict[str, int] = {}
             for cat in categories_map.get(None, []):
                 Category.objects.update_or_create(
                     id=cat["id"], defaults={"name": cat["name"], "parent_id": None}
                 )
-            for parent_id, children in categories_map.items():
-                if parent_id is None:
+                top_ids[cat["name"]] = cat["id"]
+            for cat_name, children in categories_map.items():
+                if cat_name is None:
                     continue
+                parent_id = top_ids.get(cat_name)
                 for child in children:
                     Category.objects.update_or_create(
                         id=child["id"],

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -109,7 +109,7 @@ def test_item_form_supabase_categories(monkeypatch):
     monkeypatch.setattr(forms_module, "get_units", lambda: {"kg": ["g"]})
     categories_map = {
         None: [{"id": 1, "name": "Food"}, {"id": 2, "name": "Tools"}],
-        1: [{"id": 3, "name": "Fruit"}],
+        "Food": [{"id": 3, "name": "Fruit"}],
     }
     monkeypatch.setattr(forms_module, "get_categories", lambda: categories_map)
 

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -120,7 +120,7 @@ def test_items_list_view_uses_supabase_categories(monkeypatch, client):
     monkeypatch.setattr(
         items_module,
         "get_supabase_categories",
-        lambda: {None: [{"id": 1, "name": "Food"}], 1: [{"id": 2, "name": "Fruit"}]},
+        lambda: {None: [{"id": 1, "name": "Food"}], "Food": [{"id": 2, "name": "Fruit"}]},
     )
     url = reverse("items_list")
     resp = client.get(url)

--- a/tests/test_supabase_categories.py
+++ b/tests/test_supabase_categories.py
@@ -13,11 +13,11 @@ class DummyResp:
 
 class DummyClient:
     def table(self, name):
-        assert name == "category_pairs"
+        assert name == "category"
         return self
 
     def select(self, fields):
-        assert fields == "category_id,category,sub_category_id,sub_category"
+        assert fields == "category_id,category,sub_category"
         return self
 
     def execute(self):
@@ -26,37 +26,31 @@ class DummyClient:
                 {
                     "category_id": 1,
                     "category": "Food",
-                    "sub_category_id": 3,
                     "sub_category": "Fruit",
                 },
                 {
-                    "category_id": 1,
+                    "category_id": 2,
                     "category": "Food",
-                    "sub_category_id": 4,
                     "sub_category": "Veg",
                 },
                 {
-                    "category_id": 2,
+                    "category_id": 3,
                     "category": "Tools",
-                    "sub_category_id": None,
                     "sub_category": None,
                 },
                 {
-                    "category_id": 1,
+                    "category_id": 4,
                     "category": "Food",
-                    "sub_category_id": 3,
                     "sub_category": "Fruit",
                 },
                 {
                     "category_id": None,
                     "category": "Bad",
-                    "sub_category_id": None,
                     "sub_category": None,
                 },
                 {
-                    "category_id": 4,
+                    "category_id": 5,
                     "category": None,
-                    "sub_category_id": None,
                     "sub_category": None,
                 },
             ]
@@ -71,8 +65,8 @@ def test_load_categories_from_supabase(monkeypatch):
     )
     cats = supabase_categories._load_categories_from_supabase()
     assert cats == {
-        None: [{"id": 1, "name": "Food"}, {"id": 2, "name": "Tools"}],
-        1: [{"id": 3, "name": "Fruit"}, {"id": 4, "name": "Veg"}],
+        None: [{"id": 1, "name": "Food"}, {"id": 3, "name": "Tools"}],
+        "Food": [{"id": 1, "name": "Fruit"}, {"id": 2, "name": "Veg"}],
     }
 
 


### PR DESCRIPTION
## Summary
- query new `category` table for category data
- build category mapping keyed by name and sort names alphabetically
- adapt item form and tests to new mapping structure

## Testing
- `flake8 inventory/services/supabase_categories.py inventory/forms/item_forms.py tests/test_supabase_categories.py tests/test_item_form.py tests/test_item_views.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a98d56c0f883268cd3866e6dbb0284