### PR TITLE
Improve form layout and table styling

### DIFF
--- a/app.css
+++ b/app.css
@@ -300,8 +300,9 @@ form textarea:focus {
   color: #ffffff;
 }
 
+/* Improve table row hover visibility */
 .table tbody tr:hover {
-  background-color: #f3f4f6; /* Improved hover contrast */
+  background-color: #d1d5db; /* Improved hover contrast */
 }
 
 .dark .table thead {
@@ -309,5 +310,5 @@ form textarea:focus {
 }
 
 .dark .table tbody tr:hover {
-  background-color: #1e293b; /* Dark mode hover contrast */
+  background-color: #334155; /* Dark mode hover contrast */
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1155,7 +1155,7 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 .table th,
   .table td {
   border: 1px solid var(--color-border);
-  padding: var(--space-2) var(--space-4);
+  padding: var(--space-4) var(--space-6);
   text-align: left;
 }
 
@@ -1166,10 +1166,11 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 
 .table tbody tr {
   background-color: #ffffff;
+  transition: background-color 0.15s ease-in-out;
 }
 
 .table tbody tr:hover {
-  background-color: #e5e7eb;
+  background-color: #d1d5db;
 }
 
 .dark .table th,
@@ -1187,7 +1188,7 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 }
 
 .dark .table tbody tr:hover {
-  background-color: #1e293b;
+  background-color: #334155;
 }
 
 /* Pagination controls */

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -248,14 +248,17 @@
   .table th,
   .table td {
     border: 1px solid theme('colors.table.border');
-    padding: var(--space-2) var(--space-4);
+    padding: var(--space-4) var(--space-6);
     text-align: left;
   }
   .table thead {
     background-color: var(--color-primary);
     color: theme('colors.table.headerText');
   }
-  .table tbody tr { background-color: theme('colors.form.bg', '#ffffff'); }
+  .table tbody tr {
+    background-color: theme('colors.form.bg', '#ffffff');
+    transition: background-color 0.15s ease-in-out;
+  }
   .table tbody tr:hover { background-color: theme('colors.table.hoverBg'); }
 
   .dark .table th,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -52,14 +52,14 @@ module.exports = {
           darkBorder: 'var(--color-border-dark)',
           darkText: '#f8fafc',
         },
-        table: {
-          border: 'var(--color-border)',
-          headerBg: 'var(--color-primary)',
-          headerText: '#ffffff',
-          hoverBg: '#e5e7eb',
-          darkBorder: 'var(--color-border-dark)',
-          darkHoverBg: '#1e293b',
-        },
+          table: {
+            border: 'var(--color-border)',
+            headerBg: 'var(--color-primary)',
+            headerText: '#ffffff',
+            hoverBg: '#d1d5db',
+            darkBorder: 'var(--color-border-dark)',
+            darkHoverBg: '#334155',
+          },
       },
       spacing: {
         '0.5': 'var(--space-0-5)',

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -4,7 +4,7 @@
   {% if not form.units_map %}
   <p class="text-sm text-red-600 dark:text-red-400">Could not load unit options. Please try again later.</p>
   {% endif %}
-  <div class="grid gap-4 grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
+  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
     <div id="name-field" class="space-y-1 relative">
       <label for="{{ form.name.id_for_label }}" class="block mb-1 font-medium">{{ form.name.label }}</label>
       {{ form.name }}

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -1,7 +1,7 @@
 {% extends "components/form_layout.html" %}
 {% block heading %}{% if is_edit %}Edit Supplier{% else %}New Supplier{% endif %}{% endblock %}
 {% block fields %}
-  <div class="grid gap-4 grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
+  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
     {% for field in form %}
       {% include "components/form_field.html" with field=field %}
     {% endfor %}


### PR DESCRIPTION
## Summary
- use consistent two-column layout for item and supplier forms
- add table cell padding and smoother row hover transitions
- tune table hover colors for better readability in light and dark themes

## Testing
- `flake8` *(fails: blank line at end of file, too many blank lines, expected 2 blank lines)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa1a28d1208326a8327548e6a54ba4