### PR TITLE
Refactor item category fields

### DIFF
--- a/inventory/forms/item_forms.py
+++ b/inventory/forms/item_forms.py
@@ -5,6 +5,7 @@ from django import forms
 
 from ..models import Item
 from ..services.supabase_units import get_units
+from ..services.supabase_categories import get_categories
 from .base import StyledFormMixin, INPUT_CLASS
 
 logger = logging.getLogger(__name__)
@@ -18,7 +19,6 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
             "name",
             "base_unit",
             "purchase_unit",
-            "category_id",
             "permitted_departments",
             "reorder_point",
             "current_stock",
@@ -40,6 +40,14 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
             units_map = {}
             logger.error("Failed to load units map", exc_info=True)
         self.units_map = units_map
+
+        try:
+            categories_map = get_categories()
+            logger.debug("Categories map loaded: %s", categories_map)
+        except Exception:
+            categories_map = {}
+            logger.error("Failed to load categories map", exc_info=True)
+        self.categories_map = categories_map
 
         for field in ("name", "base_unit", "purchase_unit"):
             self.fields[field].required = True
@@ -74,5 +82,73 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
         elif self.initial.get("purchase_unit"):
             purchase_field.initial = self.initial.get("purchase_unit")
 
+        # Category fields
+        selected_category = self.data.get("category")
+        selected_sub = self.data.get("sub_category")
+        if not selected_category and self.instance and self.instance.category_id:
+            cat_id = self.instance.category_id
+            for cat in categories_map.get(None, []):
+                if cat["id"] == cat_id:
+                    selected_category = cat["name"]
+                    break
+            if not selected_category:
+                for cat_name, subs in categories_map.items():
+                    if cat_name is None:
+                        continue
+                    for sub in subs:
+                        if sub["id"] == cat_id:
+                            selected_category = cat_name
+                            selected_sub = sub["name"]
+                            break
+                    if selected_category:
+                        break
+
+        self.fields["category"] = forms.ChoiceField(
+            choices=[("", "---------")] + [
+                (c["name"], c["name"]) for c in categories_map.get(None, [])
+            ],
+            required=False,
+        )
+        self.fields["category"].widget.attrs.update(
+            {"id": "id_category", "class": INPUT_CLASS}
+        )
+
+        sub_choices = [("", "---------")]
+        if selected_category:
+            sub_choices += [
+                (c["name"], c["name"]) for c in categories_map.get(selected_category, [])
+            ]
+        self.fields["sub_category"] = forms.ChoiceField(
+            choices=sub_choices,
+            required=False,
+        )
+        self.fields["sub_category"].widget.attrs.update(
+            {"id": "id_sub_category", "class": INPUT_CLASS}
+        )
+
+        if selected_category:
+            self.fields["category"].initial = selected_category
+        if selected_sub:
+            self.fields["sub_category"].initial = selected_sub
+
         # Reapply styling for any widgets replaced above
         self.apply_styling()
+
+    def _resolve_category_id(self, category: str | None, sub_category: str | None):
+        if sub_category:
+            for sub in self.categories_map.get(category, []):
+                if sub["name"] == sub_category:
+                    return sub["id"]
+        if category:
+            for cat in self.categories_map.get(None, []):
+                if cat["name"] == category:
+                    return cat["id"]
+        return None
+
+    def save(self, commit: bool = True):
+        cat_id = self._resolve_category_id(
+            self.cleaned_data.get("category"),
+            self.cleaned_data.get("sub_category"),
+        )
+        self.instance.category_id = cat_id
+        return super().save(commit)

--- a/tests/test_aa_views.py
+++ b/tests/test_aa_views.py
@@ -31,11 +31,12 @@ def test_item_edit_handles_save_error(item_factory):
     rf = RequestFactory()
     request = rf.post(
         f"/items/{item.pk}/edit/",
-        {"name": "Sugar", "category_id": "1"},
+        {"name": "Sugar"},
     )
     _add_messages(request)
     # Simulate DB error on save
     with patch("inventory.forms.item_forms.get_units", return_value={}), \
+        patch("inventory.forms.item_forms.get_categories", return_value={}), \
         patch("inventory.forms.item_forms.ItemForm.save", side_effect=DatabaseError), \
         patch("inventory.views.items.render", return_value=HttpResponse()):
         resp = ItemEditView.as_view()(request, pk=item.pk)

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -53,6 +53,11 @@ def test_item_edit_view_updates_and_clears_cache(client, monkeypatch):
     from inventory.forms import item_forms as forms_module
 
     monkeypatch.setattr(forms_module, "get_units", lambda: {"pcs": ["box"]})
+    monkeypatch.setattr(
+        forms_module,
+        "get_categories",
+        lambda: {None: [{"id": 1, "name": "Food"}], "Food": [{"id": 2, "name": "Fruit"}]},
+    )
     item_service.get_all_items_with_stock.clear()
     item_service.get_distinct_departments_from_items.clear()
 
@@ -72,7 +77,8 @@ def test_item_edit_view_updates_and_clears_cache(client, monkeypatch):
         "name": "Gadget",
         "base_unit": "pcs",
         "purchase_unit": "box",
-        "category_id": "2",
+        "category": "Food",
+        "sub_category": "Fruit",
         "permitted_departments": "dept2",
         "reorder_point": "5",
         "current_stock": "0",


### PR DESCRIPTION
## Summary
- load categories from Supabase and expose category & subcategory as ChoiceFields
- persist selected subcategory's category_id on save
- update tests for new category fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9949aeafc8326968749b62ae20359