### PR TITLE
Refactor navigation into component and external script

### DIFF
--- a/static/js/nav.js
+++ b/static/js/nav.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', function () {
+  document.getElementById('nav-toggle').addEventListener('click', function () {
+    document.getElementById('nav-menu').classList.toggle('max-sm:hidden');
+  });
+  document.querySelectorAll('.nav-group').forEach(function (group) {
+    const btn = group.querySelector('[data-dropdown]');
+    const menu = document.getElementById(btn.dataset.dropdown);
+    let hideTimer;
+
+    group.addEventListener('mouseenter', function () {
+      clearTimeout(hideTimer);
+      if (window.matchMedia('(min-width: 641px)').matches) {
+        menu.classList.remove('hidden');
+      }
+    });
+
+    group.addEventListener('mouseleave', function () {
+      if (window.matchMedia('(min-width: 641px)').matches) {
+        hideTimer = setTimeout(function () {
+          menu.classList.add('hidden');
+        }, 200);
+      }
+    });
+
+    group.addEventListener('focusin', function () {
+      clearTimeout(hideTimer);
+      if (window.matchMedia('(min-width: 641px)').matches) {
+        menu.classList.remove('hidden');
+      }
+    });
+
+    group.addEventListener('focusout', function (e) {
+      if (window.matchMedia('(min-width: 641px)').matches && !group.contains(e.relatedTarget)) {
+        hideTimer = setTimeout(function () {
+          menu.classList.add('hidden');
+        }, 200);
+      }
+    });
+
+    btn.addEventListener('click', function (e) {
+      if (window.matchMedia('(max-width: 640px)').matches) {
+        e.preventDefault();
+        menu.classList.toggle('hidden');
+      }
+    });
+  });
+});

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -8,108 +8,10 @@
     <link href="{% static 'css/app.css' %}" rel="stylesheet">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="{% static 'js/theme.js' %}"></script>
+    <script src="{% static 'js/nav.js' %}"></script>
   </head>
   <body class="min-h-screen">
-    <nav class="bg-primary">
-      <div class="container mx-auto px-8 max-md:px-6 max-sm:px-4">
-        <div class="flex items-center justify-between h-16">
-          <div class="flex-shrink-0">
-            <a href="{% url 'root' %}" class="text-white font-bold">Inventory App</a>
-          </div>
-          <div class="flex items-center">
-            <button id="nav-toggle" class="hidden max-sm:block text-white hover:text-white focus:outline-none" aria-label="Toggle navigation">
-              <svg aria-hidden="true" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
-            </button>
-            <div id="nav-menu" class="flex space-x-4 ml-4 max-sm:hidden">
-              <div class="relative nav-group">
-                <button data-dropdown="overview-menu" class="flex items-center justify-between text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Overview</button>
-                <div id="overview-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
-                  {% url 'dashboard' as dashboard_url %}
-                  <a href="{{ dashboard_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == dashboard_url %}active{% endif %}">
-                    <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
-                    Dashboard
-                  </a>
-                  {% url 'history_reports' as reports_url %}
-                  <a href="{{ reports_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == reports_url %}active{% endif %}">
-                    <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></svg>
-                    Reports
-                  </a>
-                </div>
-              </div>
-              <div class="relative nav-group">
-                <button data-dropdown="inventory-menu" class="flex items-center justify-between text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Inventory</button>
-                <div id="inventory-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
-                  {% url 'items_list' as items_url %}
-                  <a href="{{ items_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == items_url %}active{% endif %}">
-                    <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/></svg>
-                    Items
-                  </a>
-                  {% url 'stock_movements' as movements_url %}
-                  <a href="{{ movements_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == movements_url %}active{% endif %}">
-                    <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"/></svg>
-                    Stock Movements
-                  </a>
-                </div>
-              </div>
-              <div class="relative nav-group">
-                <button data-dropdown="procurement-menu" class="flex items-center justify-between text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Procurement</button>
-                <div id="procurement-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
-                  {% url 'suppliers_list' as suppliers_url %}
-                  <a href="{{ suppliers_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == suppliers_url %}active{% endif %}">
-                    <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 0 1-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.213-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"/></svg>
-                    Suppliers
-                  </a>
-                  {% url 'indents_list' as indents_url %}
-                  <a href="{{ indents_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == indents_url %}active{% endif %}">
-                    <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"/></svg>
-                    Indents
-                  </a>
-                  {% url 'purchase_orders_list' as po_url %}
-                  <a href="{{ po_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == po_url %}active{% endif %}">
-                    <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/></svg>
-                    Purchase Orders
-                  </a>
-                  {% url 'grn_list' as grn_url %}
-                  <a href="{{ grn_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == grn_url %}active{% endif %}">
-                    <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M10.125 2.25h-4.5c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125v-9M10.125 2.25h.375a9 9 0 0 1 9 9v.375M10.125 2.25A3.375 3.375 0 0 1 13.5 5.625v1.5c0 .621.504 1.125 1.125 1.125h1.5a3.375 3.375 0 0 1 3.375 3.375M9 15l2.25 2.25L15 12"/></svg>
-                    GRNs
-                  </a>
-                </div>
-              </div>
-              <div class="relative nav-group">
-                <button data-dropdown="production-menu" class="flex items-center justify-between text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Production</button>
-                <div id="production-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
-                  {% url 'recipes_list' as recipes_url %}
-                  <a href="{{ recipes_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == recipes_url %}active{% endif %}">
-                    <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/></svg>
-                    Recipes
-                  </a>
-                </div>
-              </div>
-              <div class="relative nav-group">
-                <button data-dropdown="account-menu" class="flex items-center justify-between text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Account</button>
-                <div id="account-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
-                  {% if user.is_authenticated %}
-                    {% url 'logout' as logout_url %}
-                    <a href="{{ logout_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == logout_url %}active{% endif %}">
-                      <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15M12 9l-3 3m0 0 3 3m-3-3h12.75"/></svg>
-                      Logout
-                    </a>
-                  {% else %}
-                    {% url 'login' as login_url %}
-                    <a href="{{ login_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == login_url %}active{% endif %}">
-                      <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"/></svg>
-                      Login
-                    </a>
-                  {% endif %}
-                </div>
-              </div>
-            </div>
-            <button id="theme-toggle" class="ml-4 text-white hover:text-white dark:text-gray-200" aria-label="Toggle theme">🌓</button>
-          </div>
-        </div>
-      </div>
-    </nav>
+    {% include "components/nav.html" %}
     <div id="htmx-spinner" class="hidden fixed inset-0 flex items-center justify-center bg-black/25">
       <div class="h-12 w-12 border-4 border-primary border-t-transparent rounded-full animate-spin"></div>
     </div>
@@ -121,51 +23,6 @@
     </div>
     {% include "components/colour_customizer.html" %}
     <script>
-      document.getElementById('nav-toggle').addEventListener('click', function () {
-        document.getElementById('nav-menu').classList.toggle('max-sm:hidden');
-      });
-      document.querySelectorAll('.nav-group').forEach(function (group) {
-        const btn = group.querySelector('[data-dropdown]');
-        const menu = document.getElementById(btn.dataset.dropdown);
-        let hideTimer;
-
-        group.addEventListener('mouseenter', function () {
-          clearTimeout(hideTimer);
-          if (window.matchMedia('(min-width: 641px)').matches) {
-            menu.classList.remove('hidden');
-          }
-        });
-
-        group.addEventListener('mouseleave', function () {
-          if (window.matchMedia('(min-width: 641px)').matches) {
-            hideTimer = setTimeout(function () {
-              menu.classList.add('hidden');
-            }, 200);
-          }
-        });
-
-        group.addEventListener('focusin', function () {
-          clearTimeout(hideTimer);
-          if (window.matchMedia('(min-width: 641px)').matches) {
-            menu.classList.remove('hidden');
-          }
-        });
-
-        group.addEventListener('focusout', function (e) {
-          if (window.matchMedia('(min-width: 641px)').matches && !group.contains(e.relatedTarget)) {
-            hideTimer = setTimeout(function () {
-              menu.classList.add('hidden');
-            }, 200);
-          }
-        });
-
-        btn.addEventListener('click', function (e) {
-          if (window.matchMedia('(max-width: 640px)').matches) {
-            e.preventDefault();
-            menu.classList.toggle('hidden');
-          }
-        });
-      });
       document.body.addEventListener('htmx:request', function () {
         document.getElementById('htmx-spinner').classList.remove('hidden');
       });

--- a/templates/components/nav.html
+++ b/templates/components/nav.html
@@ -1,0 +1,100 @@
+<nav class="bg-primary">
+  <div class="container mx-auto px-8 max-md:px-6 max-sm:px-4">
+    <div class="flex items-center justify-between h-16">
+      <div class="flex-shrink-0">
+        <a href="{% url 'root' %}" class="text-white font-bold">Inventory App</a>
+      </div>
+      <div class="flex items-center">
+        <button id="nav-toggle" class="hidden max-sm:block text-white hover:text-white focus:outline-none" aria-label="Toggle navigation">
+          <svg aria-hidden="true" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
+        </button>
+        <div id="nav-menu" class="flex space-x-4 ml-4 max-sm:hidden">
+          <div class="relative nav-group">
+            <button data-dropdown="overview-menu" class="flex items-center justify-between text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Overview</button>
+            <div id="overview-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
+              {% url 'dashboard' as dashboard_url %}
+              <a href="{{ dashboard_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == dashboard_url %}active{% endif %}">
+                <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
+                Dashboard
+              </a>
+              {% url 'history_reports' as reports_url %}
+              <a href="{{ reports_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == reports_url %}active{% endif %}">
+                <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></svg>
+                Reports
+              </a>
+            </div>
+          </div>
+          <div class="relative nav-group">
+            <button data-dropdown="inventory-menu" class="flex items-center justify-between text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Inventory</button>
+            <div id="inventory-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
+              {% url 'items_list' as items_url %}
+              <a href="{{ items_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == items_url %}active{% endif %}">
+                <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/></svg>
+                Items
+              </a>
+              {% url 'stock_movements' as movements_url %}
+              <a href="{{ movements_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == movements_url %}active{% endif %}">
+                <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"/></svg>
+                Stock Movements
+              </a>
+            </div>
+          </div>
+          <div class="relative nav-group">
+            <button data-dropdown="procurement-menu" class="flex items-center justify-between text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Procurement</button>
+            <div id="procurement-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
+              {% url 'suppliers_list' as suppliers_url %}
+              <a href="{{ suppliers_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == suppliers_url %}active{% endif %}">
+                <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 0 1-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.213-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"/></svg>
+                Suppliers
+              </a>
+              {% url 'indents_list' as indents_url %}
+              <a href="{{ indents_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == indents_url %}active{% endif %}">
+                <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"/></svg>
+                Indents
+              </a>
+              {% url 'purchase_orders_list' as po_url %}
+              <a href="{{ po_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == po_url %}active{% endif %}">
+                <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/></svg>
+                Purchase Orders
+              </a>
+              {% url 'grn_list' as grn_url %}
+              <a href="{{ grn_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == grn_url %}active{% endif %}">
+                <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M10.125 2.25h-4.5c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125v-9M10.125 2.25h.375a9 9 0 0 1 9 9v.375M10.125 2.25A3.375 3.375 0 0 1 13.5 5.625v1.5c0 .621.504 1.125 1.125 1.125h1.5a3.375 3.375 0 0 1 3.375 3.375M9 15l2.25 2.25L15 12"/></svg>
+                GRNs
+              </a>
+            </div>
+          </div>
+          <div class="relative nav-group">
+            <button data-dropdown="production-menu" class="flex items-center justify-between text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Production</button>
+            <div id="production-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
+              {% url 'recipes_list' as recipes_url %}
+              <a href="{{ recipes_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == recipes_url %}active{% endif %}">
+                <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/></svg>
+                Recipes
+              </a>
+            </div>
+          </div>
+          <div class="relative nav-group">
+            <button data-dropdown="account-menu" class="flex items-center justify-between text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium">Account</button>
+            <div id="account-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
+              {% if user.is_authenticated %}
+                {% url 'logout' as logout_url %}
+                <a href="{{ logout_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == logout_url %}active{% endif %}">
+                  <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15M12 9l-3 3m0 0 3 3m-3-3h12.75"/></svg>
+                  Logout
+                </a>
+              {% else %}
+                {% url 'login' as login_url %}
+                <a href="{{ login_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == login_url %}active{% endif %}">
+                  <svg aria-hidden="true" class="w-4 h-4 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"/></svg>
+                  Login
+                </a>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+        <button id="theme-toggle" class="ml-4 text-white hover:text-white dark:text-gray-200" aria-label="Toggle theme">🌓</button>
+      </div>
+    </div>
+  </div>
+</nav>


### PR DESCRIPTION
## Summary
- extract navigation markup into reusable template component
- move nav dropdown/toggle logic to `static/js/nav.js`
- include nav component and reference new script in base template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9c3a7e34083268f0a454fa3b7e6ae