### PR TITLE
feat: improve primary dark color contrast

### DIFF
--- a/app.css
+++ b/app.css
@@ -2,7 +2,7 @@
 
 :root {
   --color-primary: #0d3a99; /* Improved contrast */
-  --color-primary-dark: #3d82d1; /* Dark mode variant with better contrast */
+  --color-primary-dark: #1d4ed8; /* Dark mode variant with better contrast */
   --color-secondary: #024427; /* Enhanced secondary color contrast */
   --color-accent: #8c4a02; /* Optimized accent color for visibility */
   --color-body-text: #111827;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -4,13 +4,12 @@
   /* Color tokens */
   --color-primary: #0D3A99;
   /* Dark mode variant */
-  --color-primary-dark: #93C5FD;
+  --color-primary-dark: #1D4ED8;
   --color-secondary: #024427;
   /* Dark mode variant */
   --color-secondary-dark: #165E2D;
   --color-accent: #8C4A02;
   --color-danger: #B91C1C;
-
   /* Body and text colors */
   --color-body: #ffffff;
   --color-body-dark: #0f172a;
@@ -21,6 +20,8 @@
   --space-1: 0.25rem;
   --space-2: 0.5rem;
   --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
   /* Font size tokens */
   --font-size-base: 1rem;
   --font-size-h1: 1.6rem;
@@ -28,7 +29,7 @@
   --font-size-badge: 0.8rem;
 }
 
-/* ! tailwindcss v3.4.1 | MIT License | https://tailwindcss.com */
+/* ! tailwindcss v3.4.4 | MIT License | https://tailwindcss.com */
 
 /*
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
@@ -239,6 +240,8 @@ textarea {
   /* 1 */
   line-height: inherit;
   /* 1 */
+  letter-spacing: inherit;
+  /* 1 */
   color: inherit;
   /* 1 */
   margin: 0;
@@ -262,9 +265,9 @@ select {
 */
 
 button,
-[type='button'],
-[type='reset'],
-[type='submit'] {
+input:where([type='button']),
+input:where([type='reset']),
+input:where([type='submit']) {
   -webkit-appearance: button;
   /* 1 */
   background-color: transparent;
@@ -482,7 +485,7 @@ body {
   --color-body: var(--color-body-dark);
   --color-body-text: var(--color-body-text-dark);
   --color-primary: var(--color-primary-dark);
-  --color-primary-dark: #0D3A99;
+  --color-primary-dark: #1D4ED8;
   --color-secondary: var(--color-secondary-dark);
   --color-secondary-dark: #024427;
 }
@@ -496,7 +499,7 @@ a {
 }
 
 a:hover,
-a:focus {
+  a:focus {
   color: var(--color-primary-dark);
 }
 
@@ -548,6 +551,10 @@ a:focus {
   --tw-backdrop-opacity:  ;
   --tw-backdrop-saturate:  ;
   --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
 }
 
 ::backdrop{
@@ -598,14 +605,26 @@ a:focus {
   --tw-backdrop-opacity:  ;
   --tw-backdrop-saturate:  ;
   --tw-backdrop-sepia:  ;
+  --tw-contain-size:  ;
+  --tw-contain-layout:  ;
+  --tw-contain-paint:  ;
+  --tw-contain-style:  ;
 }
 
 .\!container{
   width: 100% !important;
+  margin-right: auto !important;
+  margin-left: auto !important;
+  padding-right: var(--space-8) !important;
+  padding-left: var(--space-8) !important;
 }
 
 .container{
   width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--space-8);
+  padding-left: var(--space-8);
 }
 
 @media (min-width: 640px){
@@ -663,7 +682,7 @@ a:focus {
   text-decoration-line: underline;
 }
 
-/* Status badge classes */
+/* Badge component styles */
 
 .dark .badge-success{
   --tw-bg-opacity: 1;
@@ -713,7 +732,7 @@ a:focus {
   transition-duration: 150ms;
 }
 
-.btn-primary:hover{
+.btn-primary:hover {
   background-color: var(--color-primary-dark);
 }
 
@@ -747,7 +766,7 @@ a:focus {
   transition-duration: 150ms;
 }
 
-.btn-secondary:hover{
+.btn-secondary:hover {
   background-color: var(--color-secondary-dark);
 }
 
@@ -832,7 +851,7 @@ a:focus {
   transition-duration: 150ms;
 }
 
-.btn-danger:hover{
+.btn-danger:hover {
   background-color: #992626;
 }
 
@@ -882,6 +901,11 @@ a:focus {
   --tw-ring-color: #6b7280;
 }
 
+.btn-outline:disabled{
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .dark .btn-outline {
   color: #f8fafc;
   border-color: #64748b;
@@ -894,6 +918,156 @@ a:focus {
 
 .dark .btn-outline:focus {
   --tw-ring-color: #64748b;
+}
+
+/* Navigation button styles */
+
+.nav-btn{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 0.375rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: var(--space-2);
+  padding-bottom: var(--space-2);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+  background-color: transparent;
+}
+
+.nav-btn:hover,
+  .nav-btn:focus {
+  background-color: var(--color-primary-dark);
+  color: #ffffff;
+}
+
+.nav-btn:focus{
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-offset-width: 2px;
+  --tw-ring-color: var(--color-primary-dark);
+}
+
+.dark .nav-btn {
+  color: var(--color-primary-dark);
+}
+
+.dark .nav-btn:hover,
+  .dark .nav-btn:focus {
+  background-color: var(--color-primary);
+  color: #ffffff;
+}
+
+.dark .nav-btn:focus {
+  --tw-ring-color: var(--color-primary);
+}
+
+/* Alert component styles */
+
+.alert{
+  margin-bottom: var(--space-4);
+  border-radius: 0.25rem;
+  border-left-width: 4px;
+  padding-left: var(--space-8);
+  padding-right: var(--space-8);
+  padding-top: var(--space-4);
+  padding-bottom: var(--space-4);
+}
+
+@media (max-width: 639px){
+  .alert{
+    padding-left: var(--space-4);
+    padding-right: var(--space-4);
+  }
+}
+
+@media (max-width: 767px){
+  .alert{
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
+  }
+}
+
+.alert-success{
+  --tw-border-opacity: 1;
+  border-color: rgb(34 197 94 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(220 252 231 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(21 128 61 / var(--tw-text-opacity));
+}
+
+.alert-success:is(.dark *){
+  --tw-border-opacity: 1;
+  border-color: rgb(21 128 61 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(20 83 45 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(134 239 172 / var(--tw-text-opacity));
+}
+
+.alert-warning{
+  --tw-border-opacity: 1;
+  border-color: rgb(234 179 8 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 249 195 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(161 98 7 / var(--tw-text-opacity));
+}
+
+.alert-warning:is(.dark *){
+  --tw-border-opacity: 1;
+  border-color: rgb(161 98 7 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(113 63 18 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(253 224 71 / var(--tw-text-opacity));
+}
+
+.alert-error{
+  --tw-border-opacity: 1;
+  border-color: rgb(239 68 68 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 226 226 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity));
+}
+
+.alert-error:is(.dark *){
+  --tw-border-opacity: 1;
+  border-color: rgb(185 28 28 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(127 29 29 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(252 165 165 / var(--tw-text-opacity));
+}
+
+.alert-info{
+  --tw-border-opacity: 1;
+  border-color: rgb(59 130 246 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(219 234 254 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(29 78 216 / var(--tw-text-opacity));
+}
+
+.alert-info:is(.dark *){
+  --tw-border-opacity: 1;
+  border-color: rgb(29 78 216 / var(--tw-border-opacity));
+  --tw-bg-opacity: 1;
+  background-color: rgb(30 58 138 / var(--tw-bg-opacity));
+  --tw-text-opacity: 1;
+  color: rgb(147 197 253 / var(--tw-text-opacity));
 }
 
 /* Form component styles */
@@ -1031,6 +1205,17 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   border-radius: 0.25rem;
   border-width: 1px;
   padding: var(--space-1);
+}
+
+.pagination-active:focus,
+  .pagination-input:focus{
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-offset-width: 2px;
+  --tw-ring-color: var(--color-primary);
 }
 
 .dark .pagination-active{
@@ -1179,8 +1364,8 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   height: var(--space-4);
 }
 
-.h-6{
-  height: 1.5rem;
+.h-5{
+  height: 1.25rem;
 }
 
 .max-h-screen{
@@ -1203,8 +1388,8 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   width: var(--space-4);
 }
 
-.w-6{
-  width: 1.5rem;
+.w-5{
+  width: 1.25rem;
 }
 
 .w-full{
@@ -1370,37 +1555,13 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   border-width: 4px;
 }
 
-.border-l-4{
-  border-left-width: 4px;
-}
-
-.border-blue-500{
-  --tw-border-opacity: 1;
-  border-color: rgb(59 130 246 / var(--tw-border-opacity));
-}
-
 .border-form-border{
   --tw-border-opacity: 1;
   border-color: rgb(107 114 128 / var(--tw-border-opacity));
 }
 
-.border-green-500{
-  --tw-border-opacity: 1;
-  border-color: rgb(34 197 94 / var(--tw-border-opacity));
-}
-
 .border-primary{
   border-color: var(--color-primary);
-}
-
-.border-red-500{
-  --tw-border-opacity: 1;
-  border-color: rgb(239 68 68 / var(--tw-border-opacity));
-}
-
-.border-yellow-500{
-  --tw-border-opacity: 1;
-  border-color: rgb(234 179 8 / var(--tw-border-opacity));
 }
 
 .border-t-transparent{
@@ -1421,28 +1582,13 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
 
-.bg-green-100{
-  --tw-bg-opacity: 1;
-  background-color: rgb(220 252 231 / var(--tw-bg-opacity));
-}
-
 .bg-primary{
   background-color: var(--color-primary);
-}
-
-.bg-red-100{
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 226 226 / var(--tw-bg-opacity));
 }
 
 .bg-white{
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
-}
-
-.bg-yellow-100{
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 249 195 / var(--tw-bg-opacity));
 }
 
 .p-2{
@@ -1454,7 +1600,7 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 }
 
 .p-8{
-  padding: 2rem;
+  padding: var(--space-8);
 }
 
 .px-2{
@@ -1473,8 +1619,8 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 }
 
 .px-8{
-  padding-left: 2rem;
-  padding-right: 2rem;
+  padding-left: var(--space-8);
+  padding-right: var(--space-8);
 }
 
 .py-1{
@@ -1493,8 +1639,8 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 }
 
 .py-6{
-  padding-top: 1.5rem;
-  padding-bottom: 1.5rem;
+  padding-top: var(--space-6);
+  padding-bottom: var(--space-6);
 }
 
 .pl-5{
@@ -1517,24 +1663,9 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   text-align: right;
 }
 
-.text-2xl{
-  font-size: 1.5rem;
-  line-height: 2rem;
-}
-
-.text-lg{
-  font-size: 1.125rem;
-  line-height: 1.75rem;
-}
-
 .text-sm{
   font-size: 0.875rem;
   line-height: 1.25rem;
-}
-
-.text-xl{
-  font-size: 1.25rem;
-  line-height: 1.75rem;
 }
 
 .text-xs{
@@ -1554,11 +1685,6 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   font-weight: 600;
 }
 
-.text-blue-700{
-  --tw-text-opacity: 1;
-  color: rgb(29 78 216 / var(--tw-text-opacity));
-}
-
 .text-blue-800{
   --tw-text-opacity: 1;
   color: rgb(30 64 175 / var(--tw-text-opacity));
@@ -1567,11 +1693,6 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 .text-form-text{
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
-}
-
-.text-gray-400{
-  --tw-text-opacity: 1;
-  color: rgb(156 163 175 / var(--tw-text-opacity));
 }
 
 .text-gray-500{
@@ -1608,21 +1729,13 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
-.text-yellow-700{
-  --tw-text-opacity: 1;
-  color: rgb(161 98 7 / var(--tw-text-opacity));
-}
-
-.underline{
-  text-decoration-line: underline;
-}
-
 .shadow{
   --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+/* Utilities rely on CSS variables for theming */
 
 @media (max-width: 768px) {
   h1 {
@@ -1656,130 +1769,78 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
-:is(.dark .dark\:border-blue-700){
-  --tw-border-opacity: 1;
-  border-color: rgb(29 78 216 / var(--tw-border-opacity));
+.dark\:block:is(.dark *){
+  display: block;
 }
 
-:is(.dark .dark\:border-form-darkBorder){
+.dark\:hidden:is(.dark *){
+  display: none;
+}
+
+.dark\:border-form-darkBorder:is(.dark *){
   --tw-border-opacity: 1;
   border-color: rgb(100 116 139 / var(--tw-border-opacity));
 }
 
-:is(.dark .dark\:border-green-700){
-  --tw-border-opacity: 1;
-  border-color: rgb(21 128 61 / var(--tw-border-opacity));
-}
-
-:is(.dark .dark\:border-primary){
+.dark\:border-primary:is(.dark *){
   border-color: var(--color-primary);
 }
 
-:is(.dark .dark\:border-red-700){
-  --tw-border-opacity: 1;
-  border-color: rgb(185 28 28 / var(--tw-border-opacity));
-}
-
-:is(.dark .dark\:border-yellow-700){
-  --tw-border-opacity: 1;
-  border-color: rgb(161 98 7 / var(--tw-border-opacity));
-}
-
-:is(.dark .dark\:bg-blue-900){
+.dark\:bg-blue-900:is(.dark *){
   --tw-bg-opacity: 1;
   background-color: rgb(30 58 138 / var(--tw-bg-opacity));
 }
 
-:is(.dark .dark\:bg-form-darkBg){
+.dark\:bg-form-darkBg:is(.dark *){
   --tw-bg-opacity: 1;
   background-color: rgb(30 41 59 / var(--tw-bg-opacity));
 }
 
-:is(.dark .dark\:bg-green-900){
-  --tw-bg-opacity: 1;
-  background-color: rgb(20 83 45 / var(--tw-bg-opacity));
-}
-
-:is(.dark .dark\:bg-primary){
+.dark\:bg-primary:is(.dark *){
   background-color: var(--color-primary);
 }
 
-:is(.dark .dark\:bg-red-900){
-  --tw-bg-opacity: 1;
-  background-color: rgb(127 29 29 / var(--tw-bg-opacity));
-}
-
-:is(.dark .dark\:bg-slate-800){
+.dark\:bg-slate-800:is(.dark *){
   --tw-bg-opacity: 1;
   background-color: rgb(30 41 59 / var(--tw-bg-opacity));
 }
 
-:is(.dark .dark\:bg-yellow-900){
-  --tw-bg-opacity: 1;
-  background-color: rgb(113 63 18 / var(--tw-bg-opacity));
-}
-
-:is(.dark .dark\:text-blue-100){
+.dark\:text-blue-100:is(.dark *){
   --tw-text-opacity: 1;
   color: rgb(219 234 254 / var(--tw-text-opacity));
 }
 
-:is(.dark .dark\:text-blue-300){
-  --tw-text-opacity: 1;
-  color: rgb(147 197 253 / var(--tw-text-opacity));
-}
-
-:is(.dark .dark\:text-form-darkText){
+.dark\:text-form-darkText:is(.dark *){
   --tw-text-opacity: 1;
   color: rgb(248 250 252 / var(--tw-text-opacity));
 }
 
-:is(.dark .dark\:text-gray-200){
+.dark\:text-gray-200:is(.dark *){
   --tw-text-opacity: 1;
   color: rgb(229 231 235 / var(--tw-text-opacity));
 }
 
-:is(.dark .dark\:text-gray-400){
+.dark\:text-gray-400:is(.dark *){
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity));
 }
 
-:is(.dark .dark\:text-gray-500){
-  --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity));
-}
-
-:is(.dark .dark\:text-green-300){
-  --tw-text-opacity: 1;
-  color: rgb(134 239 172 / var(--tw-text-opacity));
-}
-
-:is(.dark .dark\:text-green-400){
+.dark\:text-green-400:is(.dark *){
   --tw-text-opacity: 1;
   color: rgb(74 222 128 / var(--tw-text-opacity));
 }
 
-:is(.dark .dark\:text-red-300){
-  --tw-text-opacity: 1;
-  color: rgb(252 165 165 / var(--tw-text-opacity));
-}
-
-:is(.dark .dark\:text-red-400){
+.dark\:text-red-400:is(.dark *){
   --tw-text-opacity: 1;
   color: rgb(248 113 113 / var(--tw-text-opacity));
 }
 
-:is(.dark .dark\:text-white){
+.dark\:text-white:is(.dark *){
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
-:is(.dark .dark\:text-yellow-300){
-  --tw-text-opacity: 1;
-  color: rgb(253 224 71 / var(--tw-text-opacity));
-}
-
-:is(.dark .dark\:hover\:text-white:hover){
+.dark\:hover\:text-white:hover:is(.dark *){
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
@@ -1841,8 +1902,8 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   }
 
   .max-md\:px-6{
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
   }
 }
 
@@ -1857,9 +1918,7 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   background-color: rgb(229 231 235 / var(--tw-bg-opacity));
 }
 
-:is(.dark .dark\:\[\&\>tr\:hover\]\:bg-table-darkHoverBg>tr:hover){
+.dark\:\[\&\>tr\:hover\]\:bg-table-darkHoverBg>tr:hover:is(.dark *){
   --tw-bg-opacity: 1;
   background-color: rgb(30 41 59 / var(--tw-bg-opacity));
 }
-@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap");:root{--color-primary:#0d3a99;--color-primary-dark:#93c5fd;--color-secondary:#024427;--color-secondary-dark:#165e2d;--color-accent:#8c4a02;--color-danger:#b91c1c;--color-body:#fff;--color-body-dark:#0f172a;--color-body-text:#111827;--color-body-text-dark:#f8fafc;--space-0-5:0.125rem;--space-1:0.25rem;--space-2:0.5rem;--space-4:1rem;--font-size-base:1rem;--font-size-h1:1.6rem;--font-size-h2:1.3rem;--font-size-badge:0.8rem}
-/*! tailwindcss v3.4.1 | MIT License | https://tailwindcss.com*/*,:after,:before{box-sizing:border-box;border:0 solid #e5e7eb}:after,:before{--tw-content:""}:host,html{line-height:1.5;-webkit-text-size-adjust:100%;-moz-tab-size:4;-o-tab-size:4;tab-size:4;font-family:Roboto,sans-serif;font-feature-settings:normal;font-variation-settings:normal;-webkit-tap-highlight-color:transparent}body{margin:0;line-height:inherit}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,pre,samp{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;font-feature-settings:normal;font-variation-settings:normal;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:initial}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}button,input,optgroup,select,textarea{font-family:inherit;font-feature-settings:inherit;font-variation-settings:inherit;font-size:100%;font-weight:inherit;line-height:inherit;color:inherit;margin:0;padding:0}button,select{text-transform:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button;background-color:initial;background-image:none}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}progress{vertical-align:initial}::-webkit-inner-spin-button,::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}blockquote,dd,dl,figure,h1,h2,h3,h4,h5,h6,hr,p,pre{margin:0}fieldset{margin:0}fieldset,legend{padding:0}menu,ol,ul{list-style:none;margin:0;padding:0}dialog{padding:0}textarea{resize:vertical}input::-moz-placeholder,textarea::-moz-placeholder{opacity:1;color:#9ca3af}input::placeholder,textarea::placeholder{opacity:1;color:#9ca3af}[role=button],button{cursor:pointer}:disabled{cursor:default}audio,canvas,embed,iframe,img,object,svg,video{display:block;vertical-align:middle}img,video{max-width:100%;height:auto}[hidden]{display:none}body{background-color:var(--color-body);color:var(--color-body-text);font-family:Roboto,sans-serif}.dark{--color-body:var(--color-body-dark);--color-body-text:var(--color-body-text-dark);--color-primary:var(--color-primary-dark);--color-primary-dark:#0d3a99;--color-secondary:var(--color-secondary-dark);--color-secondary-dark:#024427}a{color:var(--color-primary);text-decoration:underline}a:focus,a:hover{color:var(--color-primary-dark)}*,::backdrop,:after,:before{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:#3b82f680;--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: }.\!container{width:100%!important}.container{width:100%}@media (min-width:640px){.\!container{max-width:640px!important}.container{max-width:640px}}@media (min-width:768px){.\!container{max-width:768px!important}.container{max-width:768px}}@media (min-width:1024px){.\!container{max-width:1024px!important}.container{max-width:1024px}}@media (min-width:1280px){.\!container{max-width:1280px!important}.container{max-width:1280px}}@media (min-width:1536px){.\!container{max-width:1536px!important}.container{max-width:1536px}}.active{font-weight:700;text-decoration-line:underline}.dark .badge-success{--tw-bg-opacity:1;background-color:rgb(22 101 52/var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity))}.dark .badge-warning{--tw-bg-opacity:1;background-color:rgb(217 119 6/var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(17 24 39/var(--tw-text-opacity))}.dark .badge-error{--tw-bg-opacity:1;background-color:rgb(185 28 28/var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity))}.toast{position:absolute;left:0;top:100%;z-index:10;margin-top:var(--space-1)}.btn-primary{background-color:var(--color-primary);border-radius:.25rem;padding:var(--space-2) var(--space-4);--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity));text-decoration-line:none;transition-property:color,background-color,border-color,text-decoration-color,fill,stroke;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.btn-primary:hover{background-color:var(--color-primary-dark)}.btn-primary:focus{outline:2px solid #0000;outline-offset:2px;--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000);--tw-ring-offset-width:2px;--tw-ring-color:var(--color-primary)}.btn-primary:disabled{cursor:not-allowed;opacity:.5}.btn-secondary{background-color:var(--color-secondary);border-radius:.25rem;padding:var(--space-2) var(--space-4);--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity));text-decoration-line:none;transition-property:color,background-color,border-color,text-decoration-color,fill,stroke;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.btn-secondary:hover{background-color:var(--color-secondary-dark)}.btn-secondary:focus{outline:2px solid #0000;outline-offset:2px;--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000);--tw-ring-offset-width:2px;--tw-ring-color:var(--color-secondary)}.btn-secondary:disabled{cursor:not-allowed;opacity:.5}.btn-tertiary{border-radius:.25rem;border-width:1px;padding:var(--space-2) var(--space-4);text-decoration-line:none;transition-property:color,background-color,border-color,text-decoration-color,fill,stroke;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s;background-color:#fff;color:#111827;border-color:#6b7280}.btn-tertiary:hover{--tw-bg-opacity:1;background-color:rgb(243 244 246/var(--tw-bg-opacity))}.btn-tertiary:focus{outline:2px solid #0000;outline-offset:2px;--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000);--tw-ring-offset-width:2px;--tw-ring-color:#6b7280}.btn-tertiary:disabled{cursor:not-allowed;opacity:.5}.dark .btn-tertiary{background-color:#1e293b;color:#f8fafc;border-color:#64748b}.dark .btn-tertiary:hover{--tw-bg-opacity:1;background-color:rgb(55 65 81/var(--tw-bg-opacity))}.dark .btn-tertiary:focus{--tw-ring-color:#64748b}.btn-danger{background-color:var(--color-danger);border-radius:.25rem;padding:var(--space-2) var(--space-4);--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity));text-decoration-line:none;transition-property:color,background-color,border-color,text-decoration-color,fill,stroke;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.btn-danger:hover{background-color:#992626}.btn-danger:focus{outline:2px solid #0000;outline-offset:2px;--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000);--tw-ring-offset-width:2px;--tw-ring-color:var(--color-danger)}.btn-danger:disabled{cursor:not-allowed;opacity:.5}.btn-outline{border-radius:.25rem;border-width:1px;padding:var(--space-2) var(--space-4);text-decoration-line:none;transition-property:color,background-color,border-color,text-decoration-color,fill,stroke;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s;background-color:initial;color:#111827;border-color:#6b7280}.btn-outline:hover{--tw-bg-opacity:1;background-color:rgb(243 244 246/var(--tw-bg-opacity))}.btn-outline:focus{outline:2px solid #0000;outline-offset:2px;--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000);--tw-ring-offset-width:2px;--tw-ring-color:#6b7280}.btn-outline:disabled{cursor:not-allowed;opacity:.5}.dark .btn-outline{color:#f8fafc;border-color:#64748b}.dark .btn-outline:hover{--tw-bg-opacity:1;background-color:rgb(55 65 81/var(--tw-bg-opacity))}.dark .btn-outline:focus{--tw-ring-color:#64748b}.nav-btn{display:flex;align-items:center;justify-content:space-between;border-radius:.375rem;padding-left:.75rem;padding-right:.75rem;padding-top:var(--space-2);padding-bottom:var(--space-2);font-size:.875rem;line-height:1.25rem;font-weight:500;--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity));outline:2px solid #0000;outline-offset:2px;transition-property:color,background-color,border-color,text-decoration-color,fill,stroke;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s;background-color:initial}.nav-btn:focus,.nav-btn:hover{background-color:var(--color-primary-dark);color:#fff}.nav-btn:focus{--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000);--tw-ring-offset-width:2px;--tw-ring-color:var(--color-primary-dark)}.dark .nav-btn{color:var(--color-primary-dark)}.dark .nav-btn:focus,.dark .nav-btn:hover{background-color:var(--color-primary);color:#fff}.dark .nav-btn:focus{--tw-ring-color:var(--color-primary)}.alert{margin-bottom:var(--space-4);border-radius:.25rem;border-left-width:4px;padding-left:2rem;padding-right:2rem;padding-top:var(--space-4);padding-bottom:var(--space-4)}@media (max-width:639px){.alert{padding-left:var(--space-4);padding-right:var(--space-4)}}@media (max-width:767px){.alert{padding-left:1.5rem;padding-right:1.5rem}}.alert-success{border-color:rgb(34 197 94/var(--tw-border-opacity));background-color:rgb(220 252 231/var(--tw-bg-opacity));color:rgb(21 128 61/var(--tw-text-opacity))}.alert-success,:is(.dark .alert-success){--tw-border-opacity:1;--tw-bg-opacity:1;--tw-text-opacity:1}:is(.dark .alert-success){border-color:rgb(21 128 61/var(--tw-border-opacity));background-color:rgb(20 83 45/var(--tw-bg-opacity));color:rgb(134 239 172/var(--tw-text-opacity))}.alert-warning{border-color:rgb(234 179 8/var(--tw-border-opacity));background-color:rgb(254 249 195/var(--tw-bg-opacity));color:rgb(161 98 7/var(--tw-text-opacity))}.alert-warning,:is(.dark .alert-warning){--tw-border-opacity:1;--tw-bg-opacity:1;--tw-text-opacity:1}:is(.dark .alert-warning){border-color:rgb(161 98 7/var(--tw-border-opacity));background-color:rgb(113 63 18/var(--tw-bg-opacity));color:rgb(253 224 71/var(--tw-text-opacity))}.alert-error{border-color:rgb(239 68 68/var(--tw-border-opacity));background-color:rgb(254 226 226/var(--tw-bg-opacity));color:rgb(185 28 28/var(--tw-text-opacity))}.alert-error,:is(.dark .alert-error){--tw-border-opacity:1;--tw-bg-opacity:1;--tw-text-opacity:1}:is(.dark .alert-error){border-color:rgb(185 28 28/var(--tw-border-opacity));background-color:rgb(127 29 29/var(--tw-bg-opacity));color:rgb(252 165 165/var(--tw-text-opacity))}.alert-info{border-color:rgb(59 130 246/var(--tw-border-opacity));background-color:rgb(219 234 254/var(--tw-bg-opacity));color:rgb(29 78 216/var(--tw-text-opacity))}.alert-info,:is(.dark .alert-info){--tw-border-opacity:1;--tw-bg-opacity:1;--tw-text-opacity:1}:is(.dark .alert-info){border-color:rgb(29 78 216/var(--tw-border-opacity));background-color:rgb(30 58 138/var(--tw-bg-opacity));color:rgb(147 197 253/var(--tw-text-opacity))}form label{margin-bottom:var(--space-2);display:block}.form-control,form input:not([type=checkbox]):not([type=radio]),form select,form textarea{font-family:Roboto,sans-serif;border:1px solid #6b7280;background-color:#fff;color:#111827;padding:var(--space-2);border-radius:var(--space-1);width:100%}.form-control:focus,form input:not([type=checkbox]):not([type=radio]):focus,form select:focus,form textarea:focus{outline:none;border-color:var(--color-primary);--tw-shadow:0 0 0 2px #1d4ed866;--tw-shadow-colored:0 0 0 2px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.form-radio{border:1px solid #6b7280;background-color:#fff;color:#111827;border-radius:9999px;accent-color:var(--color-primary)}.dark .form-control,.dark form input:not([type=checkbox]):not([type=radio]),.dark form select,.dark form textarea{border:1px solid #64748b;background-color:#1e293b;color:#f8fafc}.dark .form-control:focus,.dark form input:not([type=checkbox]):not([type=radio]):focus,.dark form select:focus,.dark form textarea:focus{outline:none;border-color:var(--color-primary);--tw-shadow:0 0 0 2px #1d4ed899;--tw-shadow-colored:0 0 0 2px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.dark .form-checkbox,.dark .form-radio{border:1px solid #64748b;background-color:#1e293b;color:#f8fafc}.dark .form-radio{border-radius:9999px;accent-color:var(--color-primary)}.table{width:100%;border-collapse:collapse}.table td,.table th{border:1px solid #6b7280;padding:var(--space-2) var(--space-4);text-align:left}.table thead{background-color:var(--color-primary);color:#fff}.table tbody tr{background-color:#fff}.table tbody tr:hover{background-color:#e5e7eb}.dark .table td,.dark .table th{border:1px solid #64748b}.dark .table thead{background-color:var(--color-primary);color:#fff}.dark .table tbody tr{background-color:#0f172a}.dark .table tbody tr:hover{background-color:#1e293b}.pagination-active{border-radius:.25rem;border-width:1px;--tw-bg-opacity:1;background-color:rgb(229 231 235/var(--tw-bg-opacity));padding-left:.75rem;padding-right:.75rem;padding-top:var(--space-1);padding-bottom:var(--space-1)}.pagination-input{border-radius:.25rem;border-width:1px;padding:var(--space-1)}.pagination-active:focus,.pagination-input:focus{outline:2px solid #0000;outline-offset:2px;--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000);--tw-ring-offset-width:2px;--tw-ring-color:var(--color-primary)}.dark .pagination-active{background-color:rgb(55 65 81/var(--tw-bg-opacity))}.dark .pagination-active,.dark .pagination-input{--tw-border-opacity:1;border-color:rgb(100 116 139/var(--tw-border-opacity));--tw-bg-opacity:1}.dark .pagination-input{background-color:rgb(30 41 59/var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(248 250 252/var(--tw-text-opacity))}.static{position:static}.fixed{position:fixed}.absolute{position:absolute}.relative{position:relative}.sticky{position:sticky}.inset-0{inset:0}.bottom-4{bottom:var(--space-4)}.right-4{right:var(--space-4)}.top-0{top:0}.mx-auto{margin-left:auto;margin-right:auto}.my-4{margin-top:var(--space-4);margin-bottom:var(--space-4)}.mb-1{margin-bottom:var(--space-1)}.mb-2{margin-bottom:var(--space-2)}.mb-4{margin-bottom:var(--space-4)}.ml-2{margin-left:var(--space-2)}.ml-4{margin-left:var(--space-4)}.ml-auto{margin-left:auto}.mr-1{margin-right:var(--space-1)}.mr-2{margin-right:var(--space-2)}.mr-4{margin-right:var(--space-4)}.mt-2{margin-top:var(--space-2)}.mt-3{margin-top:.75rem}.mt-4{margin-top:var(--space-4)}.block{display:block}.inline{display:inline}.flex{display:flex}.table{display:table}.grid{display:grid}.hidden{display:none}.h-12{height:3rem}.h-16{height:4rem}.h-4{height:var(--space-4)}.h-6{height:1.5rem}.max-h-screen{max-height:100vh}.min-h-screen{min-height:100vh}.w-12{width:3rem}.w-24{width:6rem}.w-4{width:var(--space-4)}.w-6{width:1.5rem}.w-full{width:100%}.w-max{width:-moz-max-content;width:max-content}.max-w-2xl{max-width:42rem}.max-w-sm{max-width:24rem}.max-w-xs{max-width:20rem}.flex-1{flex:1 1 0%}.flex-shrink-0{flex-shrink:0}.table-auto{table-layout:auto}@keyframes spin{to{transform:rotate(1turn)}}.animate-spin{animation:spin 1s linear infinite}.list-disc{list-style-type:disc}.grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr))}.grid-cols-5{grid-template-columns:repeat(5,minmax(0,1fr))}.grid-cols-7{grid-template-columns:repeat(7,minmax(0,1fr))}.flex-col{flex-direction:column}.flex-wrap{flex-wrap:wrap}.items-start{align-items:flex-start}.items-end{align-items:flex-end}.items-center{align-items:center}.justify-end{justify-content:flex-end}.justify-center{justify-content:center}.justify-between{justify-content:space-between}.gap-1{gap:var(--space-1)}.gap-2{gap:var(--space-2)}.gap-3{gap:.75rem}.gap-4{gap:var(--space-4)}.space-x-4>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(var(--space-4)*var(--tw-space-x-reverse));margin-left:calc(var(--space-4)*(1 - var(--tw-space-x-reverse)))}.space-y-1>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(var(--space-1)*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(var(--space-1)*var(--tw-space-y-reverse))}.space-y-2>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(var(--space-2)*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(var(--space-2)*var(--tw-space-y-reverse))}.space-y-4>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(var(--space-4)*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(var(--space-4)*var(--tw-space-y-reverse))}.overflow-y-auto{overflow-y:auto}.rounded{border-radius:.25rem}.rounded-full{border-radius:9999px}.rounded-md{border-radius:.375rem}.border{border-width:1px}.border-4{border-width:4px}.border-form-border{--tw-border-opacity:1;border-color:rgb(107 114 128/var(--tw-border-opacity))}.border-primary{border-color:var(--color-primary)}.border-t-transparent{border-top-color:#0000}.bg-black\/25{background-color:#00000040}.bg-blue-100{--tw-bg-opacity:1;background-color:rgb(219 234 254/var(--tw-bg-opacity))}.bg-form-bg{--tw-bg-opacity:1;background-color:rgb(255 255 255/var(--tw-bg-opacity))}.bg-primary{background-color:var(--color-primary)}.bg-white{--tw-bg-opacity:1;background-color:rgb(255 255 255/var(--tw-bg-opacity))}.p-2{padding:var(--space-2)}.p-4{padding:var(--space-4)}.p-8{padding:2rem}.px-2{padding-left:var(--space-2);padding-right:var(--space-2)}.px-3{padding-left:.75rem;padding-right:.75rem}.px-4{padding-left:var(--space-4);padding-right:var(--space-4)}.px-8{padding-left:2rem;padding-right:2rem}.py-1{padding-top:var(--space-1);padding-bottom:var(--space-1)}.py-2{padding-top:var(--space-2);padding-bottom:var(--space-2)}.py-4{padding-top:var(--space-4);padding-bottom:var(--space-4)}.py-6{padding-top:1.5rem;padding-bottom:1.5rem}.pl-5{padding-left:1.25rem}.pr-4{padding-right:var(--space-4)}.text-left{text-align:left}.text-center{text-align:center}.text-right{text-align:right}.text-sm{font-size:.875rem;line-height:1.25rem}.text-xs{font-size:.75rem;line-height:1rem}.font-bold{font-weight:700}.font-medium{font-weight:500}.font-semibold{font-weight:600}.text-blue-800{--tw-text-opacity:1;color:rgb(30 64 175/var(--tw-text-opacity))}.text-form-text{--tw-text-opacity:1;color:rgb(17 24 39/var(--tw-text-opacity))}.text-gray-400{--tw-text-opacity:1;color:rgb(156 163 175/var(--tw-text-opacity))}.text-gray-500{--tw-text-opacity:1;color:rgb(107 114 128/var(--tw-text-opacity))}.text-green-700{--tw-text-opacity:1;color:rgb(21 128 61/var(--tw-text-opacity))}.text-primary{color:var(--color-primary)}.text-red-400{--tw-text-opacity:1;color:rgb(248 113 113/var(--tw-text-opacity))}.text-red-600{--tw-text-opacity:1;color:rgb(220 38 38/var(--tw-text-opacity))}.text-red-700{--tw-text-opacity:1;color:rgb(185 28 28/var(--tw-text-opacity))}.text-white{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity))}.shadow{--tw-shadow:0 1px 3px 0 #0000001a,0 1px 2px -1px #0000001a;--tw-shadow-colored:0 1px 3px 0 var(--tw-shadow-color),0 1px 2px -1px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}@media (max-width:768px){h1{font-size:var(--font-size-h1)}h2{font-size:var(--font-size-h2)}.badge-error,.badge-success,.badge-warning{font-size:var(--font-size-badge);padding:var(--space-0-5) var(--space-1)}}.odd\:bg-gray-50:nth-child(odd){--tw-bg-opacity:1;background-color:rgb(249 250 251/var(--tw-bg-opacity))}.hover\:bg-gray-100:hover{--tw-bg-opacity:1;background-color:rgb(243 244 246/var(--tw-bg-opacity))}.hover\:text-white:hover{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity))}:is(.dark .dark\:border-form-darkBorder){--tw-border-opacity:1;border-color:rgb(100 116 139/var(--tw-border-opacity))}:is(.dark .dark\:border-primary){border-color:var(--color-primary)}:is(.dark .dark\:bg-blue-900){--tw-bg-opacity:1;background-color:rgb(30 58 138/var(--tw-bg-opacity))}:is(.dark .dark\:bg-form-darkBg){--tw-bg-opacity:1;background-color:rgb(30 41 59/var(--tw-bg-opacity))}:is(.dark .dark\:bg-primary){background-color:var(--color-primary)}:is(.dark .dark\:bg-slate-800){--tw-bg-opacity:1;background-color:rgb(30 41 59/var(--tw-bg-opacity))}:is(.dark .dark\:text-blue-100){--tw-text-opacity:1;color:rgb(219 234 254/var(--tw-text-opacity))}:is(.dark .dark\:text-form-darkText){--tw-text-opacity:1;color:rgb(248 250 252/var(--tw-text-opacity))}:is(.dark .dark\:text-gray-200){--tw-text-opacity:1;color:rgb(229 231 235/var(--tw-text-opacity))}:is(.dark .dark\:text-gray-400){--tw-text-opacity:1;color:rgb(156 163 175/var(--tw-text-opacity))}:is(.dark .dark\:text-gray-500){--tw-text-opacity:1;color:rgb(107 114 128/var(--tw-text-opacity))}:is(.dark .dark\:text-green-400){--tw-text-opacity:1;color:rgb(74 222 128/var(--tw-text-opacity))}:is(.dark .dark\:text-red-400){--tw-text-opacity:1;color:rgb(248 113 113/var(--tw-text-opacity))}:is(.dark .dark\:hover\:text-white:hover),:is(.dark .dark\:text-white){--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity))}@media (max-width:639px){.max-sm\:static{position:static}.max-sm\:mt-0{margin-top:0}.max-sm\:block{display:block}.max-sm\:hidden{display:none}.max-sm\:max-w-md{max-width:28rem}.max-sm\:grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.max-sm\:rounded-none{border-radius:0}.max-sm\:bg-transparent{background-color:initial}.max-sm\:p-4{padding:var(--space-4)}.max-sm\:px-4{padding-left:var(--space-4);padding-right:var(--space-4)}}@media (max-width:767px){.max-md\:max-w-xl{max-width:36rem}.max-md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.max-md\:overflow-x-auto{overflow-x:auto}.max-md\:px-6{padding-left:1.5rem;padding-right:1.5rem}}@media (max-width:1023px){.max-lg\:grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr))}}.\[\&\>tr\:hover\]\:bg-table-hoverBg>tr:hover{--tw-bg-opacity:1;background-color:rgb(229 231 235/var(--tw-bg-opacity))}:is(.dark .dark\:\[\&\>tr\:hover\]\:bg-table-darkHoverBg>tr:hover){--tw-bg-opacity:1;background-color:rgb(30 41 59/var(--tw-bg-opacity))}

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -16,7 +16,7 @@
     --color-body: var(--color-body-dark);
     --color-body-text: var(--color-body-text-dark);
     --color-primary: var(--color-primary-dark);
-    --color-primary-dark: #0D3A99;
+    --color-primary-dark: #1D4ED8;
     --color-secondary: var(--color-secondary-dark);
     --color-secondary-dark: #024427;
   }

--- a/static/src/tokens.css
+++ b/static/src/tokens.css
@@ -2,7 +2,7 @@
   /* Color tokens */
   --color-primary: #0D3A99;
   /* Dark mode variant */
-  --color-primary-dark: #93C5FD;
+  --color-primary-dark: #1D4ED8;
   --color-secondary: #024427;
   /* Dark mode variant */
   --color-secondary-dark: #165E2D;


### PR DESCRIPTION
## Summary
- adjust `--color-primary-dark` token to #1D4ED8 for WCAG-compliant contrast with white text
- align dark mode variables to the new token
- rebuild compiled CSS for consistent usage

## Testing
- `python - <<'PY'
from math import pow


def contrast_ratio(bg_hex, fg_hex='#ffffff'):
    def luminance(hexcolor):
        rgb=tuple(int(hexcolor[i:i+2],16)/255 for i in (0,2,4))
        def transform(c):
            return c/12.92 if c<=0.03928 else ((c+0.055)/1.055)**2.4
        r,g,b=[transform(c) for c in rgb]
        return 0.2126*r+0.7152*g+0.0722*b
    L1=luminance(bg_hex)
    L2=luminance(fg_hex[1:])
    ratio=(L2+0.05)/(L1+0.05) if L1<L2 else (L1+0.05)/(L2+0.05)
    return ratio

for hexcolor in ['1d4ed8']:
    print(hexcolor,contrast_ratio(hexcolor))
PY`
- `npx tailwindcss -i ./static/src/app.css -o ./static/css/app.css`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa0dac30cc83269a9d5bca2703b537