### PR TITLE
Validate positive quantities and unit prices in forms

### DIFF
--- a/inventory/forms/indent_forms.py
+++ b/inventory/forms/indent_forms.py
@@ -41,6 +41,12 @@ class IndentItemForm(StyledFormMixin, forms.ModelForm):
         self.fields["item"].widget.attrs.update(item_attrs)
         self.apply_styling()
 
+    def clean_requested_qty(self):
+        qty = self.cleaned_data.get("requested_qty")
+        if qty is None or qty <= 0:
+            raise forms.ValidationError("Quantity must be positive")
+        return qty
+
 
 IndentItemFormSet = forms.inlineformset_factory(
     Indent,

--- a/inventory/forms/purchase_forms.py
+++ b/inventory/forms/purchase_forms.py
@@ -58,6 +58,18 @@ class PurchaseOrderItemForm(StyledFormMixin, forms.ModelForm):
         self.fields["item"].widget.attrs.update(item_attrs)
         self.apply_styling()
 
+    def clean_quantity_ordered(self):
+        qty = self.cleaned_data.get("quantity_ordered")
+        if qty is None or qty <= 0:
+            raise forms.ValidationError("Quantity must be positive")
+        return qty
+
+    def clean_unit_price(self):
+        price = self.cleaned_data.get("unit_price")
+        if price is None or price <= 0:
+            raise forms.ValidationError("Unit price must be positive")
+        return price
+
 
 PurchaseOrderItemFormSet = forms.inlineformset_factory(
     PurchaseOrder,

--- a/tests/test_indent_forms.py
+++ b/tests/test_indent_forms.py
@@ -2,7 +2,7 @@ import django
 from django.conf import settings
 
 import pytest
-from inventory.forms.indent_forms import IndentForm, IndentItemFormSet
+from inventory.forms.indent_forms import IndentForm, IndentItemFormSet, IndentItemForm
 
 
 @pytest.mark.django_db
@@ -35,3 +35,12 @@ def test_indent_form_and_formset_save(item_factory):
     assert indent.status == "SUBMITTED"
     assert indent.indentitem_set.count() == 1
     assert indent.indentitem_set.first().item_id == item.pk
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("qty", [0, -1])
+def test_indent_item_form_requires_positive_quantity(item_factory, qty):
+    item = item_factory(name="Sugar")
+    form = IndentItemForm(data={"item": item.pk, "requested_qty": qty})
+    assert not form.is_valid()
+    assert form.errors["requested_qty"] == ["Quantity must be positive"]

--- a/tests/test_purchase_forms.py
+++ b/tests/test_purchase_forms.py
@@ -1,0 +1,24 @@
+import pytest
+from inventory.forms.purchase_forms import PurchaseOrderItemForm
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("qty", [0, -1])
+def test_purchase_order_item_form_requires_positive_quantity(item_factory, qty):
+    item = item_factory(name="Sugar")
+    form = PurchaseOrderItemForm(
+        data={"item": item.pk, "quantity_ordered": qty, "unit_price": 10}
+    )
+    assert not form.is_valid()
+    assert form.errors["quantity_ordered"] == ["Quantity must be positive"]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("price", [0, -1])
+def test_purchase_order_item_form_requires_positive_unit_price(item_factory, price):
+    item = item_factory(name="Sugar")
+    form = PurchaseOrderItemForm(
+        data={"item": item.pk, "quantity_ordered": 5, "unit_price": price}
+    )
+    assert not form.is_valid()
+    assert form.errors["unit_price"] == ["Unit price must be positive"]


### PR DESCRIPTION
## Summary
- ensure indent item requested quantities must be greater than zero
- validate purchase order items for positive quantities and unit prices
- test forms reject non-positive values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9dad3e4a48326bde9f8a9281fcbb1