### PR TITLE
refactor: remove category model usage

### DIFF
--- a/inventory/migrations/0012_remove_category_model.py
+++ b/inventory/migrations/0012_remove_category_model.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("inventory", "0011_auto_20250822_2123"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="item",
+            name="category",
+        ),
+        migrations.RemoveField(
+            model_name="item",
+            name="sub_category",
+        ),
+        migrations.DeleteModel(
+            name="Category",
+        ),
+        migrations.AddField(
+            model_name="item",
+            name="category_id",
+            field=models.IntegerField(blank=True, null=True),
+        ),
+    ]

--- a/inventory/models/__init__.py
+++ b/inventory/models/__init__.py
@@ -22,7 +22,7 @@ class CoerceFloatField(models.DecimalField):
         return self.to_python(value)
 
 
-from .items import Category, Item, StockTransaction
+from .items import Item, StockTransaction
 from .suppliers import Supplier
 from .orders import (
     Indent,
@@ -102,7 +102,6 @@ class SaleTransaction(models.Model):
 
 __all__ = [
     "CoerceFloatField",
-    "Category",
     "Item",
     "StockTransaction",
     "Supplier",

--- a/inventory/models/items.py
+++ b/inventory/models/items.py
@@ -4,45 +4,12 @@ from django.db import models
 from . import CoerceFloatField
 
 
-class Category(models.Model):
-    id = models.AutoField(primary_key=True)
-    name = models.CharField(max_length=100, blank=False, null=False)
-    parent = models.ForeignKey(
-        "self",
-        models.DO_NOTHING,
-        db_column="parent_id",
-        blank=True,
-        null=True,
-        related_name="children",
-    )
-
-    class Meta:
-        db_table = "category"
-        ordering = ("name",)
-
-    def __str__(self) -> str:  # pragma: no cover - simple representation
-        return self.name or f"Category {self.pk}"
-
-
 class Item(models.Model):
     item_id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255, blank=False, null=False)
     base_unit = models.CharField(max_length=50, blank=False, null=False)
     purchase_unit = models.CharField(max_length=50, blank=False, null=False)
-    category = models.ForeignKey(
-        Category,
-        models.DO_NOTHING,
-        related_name="items",
-        blank=True,
-        null=True,
-    )
-    sub_category = models.ForeignKey(
-        Category,
-        models.DO_NOTHING,
-        related_name="sub_items",
-        blank=True,
-        null=True,
-    )
+    category_id = models.IntegerField(blank=True, null=True)
     permitted_departments = models.CharField(max_length=255, blank=True, null=True)
     reorder_point = CoerceFloatField(default=Decimal("0"), blank=True, null=True)
     current_stock = CoerceFloatField(default=Decimal("0"), blank=True, null=True)

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -10,7 +10,6 @@ from .views.items import (
     ItemDeleteView,
     ItemSearchView,
     ItemsBulkUploadView,
-    SubCategoryOptionsView,
 )
 from .views.suppliers import (
     SuppliersListView,
@@ -59,7 +58,6 @@ urlpatterns = [
     path("items/<int:pk>/", ItemDetailView.as_view(), name="item_detail"),
     path("items/search/", ItemSearchView.as_view(), name="item_search"),
     path("items/bulk-upload/", ItemsBulkUploadView.as_view(), name="items_bulk_upload"),
-    path("items/subcategories/", SubCategoryOptionsView.as_view(), name="item_subcategory_options"),
 
     path("suppliers/", SuppliersListView.as_view(), name="suppliers_list"),
     path("suppliers/table/", SuppliersTableView.as_view(), name="suppliers_table"),

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -22,20 +22,6 @@
     Base Unit{% if sort == 'base_unit' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
     </a>
   </th>
-<th class="px-4 py-2">
-  <a hx-get="{% url 'items_table' %}?sort=category__name&direction={% if sort == 'category__name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-     hx-target="#items_table" hx-include="#filters"
-     hx-on:click="document.querySelector('#filters input[name=sort]').value='category__name';document.querySelector('#filters input[name=direction]').value='{% if sort == 'category__name' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-    Category{% if sort == 'category__name' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-  </a>
-  </th>
-<th class="px-4 py-2">
-  <a hx-get="{% url 'items_table' %}?sort=sub_category__name&direction={% if sort == 'sub_category__name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-     hx-target="#items_table" hx-include="#filters"
-     hx-on:click="document.querySelector('#filters input[name=sort]').value='sub_category__name';document.querySelector('#filters input[name=direction]').value='{% if sort == 'sub_category__name' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-    Subcategory{% if sort == 'sub_category__name' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-  </a>
-  </th>
 <th class="px-4 py-2 text-right">
   <a hx-get="{% url 'items_table' %}?sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
@@ -66,8 +52,6 @@
   <td class="px-4 py-2 text-right">{{ row.item_id }}</td>
   <td class="px-4 py-2">{{ row.name }}</td>
   <td class="px-4 py-2">{{ row.base_unit }}</td>
-  <td class="px-4 py-2">{{ row.category }}</td>
-  <td class="px-4 py-2">{{ row.sub_category }}</td>
   <td class="px-4 py-2 text-right">{{ row.current_stock }}</td>
   <td class="px-4 py-2 text-right">{{ row.reorder_point }}</td>
   <td class="px-4 py-2">{{ row.is_active }}</td>
@@ -91,17 +75,17 @@
 <div class="flex items-center gap-3 mt-3 flex-wrap">
   <div class="flex items-center gap-1">
     {% if page_obj.has_previous %}
-      <a hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">Prev</a>
+      <a hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">Prev</a>
     {% endif %}
     {% for num in page_obj.paginator.page_range %}
       {% if num == page_obj.number %}
         <span class="px-3 py-1 border rounded bg-gray-200">{{ num }}</span>
       {% else %}
-        <a hx-get="{% url 'items_table' %}?page={{ num }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">{{ num }}</a>
+        <a hx-get="{% url 'items_table' %}?page={{ num }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">{{ num }}</a>
       {% endif %}
     {% endfor %}
     {% if page_obj.has_next %}
-      <a hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&category={{ category|urlencode }}&subcategory={{ subcategory|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">Next</a>
+      <a hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">Next</a>
     {% endif %}
   </div>
   <div class="ml-auto flex items-center gap-2">

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -6,8 +6,7 @@
       <tr><th class="text-left pr-4">ID</th><td>{{ item.item_id }}</td></tr>
       <tr><th class="text-left pr-4">Base Unit</th><td>{{ item.base_unit }}</td></tr>
       <tr><th class="text-left pr-4">Purchase Unit</th><td>{{ item.purchase_unit }}</td></tr>
-      <tr><th class="text-left pr-4">Category</th><td>{{ item.category }}</td></tr>
-      <tr><th class="text-left pr-4">Subcategory</th><td>{{ item.sub_category }}</td></tr>
+      <tr><th class="text-left pr-4">Category ID</th><td>{{ item.category_id }}</td></tr>
       <tr><th class="text-left pr-4">Current Stock</th><td>{{ item.current_stock }}</td></tr>
       <tr><th class="text-left pr-4">Reorder Point</th><td>{{ item.reorder_point }}</td></tr>
       <tr><th class="text-left pr-4">Notes</th><td>{{ item.notes }}</td></tr>

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -10,9 +10,6 @@
     {% if not form.units_map %}
     <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
     {% endif %}
-    {% if form.supabase_categories_failed %}
-    <p class="text-sm text-red-600">Could not load category options. Please try again later.</p>
-    {% endif %}
     {% if form.non_field_errors %}
     <ul class="text-red-600 list-disc pl-5">
       {% for error in form.non_field_errors %}
@@ -37,7 +34,6 @@
       </div>
       {% include "components/form_field.html" with field=form.base_unit %}
       {% include "components/form_field.html" with field=form.purchase_unit %}
-      {% include "components/form_field.html" with field=form.category %}
       {% for field in form %}
         {% if field.name not in excluded_fields %}
           {% include "components/form_field.html" with field=field %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -25,50 +25,6 @@
         />
       </div>
       <div class="flex flex-col gap-1">
-        <label for="filter-category" class="text-sm font-medium">Category</label>
-        <input
-          id="filter-category"
-          type="text"
-          name="category"
-          list="item-categories"
-          class="form-control w-full"
-          value="{{ category }}"
-          hx-get="{% url 'items_table' %}"
-          hx-target="#items_table"
-          hx-trigger="change"
-          hx-include="#filters"
-          hx-indicator="#htmx-spinner"
-        />
-        <datalist id="item-categories">
-          <option value="" label="All Categories"></option>
-          {% for cat in categories %}
-          <option value="{{ cat }}"></option>
-          {% endfor %}
-        </datalist>
-      </div>
-      <div class="flex flex-col gap-1">
-        <label for="filter-subcategory" class="text-sm font-medium">Subcategory</label>
-        <input
-          id="filter-subcategory"
-          type="text"
-          name="subcategory"
-          list="item-subcategories"
-          class="form-control w-full"
-          value="{{ subcategory }}"
-          hx-get="{% url 'items_table' %}"
-          hx-target="#items_table"
-          hx-trigger="change"
-          hx-include="#filters"
-          hx-indicator="#htmx-spinner"
-        />
-        <datalist id="item-subcategories">
-          <option value="" label="All Subcategories"></option>
-          {% for sub in subcategories %}
-          <option value="{{ sub }}"></option>
-          {% endfor %}
-        </datalist>
-      </div>
-      <div class="flex flex-col gap-1">
         <label for="filter-active" class="text-sm font-medium">Status</label>
         <input
           id="filter-active"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import django
 
 import pytest
 
-from inventory.models import Item, Category
+from inventory.models import Item
 
 # Ensure project root is on sys.path
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -18,18 +18,10 @@ django.setup()
 @pytest.fixture
 def item_factory():
     def create_item(**kwargs):
-        category = kwargs.pop("category", "Cat")
-        if isinstance(category, str):
-            category = Category.objects.create(name=category)
-        sub_category = kwargs.pop("sub_category", None)
-        if isinstance(sub_category, str) or sub_category is None:
-            sub_category = Category.objects.create(name=sub_category or "Sub", parent=category)
         defaults = {
             "name": "Item",
             "base_unit": "kg",
             "purchase_unit": "g",
-            "category": category,
-            "sub_category": sub_category,
         }
         defaults.update(kwargs)
         return Item.objects.create(**defaults)

--- a/tests/test_aa_views.py
+++ b/tests/test_aa_views.py
@@ -31,12 +31,11 @@ def test_item_edit_handles_save_error(item_factory):
     rf = RequestFactory()
     request = rf.post(
         f"/items/{item.pk}/edit/",
-        {"name": "Sugar", "category": str(item.category_id), "sub_category": str(item.sub_category_id)},
+        {"name": "Sugar", "category_id": "1"},
     )
     _add_messages(request)
     # Simulate DB error on save
     with patch("inventory.forms.item_forms.get_units", return_value={}), \
-        patch("inventory.forms.item_forms.get_categories", return_value={}), \
         patch("inventory.forms.item_forms.ItemForm.save", side_effect=DatabaseError), \
         patch("inventory.views.items.render", return_value=HttpResponse()):
         resp = ItemEditView.as_view()(request, pk=item.pk)
@@ -61,7 +60,6 @@ def test_item_edit_handles_non_numeric_values(item_factory):
     request = rf.get(f"/items/{item.pk}/edit/")
     _add_messages(request)
     with patch("inventory.forms.item_forms.get_units", return_value={}), \
-        patch("inventory.forms.item_forms.get_categories", return_value={}), \
         patch("inventory.views.items.render", return_value=HttpResponse()):
         resp = ItemEditView.as_view()(request, pk=item.pk)
     assert resp.status_code == 200
@@ -77,7 +75,6 @@ def test_item_edit_db_error_returns_404():
     _add_messages(request)
     # Simulate DB error when fetching the object
     with patch("inventory.forms.item_forms.get_units", return_value={}), \
-        patch("inventory.forms.item_forms.get_categories", return_value={}), \
         patch("inventory.views.items.get_object_or_404", side_effect=DatabaseError):
         with pytest.raises(Http404):
             ItemEditView.as_view()(request, pk=1)

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -8,13 +8,11 @@ from django.urls import reverse
 from inventory.forms.item_forms import ItemForm
 from inventory.forms import item_forms as forms_module
 from inventory.services import supabase_units
-from inventory.models import Category
 
 
 @pytest.mark.django_db
 def test_item_form_preserves_metadata(monkeypatch):
     monkeypatch.setattr(forms_module, "get_units", lambda: {"kg": ["g"]})
-    monkeypatch.setattr(forms_module, "get_categories", lambda: {})
     form = ItemForm()
     base_field = form.fields["base_unit"]
     purchase_field = form.fields["purchase_unit"]
@@ -29,7 +27,6 @@ def test_item_form_preserves_metadata(monkeypatch):
 @pytest.mark.django_db
 def test_purchase_unit_includes_base(monkeypatch):
     monkeypatch.setattr(forms_module, "get_units", lambda: {"kg": ["kg", "g"]})
-    monkeypatch.setattr(forms_module, "get_categories", lambda: {})
     form = ItemForm(data={"base_unit": "kg"})
     purchase_choices = [c[0] for c in form.fields["purchase_unit"].choices]
     assert "kg" in purchase_choices
@@ -41,7 +38,6 @@ def test_item_form_units_fallback(monkeypatch, caplog):
         raise Exception("boom")
 
     monkeypatch.setattr(forms_module, "get_units", fail)
-    monkeypatch.setattr(forms_module, "get_categories", lambda: {})
     with caplog.at_level("ERROR"):
         form = ItemForm()
     assert form.units_map == {}
@@ -55,105 +51,3 @@ def test_item_form_units_fallback(monkeypatch, caplog):
     assert "Failed to load units map" in caplog.text
 
 
-@pytest.mark.django_db
-def test_item_form_categories_and_subcategories(monkeypatch):
-    monkeypatch.setattr(supabase_units, "get_units", lambda: {"kg": ["g"]})
-    monkeypatch.setattr(forms_module, "get_categories", lambda: {})
-    Category.objects.create(id=1, name="Food")
-    Category.objects.create(id=2, name="Tools")
-    Category.objects.create(id=3, name="Fruit", parent_id=1)
-    Category.objects.create(id=4, name="Veg", parent_id=1)
-    Category.objects.create(id=5, name="Hammer", parent_id=2)
-
-    form = ItemForm()
-    cat_choices = [
-        (("" if val is None else str(val)), label)
-        for val, label in form.fields["category"].choices
-    ]
-    assert cat_choices == [
-        ("", "---------"),
-        ("1", "Food"),
-        ("2", "Tools"),
-    ]
-    sub_choices = [
-        (("" if val is None else str(val)), label)
-        for val, label in form.fields["sub_category"].choices
-    ]
-    assert sub_choices == [("", "---------")]
-
-    data = {
-        "name": "Apple",
-        "base_unit": "kg",
-        "purchase_unit": "g",
-        "category": "1",
-        "sub_category": "3",
-    }
-    form = ItemForm(data=data)
-    sub_choices = [
-        (("" if val is None else str(val)), label)
-        for val, label in form.fields["sub_category"].choices
-    ]
-    assert sub_choices == [
-        ("", "---------"),
-        ("3", "Fruit"),
-        ("4", "Veg"),
-    ]
-    assert form.is_valid()
-    item = form.save()
-    assert item.category.name == "Food"
-    assert item.sub_category.name == "Fruit"
-
-
-@pytest.mark.django_db
-def test_item_form_supabase_categories(monkeypatch):
-    monkeypatch.setattr(forms_module, "get_units", lambda: {"kg": ["g"]})
-    categories_map = {
-        None: [{"id": 1, "name": "Food"}, {"id": 2, "name": "Tools"}],
-        "Food": [{"id": 3, "name": "Fruit"}],
-    }
-    monkeypatch.setattr(forms_module, "get_categories", lambda: categories_map)
-
-    assert Category.objects.count() == 0
-    form = ItemForm()
-    cat_choices = [
-        (("" if val is None else str(val)), label)
-        for val, label in form.fields["category"].choices
-    ]
-    assert ("1", "Food") in cat_choices
-    assert Category.objects.filter(id=1, name="Food").exists()
-    # Ensure subcategories are created
-    assert Category.objects.filter(id=3, name="Fruit", parent_id=1).exists()
-
-
-@pytest.mark.django_db
-def test_item_form_categories_warning(monkeypatch, caplog):
-    monkeypatch.setattr(forms_module, "get_units", lambda: {"kg": ["g"]})
-
-    def fail():
-        raise Exception("boom")
-
-    monkeypatch.setattr(forms_module, "get_categories", fail)
-    with caplog.at_level("ERROR"):
-        form = ItemForm()
-    assert form.supabase_categories_failed
-    request = RequestFactory().get("/")
-    content = render_to_string(
-        "inventory/item_form.html",
-        {"form": form, "is_edit": False, "excluded_fields": []},
-        request=request,
-    )
-    assert "Could not load category options" in content
-    assert "Failed to load categories map" in caplog.text
-
-
-@pytest.mark.django_db
-def test_subcategory_options_view(client, monkeypatch):
-    Category.objects.create(id=1, name="Food")
-    Category.objects.create(id=3, name="Fruit", parent_id=1)
-    Category.objects.create(id=4, name="Veg", parent_id=1)
-    url = reverse("item_subcategory_options")
-    resp = client.get(url, {"category": 1})
-    assert resp.status_code == 200
-    content = resp.content.decode()
-    assert 'value="3"' in content
-    assert 'value="4"' in content

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -7,7 +7,6 @@ from inventory.models import (
     Recipe,
     IndentItem,
     PurchaseOrderItem,
-    Category,
 )
 from django.db.utils import OperationalError
 from inventory.services import item_service
@@ -24,7 +23,6 @@ def clear_tables(db):
         PurchaseOrderItem,
         StockTransaction,
         Item,
-        Category,
     ):
         try:
             model.objects.all().delete()
@@ -35,14 +33,11 @@ def clear_tables(db):
 
 
 def test_add_new_item_inserts_row():
-    cat = Category.objects.create(name="cat")
-    sub = Category.objects.create(name="sub", parent=cat)
     details = {
         "name": "Widget",
         "base_unit": "pcs",
         "purchase_unit": "box",
-        "category": cat,
-        "sub_category": sub,
+        "category_id": 1,
         "permitted_departments": "dept",
         "reorder_point": 1,
         "notes": "n",
@@ -54,14 +49,11 @@ def test_add_new_item_inserts_row():
 
 
 def test_get_all_items_with_stock_includes_unit():
-    cat = Category.objects.create(name="cat")
-    sub = Category.objects.create(name="sub", parent=cat)
     item = Item.objects.create(
         name="Widget",
         base_unit="pcs",
         purchase_unit="box",
-        category=cat,
-        sub_category=sub,
+        category_id=1,
         permitted_departments="dept",
         reorder_point=1,
         notes="n",
@@ -75,14 +67,11 @@ def test_get_all_items_with_stock_includes_unit():
 
 
 def test_get_item_details_includes_unit():
-    cat = Category.objects.create(name="cat")
-    sub = Category.objects.create(name="sub", parent=cat)
     item = Item.objects.create(
         name="Widget",
         base_unit="pcs",
         purchase_unit="box",
-        category=cat,
-        sub_category=sub,
+        category_id=1,
         permitted_departments="dept",
         reorder_point=1,
         notes="n",
@@ -95,15 +84,12 @@ def test_get_item_details_includes_unit():
 
 
 def test_add_items_bulk_inserts_rows():
-    cat = Category.objects.create(name="cat")
-    sub = Category.objects.create(name="sub", parent=cat)
     items = [
         {
             "name": "Widget",
             "base_unit": "pcs",
             "purchase_unit": "box",
-            "category": cat,
-            "sub_category": sub,
+            "category_id": 1,
             "permitted_departments": "dept",
             "reorder_point": 1,
             "notes": "n",
@@ -113,8 +99,7 @@ def test_add_items_bulk_inserts_rows():
             "name": "Gadget",
             "base_unit": "pcs",
             "purchase_unit": "each",
-            "category": cat,
-            "sub_category": sub,
+            "category_id": 1,
             "permitted_departments": "dept2",
             "reorder_point": 2,
             "notes": "n",
@@ -128,10 +113,9 @@ def test_add_items_bulk_inserts_rows():
 
 
 def test_add_items_bulk_validation_failure():
-    cat = Category.objects.create(name="cat")
     items = [
-        {"name": "Widget", "base_unit": "pcs", "purchase_unit": "box", "category": cat},
-        {"name": "", "base_unit": "pcs", "purchase_unit": "box", "category": cat},
+        {"name": "Widget", "base_unit": "pcs", "purchase_unit": "box", "category_id": 1},
+        {"name": "", "base_unit": "pcs", "purchase_unit": "box", "category_id": 1},
     ]
     inserted, errors = item_service.add_items_bulk(items)
     assert inserted == 0
@@ -140,14 +124,11 @@ def test_add_items_bulk_validation_failure():
 
 
 def test_remove_items_bulk_marks_inactive():
-    cat = Category.objects.create(name="cat")
-    sub = Category.objects.create(name="sub", parent=cat)
     widget = Item.objects.create(
         name="Widget",
         base_unit="pcs",
         purchase_unit="box",
-        category=cat,
-        sub_category=sub,
+        category_id=1,
         permitted_departments="dept",
         reorder_point=1,
         notes="n",
@@ -157,8 +138,7 @@ def test_remove_items_bulk_marks_inactive():
         name="Gadget",
         base_unit="pcs",
         purchase_unit="each",
-        category=cat,
-        sub_category=sub,
+        category_id=1,
         permitted_departments="dept2",
         reorder_point=2,
         notes="n",
@@ -178,14 +158,11 @@ def test_remove_items_bulk_requires_ids():
 
 @pytest.mark.django_db
 def test_update_item_changes_fields():
-    cat = Category.objects.create(name="cat")
-    sub = Category.objects.create(name="sub", parent=cat)
     item = Item.objects.create(
         name="Widget",
         base_unit="pcs",
         purchase_unit="box",
-        category=cat,
-        sub_category=sub,
+        category_id=1,
         permitted_departments="dept",
         reorder_point=1,
         notes="n",
@@ -206,14 +183,11 @@ def test_update_item_invalid_id():
 
 @pytest.mark.django_db
 def test_deactivate_and_reactivate_item():
-    cat = Category.objects.create(name="cat")
-    sub = Category.objects.create(name="sub", parent=cat)
     item = Item.objects.create(
         name="Widget",
         base_unit="pcs",
         purchase_unit="box",
-        category=cat,
-        sub_category=sub,
+        category_id=1,
         permitted_departments="dept",
         reorder_point=1,
         notes="n",

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -9,7 +9,6 @@ from inventory.models import (
     RecipeComponent,
     StockTransaction,
     SaleTransaction,
-    Category,
 )
 from inventory.services.recipe_service import (
     create_recipe,
@@ -46,14 +45,11 @@ def create_tables(django_db_blocker):
 
 
 def _create_item(name="Flour", base_unit="kg", purchase_unit="bag", stock=20):
-    cat = Category.objects.create(name="cat")
-    sub = Category.objects.create(name="sub", parent=cat)
     item = Item.objects.create(
         name=name,
         base_unit=base_unit,
         purchase_unit=purchase_unit,
-        category=cat,
-        sub_category=sub,
+        category_id=1,
         permitted_departments="dept",
         reorder_point=0,
         current_stock=stock,


### PR DESCRIPTION
## Summary
- drop Category model in favor of simple `category_id` on items
- simplify item forms, views and services to use category_id
- delete Category migrations and add migration removing table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a98f992d548326958e78527c8da668