### PR TITLE
style: underline links and clarify link guidelines

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -117,12 +117,24 @@ h6 {
 }
 
 /*
-Reset links to optimize for opt-in styling instead of opt-out.
+Base link styles use an underline and the primary color.
+Button-like links (.btn-*) intentionally remove the underline.
 */
 
 a {
-  color: inherit;
-  text-decoration: inherit;
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+a:hover,
+a:focus {
+  color: var(--color-primary-dark);
+}
+.dark a {
+  color: var(--color-primary-dark);
+}
+.dark a:hover,
+.dark a:focus {
+  color: var(--color-primary);
 }
 
 /*
@@ -648,6 +660,7 @@ body {
   padding-bottom: 0.5rem;
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
+  text-decoration: none;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
@@ -681,6 +694,7 @@ body {
   padding-bottom: 0.5rem;
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
+  text-decoration: none;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
@@ -714,6 +728,7 @@ body {
   padding-bottom: 0.5rem;
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
+  text-decoration: none;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -15,6 +15,23 @@
     background-color: theme('colors.body.dark');
     color: theme('colors.bodyText.dark');
   }
+  /* Base link styles: underlined with primary color.
+     Button classes (.btn-*) remove the underline. */
+  a {
+    color: var(--color-primary);
+    text-decoration: underline;
+  }
+  a:hover,
+  a:focus {
+    color: var(--color-primary-dark);
+  }
+  .dark a {
+    color: var(--color-primary-dark);
+  }
+  .dark a:hover,
+  .dark a:focus {
+    color: var(--color-primary);
+  }
 }
 
 @layer components {
@@ -34,7 +51,7 @@
   /* Button styles */
   .btn-primary {
     background-color: var(--color-primary);
-    @apply text-white px-4 py-2 rounded transition-colors;
+    @apply text-white px-4 py-2 rounded transition-colors no-underline;
   }
   .btn-primary:hover { @apply opacity-90; }
   .btn-primary:focus {
@@ -45,7 +62,7 @@
 
   .btn-secondary {
     background-color: var(--color-secondary);
-    @apply text-white px-4 py-2 rounded transition-colors;
+    @apply text-white px-4 py-2 rounded transition-colors no-underline;
   }
   .btn-secondary:hover { @apply opacity-90; }
   .btn-secondary:focus {
@@ -55,7 +72,7 @@
   .btn-secondary:disabled { @apply opacity-50 cursor-not-allowed; }
 
   .btn-tertiary {
-    @apply px-4 py-2 rounded border transition-colors;
+    @apply px-4 py-2 rounded border transition-colors no-underline;
     background-color: theme('colors.form.bg');
     color: theme('colors.bodyText.light');
     border-color: theme('colors.form.border');
@@ -76,7 +93,7 @@
 
   .btn-danger {
     background-color: theme('colors.danger');
-    @apply text-white px-4 py-2 rounded transition-colors;
+    @apply text-white px-4 py-2 rounded transition-colors no-underline;
   }
   .btn-danger:hover { @apply opacity-90; }
   .btn-danger:focus {
@@ -86,7 +103,7 @@
   .btn-danger:disabled { @apply opacity-50 cursor-not-allowed; }
 
   .btn-outline {
-    @apply px-4 py-2 border rounded transition-colors;
+    @apply px-4 py-2 border rounded transition-colors no-underline;
     background-color: transparent;
     color: theme('colors.bodyText.light');
     border-color: theme('colors.form.border');


### PR DESCRIPTION
## Summary
- underline links by default and adjust dark theme hover/focus colors
- keep button-like links unadorned and document link styling guidelines

## Testing
- `pytest` *(fails: No module named 'django')*
- `flake8` *(fails: existing style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d415c1048326a6db141751fb34d8