### PR TITLE
Improve pagination accessibility

### DIFF
--- a/templates/components/pagination.html
+++ b/templates/components/pagination.html
@@ -1,22 +1,24 @@
-<div class="flex items-center gap-1 flex-wrap">
-  {% if page_obj.has_previous %}
-    <a href="{{ base_url }}?page={{ page_obj.previous_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}"
-       {% if hx_target %}hx-get="{{ base_url }}?page={{ page_obj.previous_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
-       class="btn-outline">Prev</a>
-  {% endif %}
-  {% for num in page_obj.paginator.page_range %}
-    {% if num == page_obj.number %}
-      <span class="pagination-active">{{ num }}</span>
-    {% else %}
-      <a href="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}"
-         {% if hx_target %}hx-get="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
-         class="btn-outline">{{ num }}</a>
+<nav aria-label="Pagination">
+  <div class="flex items-center gap-1 flex-wrap">
+    {% if page_obj.has_previous %}
+      <a href="{{ base_url }}?page={{ page_obj.previous_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}"
+         {% if hx_target %}hx-get="{{ base_url }}?page={{ page_obj.previous_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
+         class="btn-outline" aria-label="Previous page">Prev</a>
     {% endif %}
-  {% endfor %}
-  {% if page_obj.has_next %}
-    <a href="{{ base_url }}?page={{ page_obj.next_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}"
-       {% if hx_target %}hx-get="{{ base_url }}?page={{ page_obj.next_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
-       class="btn-outline">Next</a>
-  {% endif %}
-  <span class="ml-2">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
-</div>
+    {% for num in page_obj.paginator.page_range %}
+      {% if num == page_obj.number %}
+        <span class="pagination-active" aria-current="page">{{ num }}</span>
+      {% else %}
+        <a href="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}"
+           {% if hx_target %}hx-get="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
+           class="btn-outline">{{ num }}</a>
+      {% endif %}
+    {% endfor %}
+    {% if page_obj.has_next %}
+      <a href="{{ base_url }}?page={{ page_obj.next_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}"
+         {% if hx_target %}hx-get="{{ base_url }}?page={{ page_obj.next_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
+         class="btn-outline" aria-label="Next page">Next</a>
+    {% endif %}
+    <span class="ml-2">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+  </div>
+</nav>


### PR DESCRIPTION
## Summary
- wrap pagination markup in a `<nav>` with a Pagination label
- add descriptive aria-labels to Prev/Next links and mark the active page with `aria-current="page"`

## Testing
- `flake8` *(fails: blank line at end of file, E303 too many blank lines, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa14b19a788326948684dea1b1aec5