### PR TITLE
Remove obsolete subcategory options template

### DIFF
--- a/templates/inventory/_subcategory_options.html
+++ b/templates/inventory/_subcategory_options.html
@@ -1,5 +1,0 @@
-<option value="">---------</option>
-{% for cat in subcategories %}
-<option value="{{ cat.id }}">{{ cat.name }}</option>
-{% endfor %}
-


### PR DESCRIPTION
## Summary
- remove leftover subcategory options template no longer used

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a995ae342c8326b1b15537266635e7