### PR TITLE
feat: standardize typography

### DIFF
--- a/app.css
+++ b/app.css
@@ -28,13 +28,45 @@ a:focus {
 body {
   background-color: #ffffff;
   color: #111827;
-  font-family: Roboto, sans-serif;
+  font-family: 'Roboto', sans-serif;
+  font-weight: 400;
 }
 
 .dark body {
   background-color: #0e1a33; /* Dark mode background with improved contrast */
   color: #e5e5e5; /* Text color for better visibility in dark mode */
 }
+
+/* Heading hierarchy */
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+/* Text color utilities */
+.text-primary {
+  color: var(--color-primary);
+}
+
+.text-secondary {
+  color: var(--color-secondary);
+}
+
+.dark .text-primary {
+  color: var(--color-primary-dark);
+}
+
+.dark .text-secondary {
+  color: var(--color-secondary);
+}
+
 
 /* Status badge classes */
 .dark .badge-success {

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -1,6 +1,6 @@
 <div class="py-6 px-8 max-md:px-6 max-sm:px-4 text-center border border-form-border rounded bg-form-bg dark:bg-form-darkBg dark:border-form-darkBorder">
   <svg class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-  <h2 class="mt-4 mb-2 text-lg font-semibold">{{ title }}</h2>
+  <h2 class="mt-4 mb-2">{{ title }}</h2>
   <p class="mb-4 text-form-text dark:text-form-darkText">{{ message }}</p>
   <a href="{{ cta_url }}" class="btn-primary">{{ cta_label }}</a>
 </div>

--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block content %}
 <div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">
+  <h1 class="mb-4">
     {% block heading %}{% endblock %}
   </h1>
   {% if form %}

--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block content %}
 <div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
+  <h1 class="mb-4">{{ title }}</h1>
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}

--- a/templates/inventory/grns/detail.html
+++ b/templates/inventory/grns/detail.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">GRN {{ grn.pk }}</h1>
+  <h1 class="mb-4">GRN {{ grn.pk }}</h1>
   <p class="mb-2"><strong>PO:</strong> <a class="text-primary" href="{% url 'purchase_order_detail' grn.purchase_order_id %}">{{ grn.purchase_order_id }}</a></p>
   <p class="mb-2"><strong>Supplier:</strong> {{ grn.supplier.name }}</p>
   <p class="mb-4"><strong>Date:</strong> {{ grn.received_date }}</p>

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Goods Received Notes</h1>
+  <h1 class="mb-4">Goods Received Notes</h1>
   <form method="get" class="mb-4 grid gap-2 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
       <label class="block text-sm">Supplier</label>

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">History Reports</h1>
+  <h1 class="mb-4">History Reports</h1>
     <form id="filters" method="get" class="grid gap-2 mb-4 grid-cols-7 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1"
           hx-get="{% url 'history_reports' %}"
           hx-target="#history_table"

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -1,13 +1,13 @@
 {% extends "_base.html" %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Indent {{ indent.indent_id }}</h1>
+  <h1 class="mb-4">Indent {{ indent.indent_id }}</h1>
   <div class="mb-2">Status: <span class="px-2 py-1 rounded {{ badges[indent.status|upper] }}">{{ indent.status }}</span></div>
   <div class="mb-2">Requested By: {{ indent.requested_by }}</div>
   <div class="mb-2">Department: {{ indent.department }}</div>
   <div class="mb-4">
     <a href="{% url 'indent_pdf' indent.indent_id %}" class="btn-tertiary">Download PDF</a>
   </div>
-  <h2 class="text-xl font-semibold mb-2">Items</h2>
+  <h2 class="mb-2">Items</h2>
   <table class="table">
     <thead><tr><th>Item</th><th>Qty</th></tr></thead>
     <tbody>

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Indents ({{ total_indents }})</h1>
+  <h1 class="mb-4">Indents ({{ total_indents }})</h1>
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'indent_create' %}" class="btn-primary">New Indent</a>
   </div>

--- a/templates/inventory/item_confirm_delete.html
+++ b/templates/inventory/item_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block content %}
 <div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">Delete/Deactivate Item</h1>
+  <h1 class="mb-4">Delete/Deactivate Item</h1>
   <p class="mb-4">Are you sure you want to delete or deactivate "{{ item.name }}"?</p>
   <form method="post" class="flex gap-2">
     {% csrf_token %}

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">{{ item.name }}</h1>
+  <h1 class="mb-4">{{ item.name }}</h1>
   <table class="table">
     <tbody>
       <tr><th class="text-left pr-4">ID</th><td>{{ item.item_id }}</td></tr>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Items</h1>
+  <h1 class="mb-4">Items</h1>
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'item_create' %}" class="btn-primary">New Item</a>
     <a href="{% url 'items_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -1,10 +1,10 @@
 {% extends "_base.html" %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Purchase Order {{ po.pk }}</h1>
+  <h1 class="mb-4">Purchase Order {{ po.pk }}</h1>
   <p class="mb-2"><strong>Supplier:</strong> {{ po.supplier.name }}</p>
   <p class="mb-2"><strong>Order Date:</strong> {{ po.order_date }}</p>
   <p class="mb-4"><span class="px-2 py-1 rounded text-xs {{ badge_class }}">{{ po.get_status_display }}</span></p>
-  <h2 class="text-xl mb-2">Items</h2>
+  <h2 class="mb-2">Items</h2>
   <table class="table mb-4">
     <thead><tr><th>Item</th><th>Ordered</th><th>Received</th></tr></thead>
     <tbody>

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Purchase Orders</h1>
+  <h1 class="mb-4">Purchase Orders</h1>
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'purchase_order_create' %}" class="btn-primary">New PO</a>
     <a href="{% url 'grn_list' %}" class="btn-secondary">GRNs</a>

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block content %}
 <div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">Receive Goods for PO {{ po.pk }}</h1>
+  <h1 class="mb-4">Receive Goods for PO {{ po.pk }}</h1>
   <form method="post" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block content %}
 <div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
-  <h1 class="text-xl font-bold mb-4">{% if recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}</h1>
+  <h1 class="mb-4">{% if recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}</h1>
   <form method="post" id="recipe-form">
     {% csrf_token %}
     {% if form.non_field_errors %}

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -1,10 +1,10 @@
 {% extends "_base.html" %}
 {% block content %}
-<h1 class="text-xl font-bold mb-4">Recipes</h1>
-<p class="mb-4"><a class="text-primary underline" href="{% url 'recipe_create' %}">Create Recipe</a></p>
+<h1 class="mb-4">Recipes</h1>
+<p class="mb-4"><a class="text-primary" href="{% url 'recipe_create' %}">Create Recipe</a></p>
 <ul class="list-disc pl-5">
   {% for r in recipes %}
-    <li><a class="text-primary underline" href="{% url 'recipe_detail' r.recipe_id %}">{{ r.name }}</a></li>
+    <li><a class="text-primary" href="{% url 'recipe_detail' r.recipe_id %}">{{ r.name }}</a></li>
   {% empty %}
     <li>No recipes available.</li>
   {% endfor %}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% load static %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Stock Movements</h1>
+  <h1 class="mb-4">Stock Movements</h1>
   <form method="get" id="section-form" class="mb-4">
     {% for key, label in sections.items %}
         <label class="mr-4">
@@ -13,7 +13,7 @@
     {% include "components/alert.html" %}
   {% endif %}
   {% if active_section == 'receive' %}
-    <h2 class="text-xl font-semibold mb-2">Goods Received</h2>
+    <h2 class="mb-2">Goods Received</h2>
     <form method="post" class="mb-4">
       {% csrf_token %}
       {% if receive_form.non_field_errors %}
@@ -29,7 +29,7 @@
       <button type="submit" name="submit_receive" class="btn-primary">Record</button>
     </form>
   {% elif active_section == 'adjust' %}
-    <h2 class="text-xl font-semibold mb-2">Stock Adjustment</h2>
+    <h2 class="mb-2">Stock Adjustment</h2>
     <form method="post" class="mb-4">
       {% csrf_token %}
       {% if adjust_form.non_field_errors %}
@@ -45,7 +45,7 @@
       <button type="submit" name="submit_adjust" class="btn-primary">Record</button>
     </form>
   {% elif active_section == 'waste' %}
-    <h2 class="text-xl font-semibold mb-2">Wastage/Spoilage</h2>
+    <h2 class="mb-2">Wastage/Spoilage</h2>
     <form method="post" class="mb-4">
       {% csrf_token %}
       {% if waste_form.non_field_errors %}
@@ -63,8 +63,8 @@
   {% endif %}
   <datalist id="item-options"></datalist>
   <hr class="my-4"/>
-  <h2 class="text-xl font-semibold mb-2">Bulk Upload Stock Transactions</h2>
-  <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary underline">Download sample CSV</a></p>
+  <h2 class="mb-2">Bulk Upload Stock Transactions</h2>
+  <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary">Download sample CSV</a></p>
   <form method="post" enctype="multipart/form-data" class="mb-4">
     {% csrf_token %}
     {% if bulk_form.non_field_errors %}
@@ -90,7 +90,7 @@
     </ul>
   {% endif %}
   <hr class="my-4"/>
-  <h2 class="text-xl font-semibold mb-2">Recent Transactions</h2>
+  <h2 class="mb-2">Recent Transactions</h2>
   <div class="max-md:overflow-x-auto">
     <table class="table">
       <thead>

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -1,6 +1,6 @@
 {% extends "_base.html" %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Suppliers ({{ total_suppliers }})</h1>
+  <h1 class="mb-4">Suppliers ({{ total_suppliers }})</h1>
   <div class="mb-4 flex justify-end gap-2">
     <a href="{% url 'supplier_create' %}" class="btn-primary">New Supplier</a>
     <a href="{% url 'suppliers_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block content %}
 <div class="max-w-sm mx-auto space-y-4">
-  <h1 class="text-2xl font-semibold">Login</h1>
+  <h1>Login</h1>
   <form method="post" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}


### PR DESCRIPTION
## Summary
- use Roboto 400/700 globally with consistent h1/h2 styling
- default underline link style and text color utilities
- clean up templates to rely on global typography

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa0216efbc8326b85045062b32abd0