### PR TITLE
Enable predictive dropdowns across forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This project uses a desktop-first Tailwind CSS strategy. Base styles target larg
 <div class="grid grid-cols-4 max-md:grid-cols-1"></div>
 ```
 
+## Predictive Dropdowns
+
+Any `<select>` element with the `predictive` class is automatically enhanced with a text input and datalist that filters options as you type. Django forms that use `StyledFormMixin` add this class to select widgets by default. To enable the predictive behaviour on your own dropdown, add `class="predictive"` to the `<select>` or include the class in the widget's `attrs` when defining the form field.
+
 ## Installation
 
 Install dependencies using `pip`:

--- a/inventory/forms/base.py
+++ b/inventory/forms/base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from django import forms
+
 INPUT_CLASS = "w-full px-3 py-2 border rounded"
 CHECKBOX_CLASS = "h-4 w-4 text-blue-600"
 
@@ -9,10 +11,14 @@ class StyledFormMixin:
 
     def apply_styling(self) -> None:
         for field in self.fields.values():
-            if getattr(field.widget, "input_type", None) == "checkbox":
-                field.widget.attrs.update({"class": CHECKBOX_CLASS})
+            widget = field.widget
+            if getattr(widget, "input_type", None) == "checkbox":
+                widget.attrs.update({"class": CHECKBOX_CLASS})
             else:
-                field.widget.attrs.update({"class": INPUT_CLASS})
+                classes = INPUT_CLASS
+                if isinstance(widget, (forms.Select, forms.SelectMultiple)):
+                    classes += " predictive"
+                widget.attrs.update({"class": classes})
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/static/js/predictive-dropdown.js
+++ b/static/js/predictive-dropdown.js
@@ -1,0 +1,55 @@
+(function () {
+  function upgradeSelect(select) {
+    const dlId = (select.id || Math.random().toString(36).slice(2)) + '-options';
+
+    const textInput = document.createElement('input');
+    textInput.type = 'text';
+    textInput.setAttribute('list', dlId);
+    textInput.className = select.className.replace('predictive', '').trim();
+    const textId = select.id ? select.id + '_text' : '';
+    if (textId) {
+      textInput.id = textId;
+    }
+
+    const hiddenInput = document.createElement('input');
+    hiddenInput.type = 'hidden';
+    hiddenInput.name = select.name;
+    if (select.id) {
+      hiddenInput.id = select.id;
+    }
+
+    const datalist = document.createElement('datalist');
+    datalist.id = dlId;
+
+    Array.from(select.options).forEach((opt) => {
+      const option = document.createElement('option');
+      option.value = opt.text;
+      option.dataset.value = opt.value;
+      datalist.appendChild(option);
+      if (opt.selected) {
+        textInput.value = opt.text;
+        hiddenInput.value = opt.value;
+      }
+    });
+
+    textInput.addEventListener('input', () => {
+      const match = Array.from(datalist.options).find(
+        (o) => o.value === textInput.value
+      );
+      hiddenInput.value = match ? match.dataset.value : '';
+    });
+
+    if (select.id) {
+      const label = document.querySelector(`label[for="${select.id}"]`);
+      if (label) label.setAttribute('for', textInput.id);
+    }
+
+    select.replaceWith(textInput);
+    textInput.insertAdjacentElement('afterend', hiddenInput);
+    hiddenInput.insertAdjacentElement('afterend', datalist);
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('select.predictive').forEach(upgradeSelect);
+  });
+})();

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -8,6 +8,7 @@
     <link href="{% static 'css/app.css' %}" rel="stylesheet">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="{% static 'js/theme.js' %}"></script>
+    <script src="{% static 'js/predictive-dropdown.js' %}"></script>
     <script src="{% static 'js/nav.js' %}"></script>
   </head>
   <body class="min-h-screen">


### PR DESCRIPTION
## Summary
- Add predictive dropdown script that converts `<select>` elements into filterable datalist inputs
- Load predictive dropdown script in the base template after the theme script
- Apply `predictive` class to select widgets via `StyledFormMixin` and document usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9ce1c3c888326ad4cf7fa9a0363f0