### PR TITLE
feat: improve table row styling for dark mode

### DIFF
--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -49,7 +49,7 @@
     </thead>
       <tbody>
       {% for row in page_obj %}
-      <tr class="odd:bg-gray-50 hover:bg-gray-100">
+      <tr class="odd:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:hover:bg-gray-700">
         <td class="px-4 py-2 text-right">{{ row.transaction_id }}</td>
         <td class="px-4 py-2">{{ row.item.name }}</td>
         <td class="px-4 py-2">{{ row.transaction_type }}</td>

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -12,7 +12,7 @@
     </thead>
       <tbody>
       {% for row in page_obj %}
-      <tr class="odd:bg-gray-50 hover:bg-gray-100">
+      <tr class="odd:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:hover:bg-gray-700">
         <td class="px-4 py-2 text-right">{{ row.indent_id }}</td>
         <td class="px-4 py-2 text-right">{{ row.mrn }}</td>
         <td class="px-4 py-2">{{ row.requested_by }}</td>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -54,7 +54,7 @@
 
 {% block rows %}
 {% for row in page_obj %}
-<tr class="odd:bg-gray-50 hover:bg-gray-100">
+<tr class="odd:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:hover:bg-gray-700">
   <td class="px-4 py-2 text-right">{{ row.item_id }}</td>
   <td class="px-4 py-2">{{ row.name }}</td>
   <td class="px-4 py-2">{{ row.base_unit }}</td>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -13,7 +13,7 @@
     </thead>
       <tbody>
       {% for row in page_obj %}
-      <tr class="odd:bg-gray-50 hover:bg-gray-100">
+      <tr class="odd:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:hover:bg-gray-700">
         <td class="px-4 py-2 text-right">{{ row.supplier_id }}</td>
         <td class="px-4 py-2">{{ row.name }}</td>
         <td class="px-4 py-2">{{ row.contact_person }}</td>

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -9,7 +9,7 @@
 
 {% block rows %}
 {% for po in orders %}
-<tr class="odd:bg-gray-50 hover:bg-gray-100">
+<tr class="odd:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:hover:bg-gray-700">
   <td class="px-4 py-2 text-right"><a class="text-primary" href="{% url 'purchase_order_detail' po.pk %}">{{ po.pk }}</a></td>
   <td class="px-4 py-2">{{ po.supplier.name }}</td>
   <td class="px-4 py-2">{{ po.order_date }}</td>


### PR DESCRIPTION
## Summary
- add dark mode hover and zebra classes to table rows

## Testing
- `pytest`
- `flake8` *(fails: blank line at end of file, too many blank lines, continuation line with same indent, expected 2 blank lines)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b90bbc4c832694c9c30ef3a93984