### PR TITLE
Add model docstrings and explicit serializer fields

### DIFF
--- a/inventory/models/items.py
+++ b/inventory/models/items.py
@@ -5,6 +5,7 @@ from . import CoerceFloatField
 
 
 class Item(models.Model):
+    """An inventory item and its stock tracking details."""
     item_id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255, blank=False, null=False)
     base_unit = models.CharField(max_length=50, blank=False, null=False)
@@ -25,6 +26,7 @@ class Item(models.Model):
 
 
 class StockTransaction(models.Model):
+    """Records inventory stock increases or decreases for an item."""
     transaction_id = models.AutoField(primary_key=True)
     item = models.ForeignKey(
         Item, models.DO_NOTHING, db_column="item_id", blank=True, null=True

--- a/inventory/models/orders.py
+++ b/inventory/models/orders.py
@@ -7,6 +7,7 @@ from .suppliers import Supplier
 
 
 class Indent(models.Model):
+    """Represents a material requisition from a department."""
     indent_id = models.AutoField(primary_key=True)
     mrn = models.CharField(max_length=100, unique=True, null=False, blank=False)
     requested_by = models.CharField(max_length=255, blank=True, null=True)
@@ -28,6 +29,7 @@ class Indent(models.Model):
 
 
 class IndentItem(models.Model):
+    """Links an item to an indent with requested and issued quantities."""
     indent_item_id = models.AutoField(primary_key=True)
     indent = models.ForeignKey(
         Indent, models.DO_NOTHING, db_column="indent_id", blank=True, null=True
@@ -52,6 +54,7 @@ class IndentItem(models.Model):
 
 
 class PurchaseOrder(models.Model):
+    """Orders items from a supplier based on approved indents."""
     po_id = models.AutoField(primary_key=True)
     supplier = models.ForeignKey(
         Supplier, models.CASCADE, db_column="supplier_id"
@@ -79,6 +82,7 @@ class PurchaseOrder(models.Model):
 
 
 class PurchaseOrderItem(models.Model):
+    """Line item detailing quantity and price for a purchase order."""
     po_item_id = models.AutoField(primary_key=True)
     purchase_order = models.ForeignKey(
         PurchaseOrder, models.CASCADE, db_column="po_id"
@@ -106,6 +110,7 @@ class PurchaseOrderItem(models.Model):
 
 
 class GoodsReceivedNote(models.Model):
+    """Acknowledges receipt of goods for a purchase order."""
     grn_id = models.AutoField(primary_key=True)
     purchase_order = models.ForeignKey(
         PurchaseOrder, models.CASCADE, db_column="po_id"
@@ -124,6 +129,7 @@ class GoodsReceivedNote(models.Model):
 
 
 class GRNItem(models.Model):
+    """Tracks individual items received against a GRN and PO item."""
     grn_item_id = models.AutoField(primary_key=True)
     grn = models.ForeignKey(GoodsReceivedNote, models.CASCADE, db_column="grn_id")
     po_item = models.ForeignKey(

--- a/inventory/models/suppliers.py
+++ b/inventory/models/suppliers.py
@@ -2,6 +2,7 @@ from django.db import models
 
 
 class Supplier(models.Model):
+    """Stores vendor contact and activity information."""
     supplier_id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255, unique=True, null=False, blank=False)
     contact_person = models.CharField(max_length=255, blank=True, null=True)

--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -17,74 +17,212 @@ from .models import (
 
 
 class ItemSerializer(serializers.ModelSerializer):
+    """Expose basic item details and stock levels."""
+
     class Meta:
         model = Item
-        fields = "__all__"
+        fields = [
+            "item_id",
+            "name",
+            "base_unit",
+            "purchase_unit",
+            "category_id",
+            "permitted_departments",
+            "reorder_point",
+            "current_stock",
+            "notes",
+            "is_active",
+            "updated_at",
+        ]
 
 
 class SupplierSerializer(serializers.ModelSerializer):
+    """Serialize supplier contact and status information."""
+
     class Meta:
         model = Supplier
-        fields = "__all__"
+        fields = [
+            "supplier_id",
+            "name",
+            "contact_person",
+            "phone",
+            "email",
+            "address",
+            "notes",
+            "is_active",
+            "updated_at",
+        ]
 
 
 class StockTransactionSerializer(serializers.ModelSerializer):
+    """Show inventory adjustments for a specific item."""
+
     class Meta:
         model = StockTransaction
-        fields = "__all__"
+        fields = [
+            "transaction_id",
+            "item",
+            "quantity_change",
+            "transaction_type",
+            "user_id",
+            "related_mrn",
+            "related_po_id",
+            "notes",
+            "transaction_date",
+        ]
 
 
 class IndentSerializer(serializers.ModelSerializer):
+    """Expose requisition details submitted by departments."""
+
     class Meta:
         model = Indent
-        fields = "__all__"
+        fields = [
+            "indent_id",
+            "mrn",
+            "requested_by",
+            "department",
+            "date_required",
+            "notes",
+            "status",
+            "date_submitted",
+            "processed_by_user_id",
+            "date_processed",
+            "created_at",
+            "updated_at",
+        ]
 
 
 class IndentItemSerializer(serializers.ModelSerializer):
+    """Serialize the items and quantities within an indent."""
+
     class Meta:
         model = IndentItem
-        fields = "__all__"
+        fields = [
+            "indent_item_id",
+            "indent",
+            "item",
+            "requested_qty",
+            "issued_qty",
+            "item_status",
+            "notes",
+        ]
 
 
 class PurchaseOrderSerializer(serializers.ModelSerializer):
+    """Provide purchase order headers sent to suppliers."""
+
     class Meta:
         model = PurchaseOrder
-        fields = "__all__"
+        fields = [
+            "po_id",
+            "supplier",
+            "order_date",
+            "expected_delivery_date",
+            "status",
+            "notes",
+        ]
 
 
 class PurchaseOrderItemSerializer(serializers.ModelSerializer):
+    """Detail quantities and prices for ordered items."""
+
     class Meta:
         model = PurchaseOrderItem
-        fields = "__all__"
+        fields = [
+            "po_item_id",
+            "purchase_order",
+            "item",
+            "quantity_ordered",
+            "unit_price",
+        ]
 
 
 class GoodsReceivedNoteSerializer(serializers.ModelSerializer):
+    """Serialize acknowledgments of received purchase orders."""
+
     class Meta:
         model = GoodsReceivedNote
-        fields = "__all__"
+        fields = [
+            "grn_id",
+            "purchase_order",
+            "supplier",
+            "received_date",
+            "notes",
+        ]
 
 
 class GRNItemSerializer(serializers.ModelSerializer):
+    """Detail items and quantities recorded on a GRN."""
+
     class Meta:
         model = GRNItem
-        fields = "__all__"
+        fields = [
+            "grn_item_id",
+            "grn",
+            "po_item",
+            "quantity_ordered_on_po",
+            "quantity_received",
+            "unit_price_at_receipt",
+            "item_notes",
+        ]
 
 
 class SaleTransactionSerializer(serializers.ModelSerializer):
+    """Expose sales of prepared recipes."""
+
     class Meta:
         model = SaleTransaction
-        fields = "__all__"
+        fields = [
+            "sale_id",
+            "recipe",
+            "quantity",
+            "user_id",
+            "notes",
+            "sale_date",
+        ]
 
 
 class RecipeComponentSerializer(serializers.ModelSerializer):
+    """Serialize components that make up a recipe."""
+
     class Meta:
         model = RecipeComponent
-        fields = "__all__"
+        fields = [
+            "id",
+            "parent_recipe",
+            "component_kind",
+            "component_id",
+            "quantity",
+            "unit",
+            "loss_pct",
+            "sort_order",
+            "notes",
+            "created_at",
+            "updated_at",
+        ]
 
 
 class RecipeSerializer(serializers.ModelSerializer):
+    """Represent a recipe and its component breakdown."""
     components = RecipeComponentSerializer(many=True, read_only=True)
 
     class Meta:
         model = Recipe
-        fields = "__all__"
+        fields = [
+            "recipe_id",
+            "name",
+            "description",
+            "is_active",
+            "type",
+            "default_yield_qty",
+            "default_yield_unit",
+            "plating_notes",
+            "tags",
+            "version",
+            "effective_from",
+            "effective_to",
+            "created_at",
+            "updated_at",
+            "components",
+        ]


### PR DESCRIPTION
## Summary
- document key inventory models with concise class docstrings
- define explicit field lists and docstrings for all serializers

## Testing
- `flake8 inventory/models inventory/serializers.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9ff5369a88326a7a145474147abeb