### PR TITLE
Use design tokens for Tailwind and custom CSS

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -1,10 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
-
-:root {
-  --color-primary: #1a46c2;
-  --color-secondary: #036045;
-  --color-accent: #ad5f04;
-}
+@import './tokens.css';
 
 @tailwind base;
 @tailwind components;
@@ -80,8 +75,8 @@
     border: 1px solid theme('colors.form.border');
     background-color: theme('colors.form.bg');
     color: theme('colors.form.text');
-    padding: 0.5rem;
-    border-radius: 0.25rem;
+    padding: var(--space-2);
+    border-radius: var(--space-1);
     width: 100%;
   }
   form input:not([type='checkbox']):not([type='radio']):focus,
@@ -97,7 +92,7 @@
     border: 1px solid theme('colors.form.border');
     background-color: theme('colors.form.bg');
     color: theme('colors.form.text');
-    border-radius: 0.25rem;
+    border-radius: var(--space-1);
   }
 
   .form-radio {
@@ -145,7 +140,7 @@
   .table th,
   .table td {
     border: 1px solid theme('colors.table.border');
-    padding: 0.5rem 1rem;
+    padding: var(--space-2) var(--space-4);
     text-align: left;
   }
   .table thead {
@@ -170,9 +165,12 @@
 }
 
 @media (max-width: 768px) {
-  h1 { font-size: 1.6rem; }
-  h2 { font-size: 1.3rem; }
+  h1 { font-size: var(--font-size-h1); }
+  h2 { font-size: var(--font-size-h2); }
   .badge-success,
   .badge-warning,
-  .badge-error { font-size: 0.8rem; padding: 2px 4px; }
+  .badge-error {
+    font-size: var(--font-size-badge);
+    padding: var(--space-0-5) var(--space-1);
+  }
 }

--- a/static/src/tokens.css
+++ b/static/src/tokens.css
@@ -1,0 +1,19 @@
+:root {
+  /* Color tokens */
+  --color-primary: #1a46c2;
+  --color-secondary: #036045;
+  --color-accent: #ad5f04;
+
+  /* Spacing tokens */
+  --space-0-5: 0.125rem;
+  --space-1: 0.25rem;
+  --space-1-5: 0.375rem;
+  --space-2: 0.5rem;
+  --space-4: 1rem;
+
+  /* Font size tokens */
+  --font-size-base: 1rem;
+  --font-size-h1: 1.6rem;
+  --font-size-h2: 1.3rem;
+  --font-size-badge: 0.8rem;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,12 +39,25 @@ module.exports = {
         },
         table: {
           border: '#6b7280',
-          headerBg: '#1a46c2',
+          headerBg: 'var(--color-primary)',
           headerText: '#ffffff',
           hoverBg: '#e5e7eb',
           darkBorder: '#64748b',
           darkHoverBg: '#1e293b',
         },
+      },
+      spacing: {
+        '0.5': 'var(--space-0-5)',
+        '1': 'var(--space-1)',
+        '1.5': 'var(--space-1-5)',
+        '2': 'var(--space-2)',
+        '4': 'var(--space-4)',
+      },
+      fontSize: {
+        base: 'var(--font-size-base)',
+        h1: 'var(--font-size-h1)',
+        h2: 'var(--font-size-h2)',
+        badge: 'var(--font-size-badge)',
       },
       fontFamily: {
         sans: ['Roboto', 'sans-serif'],


### PR DESCRIPTION
## Summary
- add tokens.css with color, spacing, and font-size variables
- import tokens in app.css and replace hard-coded values
- update Tailwind config to reference shared tokens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9c2b19b8c8326b8fd99d50cab9c9c