### PR TITLE
Refactor pagination with reusable component

### DIFF
--- a/templates/components/pagination.html
+++ b/templates/components/pagination.html
@@ -1,0 +1,22 @@
+<div class="flex items-center gap-1 flex-wrap">
+  {% if page_obj.has_previous %}
+    <a href="{{ base_url }}?page={{ page_obj.previous_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}"
+       {% if hx_target %}hx-get="{{ base_url }}?page={{ page_obj.previous_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
+       class="btn-outline">Prev</a>
+  {% endif %}
+  {% for num in page_obj.paginator.page_range %}
+    {% if num == page_obj.number %}
+      <span class="pagination-active">{{ num }}</span>
+    {% else %}
+      <a href="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}"
+         {% if hx_target %}hx-get="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
+         class="btn-outline">{{ num }}</a>
+    {% endif %}
+  {% endfor %}
+  {% if page_obj.has_next %}
+    <a href="{{ base_url }}?page={{ page_obj.next_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}"
+       {% if hx_target %}hx-get="{{ base_url }}?page={{ page_obj.next_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
+       class="btn-outline">Next</a>
+  {% endif %}
+  <span class="ml-2">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+</div>

--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -73,16 +73,7 @@
     </tfoot>
   </table>
 </div>
-<div class="flex items-center gap-3 mt-3">
-  {% if page_obj.has_previous %}
-  <a hx-get="{% url 'history_reports' %}?page={{ page_obj.previous_page_number }}"
-     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-     class="btn-outline">Prev</a>
-  {% endif %}
-  <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
-  {% if page_obj.has_next %}
-  <a hx-get="{% url 'history_reports' %}?page={{ page_obj.next_page_number }}"
-     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-     class="btn-outline">Next</a>
-  {% endif %}
+{% url 'history_reports' as history_url %}
+<div class="mt-3">
+  {% include "components/pagination.html" with page_obj=page_obj base_url=history_url extra_query="" hx_target="#history_table" hx_include="#filters" hx_indicator="#htmx-spinner" %}
 </div>

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -31,12 +31,9 @@
     </tbody>
   </table>
 </div>
-<div class="flex items-center gap-3 mt-3">
-  {% if page_obj.has_previous %}
-    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.previous_page_number }}&status={{ status|urlencode }}&q={{ q|urlencode }}" hx-target="#indents_table" class="btn-outline">Prev</a>
-  {% endif %}
-  <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
-  {% if page_obj.has_next %}
-    <a hx-get="{% url 'indents_table' %}?page={{ page_obj.next_page_number }}&status={{ status|urlencode }}&q={{ q|urlencode }}" hx-target="#indents_table" class="btn-outline">Next</a>
-  {% endif %}
-</div>
+  {% url 'indents_table' as table_url %}
+  {% with extra_query='status='|add:status|urlencode|add:'&q='|add:q|urlencode %}
+  <div class="mt-3">
+    {% include "components/pagination.html" with page_obj=page_obj base_url=table_url extra_query=extra_query hx_target="#indents_table" %}
+  </div>
+  {% endwith %}

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -79,27 +79,10 @@
 
 {% block footer %}
 <div class="flex items-center gap-3 mt-3 flex-wrap">
-  <div class="flex items-center gap-1">
-    {% if page_obj.has_previous %}
-      <a href="{% url 'items_list' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-         hx-get="{% url 'items_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-         hx-target="#items_table" class="btn-outline">Prev</a>
-    {% endif %}
-    {% for num in page_obj.paginator.page_range %}
-      {% if num == page_obj.number %}
-        <span class="pagination-active">{{ num }}</span>
-      {% else %}
-        <a href="{% url 'items_list' %}?page={{ num }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-           hx-get="{% url 'items_table' %}?page={{ num }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-           hx-target="#items_table" class="btn-outline">{{ num }}</a>
-      {% endif %}
-    {% endfor %}
-    {% if page_obj.has_next %}
-      <a href="{% url 'items_list' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-         hx-get="{% url 'items_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-         hx-target="#items_table" class="btn-outline">Next</a>
-    {% endif %}
-  </div>
+    {% url 'items_table' as table_url %}
+    {% with extra_query='q='|add:q|urlencode|add:'&active='|add:active|urlencode|add:'&page_size='|add:page_size|add:'&sort='|add:sort|urlencode|add:'&direction='|add:direction|urlencode %}
+      {% include "components/pagination.html" with page_obj=page_obj base_url=table_url extra_query=extra_query hx_target="#items_table" hx_include="#filters" %}
+    {% endwith %}
   <div class="ml-auto flex items-center gap-2">
     <label for="page_size" class="text-sm">Per page:</label>
     <input

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -51,15 +51,10 @@
     </tbody>
   </table>
 </div>
-<div class="flex items-center gap-3 mt-3">
-  {% if page_obj.has_previous %}
-    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.previous_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-       hx-target="#suppliers_table" class="btn-outline">Prev</a>
-  {% endif %}
-  <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
-  {% if page_obj.has_next %}
-    <a hx-get="{% url 'suppliers_table' %}?page={{ page_obj.next_page_number }}&q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort={{ sort|urlencode }}&direction={{ direction|urlencode }}"
-       hx-target="#suppliers_table" class="btn-outline">Next</a>
-  {% endif %}
-</div>
+  {% url 'suppliers_table' as table_url %}
+  {% with extra_query='q='|add:q|urlencode|add:'&active='|add:active|urlencode|add:'&page_size='|add:page_size|add:'&sort='|add:sort|urlencode|add:'&direction='|add:direction|urlencode %}
+  <div class="mt-3">
+    {% include "components/pagination.html" with page_obj=page_obj base_url=table_url extra_query=extra_query hx_target="#suppliers_table" %}
+  </div>
+  {% endwith %}
 

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -45,13 +45,7 @@
     {% endfor %}
     </tbody>
   </table>
-  <div class="mt-4 flex justify-between">
-    {% if page_obj.has_previous %}
-    <a href="?page={{ page_obj.previous_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-primary">Previous</a>
-    {% endif %}
-    <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-    <a href="?page={{ page_obj.next_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-primary">Next</a>
-    {% endif %}
+  <div class="mt-4">
+    {% include "components/pagination.html" with page_obj=page_obj base_url="" extra_query=querystring %}
   </div>
 {% endblock %}

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -26,13 +26,7 @@
 {% endblock %}
 
 {% block footer %}
-<div class="mt-4 flex justify-between">
-  {% if page_obj.has_previous %}
-  <a href="?page={{ page_obj.previous_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-primary">Previous</a>
-  {% endif %}
-  <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
-  {% if page_obj.has_next %}
-  <a href="?page={{ page_obj.next_page_number }}{% if querystring %}&{{ querystring }}{% endif %}" class="text-primary">Next</a>
-  {% endif %}
+<div class="mt-4">
+  {% include "components/pagination.html" with page_obj=page_obj base_url="" extra_query=querystring %}
 </div>
 {% endblock %}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -122,13 +122,7 @@
       </tbody>
     </table>
   </div>
-  <div class="flex items-center gap-3 mt-3">
-    {% if page_obj.has_previous %}
-    <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.previous_page_number }}" class="btn-outline">Prev</a>
-    {% endif %}
-    <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
-    {% if page_obj.has_next %}
-    <a href="?{% if query_string %}{{ query_string }}&{% endif %}page={{ page_obj.next_page_number }}" class="btn-outline">Next</a>
-    {% endif %}
+  <div class="mt-3">
+    {% include "components/pagination.html" with page_obj=page_obj base_url="" extra_query=query_string %}
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add reusable pagination component with `btn-*` styling
- reuse component across inventory tables

## Testing
- `python -m pytest`
- `flake8` *(fails: inventory/migrations/0010_category.py:32:1: W391 blank line at end of file, inventory/services/item_service.py:68:1: E303 too many blank lines (4), inventory/services/item_service.py:123:1: E303 too many blank lines (4), inventory/views/items.py:324:1: E303 too many blank lines (3), tests/test_aa_views.py:25:5: E303 too many blank lines (2), tests/test_aa_views.py:28:1: E302 expected 2 blank lines, found 0, tests/test_aa_views.py:41:9: E125 continuation line with same indent as next logical line, tests/test_aa_views.py:64:9: E125 continuation line with same indent as next logical line, tests/test_aa_views.py:79:9: E125 continuation line with same indent as next logical line, tests/test_aa_views.py:84:5: E303 too many blank lines (2), tests/test_aa_views.py:88:1: E302 expected 2 blank lines, found 0, tests/test_item_form.py:87:1: W391 blank line at end of file)`


------
https://chatgpt.com/codex/tasks/task_e_68a9c84e850c832685a81457124494a5