### PR TITLE
style: standardize anchor buttons with new outline variant

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -65,6 +65,24 @@
   }
   .btn-danger:disabled { @apply opacity-50 cursor-not-allowed; }
 
+  .btn-outline {
+    @apply px-4 py-2 border rounded transition-colors;
+    background-color: transparent;
+    color: theme('colors.bodyText.light');
+    border-color: theme('colors.form.border');
+  }
+  .btn-outline:hover { @apply bg-gray-100; }
+  .btn-outline:focus {
+    @apply outline-none ring-2 ring-offset-2;
+    --tw-ring-color: theme('colors.form.border');
+  }
+  .dark .btn-outline {
+    color: theme('colors.bodyText.dark');
+    border-color: theme('colors.form.darkBorder');
+  }
+  .dark .btn-outline:hover { @apply bg-gray-700; }
+  .dark .btn-outline:focus { --tw-ring-color: theme('colors.form.darkBorder'); }
+
   /* Form component styles */
   form label { @apply block mb-2; }
   form input:not([type='checkbox']):not([type='radio']),

--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -77,12 +77,12 @@
   {% if page_obj.has_previous %}
   <a hx-get="{% url 'history_reports' %}?page={{ page_obj.previous_page_number }}"
      hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-     class="px-3 py-1 border rounded">Prev</a>
+     class="btn-outline">Prev</a>
   {% endif %}
   <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
   {% if page_obj.has_next %}
   <a hx-get="{% url 'history_reports' %}?page={{ page_obj.next_page_number }}"
      hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-     class="px-3 py-1 border rounded">Next</a>
+     class="btn-outline">Next</a>
   {% endif %}
 </div>

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -33,10 +33,10 @@
 </div>
 <div class="flex items-center gap-3 mt-3">
   {% if page_obj.has_previous %}
-    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.previous_page_number }}&status={{ status|urlencode }}&q={{ q|urlencode }}" hx-target="#indents_table" class="px-3 py-1 border rounded">Prev</a>
+    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.previous_page_number }}&status={{ status|urlencode }}&q={{ q|urlencode }}" hx-target="#indents_table" class="btn-outline">Prev</a>
   {% endif %}
   <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
   {% if page_obj.has_next %}
-    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.next_page_number }}&status={{ status|urlencode }}&q={{ q|urlencode }}" hx-target="#indents_table" class="px-3 py-1 border rounded">Next</a>
+    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.next_page_number }}&status={{ status|urlencode }}&q={{ q|urlencode }}" hx-target="#indents_table" class="btn-outline">Next</a>
   {% endif %}
 </div>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -83,7 +83,7 @@
     {% if page_obj.has_previous %}
       <a href="{% url 'items_list' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
          hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-         hx-target="#items_table" class="px-3 py-1 border rounded">Prev</a>
+         hx-target="#items_table" class="btn-outline">Prev</a>
     {% endif %}
     {% for num in page_obj.paginator.page_range %}
       {% if num == page_obj.number %}
@@ -91,13 +91,13 @@
       {% else %}
         <a href="{% url 'items_list' %}?page={{ num }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
            hx-get="{% url 'items_table' %}?page={{ num }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-           hx-target="#items_table" class="px-3 py-1 border rounded">{{ num }}</a>
+           hx-target="#items_table" class="btn-outline">{{ num }}</a>
       {% endif %}
     {% endfor %}
     {% if page_obj.has_next %}
       <a href="{% url 'items_list' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
          hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-         hx-target="#items_table" class="px-3 py-1 border rounded">Next</a>
+         hx-target="#items_table" class="btn-outline">Next</a>
     {% endif %}
   </div>
   <div class="ml-auto flex items-center gap-2">

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -54,12 +54,12 @@
 <div class="flex items-center gap-3 mt-3">
   {% if page_obj.has_previous %}
     <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-       hx-target="#suppliers_table" class="px-3 py-1 border rounded">Prev</a>
+       hx-target="#suppliers_table" class="btn-outline">Prev</a>
   {% endif %}
   <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
   {% if page_obj.has_next %}
     <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-       hx-target="#suppliers_table" class="px-3 py-1 border rounded">Next</a>
+       hx-target="#suppliers_table" class="btn-outline">Next</a>
   {% endif %}
 </div>
 

--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -14,7 +14,7 @@
     {% endfor %}
     <div class="flex gap-2">
       <button type="submit" class="btn-danger">Delete</button>
-      <a href="{% url back_url %}" class="px-4 py-2 border rounded">Back</a>
+      <a href="{% url back_url %}" class="btn-outline">Back</a>
     </div>
   </form>
   {% if deleted %}

--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -14,7 +14,7 @@
     {% endfor %}
     <div class="flex gap-2">
       <button type="submit" class="btn-primary">Upload</button>
-      <a href="{% url back_url %}" class="px-4 py-2 border rounded">Back</a>
+      <a href="{% url back_url %}" class="btn-outline">Back</a>
     </div>
   </form>
   {% if inserted %}

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -49,7 +49,7 @@
       <input type="hidden" name="sort" value="{{ sort|default:'date' }}" />
       <input type="hidden" name="direction" value="{{ direction|default:'desc' }}" />
       <button type="submit" class="btn-primary w-full">Filter</button>
-      <a href="?{% if query_string %}{{ query_string }}&{% endif %}export=csv" class="px-4 py-2 border rounded w-full">Export CSV</a>
+      <a href="?{% if query_string %}{{ query_string }}&{% endif %}export=csv" class="btn-outline w-full">Export CSV</a>
     </form>
     <div id="history_table">
       {% include "inventory/_history_table.html" %}

--- a/templates/inventory/item_confirm_delete.html
+++ b/templates/inventory/item_confirm_delete.html
@@ -6,7 +6,7 @@
   <form method="post" class="flex gap-2">
     {% csrf_token %}
     <button type="submit" class="btn-danger">Confirm</button>
-    <a href="{% url 'items_list' %}" class="px-4 py-2 border rounded">Cancel</a>
+    <a href="{% url 'items_list' %}" class="btn-outline">Cancel</a>
   </form>
 </div>
 {% endblock %}

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -42,7 +42,7 @@
     </div>
     <div class="flex gap-2">
       <button type="submit" class="btn-primary">Save</button>
-      <a href="{% url 'items_list' %}" class="px-4 py-2 border rounded">Cancel</a>
+      <a href="{% url 'items_list' %}" class="btn-outline">Cancel</a>
     </div>
   </form>
   {{ form.units_map|json_script:"units-data" }}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -124,11 +124,11 @@
   </div>
   <div class="flex items-center gap-3 mt-3">
     {% if page_obj.has_previous %}
-    <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.previous_page_number }}" class="px-3 py-1 border rounded">Prev</a>
+    <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.previous_page_number }}" class="btn-outline">Prev</a>
     {% endif %}
     <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
     {% if page_obj.has_next %}
-    <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.next_page_number }}" class="px-3 py-1 border rounded">Next</a>
+    <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.next_page_number }}" class="btn-outline">Next</a>
     {% endif %}
   </div>
 {% endblock %}

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -20,7 +20,7 @@
     </div>
     <div class="flex gap-2">
       <button type="submit" class="btn-primary">Save</button>
-      <a href="{% url 'suppliers_list' %}" class="px-4 py-2 border rounded">Cancel</a>
+      <a href="{% url 'suppliers_list' %}" class="btn-outline">Cancel</a>
     </div>
   </form>
 </div>


### PR DESCRIPTION
## Summary
- add `.btn-outline` utility with light/dark support
- convert anchor-based controls to use `btn-outline`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9c4cecadc8326ac9e87e22a90b535