### PR TITLE
Validate positive quantity for stock receiving

### DIFF
--- a/inventory/forms/stock_forms.py
+++ b/inventory/forms/stock_forms.py
@@ -31,6 +31,12 @@ class StockReceivingForm(StyledFormMixin, forms.ModelForm):
         self.fields["item"].widget.attrs.update(item_attrs)
         self.apply_styling()
 
+    def clean_quantity_change(self):
+        qty = self.cleaned_data.get("quantity_change")
+        if qty is None or qty <= 0:
+            raise forms.ValidationError("Quantity must be positive")
+        return qty
+
     def save(self, commit: bool = True):
         obj = super().save(commit=False)
         obj.transaction_type = "RECEIVING"

--- a/tests/test_stock_forms.py
+++ b/tests/test_stock_forms.py
@@ -7,6 +7,7 @@ from inventory.forms.stock_forms import (
     StockAdjustmentForm,
     StockWastageForm,
 )
+from inventory.models import Item
 
 
 @pytest.mark.django_db
@@ -37,3 +38,12 @@ def test_stock_movements_page_has_datalist(client):
     assert 'hx-target="#item-options"' in content
     assert 'hx-trigger="keyup changed delay:500ms"' in content
     assert 'list="item-options"' in content
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("qty", [0, -1])
+def test_stock_receiving_form_requires_positive_quantity(qty):
+    item = Item.objects.create(name="Test", base_unit="kg", purchase_unit="kg")
+    form = StockReceivingForm(data={"item": item.pk, "quantity_change": qty})
+    assert not form.is_valid()
+    assert form.errors["quantity_change"] == ["Quantity must be positive"]


### PR DESCRIPTION
## Summary
- require StockReceivingForm quantity to be strictly positive
- test validation for non-positive quantities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9d980e3408326a0ae8681219c3e52