### PR TITLE
Add category filters to items list view

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -60,19 +60,36 @@ class ItemsListView(TemplateView):
         ctx = super().get_context_data(**kwargs)
         request = self.request
         q = (request.GET.get("q") or "").strip()
+        category = (request.GET.get("category") or "").strip()
+        subcategory = (request.GET.get("subcategory") or "").strip()
         active = (request.GET.get("active") or "").strip()
         page_size = (request.GET.get("page_size") or "25").strip()
         sort = (request.GET.get("sort") or "name").strip()
         direction = (request.GET.get("direction") or "asc").strip()
+        categories_map: dict | None = None
+        try:
+            categories_map = get_supabase_categories()
+        except Exception:  # pragma: no cover - defensive
+            categories_map = {}
+            logger.exception("Failed to load categories")
+        categories = [c["name"] for c in categories_map.get(None, [])]
+        subcategories: list[str] = []
+        if category:
+            subcategories = [
+                c["name"] for c in categories_map.get(category, [])
+            ]
         ctx.update(
             {
                 "q": q,
+                "category": category,
+                "subcategory": subcategory,
                 "active": active,
                 "page_size": page_size,
                 "sort": sort,
                 "direction": direction,
-                "categories": [],
-                "subcategories": [],
+                "categories": categories,
+                "subcategories": subcategories,
+                "categories_map": categories_map,
             }
         )
         return ctx

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -46,6 +46,42 @@
         </datalist>
       </div>
       <div class="flex flex-col gap-1">
+        <label for="filter-category" class="text-sm font-medium">Category</label>
+        <select
+          id="filter-category"
+          name="category"
+          class="form-control w-full"
+          hx-get="{% url 'items_table' %}"
+          hx-target="#items_table"
+          hx-trigger="change"
+          hx-include="#filters"
+          hx-indicator="#htmx-spinner"
+        >
+          <option value="">All</option>
+          {% for c in categories %}
+          <option value="{{ c }}"{% if c == category %} selected{% endif %}>{{ c }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="flex flex-col gap-1">
+        <label for="filter-subcategory" class="text-sm font-medium">Subcategory</label>
+        <select
+          id="filter-subcategory"
+          name="subcategory"
+          class="form-control w-full"
+          hx-get="{% url 'items_table' %}"
+          hx-target="#items_table"
+          hx-trigger="change"
+          hx-include="#filters"
+          hx-indicator="#htmx-spinner"
+        >
+          <option value="">All</option>
+          {% for sc in subcategories %}
+          <option value="{{ sc }}"{% if sc == subcategory %} selected{% endif %}>{{ sc }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="flex flex-col gap-1">
         <label class="text-sm font-medium" for="export-btn">&nbsp;</label>
         <button id="export-btn" type="submit" formaction="{% url 'items_export' %}" formmethod="get" class="btn-secondary w-full">Export</button>
       </div>
@@ -54,6 +90,40 @@
     <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
     <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">
   </form>
+  {{ categories_map|json_script:"categories-data" }}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const categories = JSON.parse(document.getElementById('categories-data').textContent);
+      const categorySelect = document.getElementById('filter-category');
+      const subSelect = document.getElementById('filter-subcategory');
+
+      function refreshSubcategories(selected) {
+        const cat = categorySelect.value;
+        const options = categories[cat] || [];
+        subSelect.innerHTML = '<option value="">All</option>';
+        options.forEach(function (opt) {
+          const o = document.createElement('option');
+          o.value = opt.name;
+          o.textContent = opt.name;
+          subSelect.appendChild(o);
+        });
+        if (
+          selected &&
+          options.some(function (o) {
+            return o.name === selected;
+          })
+        ) {
+          subSelect.value = selected;
+        }
+      }
+
+      const initialSub = subSelect.value;
+      refreshSubcategories(initialSub);
+      categorySelect.addEventListener('change', function () {
+        refreshSubcategories();
+      });
+    });
+  </script>
   <div id="items_table"
        hx-get="{% url 'items_table' %}"
        hx-trigger="load"

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -135,6 +135,20 @@ def test_items_list_view_shows_empty_categories(client):
     assert resp.context["subcategories"] == []
 
 
+def test_items_list_view_populates_categories(client, monkeypatch):
+    monkeypatch.setattr(
+        "inventory.views.items.get_supabase_categories",
+        lambda: {None: [{"id": 1, "name": "Food"}], "Food": [{"id": 2, "name": "Fruit"}]},
+    )
+    url = reverse("items_list") + "?category=Food&subcategory=Fruit"
+    resp = client.get(url)
+    assert resp.status_code == 200
+    assert resp.context["categories"] == ["Food"]
+    assert resp.context["subcategories"] == ["Fruit"]
+    assert resp.context["category"] == "Food"
+    assert resp.context["subcategory"] == "Fruit"
+
+
 def test_items_export_view_returns_csv(client):
     _create_item()
     url = reverse("items_export")


### PR DESCRIPTION
## Summary
- load Supabase categories in items list view and expose selected values for filtering
- add category and subcategory dropdowns to items list template with dynamic subcategory updates
- test that items list view populates categories and subcategories

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9a11c2d9883269117c37494d5f37f