### PR TITLE
Fix form background theme resolution

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -81,7 +81,7 @@
 
   .btn-tertiary {
     @apply px-4 py-2 rounded border transition-colors no-underline;
-    background-color: theme('colors.form.bg');
+    background-color: theme('colors.form.bg', '#ffffff');
     color: theme('colors.bodyText.light');
     border-color: theme('colors.form.border');
   }
@@ -180,7 +180,7 @@
   .form-control {
     font-family: theme('fontFamily.sans');
     border: 1px solid theme('colors.form.border');
-    background-color: theme('colors.form.bg');
+    background-color: theme('colors.form.bg', '#ffffff');
     color: theme('colors.form.text');
     padding: var(--space-2);
     border-radius: var(--space-1);
@@ -197,14 +197,14 @@
 
   .form-checkbox {
     border: 1px solid theme('colors.form.border');
-    background-color: theme('colors.form.bg');
+    background-color: theme('colors.form.bg', '#ffffff');
     color: theme('colors.form.text');
     border-radius: var(--space-1);
   }
 
   .form-radio {
     border: 1px solid theme('colors.form.border');
-    background-color: theme('colors.form.bg');
+    background-color: theme('colors.form.bg', '#ffffff');
     color: theme('colors.form.text');
     border-radius: 9999px;
     accent-color: var(--color-primary);
@@ -254,7 +254,7 @@
     background-color: var(--color-primary);
     color: theme('colors.table.headerText');
   }
-  .table tbody tr { background-color: theme('colors.form.bg'); }
+  .table tbody tr { background-color: theme('colors.form.bg', '#ffffff'); }
   .table tbody tr:hover { background-color: theme('colors.table.hoverBg'); }
 
   .dark .table th,


### PR DESCRIPTION
## Summary
- provide fallback values for `theme('colors.form.bg')` references to prevent unresolved theme errors

## Testing
- `flake8` (fails: W391 E303 E302 E125)
- `pytest`
- `npx tailwindcss@3.3.2 -i static/src/app.css -o static/css/app.css` (fails: command interrupted)


------
https://chatgpt.com/codex/tasks/task_e_68aa1785dd888326855355c9111fd6f4