### PR TITLE
Use button style for supplier toggle

### DIFF
--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -36,7 +36,7 @@
             <input type="hidden" name="page_size" value="{{ page_size }}" />
             <input type="hidden" name="sort" value="{{ sort }}" />
             <input type="hidden" name="direction" value="{{ direction }}" />
-            <button type="submit" class="text-primary">Toggle</button>
+            <button type="submit" class="btn-outline">Toggle</button>
           </form>
         </td>
       </tr>


### PR DESCRIPTION
## Summary
- style supplier toggle with btn-outline instead of plain text link

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9df2757e48326b98cb1e1a3b80b27