### PR TITLE
Fix table visibility and improve theme switching

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -824,8 +824,12 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 }
 
 .table thead {
-  background-color: #1a46c2;
+  background-color: var(--color-primary);
   color: #ffffff;
+}
+
+.table tbody tr {
+  background-color: #ffffff;
 }
 
 .table tbody tr:hover {
@@ -833,8 +837,17 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 }
 
 .dark .table th,
-  .dark .table td {
+.dark .table td {
   border: 1px solid #64748b;
+}
+
+.dark .table thead {
+  background-color: var(--color-primary);
+  color: #ffffff;
+}
+
+.dark .table tbody tr {
+  background-color: #0f172a;
 }
 
 .dark .table tbody tr:hover {

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -6,13 +6,16 @@
       document.documentElement.classList.remove('dark');
     }
   }
+
+  // Apply the user's preferred theme immediately to avoid flashes of incorrect styling
+  const stored = localStorage.getItem('theme');
+  if (stored) {
+    applyTheme(stored);
+  } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    applyTheme('dark');
+  }
+
   document.addEventListener('DOMContentLoaded', function() {
-    const stored = localStorage.getItem('theme');
-    if (stored) {
-      applyTheme(stored);
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      applyTheme('dark');
-    }
     const toggle = document.getElementById('theme-toggle');
     if (toggle) {
       toggle.addEventListener('click', function() {

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -149,13 +149,19 @@
     text-align: left;
   }
   .table thead {
-    background-color: theme('colors.table.headerBg');
+    background-color: var(--color-primary);
     color: theme('colors.table.headerText');
   }
+  .table tbody tr { background-color: theme('colors.form.bg'); }
   .table tbody tr:hover { background-color: theme('colors.table.hoverBg'); }
 
   .dark .table th,
   .dark .table td { border: 1px solid theme('colors.table.darkBorder'); }
+  .dark .table thead {
+    background-color: var(--color-primary);
+    color: theme('colors.table.headerText');
+  }
+  .dark .table tbody tr { background-color: theme('colors.body.dark'); }
   .dark .table tbody tr:hover { background-color: theme('colors.table.darkHoverBg'); }
 }
 


### PR DESCRIPTION
## Summary
- apply saved theme immediately to avoid flash of incorrect styles
- style table headers and rows with theme-aware colors for light/dark modes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9c03e148c8326a0b8e80c73d16d4d