### PR TITLE
Add tertiary and outline button styles

### DIFF
--- a/app.css
+++ b/app.css
@@ -5,6 +5,12 @@
   --color-primary-dark: #3d82d1; /* Dark mode variant with better contrast */
   --color-secondary: #024427; /* Enhanced secondary color contrast */
   --color-accent: #8c4a02; /* Optimized accent color for visibility */
+  --color-body-text: #111827;
+  --color-body-text-dark: #e5e5e5;
+  --color-form-bg: #ffffff;
+  --color-form-bg-dark: #1e293b;
+  --color-form-border: #6b7280;
+  --color-form-border-dark: #64748b;
 }
 
 /* Base link styles use an underline and the primary color */
@@ -126,6 +132,86 @@ h2 {
 
 .btn-danger:focus {
   box-shadow: 0 0 0 2px #992626; /* Focus ring for accessibility */
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled,
+.btn-danger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-tertiary {
+  background-color: var(--color-form-bg);
+  color: var(--color-body-text);
+  border: 1px solid var(--color-form-border);
+  text-decoration: none;
+  transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.btn-tertiary:hover {
+  background-color: #f3f4f6;
+}
+
+.btn-tertiary:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px var(--color-form-border);
+}
+
+.btn-tertiary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dark .btn-tertiary {
+  background-color: var(--color-form-bg-dark);
+  color: var(--color-body-text-dark);
+  border-color: var(--color-form-border-dark);
+}
+
+.dark .btn-tertiary:hover {
+  background-color: #374151;
+}
+
+.dark .btn-tertiary:focus {
+  box-shadow: 0 0 0 2px var(--color-form-border-dark);
+}
+
+.btn-outline {
+  background-color: transparent;
+  color: var(--color-body-text);
+  border: 1px solid var(--color-form-border);
+  text-decoration: none;
+  transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.btn-outline:hover {
+  background-color: #f3f4f6;
+}
+
+.btn-outline:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px var(--color-form-border);
+}
+
+.btn-outline:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dark .btn-outline {
+  color: var(--color-body-text-dark);
+  border-color: var(--color-form-border-dark);
+}
+
+.dark .btn-outline:hover {
+  background-color: #374151;
+}
+
+.dark .btn-outline:focus {
+  box-shadow: 0 0 0 2px var(--color-form-border-dark);
 }
 
 /* Navigation button styles */


### PR DESCRIPTION
## Summary
- add tokenized variables for body text and form colors
- add tertiary and outline button classes with hover, focus, disabled, and dark-mode states
- apply disabled styling to primary, secondary, and danger buttons

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa0c0eed5483268fc197db51c60312