### PR TITLE
feat: improve dark mode styling

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -176,6 +176,12 @@
   }
   .dark .table tbody tr { background-color: theme('colors.body.dark'); }
   .dark .table tbody tr:hover { background-color: theme('colors.table.darkHoverBg'); }
+
+  /* Pagination controls */
+  .pagination-active { @apply px-3 py-1 border rounded bg-gray-200; }
+  .pagination-input { @apply border rounded p-1; }
+  .dark .pagination-active { @apply border-form-darkBorder bg-gray-700; }
+  .dark .pagination-input { @apply border-form-darkBorder bg-form-darkBg text-form-darkText; }
 }
 
 @layer utilities {

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -13,7 +13,7 @@
   <body class="min-h-screen">
     {% include "components/nav.html" %}
     <div id="htmx-spinner" class="hidden fixed inset-0 flex items-center justify-center bg-black/25">
-      <div class="h-12 w-12 border-4 border-primary border-t-transparent rounded-full animate-spin"></div>
+      <div class="h-12 w-12 border-4 border-primary dark:border-primary border-t-transparent rounded-full animate-spin"></div>
     </div>
     <div class="container mx-auto px-8 max-md:px-6 max-sm:px-4 py-4">
       {% if messages %}

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -1,18 +1,18 @@
 {% for message in messages %}
   {% if 'error' in message.tags %}
-    {% with bg='bg-red-100' border='border-red-500' text='text-red-700' %}
+    {% with bg='bg-red-100 dark:bg-red-900' border='border-red-500 dark:border-red-700' text='text-red-700 dark:text-red-300' %}
       <div class="{{ bg }} {{ text }} px-8 max-md:px-6 max-sm:px-4 py-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
     {% endwith %}
   {% elif 'warning' in message.tags %}
-    {% with bg='bg-yellow-100' border='border-yellow-500' text='text-yellow-700' %}
+    {% with bg='bg-yellow-100 dark:bg-yellow-900' border='border-yellow-500 dark:border-yellow-700' text='text-yellow-700 dark:text-yellow-300' %}
       <div class="{{ bg }} {{ text }} px-8 max-md:px-6 max-sm:px-4 py-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
     {% endwith %}
   {% elif 'success' in message.tags %}
-    {% with bg='bg-green-100' border='border-green-500' text='text-green-700' %}
+    {% with bg='bg-green-100 dark:bg-green-900' border='border-green-500 dark:border-green-700' text='text-green-700 dark:text-green-300' %}
       <div class="{{ bg }} {{ text }} px-8 max-md:px-6 max-sm:px-4 py-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
     {% endwith %}
   {% else %}
-    {% with bg='bg-blue-100' border='border-blue-500' text='text-blue-700' %}
+    {% with bg='bg-blue-100 dark:bg-blue-900' border='border-blue-500 dark:border-blue-700' text='text-blue-700 dark:text-blue-300' %}
       <div class="{{ bg }} {{ text }} px-8 max-md:px-6 max-sm:px-4 py-4 mb-4 border-l-4 {{ border }}" role="alert">{{ message }}</div>
     {% endwith %}
   {% endif %}

--- a/templates/components/colour_customizer.html
+++ b/templates/components/colour_customizer.html
@@ -1,15 +1,15 @@
 <div id="colour-customizer" class="fixed bottom-4 right-4 bg-white dark:bg-slate-800 p-4 rounded shadow space-y-2">
   <label class="block text-sm">
     Primary
-    <input type="color" id="picker-primary" value="#1a46c2" class="ml-2 border rounded">
+    <input type="color" id="picker-primary" value="#1a46c2" class="ml-2 border dark:border-form-darkBorder dark:bg-form-darkBg dark:text-form-darkText rounded">
   </label>
   <label class="block text-sm">
     Secondary
-    <input type="color" id="picker-secondary" value="#036045" class="ml-2 border rounded">
+    <input type="color" id="picker-secondary" value="#036045" class="ml-2 border dark:border-form-darkBorder dark:bg-form-darkBg dark:text-form-darkText rounded">
   </label>
   <label class="block text-sm">
     Accent
-    <input type="color" id="picker-accent" value="#ad5f04" class="ml-2 border rounded">
+    <input type="color" id="picker-accent" value="#ad5f04" class="ml-2 border dark:border-form-darkBorder dark:bg-form-darkBg dark:text-form-darkText rounded">
   </label>
   <button id="colour-reset" type="button" class="btn-secondary w-full mt-2">Reset to default</button>
 </div>

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -1,5 +1,5 @@
 <div class="py-6 px-8 max-md:px-6 max-sm:px-4 text-center border border-form-border rounded bg-form-bg dark:bg-form-darkBg dark:border-form-darkBorder">
-  <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+  <svg class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
   <h2 class="mt-4 mb-2 text-lg font-semibold">{{ title }}</h2>
   <p class="mb-4 text-form-text dark:text-form-darkText">{{ message }}</p>
   <a href="{{ cta_url }}" class="btn-primary">{{ cta_label }}</a>

--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -1,5 +1,5 @@
 {% load form_tags %}
-{% with input_class="w-full px-3 py-2 border rounded" checkbox_class="h-4 w-4 text-primary" %}
+{% with input_class="w-full px-3 py-2 border dark:border-form-darkBorder rounded" checkbox_class="h-4 w-4 text-primary" %}
 <div class="space-y-1">
   <label for="{{ field.id_for_label }}" class="block mb-1 font-medium">{{ field.label }}</label>
   {% if field.field.widget.attrs.class %}
@@ -10,10 +10,10 @@
     {{ field|add_class:input_class }}
   {% endif %}
   {% if field.help_text %}
-    <p class="text-sm text-gray-500">{{ field.help_text }}</p>
+    <p class="text-sm text-gray-500 dark:text-gray-400">{{ field.help_text }}</p>
   {% endif %}
   {% if field.errors %}
-    <ul class="text-sm text-red-600 list-disc pl-5">
+    <ul class="text-sm text-red-600 dark:text-red-400 list-disc pl-5">
       {% for error in field.errors %}
         <li>{{ error }}</li>
       {% endfor %}

--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -8,7 +8,7 @@
   <form method="post" {% block form_attrs %}{% endblock %} class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
+    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
       {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
     </ul>
     {% endif %}

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -87,7 +87,7 @@
     {% endif %}
     {% for num in page_obj.paginator.page_range %}
       {% if num == page_obj.number %}
-        <span class="px-3 py-1 border rounded bg-gray-200">{{ num }}</span>
+        <span class="pagination-active">{{ num }}</span>
       {% else %}
         <a href="{% url 'items_list' %}?page={{ num }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
            hx-get="{% url 'items_table' %}?page={{ num }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
@@ -107,7 +107,7 @@
       id="page_size"
       name="page_size"
       list="page_size_options"
-      class="border rounded p-1"
+      class="pagination-input"
       value="{{ page_size }}"
       form="filters"
       hx-get="{% url 'items_table' %}"

--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -5,7 +5,7 @@
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
+    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
       {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
     </ul>
     {% endif %}
@@ -18,12 +18,12 @@
     </div>
   </form>
   {% if deleted %}
-  <p class="mt-4 text-green-700">Deleted {{ deleted }} supplier(s).</p>
+  <p class="mt-4 text-green-700 dark:text-green-400">Deleted {{ deleted }} supplier(s).</p>
   {% endif %}
   {% if errors %}
   <div class="mt-4">
-    <p class="text-red-700">Errors:</p>
-    <ul class="list-disc pl-5">
+    <p class="text-red-700 dark:text-red-400">Errors:</p>
+    <ul class="list-disc pl-5 dark:text-red-400">
       {% for err in errors %}
       <li>{{ err }}</li>
       {% endfor %}

--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -11,12 +11,12 @@
 {% block back_text %}Back{% endblock %}
 {% block extra %}
   {% if inserted %}
-  <p class="mt-4 text-green-700">Inserted {{ inserted }} record(s).</p>
+  <p class="mt-4 text-green-700 dark:text-green-400">Inserted {{ inserted }} record(s).</p>
   {% endif %}
   {% if errors %}
   <div class="mt-4">
-    <p class="text-red-700">Errors:</p>
-    <ul class="list-disc pl-5">
+    <p class="text-red-700 dark:text-red-400">Errors:</p>
+    <ul class="list-disc pl-5 dark:text-red-400">
       {% for err in errors %}
       <li>{{ err }}</li>
       {% endfor %}

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -8,7 +8,7 @@
         type="text"
         name="supplier"
         list="grn-suppliers"
-        class="border rounded px-2 py-1 w-full"
+        class="form-control w-full"
         value="{{ current_supplier }}"
       />
       <datalist id="grn-suppliers">
@@ -20,11 +20,11 @@
     </div>
     <div class="space-y-1">
       <label class="block text-sm">Start Date</label>
-      <input type="date" name="start_date" value="{{ start_date }}" class="border rounded px-2 py-1 w-full" />
+      <input type="date" name="start_date" value="{{ start_date }}" class="form-control w-full" />
     </div>
     <div class="space-y-1">
       <label class="block text-sm">End Date</label>
-      <input type="date" name="end_date" value="{{ end_date }}" class="border rounded px-2 py-1 w-full" />
+      <input type="date" name="end_date" value="{{ end_date }}" class="form-control w-full" />
     </div>
     <div class="space-y-1">
       <button type="submit" class="btn-primary w-full">Filter</button>

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -19,15 +19,15 @@
   <div class="mt-4 flex gap-2">
     <form action="{% url 'indent_update_status' indent.indent_id 'PROCESSING' %}" method="post" class="inline">
       {% csrf_token %}
-      <button type="submit" class="px-3 py-2 border rounded">Mark Processing</button>
+      <button type="submit" class="px-3 py-2 border dark:border-form-darkBorder rounded">Mark Processing</button>
     </form>
     <form action="{% url 'indent_update_status' indent.indent_id 'COMPLETED' %}" method="post" class="inline">
       {% csrf_token %}
-      <button type="submit" class="px-3 py-2 border rounded">Mark Completed</button>
+      <button type="submit" class="px-3 py-2 border dark:border-form-darkBorder rounded">Mark Completed</button>
     </form>
     <form action="{% url 'indent_update_status' indent.indent_id 'CANCELLED' %}" method="post" class="inline">
       {% csrf_token %}
-      <button type="submit" class="px-3 py-2 border rounded">Cancel</button>
+      <button type="submit" class="px-3 py-2 border dark:border-form-darkBorder rounded">Cancel</button>
     </form>
   </div>
 {% endblock %}

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -6,7 +6,7 @@
   <form method="post" id="indent-form" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
+    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
       {% for error in form.non_field_errors %}
       <li>{{ error }}</li>
       {% endfor %}
@@ -19,7 +19,7 @@
     </div>
     {{ formset.management_form }}
     {% if formset.non_form_errors %}
-    <ul class="text-red-600 list-disc pl-5">
+    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
       {% for error in formset.non_form_errors %}
       <li>{{ error }}</li>
       {% endfor %}
@@ -40,14 +40,14 @@
           <td>{% include "components/form_field.html" with field=item_form.item %}</td>
           <td>{% include "components/form_field.html" with field=item_form.requested_qty %}</td>
           <td>{% include "components/form_field.html" with field=item_form.notes %}</td>
-          <td><button type="button" class="remove-row text-red-600">Remove</button></td>
+          <td><button type="button" class="remove-row text-red-600 dark:text-red-400">Remove</button></td>
         </tr>
       {% endfor %}
       </tbody>
     </table>
     <datalist id="item-options"></datalist>
     <div class="mt-2">
-      <button type="button" id="add-row" class="px-4 py-2 border rounded">Add Item</button>
+      <button type="button" id="add-row" class="px-4 py-2 border dark:border-form-darkBorder rounded">Add Item</button>
     </div>
     <div class="mt-4">
       <button type="submit" class="btn-primary">Submit</button>

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -2,17 +2,17 @@
 {% block heading %}{% if is_edit %}Edit Item{% else %}Add Item{% endif %}{% endblock %}
 {% block fields %}
   {% if not form.units_map %}
-  <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
+  <p class="text-sm text-red-600 dark:text-red-400">Could not load unit options. Please try again later.</p>
   {% endif %}
   <div class="grid gap-4 grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
     <div id="name-field" class="space-y-1 relative">
       <label for="{{ form.name.id_for_label }}" class="block mb-1 font-medium">{{ form.name.label }}</label>
       {{ form.name }}
       {% if form.name.help_text %}
-        <p class="text-sm text-gray-500">{{ form.name.help_text }}</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">{{ form.name.help_text }}</p>
       {% endif %}
       {% if form.name.errors %}
-        <ul class="text-sm text-red-600 list-disc pl-5">
+        <ul class="text-sm text-red-600 dark:text-red-400 list-disc pl-5">
           {% for error in form.name.errors %}
             <li>{{ error }}</li>
           {% endfor %}

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -5,7 +5,7 @@
   <form method="post" class="space-y-4" id="po-form">
     {% csrf_token %}
     {% if form.non_field_errors %}
-      <ul class="text-red-600 list-disc pl-5">
+      <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
         {% for error in form.non_field_errors %}
           <li>{{ error }}</li>
         {% endfor %}
@@ -20,16 +20,16 @@
     <div id="items-formset">
       {{ formset.management_form }}
       {% if formset.non_form_errors %}
-        <ul class="text-red-600 list-disc pl-5">
+        <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
           {% for error in formset.non_form_errors %}
             <li>{{ error }}</li>
           {% endfor %}
         </ul>
       {% endif %}
       {% for f in formset %}
-      <div class="border p-2 item-form">
+      <div class="border dark:border-form-darkBorder p-2 item-form">
         {% if f.non_field_errors %}
-          <ul class="text-red-600 list-disc pl-5">
+          <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
             {% for error in f.non_field_errors %}<li>{{ error }}</li>{% endfor %}
           </ul>
         {% endif %}
@@ -46,7 +46,7 @@
     </div>
   </form>
   <template id="item-empty-form">
-    <div class="border p-2 item-form">
+    <div class="border dark:border-form-darkBorder p-2 item-form">
       {% for field in formset.empty_form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -12,7 +12,7 @@
         type="text"
         name="status"
         list="po-statuses"
-        class="border rounded px-2 py-1 w-full"
+        class="form-control w-full"
         value="{{ current_status }}"
       />
       <datalist id="po-statuses">
@@ -28,7 +28,7 @@
         type="text"
         name="supplier"
         list="po-suppliers"
-        class="border rounded px-2 py-1 w-full"
+        class="form-control w-full"
         value="{{ current_supplier }}"
       />
       <datalist id="po-suppliers">
@@ -40,11 +40,11 @@
     </div>
     <div class="space-y-1">
       <label class="block text-sm">Start Date</label>
-      <input type="date" name="start_date" value="{{ start_date }}" class="border rounded px-2 py-1 w-full" />
+      <input type="date" name="start_date" value="{{ start_date }}" class="form-control w-full" />
     </div>
     <div class="space-y-1">
       <label class="block text-sm">End Date</label>
-      <input type="date" name="end_date" value="{{ end_date }}" class="border rounded px-2 py-1 w-full" />
+      <input type="date" name="end_date" value="{{ end_date }}" class="form-control w-full" />
     </div>
     <div class="space-y-1">
       <button type="submit" class="btn-primary w-full">Filter</button>

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -5,7 +5,7 @@
   <form method="post" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
+    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
       {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
     </ul>
     {% endif %}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -5,7 +5,7 @@
   <form method="post" id="recipe-form">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
+    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
       {% for error in form.non_field_errors %}
       <li>{{ error }}</li>
       {% endfor %}
@@ -18,7 +18,7 @@
     </div>
     {{ formset.management_form }}
     {% if formset.non_form_errors %}
-    <ul class="text-red-600 list-disc pl-5">
+    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
       {% for error in formset.non_form_errors %}
       <li>{{ error }}</li>
       {% endfor %}
@@ -44,14 +44,14 @@
           <td>{% include "components/form_field.html" with field=cform.unit %}</td>
           <td>{% include "components/form_field.html" with field=cform.loss_pct %}</td>
           <td>
-            {{ cform.DELETE }}<button type="button" class="remove-row text-red-600">Remove</button>
+            {{ cform.DELETE }}<button type="button" class="remove-row text-red-600 dark:text-red-400">Remove</button>
           </td>
         </tr>
       {% endfor %}
       </tbody>
     </table>
     <div class="mt-2">
-      <button type="button" id="add-row" class="px-4 py-2 border rounded">Add Component</button>
+      <button type="button" id="add-row" class="px-4 py-2 border dark:border-form-darkBorder rounded">Add Component</button>
     </div>
     <div class="mt-4">
       <button type="submit" class="btn-primary">Save</button>

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -17,7 +17,7 @@
     <form method="post" class="mb-4">
       {% csrf_token %}
       {% if receive_form.non_field_errors %}
-      <ul class="text-red-600 list-disc pl-5">
+      <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
         {% for error in receive_form.non_field_errors %}
         <li>{{ error }}</li>
         {% endfor %}
@@ -33,7 +33,7 @@
     <form method="post" class="mb-4">
       {% csrf_token %}
       {% if adjust_form.non_field_errors %}
-      <ul class="text-red-600 list-disc pl-5">
+      <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
         {% for error in adjust_form.non_field_errors %}
         <li>{{ error }}</li>
         {% endfor %}
@@ -49,7 +49,7 @@
     <form method="post" class="mb-4">
       {% csrf_token %}
       {% if waste_form.non_field_errors %}
-      <ul class="text-red-600 list-disc pl-5">
+      <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
         {% for error in waste_form.non_field_errors %}
         <li>{{ error }}</li>
         {% endfor %}
@@ -67,7 +67,7 @@
   <form method="post" enctype="multipart/form-data" class="mb-4">
     {% csrf_token %}
     {% if bulk_form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
+    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
       {% for error in bulk_form.non_field_errors %}
       <li>{{ error }}</li>
       {% endfor %}
@@ -82,7 +82,7 @@
     <p>{{ bulk_success_count }} transaction(s) recorded successfully.</p>
   {% endif %}
   {% if bulk_errors %}
-    <ul class="text-red-700">
+    <ul class="text-red-700 dark:text-red-400">
       {% for e in bulk_errors %}
         <li>{{ e }}</li>
       {% endfor %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -5,7 +5,7 @@
   <form method="post" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
+    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
       {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
     </ul>
     {% endif %}


### PR DESCRIPTION
## Summary
- add dark mode variants for template borders and text colors
- add pagination dark styles and utility classes
- include dark styles for alert component and various forms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9c6d741a08326b30bd4c62c5252cb