### PR TITLE
refactor: centralize table styles with component

### DIFF
--- a/templates/components/table.html
+++ b/templates/components/table.html
@@ -1,15 +1,16 @@
 {% comment %}Reusable table component with sticky headers and optional actions and footer slots{% endcomment %}
 <div class="max-md:overflow-x-auto">
   {% block actions %}{% endblock %}
-  <table class="table w-full table-auto text-sm dark:text-white">
-    <thead class="sticky top-0">
+  <table class="table w-full table-auto text-sm border border-table-border dark:border-table-darkBorder dark:text-white">
+    <thead class="sticky top-0 bg-table-headerBg text-table-headerText dark:bg-table-darkHeaderBg dark:text-table-darkHeaderText [&>tr>th]:px-4 [&>tr>th]:py-2">
       <tr>
         {% block headers %}{% endblock %}
       </tr>
     </thead>
-    <tbody class="[&>tr:hover]:bg-table-hoverBg dark:[&>tr:hover]:bg-table-darkHoverBg">
+    <tbody class="divide-y divide-table-border dark:divide-table-darkBorder [&>tr:nth-child(odd)]:bg-gray-50 dark:[&>tr:nth-child(odd)]:bg-gray-800 [&>tr:hover]:bg-table-hoverBg dark:[&>tr:hover]:bg-table-darkHoverBg [&>tr>td]:px-4 [&>tr>td]:py-2">
       {% block rows %}{% endblock %}
     </tbody>
+    {% block table_footer %}{% endblock %}
   </table>
 </div>
 {% block footer %}{% endblock %}

--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -1,88 +1,88 @@
-<div class="max-md:overflow-x-auto">
-  <table class="table w-full table-auto text-sm">
-    <thead>
-      <tr>
-        <th class="px-4 py-2 text-right">
-          <a hx-get="{% url 'history_reports' %}?sort=id&direction={% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='id';document.querySelector('#filters input[name=direction]').value='{% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            ID{% if sort == 'id' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2">
-          <a hx-get="{% url 'history_reports' %}?sort=item&direction={% if sort == 'item' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='item';document.querySelector('#filters input[name=direction]').value='{% if sort == 'item' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Item{% if sort == 'item' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2">
-          <a hx-get="{% url 'history_reports' %}?sort=type&direction={% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='type';document.querySelector('#filters input[name=direction]').value='{% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Type{% if sort == 'type' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2 text-right">
-          <a hx-get="{% url 'history_reports' %}?sort=qty&direction={% if sort == 'qty' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='qty';document.querySelector('#filters input[name=direction]').value='{% if sort == 'qty' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Qty{% if sort == 'qty' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2 text-right">
-          <a hx-get="{% url 'history_reports' %}?sort=user&direction={% if sort == 'user' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='user';document.querySelector('#filters input[name=direction]').value='{% if sort == 'user' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            User{% if sort == 'user' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2">
-          <a hx-get="{% url 'history_reports' %}?sort=date&direction={% if sort == 'date' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='date';document.querySelector('#filters input[name=direction]').value='{% if sort == 'date' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Date{% if sort == 'date' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2">Notes</th>
-      </tr>
-    </thead>
-      <tbody>
-      {% for row in page_obj %}
-      <tr class="odd:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:hover:bg-gray-700">
-        <td class="px-4 py-2 text-right">{{ row.transaction_id }}</td>
-        <td class="px-4 py-2">{{ row.item.name }}</td>
-        <td class="px-4 py-2">{{ row.transaction_type }}</td>
-        <td class="px-4 py-2 text-right">{{ row.quantity_change }}</td>
-        <td class="px-4 py-2 text-right">{{ row.user_id }}</td>
-        <td class="px-4 py-2">{{ row.transaction_date }}</td>
-        <td class="px-4 py-2">{{ row.notes }}</td>
-      </tr>
-      {% empty %}
-      <tr>
-        <td colspan="7" class="px-4 py-2">No transactions found.</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-    <tfoot>
-      <tr>
-        <td colspan="3" class="px-4 py-2 font-semibold text-right">Total</td>
-        <td class="px-4 py-2 font-semibold text-right">{{ total_quantity }}</td>
-        <td colspan="3"></td>
-      </tr>
-    </tfoot>
-  </table>
-</div>
+{% extends "components/table.html" %}
+
+{% block headers %}
+<th class="text-right">
+  <a hx-get="{% url 'history_reports' %}?sort=id&direction={% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='id';document.querySelector('#filters input[name=direction]').value='{% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    ID{% if sort == 'id' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th>
+  <a hx-get="{% url 'history_reports' %}?sort=item&direction={% if sort == 'item' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='item';document.querySelector('#filters input[name=direction]').value='{% if sort == 'item' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Item{% if sort == 'item' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th>
+  <a hx-get="{% url 'history_reports' %}?sort=type&direction={% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='type';document.querySelector('#filters input[name=direction]').value='{% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Type{% if sort == 'type' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="text-right">
+  <a hx-get="{% url 'history_reports' %}?sort=qty&direction={% if sort == 'qty' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='qty';document.querySelector('#filters input[name=direction]').value='{% if sort == 'qty' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Qty{% if sort == 'qty' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="text-right">
+  <a hx-get="{% url 'history_reports' %}?sort=user&direction={% if sort == 'user' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='user';document.querySelector('#filters input[name=direction]').value='{% if sort == 'user' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    User{% if sort == 'user' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th>
+  <a hx-get="{% url 'history_reports' %}?sort=date&direction={% if sort == 'date' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='date';document.querySelector('#filters input[name=direction]').value='{% if sort == 'date' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Date{% if sort == 'date' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th>Notes</th>
+{% endblock %}
+
+{% block rows %}
+{% for row in page_obj %}
+<tr>
+  <td class="text-right">{{ row.transaction_id }}</td>
+  <td>{{ row.item.name }}</td>
+  <td>{{ row.transaction_type }}</td>
+  <td class="text-right">{{ row.quantity_change }}</td>
+  <td class="text-right">{{ row.user_id }}</td>
+  <td>{{ row.transaction_date }}</td>
+  <td>{{ row.notes }}</td>
+</tr>
+{% empty %}
+<tr>
+  <td colspan="7">No transactions found.</td>
+</tr>
+{% endfor %}
+{% endblock %}
+
+{% block table_footer %}
+<tfoot>
+  <tr>
+    <td colspan="3" class="font-semibold text-right">Total</td>
+    <td class="font-semibold text-right">{{ total_quantity }}</td>
+    <td colspan="3"></td>
+  </tr>
+</tfoot>
+{% endblock %}
+
+{% block footer %}
 <div class="flex items-center gap-3 mt-3">
   {% if page_obj.has_previous %}
-  <a hx-get="{% url 'history_reports' %}?page={{ page_obj.previous_page_number }}"
-     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-     class="px-3 py-1 border rounded">Prev</a>
+  <a hx-get="{% url 'history_reports' %}?page={{ page_obj.previous_page_number }}" hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner" class="px-3 py-1 border rounded">Prev</a>
   {% endif %}
   <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
   {% if page_obj.has_next %}
-  <a hx-get="{% url 'history_reports' %}?page={{ page_obj.next_page_number }}"
-     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-     class="px-3 py-1 border rounded">Next</a>
+  <a hx-get="{% url 'history_reports' %}?page={{ page_obj.next_page_number }}" hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner" class="px-3 py-1 border rounded">Next</a>
   {% endif %}
 </div>
+{% endblock %}
+

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -1,36 +1,35 @@
-<div class="max-md:overflow-x-auto">
-    <table class="table w-full table-auto text-sm">
-    <thead>
-      <tr>
-        <th class="px-4 py-2 text-right">ID</th>
-        <th class="px-4 py-2 text-right">MRN</th>
-        <th class="px-4 py-2">Requested By</th>
-        <th class="px-4 py-2">Department</th>
-        <th class="px-4 py-2">Status</th>
-        <th class="px-4 py-2">Actions</th>
-      </tr>
-    </thead>
-      <tbody>
-      {% for row in page_obj %}
-      <tr class="odd:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:hover:bg-gray-700">
-        <td class="px-4 py-2 text-right">{{ row.indent_id }}</td>
-        <td class="px-4 py-2 text-right">{{ row.mrn }}</td>
-        <td class="px-4 py-2">{{ row.requested_by }}</td>
-        <td class="px-4 py-2">{{ row.department }}</td>
-        <td class="px-4 py-2"><span class="px-2 py-1 rounded {{ badges[row.status|upper] }}">{{ row.status }}</span></td>
-        <td class="px-4 py-2"><a href="{% url 'indent_detail' row.indent_id %}" class="text-primary">View</a></td>
-      </tr>
-      {% empty %}
-      <tr>
-        <td colspan="6" class="px-4 py-2 text-center">
-          0 indents yet.
-          <a href="{% url 'indent_create' %}" class="btn-primary ml-2">New Indent</a>
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
+{% extends "components/table.html" %}
+
+{% block headers %}
+<th class="text-right">ID</th>
+<th class="text-right">MRN</th>
+<th>Requested By</th>
+<th>Department</th>
+<th>Status</th>
+<th>Actions</th>
+{% endblock %}
+
+{% block rows %}
+{% for row in page_obj %}
+<tr>
+  <td class="text-right">{{ row.indent_id }}</td>
+  <td class="text-right">{{ row.mrn }}</td>
+  <td>{{ row.requested_by }}</td>
+  <td>{{ row.department }}</td>
+  <td><span class="px-2 py-1 rounded {{ badges[row.status|upper] }}">{{ row.status }}</span></td>
+  <td><a href="{% url 'indent_detail' row.indent_id %}" class="text-primary">View</a></td>
+</tr>
+{% empty %}
+<tr>
+  <td colspan="6" class="text-center">
+    0 indents yet.
+    <a href="{% url 'indent_create' %}" class="btn-primary ml-2">New Indent</a>
+  </td>
+</tr>
+{% endfor %}
+{% endblock %}
+
+{% block footer %}
 <div class="flex items-center gap-3 mt-3">
   {% if page_obj.has_previous %}
     <a hx-get="{% url 'indents_table' %}?page={{ page_obj.previous_page_number }}&status={{ status|urlencode }}&q={{ q|urlencode }}" hx-target="#indents_table" class="px-3 py-1 border rounded">Prev</a>
@@ -40,3 +39,5 @@
     <a hx-get="{% url 'indents_table' %}?page={{ page_obj.next_page_number }}&status={{ status|urlencode }}&q={{ q|urlencode }}" hx-target="#indents_table" class="px-3 py-1 border rounded">Next</a>
   {% endif %}
 </div>
+{% endblock %}
+

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,7 +1,7 @@
 {% extends "components/table.html" %}
 
 {% block headers %}
-<th class="px-4 py-2 text-right">
+<th class="text-right">
   <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=item_id&direction={% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-get="{% url 'items_table' %}?sort=item_id&direction={% if sort == 'item_id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
@@ -9,7 +9,7 @@
     ID{% if sort == 'item_id' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
   </a>
   </th>
-  <th class="px-4 py-2">
+  <th>
   <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-get="{% url 'items_table' %}?sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
@@ -17,7 +17,7 @@
     Name{% if sort == 'name' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
     </a>
   </th>
-<th class="px-4 py-2">
+  <th>
   <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=base_unit&direction={% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-get="{% url 'items_table' %}?sort=base_unit&direction={% if sort == 'base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
@@ -25,7 +25,7 @@
     Base Unit{% if sort == 'base_unit' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
     </a>
   </th>
-<th class="px-4 py-2 text-right">
+  <th class="text-right">
   <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-get="{% url 'items_table' %}?sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
@@ -33,7 +33,7 @@
     Current Stock{% if sort == 'current_stock' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
     </a>
   </th>
-<th class="px-4 py-2 text-right">
+  <th class="text-right">
   <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=reorder_point&direction={% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-get="{% url 'items_table' %}?sort=reorder_point&direction={% if sort == 'reorder_point' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
@@ -41,7 +41,7 @@
     Reorder Point{% if sort == 'reorder_point' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
     </a>
   </th>
-<th class="px-4 py-2">
+<th>
   <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-get="{% url 'items_table' %}?sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#items_table" hx-include="#filters"
@@ -49,19 +49,19 @@
     Active{% if sort == 'is_active' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
   </a>
 </th>
-<th class="px-4 py-2">Actions</th>
+<th>Actions</th>
 {% endblock %}
 
 {% block rows %}
 {% for row in page_obj %}
-<tr class="odd:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:hover:bg-gray-700">
-  <td class="px-4 py-2 text-right">{{ row.item_id }}</td>
-  <td class="px-4 py-2">{{ row.name }}</td>
-  <td class="px-4 py-2">{{ row.base_unit }}</td>
-  <td class="px-4 py-2 text-right">{{ row.current_stock }}</td>
-  <td class="px-4 py-2 text-right">{{ row.reorder_point }}</td>
-  <td class="px-4 py-2">{{ row.is_active }}</td>
-  <td class="px-4 py-2">
+<tr>
+  <td class="text-right">{{ row.item_id }}</td>
+  <td>{{ row.name }}</td>
+  <td>{{ row.base_unit }}</td>
+  <td class="text-right">{{ row.current_stock }}</td>
+  <td class="text-right">{{ row.reorder_point }}</td>
+  <td>{{ row.is_active }}</td>
+  <td>
     <a href="{% url 'item_detail' row.item_id %}" class="text-primary mr-2">View</a>
     <a href="{% url 'item_edit' row.item_id %}" class="text-primary mr-2">Edit</a>
     <a href="{% url 'item_delete' row.item_id %}" class="text-primary">Delete/Deactivate</a>
@@ -69,7 +69,7 @@
 </tr>
 {% empty %}
 <tr>
-  <td colspan="9" class="px-4 py-2">
+  <td colspan="9">
     {% url 'item_create' as item_create_url %}
     {% include "components/empty_state.html" with title="No Items" message="No items found." cta_label="Add Item" cta_url=item_create_url %}
   </td>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -1,56 +1,55 @@
-<div class="max-md:overflow-x-auto">
-    <table class="table w-full table-auto text-sm">
-    <thead>
-      <tr>
-        <th class="px-4 py-2 text-right">ID</th>
-        <th class="px-4 py-2">Name</th>
-        <th class="px-4 py-2">Contact</th>
-        <th class="px-4 py-2">Email</th>
-        <th class="px-4 py-2 text-right">Phone</th>
-        <th class="px-4 py-2">Active</th>
-        <th class="px-4 py-2">Actions</th>
-      </tr>
-    </thead>
-      <tbody>
-      {% for row in page_obj %}
-      <tr class="odd:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:hover:bg-gray-700">
-        <td class="px-4 py-2 text-right">{{ row.supplier_id }}</td>
-        <td class="px-4 py-2">{{ row.name }}</td>
-        <td class="px-4 py-2">{{ row.contact_person }}</td>
-        <td class="px-4 py-2">{{ row.email }}</td>
-        <td class="px-4 py-2 text-right">{{ row.phone }}</td>
-        <td class="px-4 py-2">{{ row.is_active }}</td>
-        <td class="px-4 py-2">
-          <a href="{% url 'supplier_edit' row.supplier_id %}" class="text-primary mr-2">Edit</a>
-          <form
-            hx-post="{% url 'supplier_toggle_active' row.supplier_id %}"
-            hx-target="#suppliers_table"
-            hx-confirm="Are you sure you want to toggle this supplier?"
-            method="post"
-            class="inline"
-          >
-            {% csrf_token %}
-            <input type="hidden" name="q" value="{{ q }}" />
-            <input type="hidden" name="page" value="{{ page_obj.number }}" />
-            <input type="hidden" name="active" value="{{ active }}" />
-            <input type="hidden" name="page_size" value="{{ page_size }}" />
-            <input type="hidden" name="sort" value="{{ sort }}" />
-            <input type="hidden" name="direction" value="{{ direction }}" />
-            <button type="submit" class="text-primary">Toggle</button>
-          </form>
-        </td>
-      </tr>
-      {% empty %}
-      <tr>
-        <td colspan="7" class="px-4 py-2 text-center">
-          0 suppliers yet.
-          <a href="{% url 'supplier_create' %}" class="btn-primary ml-2">Add Supplier</a>
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
+{% extends "components/table.html" %}
+
+{% block headers %}
+<th class="text-right">ID</th>
+<th>Name</th>
+<th>Contact</th>
+<th>Email</th>
+<th class="text-right">Phone</th>
+<th>Active</th>
+<th>Actions</th>
+{% endblock %}
+
+{% block rows %}
+{% for row in page_obj %}
+<tr>
+  <td class="text-right">{{ row.supplier_id }}</td>
+  <td>{{ row.name }}</td>
+  <td>{{ row.contact_person }}</td>
+  <td>{{ row.email }}</td>
+  <td class="text-right">{{ row.phone }}</td>
+  <td>{{ row.is_active }}</td>
+  <td>
+    <a href="{% url 'supplier_edit' row.supplier_id %}" class="text-primary mr-2">Edit</a>
+    <form
+      hx-post="{% url 'supplier_toggle_active' row.supplier_id %}"
+      hx-target="#suppliers_table"
+      hx-confirm="Are you sure you want to toggle this supplier?"
+      method="post"
+      class="inline"
+    >
+      {% csrf_token %}
+      <input type="hidden" name="q" value="{{ q }}" />
+      <input type="hidden" name="page" value="{{ page_obj.number }}" />
+      <input type="hidden" name="active" value="{{ active }}" />
+      <input type="hidden" name="page_size" value="{{ page_size }}" />
+      <input type="hidden" name="sort" value="{{ sort }}" />
+      <input type="hidden" name="direction" value="{{ direction }}" />
+      <button type="submit" class="text-primary">Toggle</button>
+    </form>
+  </td>
+</tr>
+{% empty %}
+<tr>
+  <td colspan="7" class="text-center">
+    0 suppliers yet.
+    <a href="{% url 'supplier_create' %}" class="btn-primary ml-2">Add Supplier</a>
+  </td>
+</tr>
+{% endfor %}
+{% endblock %}
+
+{% block footer %}
 <div class="flex items-center gap-3 mt-3">
   {% if page_obj.has_previous %}
     <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
@@ -62,4 +61,5 @@
        hx-target="#suppliers_table" class="px-3 py-1 border rounded">Next</a>
   {% endif %}
 </div>
+{% endblock %}
 

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -1,23 +1,23 @@
 {% extends "components/table.html" %}
 
 {% block headers %}
-<th class="px-4 py-2 text-right">PO #</th>
-<th class="px-4 py-2">Supplier</th>
-<th class="px-4 py-2">Order Date</th>
-<th class="px-4 py-2">Status</th>
+<th class="text-right">PO #</th>
+<th>Supplier</th>
+<th>Order Date</th>
+<th>Status</th>
 {% endblock %}
 
 {% block rows %}
 {% for po in orders %}
-<tr class="odd:bg-gray-50 hover:bg-gray-100 dark:odd:bg-gray-800 dark:hover:bg-gray-700">
-  <td class="px-4 py-2 text-right"><a class="text-primary" href="{% url 'purchase_order_detail' po.pk %}">{{ po.pk }}</a></td>
-  <td class="px-4 py-2">{{ po.supplier.name }}</td>
-  <td class="px-4 py-2">{{ po.order_date }}</td>
-  <td class="px-4 py-2"><span class="px-2 py-1 rounded text-xs {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
+<tr>
+  <td class="text-right"><a class="text-primary" href="{% url 'purchase_order_detail' po.pk %}">{{ po.pk }}</a></td>
+  <td>{{ po.supplier.name }}</td>
+  <td>{{ po.order_date }}</td>
+  <td><span class="px-2 py-1 rounded text-xs {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
 </tr>
 {% empty %}
 <tr>
-  <td colspan="4" class="px-4 py-2">
+  <td colspan="4">
     {% url 'purchase_order_create' as po_create_url %}
     {% include "components/empty_state.html" with title="No Purchase Orders" message="Create a new purchase order to get started." cta_label="New PO" cta_url=po_create_url %}
   </td>


### PR DESCRIPTION
## Summary
- centralize table structure and coloring in a reusable component
- replace inline table markup in inventory partials with table component

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9bb792ff083269fea93ddcb538a96