### PR TITLE
Add flake8 linting via pre-commit and CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: "--all-files"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bugbear]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ Install dependencies using `pip`:
 pip install -r requirements.txt
 ```
 
+## Code Style and Linting
+
+This project uses [pre-commit](https://pre-commit.com/) with `flake8` to enforce
+style rules.
+
+Install the git hooks:
+
+```bash
+pre-commit install
+```
+
+Run lint checks for all files:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Configuration
 
 Configuration is controlled via environment variables. Copy `.env.example` to `.env` and set values for your database and other settings:
@@ -155,4 +172,3 @@ The application exposes the following REST endpoints under `/api/`:
 - `/api/purchase-order-items/` – line items within a purchase order.
 - `/api/goods-received-notes/` – log received goods.
 - `/api/grn-items/` – items contained in a goods received note.
-

--- a/inventory/services/item_service.py
+++ b/inventory/services/item_service.py
@@ -63,8 +63,6 @@ def get_all_items_with_stock(include_inactive: bool = False) -> List[Dict[str, A
 get_all_items_with_stock.clear = get_all_items_with_stock.cache_clear  # type: ignore[attr-defined]
 
 
-
-
 @lru_cache(maxsize=None)
 def get_distinct_departments_from_items() -> List[str]:
     """Return a sorted list of unique department names from active items."""
@@ -116,8 +114,6 @@ def add_new_item(details: Dict[str, Any]) -> Tuple[bool, str]:
             traceback.format_exc(),
         )
         return False, "A database error occurred while adding the item."
-
-
 
 
 def _validate_required(

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ pydantic
 pytest
 pytest-django
 supabase
+flake8==7.3.0
+flake8-bugbear==24.12.12

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -89,5 +89,3 @@ def test_item_form_categories_and_save(monkeypatch):
     assert form.is_valid()
     item = form.save()
     assert item.category_id == 2
-
-


### PR DESCRIPTION
## Summary
- add flake8 and bugbear to dependencies
- configure pre-commit with flake8 hook
- run lint checks in GitHub Actions
- document lint workflow in README

## Testing
- `flake8`
- `pre-commit run --files requirements.txt README.md inventory/services/item_service.py tests/test_aa_views.py tests/test_item_form.py .pre-commit-config.yaml .github/workflows/lint.yml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa1b1b8e00832691872b468eda42c1