### PR TITLE
refactor: use shared table class

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 
 /*
-! tailwindcss v3.3.3 | MIT License | https://tailwindcss.com
+! tailwindcss v3.4.1 | MIT License | https://tailwindcss.com
 */
 
 /*
@@ -34,9 +34,11 @@
 4. Use the user's configured `sans` font-family by default.
 5. Use the user's configured `sans` font-feature-settings by default.
 6. Use the user's configured `sans` font-variation-settings by default.
+7. Disable tap highlights on iOS
 */
 
-html {
+html,
+:host {
   line-height: 1.5;
   /* 1 */
   -webkit-text-size-adjust: 100%;
@@ -52,6 +54,8 @@ html {
   /* 5 */
   font-variation-settings: normal;
   /* 6 */
+  -webkit-tap-highlight-color: transparent;
+  /* 7 */
 }
 
 /*
@@ -123,8 +127,10 @@ strong {
 }
 
 /*
-1. Use the user's configured `mono` font family by default.
-2. Correct the odd `em` font sizing in all browsers.
+1. Use the user's configured `mono` font-family by default.
+2. Use the user's configured `mono` font-feature-settings by default.
+3. Use the user's configured `mono` font-variation-settings by default.
+4. Correct the odd `em` font sizing in all browsers.
 */
 
 code,
@@ -133,8 +139,12 @@ samp,
 pre {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   /* 1 */
-  font-size: 1em;
+  font-feature-settings: normal;
   /* 2 */
+  font-variation-settings: normal;
+  /* 3 */
+  font-size: 1em;
+  /* 4 */
 }
 
 /*
@@ -1117,17 +1127,6 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   margin-bottom: calc(1rem * var(--tw-space-y-reverse));
 }
 
-.divide-y > :not([hidden]) ~ :not([hidden]){
-  --tw-divide-y-reverse: 0;
-  border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
-  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
-}
-
-.divide-gray-200 > :not([hidden]) ~ :not([hidden]){
-  --tw-divide-opacity: 1;
-  border-color: rgb(229 231 235 / var(--tw-divide-opacity));
-}
-
 .overflow-y-auto{
   overflow-y: auto;
 }
@@ -1353,11 +1352,6 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   color: rgb(17 24 39 / var(--tw-text-opacity));
 }
 
-.text-gray-300{
-  --tw-text-opacity: 1;
-  color: rgb(209 213 219 / var(--tw-text-opacity));
-}
-
 .text-gray-400{
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity));
@@ -1447,11 +1441,6 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 .focus\:outline-none:focus{
   outline: 2px solid transparent;
   outline-offset: 2px;
-}
-
-:is(.dark .dark\:divide-gray-700) > :not([hidden]) ~ :not([hidden]){
-  --tw-divide-opacity: 1;
-  border-color: rgb(55 65 81 / var(--tw-divide-opacity));
 }
 
 :is(.dark .dark\:border-form-darkBorder){

--- a/templates/components/table.html
+++ b/templates/components/table.html
@@ -1,13 +1,13 @@
 {% comment %}Reusable table component with sticky headers and optional actions and footer slots{% endcomment %}
 <div class="max-md:overflow-x-auto">
   {% block actions %}{% endblock %}
-  <table class="w-full table-auto text-sm divide-y divide-gray-200 dark:divide-gray-700 dark:text-white">
+  <table class="table w-full table-auto text-sm dark:text-white">
     <thead class="sticky top-0 bg-primary text-white dark:bg-primary-700 dark:text-white">
       <tr>
         {% block headers %}{% endblock %}
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-200 dark:divide-gray-700 [&>tr:hover]:bg-table-hoverBg dark:[&>tr:hover]:bg-table-darkHoverBg">
+    <tbody class="[&>tr:hover]:bg-table-hoverBg dark:[&>tr:hover]:bg-table-darkHoverBg">
       {% block rows %}{% endblock %}
     </tbody>
   </table>

--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -1,5 +1,5 @@
 <div class="max-md:overflow-x-auto">
-  <table class="w-full table-auto text-sm divide-y divide-gray-200">
+  <table class="table w-full table-auto text-sm">
     <thead class="bg-primary text-white">
       <tr>
         <th class="px-4 py-2 text-right">
@@ -47,7 +47,7 @@
         <th class="px-4 py-2">Notes</th>
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-200">
+      <tbody>
       {% for row in page_obj %}
       <tr class="odd:bg-gray-50 hover:bg-gray-100">
         <td class="px-4 py-2 text-right">{{ row.transaction_id }}</td>

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -1,5 +1,5 @@
 <div class="max-md:overflow-x-auto">
-  <table class="w-full table-auto text-sm divide-y divide-gray-200">
+    <table class="table w-full table-auto text-sm">
     <thead class="bg-primary text-white">
       <tr>
         <th class="px-4 py-2 text-right">ID</th>
@@ -10,7 +10,7 @@
         <th class="px-4 py-2">Actions</th>
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-200">
+      <tbody>
       {% for row in page_obj %}
       <tr class="odd:bg-gray-50 hover:bg-gray-100">
         <td class="px-4 py-2 text-right">{{ row.indent_id }}</td>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -1,5 +1,5 @@
 <div class="max-md:overflow-x-auto">
-  <table class="w-full table-auto text-sm divide-y divide-gray-200">
+    <table class="table w-full table-auto text-sm">
     <thead class="bg-primary text-white">
       <tr>
         <th class="px-4 py-2 text-right">ID</th>
@@ -11,7 +11,7 @@
         <th class="px-4 py-2">Actions</th>
       </tr>
     </thead>
-    <tbody class="divide-y divide-gray-200">
+      <tbody>
       {% for row in page_obj %}
       <tr class="odd:bg-gray-50 hover:bg-gray-100">
         <td class="px-4 py-2 text-right">{{ row.supplier_id }}</td>


### PR DESCRIPTION
## Summary
- replace `divide-y divide-gray-200` with `.table` class across table templates
- rely on `colors.table.border` in Tailwind theme for higher-contrast borders
- rebuild Tailwind CSS assets

## Testing
- `npx -y tailwindcss@3.4.1 -c tailwind.config.js -i ./static/src/app.css -o ./static/css/app.css`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9a92084dc832682aff036cb1ff445