### PR TITLE
Refactor forms to use shared layout component

### DIFF
--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -1,0 +1,26 @@
+{% extends "_base.html" %}
+{% block content %}
+<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
+  <h1 class="text-2xl font-semibold mb-4">
+    {% block heading %}{% endblock %}
+  </h1>
+  {% if form %}
+  <form method="post" {% block form_attrs %}{% endblock %} class="space-y-4">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+    {% block fields %}{% endblock %}
+    <div class="flex gap-2">
+      <button type="submit" class="btn-primary">{% block submit_text %}Save{% endblock %}</button>
+      <a href="{% block back_url %}{% endblock %}" class="btn-outline">{% block back_text %}Cancel{% endblock %}</a>
+    </div>
+  </form>
+  {% block extra %}{% endblock %}
+  {% else %}
+    {% block no_form %}<p>Unable to load form.</p>{% endblock %}
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -1,22 +1,15 @@
-{% extends "_base.html" %}
-{% block content %}
-<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
-  <form method="post" enctype="multipart/form-data" class="space-y-4">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-    </ul>
-    {% endif %}
-    {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
-    {% endfor %}
-    <div class="flex gap-2">
-      <button type="submit" class="btn-primary">Upload</button>
-      <a href="{% url back_url %}" class="btn-outline">Back</a>
-    </div>
-  </form>
+{% extends "components/form_layout.html" %}
+{% block heading %}{{ title }}{% endblock %}
+{% block form_attrs %}enctype="multipart/form-data"{% endblock %}
+{% block fields %}
+  {% for field in form %}
+    {% include "components/form_field.html" with field=field %}
+  {% endfor %}
+{% endblock %}
+{% block submit_text %}Upload{% endblock %}
+{% block back_url %}{% url back_url %}{% endblock %}
+{% block back_text %}Back{% endblock %}
+{% block extra %}
   {% if inserted %}
   <p class="mt-4 text-green-700">Inserted {{ inserted }} record(s).</p>
   {% endif %}
@@ -30,5 +23,4 @@
     </ul>
   </div>
   {% endif %}
-</div>
 {% endblock %}

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -1,50 +1,35 @@
-{% extends "_base.html" %}
-{% block content %}
-<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">
-    {% if is_edit %}Edit Item{% else %}Add Item{% endif %}
-  </h1>
-  {% if form %}
-  <form method="post" class="space-y-4">
-    {% csrf_token %}
-    {% if not form.units_map %}
-    <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
-    {% endif %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}
-      <li>{{ error }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    <div class="grid gap-4 grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
-      <div id="name-field" class="space-y-1 relative">
-        <label for="{{ form.name.id_for_label }}" class="block mb-1 font-medium">{{ form.name.label }}</label>
-        {{ form.name }}
-        {% if form.name.help_text %}
-          <p class="text-sm text-gray-500">{{ form.name.help_text }}</p>
-        {% endif %}
-        {% if form.name.errors %}
-          <ul class="text-sm text-red-600 list-disc pl-5">
-            {% for error in form.name.errors %}
-              <li>{{ error }}</li>
-            {% endfor %}
-          </ul>
-        {% endif %}
-      </div>
-      {% include "components/form_field.html" with field=form.base_unit %}
-      {% include "components/form_field.html" with field=form.purchase_unit %}
-      {% for field in form %}
-        {% if field.name not in excluded_fields %}
-          {% include "components/form_field.html" with field=field %}
-        {% endif %}
-      {% endfor %}
+{% extends "components/form_layout.html" %}
+{% block heading %}{% if is_edit %}Edit Item{% else %}Add Item{% endif %}{% endblock %}
+{% block fields %}
+  {% if not form.units_map %}
+  <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
+  {% endif %}
+  <div class="grid gap-4 grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
+    <div id="name-field" class="space-y-1 relative">
+      <label for="{{ form.name.id_for_label }}" class="block mb-1 font-medium">{{ form.name.label }}</label>
+      {{ form.name }}
+      {% if form.name.help_text %}
+        <p class="text-sm text-gray-500">{{ form.name.help_text }}</p>
+      {% endif %}
+      {% if form.name.errors %}
+        <ul class="text-sm text-red-600 list-disc pl-5">
+          {% for error in form.name.errors %}
+            <li>{{ error }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
     </div>
-    <div class="flex gap-2">
-      <button type="submit" class="btn-primary">Save</button>
-      <a href="{% url 'items_list' %}" class="btn-outline">Cancel</a>
-    </div>
-  </form>
+    {% include "components/form_field.html" with field=form.base_unit %}
+    {% include "components/form_field.html" with field=form.purchase_unit %}
+    {% for field in form %}
+      {% if field.name not in excluded_fields %}
+        {% include "components/form_field.html" with field=field %}
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endblock %}
+{% block back_url %}{% url 'items_list' %}{% endblock %}
+{% block extra %}
   {{ form.units_map|json_script:"units-data" }}
   {{ form.categories_map|json_script:"categories-data" }}
   <script>
@@ -104,8 +89,4 @@
       });
     });
   </script>
-  {% else %}
-  <p>Unable to load form.</p>
-  {% endif %}
-</div>
 {% endblock %}

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -1,27 +1,10 @@
-{% extends "_base.html" %}
-{% block content %}
-<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">
-    {% if is_edit %}Edit Supplier{% else %}Add Supplier{% endif %}
-  </h1>
-  <form method="post" class="space-y-4">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}
-      <li>{{ error }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    <div class="grid gap-4 grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
-      {% for field in form %}
-        {% include "components/form_field.html" with field=field %}
-      {% endfor %}
-    </div>
-    <div class="flex gap-2">
-      <button type="submit" class="btn-primary">Save</button>
-      <a href="{% url 'suppliers_list' %}" class="btn-outline">Cancel</a>
-    </div>
-  </form>
-</div>
+{% extends "components/form_layout.html" %}
+{% block heading %}{% if is_edit %}Edit Supplier{% else %}Add Supplier{% endif %}{% endblock %}
+{% block fields %}
+  <div class="grid gap-4 grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
+  </div>
 {% endblock %}
+{% block back_url %}{% url 'suppliers_list' %}{% endblock %}


### PR DESCRIPTION
## Summary
- add reusable `form_layout` component with CSRF and error handling
- refactor bulk upload, supplier, and item forms to use shared layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9c601644083268edb28be5ee24efc