### PR TITLE
Refactor UI components and unify terminology

### DIFF
--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -42,7 +42,21 @@ class IndentsListView(TemplateView):
         status = (self.request.GET.get("status") or "").strip()
         q = (self.request.GET.get("q") or "").strip()
         total_indents = Indent.objects.count()
-        ctx.update({"status": status, "q": q, "total_indents": total_indents})
+        filters = [
+            {
+                "name": "status",
+                "value": status,
+                "list_id": "indent-statuses",
+                "options": [
+                    {"value": "", "label": "All Statuses"},
+                    {"value": "SUBMITTED", "label": "Submitted"},
+                    {"value": "PROCESSING", "label": "Processing"},
+                    {"value": "COMPLETED", "label": "Completed"},
+                    {"value": "CANCELLED", "label": "Cancelled"},
+                ],
+            }
+        ]
+        ctx.update({"status": status, "q": q, "total_indents": total_indents, "filters": filters})
         return ctx
 
 

--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -10,6 +10,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.views import View
 from django.views.generic import TemplateView
+from django.urls import reverse
 
 from ..models import Item, StockTransaction
 from ..forms.item_forms import ItemForm
@@ -85,6 +86,33 @@ class ItemsListView(TemplateView):
         )
 
         ctx.update(params)
+        filters = [
+            {
+                "name": "active",
+                "value": params.get("active", ""),
+                "list_id": "item-active",
+                "id": "filter-active",
+                "options": [
+                    {"value": "", "label": "All"},
+                    {"value": "1", "label": "Active"},
+                    {"value": "0", "label": "Inactive"},
+                ],
+            },
+            {
+                "name": "category",
+                "value": category,
+                "list_id": "item-category",
+                "id": "filter-category",
+                "options": [{"value": "", "label": "All"}] + [{"value": c} for c in categories],
+            },
+            {
+                "name": "subcategory",
+                "value": subcategory,
+                "list_id": "item-subcategory",
+                "id": "filter-subcategory",
+                "options": [{"value": "", "label": "All"}] + [{"value": sc} for sc in subcategories],
+            },
+        ]
         ctx.update(
             {
                 "category": category,
@@ -94,6 +122,8 @@ class ItemsListView(TemplateView):
                 "categories_map": categories_map,
                 "page_size": per_page,
                 "items_table": items_table,
+                "filters": filters,
+                "export_url": reverse("items_export"),
             }
         )
         return ctx
@@ -318,7 +348,6 @@ class ItemSearchView(TemplateView):
         items = Item.objects.filter(name__icontains=query)[:20]
         ctx["items"] = items
         return ctx
-
 
 
 class ItemsBulkUploadView(View):

--- a/inventory/views/suppliers.py
+++ b/inventory/views/suppliers.py
@@ -4,6 +4,7 @@ import logging
 from django.contrib import messages
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.views import View
 from django.views.generic import TemplateView
 from django.utils.decorators import method_decorator
@@ -35,6 +36,18 @@ class SuppliersListView(TemplateView):
         sort = (self.request.GET.get("sort") or "name").strip()
         direction = (self.request.GET.get("direction") or "asc").strip()
         total_suppliers = Supplier.objects.count()
+        filters = [
+            {
+                "name": "active",
+                "value": active,
+                "list_id": "active-statuses",
+                "options": [
+                    {"value": "", "label": "All"},
+                    {"value": "1", "label": "Active"},
+                    {"value": "0", "label": "Inactive"},
+                ],
+            }
+        ]
         ctx.update(
             {
                 "q": q,
@@ -43,6 +56,8 @@ class SuppliersListView(TemplateView):
                 "sort": sort,
                 "direction": direction,
                 "total_suppliers": total_suppliers,
+                "filters": filters,
+                "export_url": reverse("suppliers_table"),
             }
         )
         return ctx

--- a/static/js/formset.js
+++ b/static/js/formset.js
@@ -1,0 +1,54 @@
+function initFormset({ formsetPrefix, addButtonId, formContainer, formClass, removeButtonClass, templateId }) {
+  const addBtn = document.getElementById(addButtonId);
+  const container = document.querySelector(formContainer);
+  if (!addBtn || !container) {
+    return;
+  }
+  const totalForms = document.getElementById(`id_${formsetPrefix}-TOTAL_FORMS`);
+  let emptyForm;
+  if (templateId) {
+    const tpl = document.getElementById(templateId);
+    emptyForm = tpl ? tpl.content : null;
+  }
+  if (!emptyForm) {
+    const firstForm = container.querySelector(`.${formClass}`);
+    emptyForm = firstForm ? firstForm.cloneNode(true) : null;
+  }
+  if (!emptyForm) {
+    return;
+  }
+  addBtn.addEventListener('click', function (e) {
+    e.preventDefault();
+    const formCount = parseInt(totalForms.value, 10);
+    const newForm = emptyForm.cloneNode(true);
+    newForm.querySelectorAll('input, select, textarea').forEach(function (el) {
+      let name = el.getAttribute('name');
+      if (!name) return;
+      if (name.indexOf('__prefix__') !== -1) {
+        name = name.replace('__prefix__', formCount);
+      } else {
+        name = name.replace(/-\d+-/, '-' + formCount + '-');
+      }
+      const id = 'id_' + name;
+      el.setAttribute('name', name);
+      el.setAttribute('id', id);
+      if (el.type !== 'hidden') {
+        el.value = '';
+      }
+    });
+    container.appendChild(newForm);
+    totalForms.value = formCount + 1;
+  });
+  if (removeButtonClass) {
+    container.addEventListener('click', function (e) {
+      if (e.target.classList.contains(removeButtonClass)) {
+        const forms = container.querySelectorAll(`.${formClass}`);
+        if (forms.length > 1) {
+          e.target.closest(`.${formClass}`).remove();
+          totalForms.value = forms.length - 1;
+        }
+      }
+    });
+  }
+}
+window.initFormset = initFormset;

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -54,6 +54,26 @@
   }
   .btn-secondary:disabled { @apply opacity-50 cursor-not-allowed; }
 
+  .btn-tertiary {
+    @apply px-4 py-2 rounded border transition-colors;
+    background-color: theme('colors.form.bg');
+    color: theme('colors.bodyText.light');
+    border-color: theme('colors.form.border');
+  }
+  .btn-tertiary:hover { @apply bg-gray-100; }
+  .btn-tertiary:focus {
+    @apply outline-none ring-2 ring-offset-2;
+    --tw-ring-color: theme('colors.form.border');
+  }
+  .btn-tertiary:disabled { @apply opacity-50 cursor-not-allowed; }
+  .dark .btn-tertiary {
+    background-color: theme('colors.form.darkBg');
+    color: theme('colors.bodyText.dark');
+    border-color: theme('colors.form.darkBorder');
+  }
+  .dark .btn-tertiary:hover { @apply bg-gray-700; }
+  .dark .btn-tertiary:focus { --tw-ring-color: theme('colors.form.darkBorder'); }
+
   .btn-danger {
     background-color: theme('colors.danger');
     @apply text-white px-4 py-2 rounded transition-colors;

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -9,6 +9,7 @@
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="{% static 'js/theme.js' %}"></script>
     <script src="{% static 'js/nav.js' %}"></script>
+    <script src="{% static 'js/formset.js' %}"></script>
   </head>
   <body class="min-h-screen">
     {% include "components/nav.html" %}

--- a/templates/components/filter_bar.html
+++ b/templates/components/filter_bar.html
@@ -1,0 +1,45 @@
+<form id="filters" class="grid gap-2 mb-4 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1" method="get">
+  <input
+    type="text"
+    name="q"
+    placeholder="{{ search_placeholder }}"
+    class="form-control w-full"
+    value="{{ q }}"
+    hx-get="{{ hx_get }}"
+    hx-target="{{ hx_target }}"
+    hx-trigger="keyup changed delay:300ms"
+    hx-include="#filters"
+    {% if hx_indicator %}hx-indicator="{{ hx_indicator }}"{% endif %}
+  />
+  {% for f in filters %}
+    <input
+      type="text"
+      name="{{ f.name }}"
+      list="{{ f.list_id }}"
+      class="form-control w-full"
+      value="{{ f.value }}"
+      hx-get="{{ hx_get }}"
+      hx-target="{{ hx_target }}"
+      hx-trigger="change"
+      hx-include="#filters"
+      {% if hx_indicator %}hx-indicator="{{ hx_indicator }}"{% endif %}
+      {% if f.id %}id="{{ f.id }}"{% endif %}
+    />
+    <datalist id="{{ f.list_id }}">
+      {% for opt in f.options %}
+        <option value="{{ opt.value }}"{% if opt.label %} label="{{ opt.label }}"{% endif %}></option>
+      {% endfor %}
+    </datalist>
+  {% endfor %}
+  {% if export_url %}
+    <button type="submit" {% if export_param_name and export_param_value %}name="{{ export_param_name }}" value="{{ export_param_value }}"{% endif %} formaction="{{ export_url }}" formmethod="get" class="btn-tertiary w-full">{{ export_label|default:'Export' }}</button>
+  {% endif %}
+  {% if page_size %}<input type="hidden" name="page_size" value="{{ page_size|default:25 }}">{% endif %}
+  {% if sort %}<input type="hidden" name="sort" value="{{ sort|default:'name' }}">{% endif %}
+  {% if direction %}<input type="hidden" name="direction" value="{{ direction|default:'asc' }}">{% endif %}
+  <noscript>
+    <div class="mt-2">
+      <button type="submit" class="btn-primary">Apply</button>
+    </div>
+  </noscript>
+</form>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -71,7 +71,7 @@
 <tr>
   <td colspan="9" class="px-4 py-2">
     {% url 'item_create' as item_create_url %}
-    {% include "components/empty_state.html" with title="No Items" message="No items found." cta_label="Add Item" cta_url=item_create_url %}
+    {% include "components/empty_state.html" with title="No Items" message="No items found." cta_label="New Item" cta_url=item_create_url %}
   </td>
 </tr>
 {% endfor %}

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -44,7 +44,7 @@
       <tr>
         <td colspan="7" class="px-4 py-2 text-center">
           0 suppliers yet.
-          <a href="{% url 'supplier_create' %}" class="btn-primary ml-2">Add Supplier</a>
+          <a href="{% url 'supplier_create' %}" class="btn-primary ml-2">New Supplier</a>
         </td>
       </tr>
       {% endfor %}

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -5,7 +5,7 @@
   <div class="mb-2">Requested By: {{ indent.requested_by }}</div>
   <div class="mb-2">Department: {{ indent.department }}</div>
   <div class="mb-4">
-    <a href="{% url 'indent_pdf' indent.indent_id %}" class="text-primary">Download PDF</a>
+    <a href="{% url 'indent_pdf' indent.indent_id %}" class="btn-tertiary">Download PDF</a>
   </div>
   <h2 class="text-xl font-semibold mb-2">Items</h2>
   <table class="table">

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -54,33 +54,15 @@
     </div>
   </form>
 </div>
-<script>
-(function() {
-  const addBtn = document.getElementById('add-row');
-  const table = document.getElementById('items-table').getElementsByTagName('tbody')[0];
-  const totalForms = document.getElementById('id_items-TOTAL_FORMS');
-  addBtn.addEventListener('click', function() {
-    const newIndex = parseInt(totalForms.value, 10);
-    const emptyRow = table.querySelector('.form-row').cloneNode(true);
-    emptyRow.querySelectorAll('input,select,textarea').forEach(function(el) {
-      const name = el.getAttribute('name').replace(/-\d+-/, '-' + newIndex + '-');
-      const id = 'id_' + name;
-      el.setAttribute('name', name);
-      el.setAttribute('id', id);
-      if (el.type !== 'hidden') { el.value = ''; }
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      initFormset({
+        formsetPrefix: 'items',
+        addButtonId: 'add-row',
+        formContainer: '#items-table tbody',
+        formClass: 'form-row',
+        removeButtonClass: 'remove-row'
+      });
     });
-    table.appendChild(emptyRow);
-    totalForms.value = newIndex + 1;
-  });
-  table.addEventListener('click', function(e){
-    if(e.target.classList.contains('remove-row')){
-      const rows = table.querySelectorAll('.form-row');
-      if(rows.length > 1){
-        e.target.closest('.form-row').remove();
-        totalForms.value = rows.length - 1;
-      }
-    }
-  });
-})();
-</script>
+  </script>
 {% endblock %}

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -4,37 +4,8 @@
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'indent_create' %}" class="btn-primary">New Indent</a>
   </div>
-    <form id="filters" class="grid gap-2 mb-4 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1">
-      <input
-        type="text"
-        name="q"
-        placeholder="Search indents..."
-        class="form-control w-full"
-        value="{{ q }}"
-        hx-get="{% url 'indents_table' %}"
-        hx-target="#indents_table"
-        hx-trigger="keyup changed delay:300ms"
-        hx-include="#filters"
-      />
-      <input
-        type="text"
-        name="status"
-        list="indent-statuses"
-        class="form-control w-full"
-        value="{{ status }}"
-        hx-get="{% url 'indents_table' %}"
-        hx-target="#indents_table"
-        hx-trigger="change"
-        hx-include="#filters"
-      />
-      <datalist id="indent-statuses">
-        <option value="" label="All Statuses"></option>
-        <option value="SUBMITTED" label="Submitted"></option>
-        <option value="PROCESSING" label="Processing"></option>
-        <option value="COMPLETED" label="Completed"></option>
-        <option value="CANCELLED" label="Cancelled"></option>
-      </datalist>
-  </form>
+  {% url 'indents_table' as indents_table_url %}
+  {% include "components/filter_bar.html" with search_placeholder="Search indents..." hx_get=indents_table_url hx_target="#indents_table" filters=filters %}
   <div id="indents_table"
        hx-get="{% url 'indents_table' %}"
        hx-trigger="load"

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -1,5 +1,5 @@
 {% extends "components/form_layout.html" %}
-{% block heading %}{% if is_edit %}Edit Item{% else %}Add Item{% endif %}{% endblock %}
+{% block heading %}{% if is_edit %}Edit Item{% else %}New Item{% endif %}{% endblock %}
 {% block fields %}
   {% if not form.units_map %}
   <p class="text-sm text-red-600 dark:text-red-400">Could not load unit options. Please try again later.</p>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -2,106 +2,11 @@
 {% block content %}
   <h1 class="text-2xl font-semibold mb-4">Items</h1>
   <div class="mb-4 flex justify-end gap-2">
-    <a href="{% url 'item_create' %}" class="btn-primary">Add Item</a>
+    <a href="{% url 'item_create' %}" class="btn-primary">New Item</a>
     <a href="{% url 'items_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
   </div>
-  <form id="filters" class="mb-4" hx-indicator="#htmx-spinner" method="get">
-    <fieldset class="grid gap-4 grid-cols-5 max-md:grid-cols-2 max-sm:grid-cols-1">
-      <legend class="sr-only">Filter Items</legend>
-      <div class="flex flex-col gap-1">
-        <label for="filter-q" class="text-sm font-medium">Search</label>
-        <input
-          id="filter-q"
-          type="text"
-          name="q"
-          placeholder="Search items..."
-          class="form-control w-full"
-          value="{{ q }}"
-          hx-get="{% url 'items_table' %}"
-          hx-target="#items_table"
-          hx-trigger="keyup changed delay:300ms"
-          hx-include="#filters"
-          hx-indicator="#htmx-spinner"
-        />
-      </div>
-      <div class="flex flex-col gap-1">
-        <label for="filter-active" class="text-sm font-medium">Status</label>
-        <input
-          id="filter-active"
-          type="text"
-          name="active"
-          list="item-active"
-          class="form-control w-full"
-          value="{{ active }}"
-          hx-get="{% url 'items_table' %}"
-          hx-target="#items_table"
-          hx-trigger="change"
-          hx-include="#filters"
-          hx-indicator="#htmx-spinner"
-        />
-        <datalist id="item-active">
-          <option value="" label="All"></option>
-          <option value="1" label="Active"></option>
-          <option value="0" label="Inactive"></option>
-        </datalist>
-      </div>
-      <div class="flex flex-col gap-1">
-        <label for="filter-category" class="text-sm font-medium">Category</label>
-        <input
-          id="filter-category"
-          type="text"
-          name="category"
-          list="item-category"
-          class="form-control w-full"
-          value="{{ category }}"
-          hx-get="{% url 'items_table' %}"
-          hx-target="#items_table"
-          hx-trigger="change"
-          hx-include="#filters"
-          hx-indicator="#htmx-spinner"
-        />
-        <datalist id="item-category">
-          <option value="" label="All"></option>
-          {% for c in categories %}
-          <option value="{{ c }}"></option>
-          {% endfor %}
-        </datalist>
-      </div>
-      <div class="flex flex-col gap-1">
-        <label for="filter-subcategory" class="text-sm font-medium">Subcategory</label>
-        <input
-          id="filter-subcategory"
-          type="text"
-          name="subcategory"
-          list="item-subcategory"
-          class="form-control w-full"
-          value="{{ subcategory }}"
-          hx-get="{% url 'items_table' %}"
-          hx-target="#items_table"
-          hx-trigger="change"
-          hx-include="#filters"
-          hx-indicator="#htmx-spinner"
-        />
-        <datalist id="item-subcategory">
-          <option value="" label="All"></option>
-          {% for sc in subcategories %}
-          <option value="{{ sc }}"></option>
-          {% endfor %}
-        </datalist>
-      </div>
-      <div class="flex flex-col gap-1">
-        <label class="text-sm font-medium" for="export-btn">&nbsp;</label>
-        <button id="export-btn" type="submit" formaction="{% url 'items_export' %}" formmethod="get" class="btn-secondary w-full">Export</button>
-      </div>
-    </fieldset>
-    <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
-    <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">
-    <noscript>
-      <div class="mt-2">
-        <button type="submit" class="btn-primary">Apply</button>
-      </div>
-    </noscript>
-  </form>
+  {% url 'items_table' as items_table_url %}
+  {% include "components/filter_bar.html" with search_placeholder="Search items..." hx_get=items_table_url hx_target="#items_table" hx_indicator="#htmx-spinner" filters=filters export_url=export_url sort=sort direction=direction %}
   {{ categories_map|json_script:"categories-data" }}
   <script>
     document.addEventListener('DOMContentLoaded', function () {

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -54,36 +54,20 @@
   </template>
 </div>
   <script>
-    (function () {
-      const formsetPrefix = "{{ formset.prefix }}";
-      const addBtn = document.getElementById("add-item");
-      const formsetDiv = document.getElementById("items-formset");
-      const totalFormsInput = document.getElementById(`id_${formsetPrefix}-TOTAL_FORMS`);
-      const emptyForm = document.getElementById("item-empty-form").content;
-
-      addBtn.addEventListener("click", function (e) {
-        e.preventDefault();
-        const formCount = parseInt(totalFormsInput.value);
-        const newForm = emptyForm.cloneNode(true);
-        newForm.querySelectorAll("input, select, textarea").forEach(function (el) {
-          const name = el.getAttribute("name").replace("__prefix__", formCount);
-          const id = `id_${name}`;
-          el.setAttribute("name", name);
-          el.setAttribute("id", id);
-          if (el.type !== "hidden") {
-            el.value = "";
-          }
-        });
-        formsetDiv.appendChild(newForm);
-        totalFormsInput.value = formCount + 1;
+    document.addEventListener('DOMContentLoaded', function () {
+      initFormset({
+        formsetPrefix: '{{ formset.prefix }}',
+        addButtonId: 'add-item',
+        formContainer: '#items-formset',
+        formClass: 'item-form',
+        templateId: 'item-empty-form'
       });
-
-      document.getElementById("po-form").addEventListener("submit", function (e) {
+      document.getElementById('po-form').addEventListener('submit', function (e) {
         if (!this.checkValidity()) {
           e.preventDefault();
           this.reportValidity();
         }
       });
-    })();
+    });
   </script>
 {% endblock %}

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -1,5 +1,5 @@
 {% extends "components/form_layout.html" %}
-{% block heading %}{% if is_edit %}Edit Supplier{% else %}Add Supplier{% endif %}{% endblock %}
+{% block heading %}{% if is_edit %}Edit Supplier{% else %}New Supplier{% endif %}{% endblock %}
 {% block fields %}
   <div class="grid gap-4 grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
     {% for field in form %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -2,50 +2,19 @@
 {% block content %}
   <h1 class="text-2xl font-semibold mb-4">Suppliers ({{ total_suppliers }})</h1>
   <div class="mb-4 flex justify-end gap-2">
-    <a href="{% url 'supplier_create' %}" class="btn-primary">Add Supplier</a>
+    <a href="{% url 'supplier_create' %}" class="btn-primary">New Supplier</a>
     <a href="{% url 'suppliers_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
     <a href="{% url 'suppliers_bulk_delete' %}" class="btn-danger">Bulk Delete</a>
   </div>
-  <form id="filters" class="grid gap-2 mb-4 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1">
-      <input
-        type="text"
-        name="q"
-        placeholder="Search suppliers..."
-        class="form-control w-full"
-        value="{{ q }}"
-        hx-get="{% url 'suppliers_table' %}"
-        hx-target="#suppliers_table"
-        hx-trigger="keyup changed delay:300ms"
-        hx-include="#filters"
-      />
-      <input
-        type="text"
-        name="active"
-        list="active-statuses"
-        class="form-control w-full"
-        value="{{ active }}"
-        hx-get="{% url 'suppliers_table' %}"
-        hx-target="#suppliers_table"
-        hx-trigger="change"
-        hx-include="#filters"
-      />
-      <datalist id="active-statuses">
-        <option value="" label="All"></option>
-        <option value="1" label="Active"></option>
-        <option value="0" label="Inactive"></option>
-      </datalist>
-      <input type="hidden" name="page_size" value="{{ page_size|default:25 }}">
-      <input type="hidden" name="sort" value="{{ sort|default:'name' }}">
-      <input type="hidden" name="direction" value="{{ direction|default:'asc' }}">
-      <button type="submit" name="export" value="1" formaction="{% url 'suppliers_table' %}" formmethod="get" class="btn-secondary w-full">Export</button>
-  </form>
+  {% url 'suppliers_table' as suppliers_table_url %}
+  {% include "components/filter_bar.html" with search_placeholder="Search suppliers..." hx_get=suppliers_table_url hx_target="#suppliers_table" filters=filters export_url=export_url export_param_name="export" export_param_value="1" page_size=page_size sort=sort direction=direction %}
   <div id="suppliers_table"
        hx-get="{% url 'suppliers_table' %}"
        hx-trigger="load"
        hx-include="#filters">
     {% if total_suppliers == 0 %}
       {% url 'supplier_create' as supplier_create_url %}
-      {% include "components/empty_state.html" with title="No Suppliers" message="Start by adding your first supplier." cta_label="Add Supplier" cta_url=supplier_create_url %}
+      {% include "components/empty_state.html" with title="No Suppliers" message="Start by adding your first supplier." cta_label="New Supplier" cta_url=supplier_create_url %}
     {% endif %}
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `.btn-tertiary` style and apply to export and PDF actions
- centralize formset row handling with reusable `formset.js`
- introduce reusable `filter_bar` component and standardize "New" terminology

## Testing
- `flake8 inventory/views/items.py inventory/views/suppliers.py inventory/views/indents.py`
- `pytest` *(fails: tests/test_item_views.py::test_item_edit_view_preselects_category_and_subcategory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cdc48fe483268bf3d0430e0b7f8c