### PR TITLE
Refactor forms to use two-column layout

### DIFF
--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -1,5 +1,5 @@
 {% load form_tags %}
-<div class="space-y-1">
+<div class="{% if container_class %}{{ container_class }} {% endif %}space-y-1">
   <label for="{{ field.id_for_label }}" class="block mb-1 text-sm font-medium">{{ field.label }}</label>
   {% if field.field.widget.attrs.class %}
     {{ field }}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -12,9 +12,13 @@
       {% endfor %}
     </ul>
     {% endif %}
-    <div class="mb-4 space-y-4">
+    <div class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
       {% for field in form %}
-        {% include "components/form_field.html" with field=field %}
+        {% if field.name in ['description', 'plating_notes'] %}
+          {% include "components/form_field.html" with field=field container_class="col-span-2" %}
+        {% else %}
+          {% include "components/form_field.html" with field=field %}
+        {% endif %}
       {% endfor %}
     </div>
     {{ formset.management_form }}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -15,7 +15,7 @@
   {% endif %}
   {% if active_section == 'receive' %}
     <h2 class="text-xl mb-4 mt-8">Goods Received</h2>
-    <form method="post" class="mb-4">
+    <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
       {% csrf_token %}
       {% if receive_form.non_field_errors %}
       <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
@@ -25,13 +25,19 @@
       </ul>
       {% endif %}
       {% for field in receive_form %}
-        {% include "components/form_field.html" with field=field %}
+        {% if field.name == 'notes' %}
+          {% include "components/form_field.html" with field=field container_class="col-span-2" %}
+        {% else %}
+          {% include "components/form_field.html" with field=field %}
+        {% endif %}
       {% endfor %}
-      <button type="submit" name="submit_receive" class="btn-primary">Record</button>
+      <div class="col-span-2">
+        <button type="submit" name="submit_receive" class="btn-primary">Record</button>
+      </div>
     </form>
   {% elif active_section == 'adjust' %}
     <h2 class="text-xl mb-4 mt-8">Stock Adjustment</h2>
-    <form method="post" class="mb-4">
+    <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
       {% csrf_token %}
       {% if adjust_form.non_field_errors %}
       <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
@@ -41,13 +47,19 @@
       </ul>
       {% endif %}
       {% for field in adjust_form %}
-        {% include "components/form_field.html" with field=field %}
+        {% if field.name == 'notes' %}
+          {% include "components/form_field.html" with field=field container_class="col-span-2" %}
+        {% else %}
+          {% include "components/form_field.html" with field=field %}
+        {% endif %}
       {% endfor %}
-      <button type="submit" name="submit_adjust" class="btn-primary">Record</button>
+      <div class="col-span-2">
+        <button type="submit" name="submit_adjust" class="btn-primary">Record</button>
+      </div>
     </form>
   {% elif active_section == 'waste' %}
     <h2 class="text-xl mb-4 mt-8">Wastage/Spoilage</h2>
-    <form method="post" class="mb-4">
+    <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
       {% csrf_token %}
       {% if waste_form.non_field_errors %}
       <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
@@ -57,16 +69,22 @@
       </ul>
       {% endif %}
       {% for field in waste_form %}
-        {% include "components/form_field.html" with field=field %}
+        {% if field.name == 'notes' %}
+          {% include "components/form_field.html" with field=field container_class="col-span-2" %}
+        {% else %}
+          {% include "components/form_field.html" with field=field %}
+        {% endif %}
       {% endfor %}
-      <button type="submit" name="submit_waste" class="btn-primary">Record</button>
+      <div class="col-span-2">
+        <button type="submit" name="submit_waste" class="btn-primary">Record</button>
+      </div>
     </form>
   {% endif %}
   <datalist id="item-options"></datalist>
   <hr class="my-4"/>
   <h2 class="text-xl mb-4 mt-8">Bulk Upload Stock Transactions</h2>
   <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary">Download sample CSV</a></p>
-  <form method="post" enctype="multipart/form-data" class="mb-4">
+  <form method="post" enctype="multipart/form-data" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
     {% csrf_token %}
     {% if bulk_form.non_field_errors %}
     <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
@@ -76,9 +94,11 @@
     </ul>
     {% endif %}
     {% for field in bulk_form %}
-      {% include "components/form_field.html" with field=field %}
+      {% include "components/form_field.html" with field=field container_class="col-span-2" %}
     {% endfor %}
-    <button type="submit" name="bulk_upload" class="btn-primary">Upload</button>
+    <div class="col-span-2">
+      <button type="submit" name="bulk_upload" class="btn-primary">Upload</button>
+    </div>
   </form>
   {% if bulk_success_count is not None %}
     <p>{{ bulk_success_count }} transaction(s) recorded successfully.</p>

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="max-w-sm mx-auto space-y-4">
   <h1 class="text-2xl font-semibold">Login</h1>
-  <form method="post" class="space-y-4">
+  <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
     {% csrf_token %}
     {% if form.non_field_errors %}
     <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
@@ -11,9 +11,11 @@
     </ul>
     {% endif %}
     {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
+      {% include "components/form_field.html" with field=field container_class="col-span-2" %}
     {% endfor %}
-    <button type="submit" class="btn-primary">Login</button>
+    <div class="col-span-2">
+      <button type="submit" class="btn-primary">Login</button>
+    </div>
   </form>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add optional container classes to `form_field` component for flexible grid placement
- Convert stock movement, recipe detail, and login pages to responsive two-column grids

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa2269f9988326b61ae0db5d29cd01