### PR TITLE
Add contrast checks for custom theme colours

### DIFF
--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -15,6 +15,33 @@
     applyTheme('dark');
   }
 
+  function hexToRgb(hex) {
+    const res = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+    return res ? [parseInt(res[1], 16), parseInt(res[2], 16), parseInt(res[3], 16)] : [0, 0, 0];
+  }
+
+  function luminance(hex) {
+    const rgb = hexToRgb(hex).map(function(v) {
+      v = v / 255;
+      return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+    });
+    return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+  }
+
+  function contrast(hex1, hex2) {
+    const lum1 = luminance(hex1);
+    const lum2 = luminance(hex2);
+    const brightest = Math.max(lum1, lum2);
+    const darkest = Math.min(lum1, lum2);
+    return (brightest + 0.05) / (darkest + 0.05);
+  }
+
+  function passesContrast(color) {
+    const lightBg = '#ffffff';
+    const darkBg = '#0f172a';
+    return contrast(color, lightBg) >= 4.5 && contrast(color, darkBg) >= 4.5;
+  }
+
   document.addEventListener('DOMContentLoaded', function() {
     const toggle = document.getElementById('theme-toggle');
     if (toggle) {
@@ -25,21 +52,39 @@
       });
     }
 
+    const feedback = document.getElementById('colour-feedback');
+    const lastColors = {};
+
     ['primary', 'secondary', 'accent'].forEach(function(key) {
-      const storedColor = localStorage.getItem('color-' + key);
       const picker = document.getElementById('picker-' + key);
-      if (storedColor) {
-        document.documentElement.style.setProperty('--color-' + key, storedColor);
-        if (picker) {
-          picker.value = storedColor;
+      if (!picker) { return; }
+
+      const storedColor = localStorage.getItem('color-' + key);
+      const initial = storedColor || picker.getAttribute('value');
+      if (initial) {
+        document.documentElement.style.setProperty('--color-' + key, initial);
+        picker.value = initial;
+        lastColors[key] = initial;
+      }
+
+      picker.addEventListener('input', function() {
+        const newColor = picker.value;
+        if (passesContrast(newColor)) {
+          document.documentElement.style.setProperty('--color-' + key, newColor);
+          localStorage.setItem('color-' + key, newColor);
+          lastColors[key] = newColor;
+          if (feedback) {
+            feedback.textContent = '';
+            feedback.classList.add('hidden');
+          }
+        } else {
+          if (feedback) {
+            feedback.textContent = 'Selected colour does not meet contrast guidelines and was reset.';
+            feedback.classList.remove('hidden');
+          }
+          picker.value = lastColors[key];
         }
-      }
-      if (picker) {
-        picker.addEventListener('input', function() {
-          document.documentElement.style.setProperty('--color-' + key, picker.value);
-          localStorage.setItem('color-' + key, picker.value);
-        });
-      }
+      });
     });
 
     const reset = document.getElementById('colour-reset');
@@ -51,9 +96,14 @@
             const defaultVal = picker.getAttribute('value');
             document.documentElement.style.setProperty('--color-' + key, defaultVal);
             picker.value = defaultVal;
+            lastColors[key] = defaultVal;
           }
           localStorage.removeItem('color-' + key);
         });
+        if (feedback) {
+          feedback.textContent = '';
+          feedback.classList.add('hidden');
+        }
       });
     }
   });

--- a/templates/components/colour_customizer.html
+++ b/templates/components/colour_customizer.html
@@ -11,5 +11,6 @@
     Accent
     <input type="color" id="picker-accent" value="#ad5f04" class="ml-2 border dark:border-form-darkBorder dark:bg-form-darkBg dark:text-form-darkText rounded">
   </label>
+  <p id="colour-feedback" class="text-xs text-red-600 dark:text-red-400 hidden"></p>
   <button id="colour-reset" type="button" class="btn-secondary w-full mt-2">Reset to default</button>
 </div>


### PR DESCRIPTION
## Summary
- ensure custom colours meet WCAG contrast for light and dark backgrounds
- notify users and reset invalid selections
- show colour feedback message in customizer

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9d38877ec83269423cbcc50c44b38