### PR TITLE
Enhance KPI cards and add links for low stock items

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,18 +1,30 @@
 <div class="grid grid-cols-4 max-md:grid-cols-1 gap-4">
   <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
-    <h2 class="text-sm font-medium text-primary">Stock Value</h2>
-    <span class="text-2xl font-bold">{{ stock_value }}</span>
+    <div class="flex items-center gap-2">
+      <svg aria-hidden="true" class="w-6 h-6 text-secondary" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
+      <h2 class="text-sm font-medium text-primary">Stock Value</h2>
+    </div>
+    <span class="text-3xl font-bold">{{ stock_value }}</span>
   </div>
   <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
-    <h2 class="text-sm font-medium text-primary">7-day Receipts</h2>
-    <span class="text-2xl font-bold">{{ receipts }}</span>
+    <div class="flex items-center gap-2">
+      <svg aria-hidden="true" class="w-6 h-6 text-secondary" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/></svg>
+      <h2 class="text-sm font-medium text-primary">7-day Receipts</h2>
+    </div>
+    <span class="text-3xl font-bold">{{ receipts }}</span>
   </div>
   <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
-    <h2 class="text-sm font-medium text-primary">7-day Issues</h2>
-    <span class="text-2xl font-bold">{{ issues }}</span>
+    <div class="flex items-center gap-2">
+      <svg aria-hidden="true" class="w-6 h-6 text-secondary" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"/></svg>
+      <h2 class="text-sm font-medium text-primary">7-day Issues</h2>
+    </div>
+    <span class="text-3xl font-bold">{{ issues }}</span>
   </div>
   <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
-    <h2 class="text-sm font-medium text-primary">Low-stock Count</h2>
-    <span class="text-2xl font-bold">{{ low_stock }}</span>
+    <div class="flex items-center gap-2">
+      <svg aria-hidden="true" class="w-6 h-6 text-secondary" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/></svg>
+      <h2 class="text-sm font-medium text-primary">Low-stock Count</h2>
+    </div>
+    <span class="text-3xl font-bold">{{ low_stock }}</span>
   </div>
 </div>

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -6,16 +6,17 @@
 
 <h2 class="text-xl mb-2 mt-8">Low Stock Items</h2>
 <table class="table">
-  <thead><tr><th>Item</th><th>Stock</th><th>Reorder Point</th></tr></thead>
+  <thead><tr><th>Item</th><th>Stock</th><th>Reorder Point</th><th>Actions</th></tr></thead>
   <tbody>
   {% for item in low_stock %}
     <tr>
       <td>{{ item.name }}</td>
       <td>{{ item.current_stock }}</td>
       <td>{{ item.reorder_point }}</td>
+      <td><a href="{% url 'item_detail' item.pk %}" class="text-primary hover:underline">View Item</a></td>
     </tr>
   {% empty %}
-    <tr><td colspan="3">No low stock items.</td></tr>
+    <tr><td colspan="4">No low stock items.</td></tr>
   {% endfor %}
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
- Emphasize KPI numbers and add icons to each card
- Include direct links to item details from the low stock table

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa207cc96c8326ab2f42e7adb4d030