### PR TITLE
feat: add dark table header tokens

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -150,6 +150,10 @@
 
   .dark .table th,
   .dark .table td { border: 1px solid theme('colors.table.darkBorder'); }
+  .dark .table thead {
+    background-color: theme('colors.table.darkHeaderBg');
+    color: theme('colors.table.darkHeaderText');
+  }
   .dark .table tbody tr:hover { background-color: theme('colors.table.darkHoverBg'); }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -70,6 +70,8 @@ module.exports = {
           hoverBg: '#e5e7eb',
           darkBorder: '#64748b',
           darkHoverBg: '#1e293b',
+          darkHeaderBg: '#1a46c2',
+          darkHeaderText: '#ffffff',
         },
       },
       fontFamily: {

--- a/templates/components/table.html
+++ b/templates/components/table.html
@@ -2,7 +2,7 @@
 <div class="max-md:overflow-x-auto">
   {% block actions %}{% endblock %}
   <table class="table w-full table-auto text-sm dark:text-white">
-    <thead class="sticky top-0 bg-primary text-white dark:bg-primary-700 dark:text-white">
+    <thead class="sticky top-0">
       <tr>
         {% block headers %}{% endblock %}
       </tr>

--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -1,6 +1,6 @@
 <div class="max-md:overflow-x-auto">
   <table class="table w-full table-auto text-sm">
-    <thead class="bg-primary dark:bg-primary-700 text-white">
+    <thead>
       <tr>
         <th class="px-4 py-2 text-right">
           <a hx-get="{% url 'history_reports' %}?sort=id&direction={% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}"

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -1,6 +1,6 @@
 <div class="max-md:overflow-x-auto">
     <table class="table w-full table-auto text-sm">
-    <thead class="bg-primary dark:bg-primary-700 text-white">
+    <thead>
       <tr>
         <th class="px-4 py-2 text-right">ID</th>
         <th class="px-4 py-2 text-right">MRN</th>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -1,6 +1,6 @@
 <div class="max-md:overflow-x-auto">
     <table class="table w-full table-auto text-sm">
-    <thead class="bg-primary dark:bg-primary-700 text-white">
+    <thead>
       <tr>
         <th class="px-4 py-2 text-right">ID</th>
         <th class="px-4 py-2">Name</th>


### PR DESCRIPTION
## Summary
- add dark table header color tokens
- use tokens in CSS for dark theme table headers
- remove hardcoded header colors from table templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9ba4e3a608326b9c602b218ffba60