### PR TITLE
Fix item edit view preselecting category and subcategory

### DIFF
--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -39,12 +39,12 @@
   </datalist>
   <datalist id="category-options">
     {% for c in form.category_options %}
-      <option value="{{ c }}"></option>
+      <option value="{{ c }}"{% if c == form.category.value %} selected{% endif %}></option>
     {% endfor %}
   </datalist>
   <datalist id="sub-category-options">
     {% for c in form.sub_category_options %}
-      <option value="{{ c }}"></option>
+      <option value="{{ c }}"{% if c == form.sub_category.value %} selected{% endif %}></option>
     {% endfor %}
   </datalist>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Ensure item edit form marks the current category and subcategory option as selected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9d0b699d08326913d483a5b238c6f