### PR TITLE
feat: add CSS variables for dark mode

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -6,8 +6,16 @@
   /* Dark mode variant */
   --color-primary-dark: #93C5FD;
   --color-secondary: #024427;
+  /* Dark mode variant */
+  --color-secondary-dark: #165E2D;
   --color-accent: #8C4A02;
   --color-danger: #B91C1C;
+
+  /* Body and text colors */
+  --color-body: #ffffff;
+  --color-body-dark: #0f172a;
+  --color-body-text: #111827;
+  --color-body-text-dark: #f8fafc;
   /* Spacing tokens */
   --space-0-5: 0.125rem;
   --space-1: 0.25rem;
@@ -465,14 +473,18 @@ video {
 }
 
 body {
-  background-color: #ffffff;
-  color: #111827;
+  background-color: var(--color-body);
+  color: var(--color-body-text);
   font-family: Roboto, sans-serif;
 }
 
-.dark body {
-  background-color: #0f172a;
-  color: #f8fafc;
+.dark {
+  --color-body: var(--color-body-dark);
+  --color-body-text: var(--color-body-text-dark);
+  --color-primary: var(--color-primary-dark);
+  --color-primary-dark: #0D3A99;
+  --color-secondary: var(--color-secondary-dark);
+  --color-secondary-dark: #024427;
 }
 
 /* Base link styles: underlined with primary color.
@@ -484,17 +496,8 @@ a {
 }
 
 a:hover,
-  a:focus {
+a:focus {
   color: var(--color-primary-dark);
-}
-
-.dark a {
-  color: var(--color-primary-dark);
-}
-
-.dark a:hover,
-  .dark a:focus {
-  color: var(--color-primary);
 }
 
 *, ::before, ::after{
@@ -711,7 +714,7 @@ a:hover,
 }
 
 .btn-primary:hover{
-  opacity: 0.9;
+  background-color: var(--color-primary-dark);
 }
 
 .btn-primary:focus{
@@ -745,7 +748,7 @@ a:hover,
 }
 
 .btn-secondary:hover{
-  opacity: 0.9;
+  background-color: var(--color-secondary-dark);
 }
 
 .btn-secondary:focus{
@@ -830,7 +833,7 @@ a:hover,
 }
 
 .btn-danger:hover{
-  opacity: 0.9;
+  background-color: #992626;
 }
 
 .btn-danger:focus{
@@ -1620,9 +1623,6 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
-.dark .text-primary {
-  color: var(--color-primary-dark);
-}
 
 @media (max-width: 768px) {
   h1 {

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -7,14 +7,20 @@
 
 @layer base {
   body {
-    background-color: theme('colors.body.light');
-    color: theme('colors.bodyText.light');
+    background-color: var(--color-body);
+    color: var(--color-body-text);
     font-family: theme('fontFamily.sans');
   }
-  .dark body {
-    background-color: theme('colors.body.dark');
-    color: theme('colors.bodyText.dark');
+
+  .dark {
+    --color-body: var(--color-body-dark);
+    --color-body-text: var(--color-body-text-dark);
+    --color-primary: var(--color-primary-dark);
+    --color-primary-dark: #0D3A99;
+    --color-secondary: var(--color-secondary-dark);
+    --color-secondary-dark: #024427;
   }
+
   /* Base link styles: underlined with primary color.
      Button classes (.btn-*) remove the underline. */
   a {
@@ -24,13 +30,6 @@
   a:hover,
   a:focus {
     color: var(--color-primary-dark);
-  }
-  .dark a {
-    color: var(--color-primary-dark);
-  }
-  .dark a:hover,
-  .dark a:focus {
-    color: var(--color-primary);
   }
 }
 
@@ -53,7 +52,9 @@
     background-color: var(--color-primary);
     @apply text-white px-4 py-2 rounded transition-colors no-underline;
   }
-  .btn-primary:hover { @apply opacity-90; }
+  .btn-primary:hover {
+    background-color: var(--color-primary-dark);
+  }
   .btn-primary:focus {
     @apply outline-none ring-2 ring-offset-2;
     --tw-ring-color: var(--color-primary);
@@ -64,7 +65,9 @@
     background-color: var(--color-secondary);
     @apply text-white px-4 py-2 rounded transition-colors no-underline;
   }
-  .btn-secondary:hover { @apply opacity-90; }
+  .btn-secondary:hover {
+    background-color: var(--color-secondary-dark);
+  }
   .btn-secondary:focus {
     @apply outline-none ring-2 ring-offset-2;
     --tw-ring-color: var(--color-secondary);
@@ -95,7 +98,9 @@
     background-color: theme('colors.danger');
     @apply text-white px-4 py-2 rounded transition-colors no-underline;
   }
-  .btn-danger:hover { @apply opacity-90; }
+  .btn-danger:hover {
+    background-color: #992626;
+  }
   .btn-danger:focus {
     @apply outline-none ring-2 ring-offset-2;
     --tw-ring-color: theme('colors.danger');
@@ -222,7 +227,7 @@
 }
 
 @layer utilities {
-  .dark .text-primary { color: var(--color-primary-dark); }
+  /* Utilities rely on CSS variables for theming */
 }
 
 @media (max-width: 768px) {

--- a/static/src/tokens.css
+++ b/static/src/tokens.css
@@ -4,8 +4,16 @@
   /* Dark mode variant */
   --color-primary-dark: #93C5FD;
   --color-secondary: #024427;
+  /* Dark mode variant */
+  --color-secondary-dark: #165E2D;
   --color-accent: #8C4A02;
   --color-danger: #B91C1C;
+
+  /* Body and text colors */
+  --color-body: #ffffff;
+  --color-body-dark: #0f172a;
+  --color-body-text: #111827;
+  --color-body-text-dark: #f8fafc;
 
   /* Spacing tokens */
   --space-0-5: 0.125rem;


### PR DESCRIPTION
## Summary
- use CSS custom properties for body and text colors
- swap theme colors via `.dark` class to enable dark mode
- ensure buttons use variable-driven hover states for better contrast

## Testing
- `flake8` *(fails: blank line at end of file, too many blank lines, expected 2 blank lines, continuation line issues)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa0498f46c8326be15047d29deaab2