### PR TITLE
Use shared form utility classes

### DIFF
--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -1,13 +1,14 @@
 {% load form_tags %}
-{% with input_class="w-full px-3 py-2 border dark:border-form-darkBorder rounded" checkbox_class="h-4 w-4 text-primary" %}
 <div class="space-y-1">
   <label for="{{ field.id_for_label }}" class="block mb-1 font-medium">{{ field.label }}</label>
   {% if field.field.widget.attrs.class %}
     {{ field }}
   {% elif field.field.widget.input_type == "checkbox" %}
-    {{ field|add_class:checkbox_class }}
+    {{ field|add_class:"form-checkbox" }}
+  {% elif field.field.widget.input_type == "radio" %}
+    {{ field|add_class:"form-radio" }}
   {% else %}
-    {{ field|add_class:input_class }}
+    {{ field|add_class:"form-control" }}
   {% endif %}
   {% if field.help_text %}
     <p class="text-sm text-gray-500 dark:text-gray-400">{{ field.help_text }}</p>
@@ -20,4 +21,3 @@
     </ul>
   {% endif %}
 </div>
-{% endwith %}


### PR DESCRIPTION
## Summary
- use `form-control`, `form-checkbox`, and `form-radio` in `form_field.html`
- add classes via `add_class` so templates share centralized styles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa11d7574c83268629c8a7f866d72b