### PR TITLE
Add title blocks for inventory templates

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Inventory App</title>
+    <title>{% block title %}Inventory App{% endblock %}</title>
     <link href="{% static 'css/app.css' %}" rel="stylesheet">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="{% static 'js/theme.js' %}"></script>

--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Form – Inventory App{% endblock %}
 {% block content %}
 <div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
   <h1 class="mb-4">

--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Bulk Delete – Inventory App{% endblock %}
 {% block content %}
 <div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
   <h1 class="mb-4">{{ title }}</h1>

--- a/templates/inventory/grns/detail.html
+++ b/templates/inventory/grns/detail.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}GRN Detail – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">GRN {{ grn.pk }}</h1>
   <p class="mb-2"><strong>PO:</strong> <a class="text-primary" href="{% url 'purchase_order_detail' grn.purchase_order_id %}">{{ grn.purchase_order_id }}</a></p>

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Goods Received Notes – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">Goods Received Notes</h1>
   <form method="get" class="mb-4 grid gap-2 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}History Reports – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">History Reports</h1>
     <form id="filters" method="get" class="grid gap-2 mb-4 grid-cols-7 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1"

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Indent Detail – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">Indent {{ indent.indent_id }}</h1>
   <div class="mb-2">Status: <span class="px-2 py-1 rounded {{ badges[indent.status|upper] }}">{{ indent.status }}</span></div>

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Indents – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">Indents ({{ total_indents }})</h1>
   <div class="mb-4 flex justify-end gap-2">

--- a/templates/inventory/item_confirm_delete.html
+++ b/templates/inventory/item_confirm_delete.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Delete Item – Inventory App{% endblock %}
 {% block content %}
 <div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
   <h1 class="mb-4">Delete/Deactivate Item</h1>

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Item Detail – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">{{ item.name }}</h1>
   <table class="table">

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Items – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">Items</h1>
   <div class="mb-4 flex justify-end gap-2">

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Purchase Order Detail – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">Purchase Order {{ po.pk }}</h1>
   <p class="mb-2"><strong>Supplier:</strong> {{ po.supplier.name }}</p>

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Purchase Orders – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">Purchase Orders</h1>
   <div class="mb-4 flex justify-end gap-2">

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Receive Purchase Order – Inventory App{% endblock %}
 {% block content %}
 <div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
   <h1 class="mb-4">Receive Goods for PO {{ po.pk }}</h1>

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Recipe Detail – Inventory App{% endblock %}
 {% block content %}
 <div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
   <h1 class="mb-4">{% if recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}</h1>

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Recipes – Inventory App{% endblock %}
 {% block content %}
 <h1 class="mb-4">Recipes</h1>
 <p class="mb-4"><a class="text-primary" href="{% url 'recipe_create' %}">Create Recipe</a></p>

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Stock Movements – Inventory App{% endblock %}
 {% load static %}
 {% block content %}
   <h1 class="mb-4">Stock Movements</h1>

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Suppliers – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">Suppliers ({{ total_suppliers }})</h1>
   <div class="mb-4 flex justify-end gap-2">

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% block title %}Login – Inventory App{% endblock %}
 {% block content %}
 <div class="max-w-sm mx-auto space-y-4">
   <h1>Login</h1>


### PR DESCRIPTION
## Summary
- allow templates to override page titles by adding a `title` block in `_base.html`
- provide descriptive titles for all pages that extend the base template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa1033113c8326a9d4d57704655142