### PR TITLE
Define text scales for headings and body text

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -42,6 +42,12 @@ Spacing utilities map to CSS variables and are mode‑independent:
 | `text-badge` / `--font-size-badge` | Badges and labels |
 | Font family `sans` | Roboto via Google Fonts for all text |
 
+#### Usage Rules
+
+- **`text-h1`**: Reserve for the main page title. Only one `text-h1` should appear per page.
+- **`text-h2`**: Use for section headings beneath the page title. Maintain sequential order without skipping levels.
+- **`text-base`**: Default body copy size. Apply to paragraphs and long-form text for consistent readability.
+
 ## Layout & Breakpoints
 
 ### Container

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -69,10 +69,10 @@ module.exports = {
         '8': 'var(--space-8)',
       },
       fontSize: {
-        base: 'var(--font-size-base)',
-        h1: 'var(--font-size-h1)',
-        h2: 'var(--font-size-h2)',
-        badge: 'var(--font-size-badge)',
+        base: ['var(--font-size-base)', { lineHeight: '1.5' }],
+        h1: ['var(--font-size-h1)', { lineHeight: '1.25' }],
+        h2: ['var(--font-size-h2)', { lineHeight: '1.3' }],
+        badge: ['var(--font-size-badge)', { lineHeight: '1' }],
       },
       fontFamily: {
         sans: ['Roboto', 'sans-serif'],


### PR DESCRIPTION
## Summary
- configure font-size tokens for base text and headings in Tailwind
- document usage rules for `text-h1`, `text-h2`, and `text-base`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa12c119c4832680b7722edf226a60