### PR TITLE
Render items table on initial load with graceful degradation

### DIFF
--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -2,42 +2,48 @@
 
 {% block headers %}
 <th class="px-4 py-2 text-right">
-  <a hx-get="{% url 'items_table' %}?sort=item_id&direction={% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+  <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=item_id&direction={% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-get="{% url 'items_table' %}?sort=item_id&direction={% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='item_id';document.querySelector('#filters input[name=direction]').value='{% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     ID{% if sort == 'item_id' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
   </a>
   </th>
   <th class="px-4 py-2">
-  <a hx-get="{% url 'items_table' %}?sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+  <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-get="{% url 'items_table' %}?sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='name';document.querySelector('#filters input[name=direction]').value='{% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     Name{% if sort == 'name' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
     </a>
   </th>
 <th class="px-4 py-2">
-  <a hx-get="{% url 'items_table' %}?sort=base_unit&direction={% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+  <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=base_unit&direction={% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-get="{% url 'items_table' %}?sort=base_unit&direction={% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='base_unit';document.querySelector('#filters input[name=direction]').value='{% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     Base Unit{% if sort == 'base_unit' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
     </a>
   </th>
 <th class="px-4 py-2 text-right">
-  <a hx-get="{% url 'items_table' %}?sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+  <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-get="{% url 'items_table' %}?sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='current_stock';document.querySelector('#filters input[name=direction]').value='{% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     Current Stock{% if sort == 'current_stock' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
     </a>
   </th>
 <th class="px-4 py-2 text-right">
-  <a hx-get="{% url 'items_table' %}?sort=reorder_point&direction={% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+  <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=reorder_point&direction={% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-get="{% url 'items_table' %}?sort=reorder_point&direction={% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='reorder_point';document.querySelector('#filters input[name=direction]').value='{% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     Reorder Point{% if sort == 'reorder_point' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
     </a>
   </th>
 <th class="px-4 py-2">
-  <a hx-get="{% url 'items_table' %}?sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+  <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-get="{% url 'items_table' %}?sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='is_active';document.querySelector('#filters input[name=direction]').value='{% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     Active{% if sort == 'is_active' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
@@ -75,17 +81,23 @@
 <div class="flex items-center gap-3 mt-3 flex-wrap">
   <div class="flex items-center gap-1">
     {% if page_obj.has_previous %}
-      <a hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">Prev</a>
+      <a href="{% url 'items_list' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
+         hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
+         hx-target="#items_table" class="px-3 py-1 border rounded">Prev</a>
     {% endif %}
     {% for num in page_obj.paginator.page_range %}
       {% if num == page_obj.number %}
         <span class="px-3 py-1 border rounded bg-gray-200">{{ num }}</span>
       {% else %}
-        <a hx-get="{% url 'items_table' %}?page={{ num }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">{{ num }}</a>
+        <a href="{% url 'items_list' %}?page={{ num }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
+           hx-get="{% url 'items_table' %}?page={{ num }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
+           hx-target="#items_table" class="px-3 py-1 border rounded">{{ num }}</a>
       {% endif %}
     {% endfor %}
     {% if page_obj.has_next %}
-      <a hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}" hx-target="#items_table" class="px-3 py-1 border rounded">Next</a>
+      <a href="{% url 'items_list' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
+         hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
+         hx-target="#items_table" class="px-3 py-1 border rounded">Next</a>
     {% endif %}
   </div>
   <div class="ml-auto flex items-center gap-2">
@@ -97,11 +109,11 @@
       list="page_size_options"
       class="border rounded p-1"
       value="{{ page_size }}"
+      form="filters"
       hx-get="{% url 'items_table' %}"
       hx-target="#items_table"
       hx-trigger="change"
       hx-include="#filters"
-      hx-on:change="document.querySelector('#filters input[name=page_size]').value=this.value"
     />
     <datalist id="page_size_options">
       <option value="10"></option>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -5,7 +5,7 @@
     <a href="{% url 'item_create' %}" class="btn-primary">Add Item</a>
     <a href="{% url 'items_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
   </div>
-  <form id="filters" class="mb-4" hx-indicator="#htmx-spinner">
+  <form id="filters" class="mb-4" hx-indicator="#htmx-spinner" method="get">
     <fieldset class="grid gap-4 grid-cols-5 max-md:grid-cols-2 max-sm:grid-cols-1">
       <legend class="sr-only">Filter Items</legend>
       <div class="flex flex-col gap-1">
@@ -86,9 +86,13 @@
         <button id="export-btn" type="submit" formaction="{% url 'items_export' %}" formmethod="get" class="btn-secondary w-full">Export</button>
       </div>
     </fieldset>
-    <input type="hidden" name="page_size" value="{{ page_size|default:25 }}">
     <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
     <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">
+    <noscript>
+      <div class="mt-2">
+        <button type="submit" class="btn-primary">Apply</button>
+      </div>
+    </noscript>
   </form>
   {{ categories_map|json_script:"categories-data" }}
   <script>
@@ -129,5 +133,6 @@
        hx-trigger="load"
        hx-include="#filters"
        hx-indicator="#htmx-spinner">
+    {{ items_table|safe }}
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Render initial item list table within `ItemsListView` and send it to the template
- Pre-populate the table in `items_list.html` and allow normal form submission when JS is off
- Provide fallback `href` attributes and form bindings so pagination and sorting work without JS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9a2b838708326a961b12e0bb125bd