### PR TITLE
Fix trailing blank line in category migration

### DIFF
--- a/inventory/migrations/0010_category.py
+++ b/inventory/migrations/0010_category.py
@@ -29,4 +29,3 @@ class Migration(migrations.Migration):
             options={"db_table": "category", "ordering": ("name",)},
         ),
     ]
-


### PR DESCRIPTION
## Summary
- remove extraneous blank line at end of category migration

## Testing
- `flake8` *(fails: E303 too many blank lines in other files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa19d8e21883268c24f13ab0c65042