### PR TITLE
Fix flake8 issues

### DIFF
--- a/inventory/services/item_service.py
+++ b/inventory/services/item_service.py
@@ -63,8 +63,6 @@ def get_all_items_with_stock(include_inactive: bool = False) -> List[Dict[str, A
 get_all_items_with_stock.clear = get_all_items_with_stock.cache_clear  # type: ignore[attr-defined]
 
 
-
-
 @lru_cache(maxsize=None)
 def get_distinct_departments_from_items() -> List[str]:
     """Return a sorted list of unique department names from active items."""
@@ -84,8 +82,6 @@ def get_distinct_departments_from_items() -> List[str]:
 get_distinct_departments_from_items.clear = (
     get_distinct_departments_from_items.cache_clear
 )  # type: ignore[attr-defined]
-
-
 # ---------------------------------------------------------------------------
 # Mutating helpers
 # ---------------------------------------------------------------------------
@@ -116,8 +112,6 @@ def add_new_item(details: Dict[str, Any]) -> Tuple[bool, str]:
             traceback.format_exc(),
         )
         return False, "A database error occurred while adding the item."
-
-
 
 
 def _validate_required(

--- a/tests/test_aa_views.py
+++ b/tests/test_aa_views.py
@@ -2,7 +2,7 @@ import pytest
 from django.test import RequestFactory
 from django.http import HttpResponse, Http404
 from django.contrib.messages.storage.fallback import FallbackStorage
-from django.db import connection, DatabaseError, transaction
+from django.db import connection, DatabaseError
 from unittest.mock import patch
 
 from inventory.models import Item, Indent, IndentItem
@@ -22,11 +22,9 @@ def _add_messages(request):
     request.user = SimpleUser()
 
 
-    """
-    Test that ItemEditView handles a DatabaseError during ItemForm.save gracefully.
-    """
 @pytest.mark.django_db
 def test_item_edit_handles_save_error(item_factory):
+    """Test graceful handling when ItemForm.save raises DatabaseError."""
     item = item_factory(name="Sugar")
     rf = RequestFactory()
     request = rf.post(
@@ -35,16 +33,20 @@ def test_item_edit_handles_save_error(item_factory):
     )
     _add_messages(request)
     # Simulate DB error on save
-    with patch("inventory.forms.item_forms.get_units", return_value={}), \
-        patch("inventory.forms.item_forms.get_categories", return_value={}), \
-        patch("inventory.forms.item_forms.ItemForm.save", side_effect=DatabaseError), \
-        patch("inventory.views.items.render", return_value=HttpResponse()):
+    with (
+        patch("inventory.forms.item_forms.get_units", return_value={}),
+        patch("inventory.forms.item_forms.get_categories", return_value={}),
+        patch("inventory.forms.item_forms.ItemForm.save", side_effect=DatabaseError),
+        patch("inventory.views.items.render", return_value=HttpResponse()),
+    ):
         resp = ItemEditView.as_view()(request, pk=item.pk)
     assert resp.status_code == 200
 
 
 @pytest.mark.django_db
-@pytest.mark.skip(reason="This test uses raw SQL that is incompatible with PostgreSQL's strict type checking.")
+@pytest.mark.skip(
+    reason="This test uses raw SQL that is incompatible with PostgreSQL's strict type checking."
+)
 def test_item_edit_handles_non_numeric_values(item_factory):
     """
     Test that ItemEditView does not crash when non-numeric values are present in numeric DB fields.
@@ -60,8 +62,10 @@ def test_item_edit_handles_non_numeric_values(item_factory):
     rf = RequestFactory()
     request = rf.get(f"/items/{item.pk}/edit/")
     _add_messages(request)
-    with patch("inventory.forms.item_forms.get_units", return_value={}), \
-        patch("inventory.views.items.render", return_value=HttpResponse()):
+    with (
+        patch("inventory.forms.item_forms.get_units", return_value={}),
+        patch("inventory.views.items.render", return_value=HttpResponse()),
+    ):
         resp = ItemEditView.as_view()(request, pk=item.pk)
     assert resp.status_code == 200
 
@@ -75,18 +79,17 @@ def test_item_edit_db_error_returns_404():
     request = rf.get("/items/1/edit/")
     _add_messages(request)
     # Simulate DB error when fetching the object
-    with patch("inventory.forms.item_forms.get_units", return_value={}), \
-        patch("inventory.views.items.get_object_or_404", side_effect=DatabaseError):
+    with (
+        patch("inventory.forms.item_forms.get_units", return_value={}),
+        patch("inventory.views.items.get_object_or_404", side_effect=DatabaseError),
+    ):
         with pytest.raises(Http404):
             ItemEditView.as_view()(request, pk=1)
 
 
-    """
-    Test that IndentCreateView does not create an Indent if IndentItemFormSet.save fails.
-    Ensures atomicity.
-    """
 @pytest.mark.django_db
 def test_indent_create_atomic_on_error(item_factory):
+    """Ensure IndentCreateView is atomic if formset save fails."""
     item = item_factory(name="Salt")
     rf = RequestFactory()
     post_data = {
@@ -105,7 +108,9 @@ def test_indent_create_atomic_on_error(item_factory):
     request = rf.post("/indents/create/", post_data)
     _add_messages(request)
     # Simulate DB error on formset save
-    with patch("inventory.forms.indent_forms.IndentItemFormSet.save", side_effect=DatabaseError):
+    with patch(
+        "inventory.forms.indent_forms.IndentItemFormSet.save", side_effect=DatabaseError
+    ):
         with patch("inventory.views.indents.render", return_value=HttpResponse()):
             resp = IndentCreateView.as_view()(request)
     assert resp.status_code == 200

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -89,5 +89,3 @@ def test_item_form_categories_and_save(monkeypatch):
     assert form.is_valid()
     item = form.save()
     assert item.category_id == 2
-
-


### PR DESCRIPTION
## Summary
- resolve flake8 warnings by cleaning up blank lines and spacing
- tidy tests to avoid continuation line warnings and move docstrings into functions

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa1a87d8e48326a393a376b38143df