### PR TITLE
feat: improve dark mode primary color

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2,6 +2,8 @@
 
 :root {
   --color-primary: #1a46c2;
+  /* Dark mode variant */
+  --color-primary-dark: #60a5fa;
   --color-secondary: #036045;
   --color-accent: #ad5f04;
 }
@@ -1451,7 +1453,7 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 }
 
 .dark .text-primary {
-  color: var(--color-primary);
+  color: var(--color-primary-dark);
 }
 
 @media (max-width: 768px) {

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -205,7 +205,7 @@
 }
 
 @layer utilities {
-  .dark .text-primary { color: var(--color-primary); }
+  .dark .text-primary { color: var(--color-primary-dark); }
 }
 
 @media (max-width: 768px) {

--- a/static/src/tokens.css
+++ b/static/src/tokens.css
@@ -1,6 +1,8 @@
 :root {
   /* Color tokens */
   --color-primary: #1a46c2;
+  /* Dark mode variant */
+  --color-primary-dark: #60a5fa;
   --color-secondary: #036045;
   --color-accent: #ad5f04;
 


### PR DESCRIPTION
## Summary
- add dark-mode `--color-primary-dark` token
- use `--color-primary-dark` for `.dark .text-primary`

## Testing
- `pytest`
- `python` contrast check for #60a5fa vs dark backgrounds


------
https://chatgpt.com/codex/tasks/task_e_68a9d2ae43c0832692e6171ad10aa7b0