### PR TITLE
Standardize spacing utilities across templates

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -25,7 +25,7 @@
         class="h-12 w-12 border-4 border-primary dark:border-primary border-t-transparent rounded-full animate-spin"
       ></div>
     </div>
-    <div class="container max-md:px-6 max-sm:px-4 py-4 grid gap-4">
+    <div class="container p-8 max-md:px-6 max-sm:px-4 grid gap-4">
       {% if messages %}
         {% include "components/alert.html" %}
       {% endif %}

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -1,6 +1,6 @@
 <div class="py-6 px-8 max-md:px-6 max-sm:px-4 text-center border border-form-border rounded bg-form-bg dark:bg-form-darkBg dark:border-form-darkBorder">
   <svg class="mx-auto w-5 h-5 text-form-text dark:text-form-darkText" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-  <h2 class="mt-4 mb-2">{{ title }}</h2>
+  <h2 class="mt-4 mb-4">{{ title }}</h2>
   <p class="mb-4 text-form-text dark:text-form-darkText">{{ message }}</p>
   <a href="{{ cta_url }}" class="btn-primary">{{ cta_label }}</a>
 </div>

--- a/templates/components/filter_bar.html
+++ b/templates/components/filter_bar.html
@@ -1,4 +1,4 @@
-<form id="filters" class="grid gap-2 mb-4 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1" method="get">
+<form id="filters" class="grid gap-4 mb-4 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1" method="get">
   <input
     type="text"
     name="q"

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -2,7 +2,7 @@
 {% block title %}Goods Received Notes – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">Goods Received Notes</h1>
-  <form method="get" class="mb-4 grid gap-2 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
+  <form method="get" class="mb-4 grid gap-4 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
       <label class="block text-sm">Supplier</label>
       <input

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -2,7 +2,7 @@
 {% block title %}History Reports – Inventory App{% endblock %}
 {% block content %}
   <h1 class="mb-4">History Reports</h1>
-    <form id="filters" method="get" class="grid gap-2 mb-4 grid-cols-7 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1"
+    <form id="filters" method="get" class="grid gap-4 mb-4 grid-cols-7 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1"
           hx-get="{% url 'history_reports' %}"
           hx-target="#history_table"
           hx-indicator="#htmx-spinner">

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -8,7 +8,7 @@
   <div class="mb-4">
     <a href="{% url 'indent_pdf' indent.indent_id %}" class="btn-outline">Download PDF</a>
   </div>
-  <h2 class="mb-2">Items</h2>
+  <h2 class="mb-4">Items</h2>
   <table class="table">
     <thead><tr><th>Item</th><th>Qty</th></tr></thead>
     <tbody>

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -5,7 +5,7 @@
   <p class="mb-2"><strong>Supplier:</strong> {{ po.supplier.name }}</p>
   <p class="mb-2"><strong>Order Date:</strong> {{ po.order_date }}</p>
   <p class="mb-4"><span class="px-2 py-1 rounded text-xs {{ badge_class }}">{{ po.get_status_display }}</span></p>
-  <h2 class="mb-2">Items</h2>
+  <h2 class="mb-4">Items</h2>
   <table class="table mb-4">
     <thead><tr><th>Item</th><th>Ordered</th><th>Received</th></tr></thead>
     <tbody>

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -6,7 +6,7 @@
     <a href="{% url 'purchase_order_create' %}" class="btn-primary">New PO</a>
     <a href="{% url 'grn_list' %}" class="btn-secondary">GRNs</a>
   </div>
-  <form method="get" class="mb-4 grid gap-2 grid-cols-5 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
+  <form method="get" class="mb-4 grid gap-4 grid-cols-5 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
       <label class="block text-sm">Status</label>
       <input

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -14,7 +14,7 @@
     {% include "components/alert.html" %}
   {% endif %}
   {% if active_section == 'receive' %}
-    <h2 class="mb-2">Goods Received</h2>
+    <h2 class="mb-4">Goods Received</h2>
     <form method="post" class="mb-4">
       {% csrf_token %}
       {% if receive_form.non_field_errors %}
@@ -30,7 +30,7 @@
       <button type="submit" name="submit_receive" class="btn-primary">Record</button>
     </form>
   {% elif active_section == 'adjust' %}
-    <h2 class="mb-2">Stock Adjustment</h2>
+    <h2 class="mb-4">Stock Adjustment</h2>
     <form method="post" class="mb-4">
       {% csrf_token %}
       {% if adjust_form.non_field_errors %}
@@ -46,7 +46,7 @@
       <button type="submit" name="submit_adjust" class="btn-primary">Record</button>
     </form>
   {% elif active_section == 'waste' %}
-    <h2 class="mb-2">Wastage/Spoilage</h2>
+    <h2 class="mb-4">Wastage/Spoilage</h2>
     <form method="post" class="mb-4">
       {% csrf_token %}
       {% if waste_form.non_field_errors %}
@@ -64,7 +64,7 @@
   {% endif %}
   <datalist id="item-options"></datalist>
   <hr class="my-4"/>
-  <h2 class="mb-2">Bulk Upload Stock Transactions</h2>
+  <h2 class="mb-4">Bulk Upload Stock Transactions</h2>
   <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary">Download sample CSV</a></p>
   <form method="post" enctype="multipart/form-data" class="mb-4">
     {% csrf_token %}
@@ -91,7 +91,7 @@
     </ul>
   {% endif %}
   <hr class="my-4"/>
-  <h2 class="mb-2">Recent Transactions</h2>
+  <h2 class="mb-4">Recent Transactions</h2>
   <div class="max-md:overflow-x-auto">
     <table class="table">
       <thead>

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -2,7 +2,7 @@
 {% block title %}Login – Inventory App{% endblock %}
 {% block content %}
 <div class="max-w-sm mx-auto space-y-4">
-  <h1>Login</h1>
+  <h1 class="mb-4">Login</h1>
   <form method="post" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}


### PR DESCRIPTION
## Summary
- Apply p-8 padding to main container
- Use mb-4 margin for headings and gap-4 for grid layouts

## Testing
- `flake8` *(fails: W391, E303, E302, E125)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa17b4f8e4832688c87011743bab57