### PR TITLE
refactor: centralize color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Inventory-App is a Django application for managing restaurant inventory with a P
 
 Refer to [STYLEGUIDE.md](STYLEGUIDE.md) for design tokens, reusable components and usage examples. When creating new templates or JavaScript-driven components, prefer Tailwind CSS utilities and the classes defined in `static/css/app.css` before adding custom styles.
 
+The color palette is centralized in `static/src/tokens.css` and consumed by `tailwind.config.js` via CSS variables. Update the tokens in that file to change colors across both light and dark themes.
+
 ## Responsive Breakpoints
 
 This project uses a desktop-first Tailwind CSS strategy. Base styles target larger screens, while `max-*` variants provide overrides for smaller viewports. Custom `max-sm`, `max-md`, `max-lg`, and `max-xl` screens are defined in `tailwind.config.js`. Use these utilities when building templates so mobile adjustments are explicit:

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -5,8 +5,10 @@ Follow this guide when building new templates or JavaScript‑driven components.
 
 ## Design Tokens
 
-Tokens are provided via CSS variables in [static/css/app.css](static/css/app.css) and surfaced to
-[Tailwind via `tailwind.config.js`](tailwind.config.js).
+The canonical tokens are defined in [static/src/tokens.css](static/src/tokens.css). The file is imported by
+[static/src/app.css](static/src/app.css) and the variables are referenced in
+[Tailwind via `tailwind.config.js`](tailwind.config.js). Updating `tokens.css` propagates color changes
+to both light and dark themes.
 
 ### Colors
 

--- a/static/src/tokens.css
+++ b/static/src/tokens.css
@@ -16,6 +16,9 @@
   --color-body-dark: #0f172a;
   --color-body-text: #111827;
   --color-body-text-dark: #f8fafc;
+  --color-form-bg-dark: #1e293b;
+  --color-table-hover-bg: #e5e7eb;
+  --color-table-hover-bg-dark: #475569;
 
   /* Spacing tokens */
   --space-0-5: 0.125rem;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,12 +32,12 @@ module.exports = {
     extend: {
       colors: {
         body: {
-          light: '#ffffff',
-          dark: '#0f172a',
+          light: 'var(--color-body)',
+          dark: 'var(--color-body-dark)',
         },
         bodyText: {
-          light: '#111827',
-          dark: '#f8fafc',
+          light: 'var(--color-body-text)',
+          dark: 'var(--color-body-text-dark)',
         },
         primary: 'var(--color-primary)',
         secondary: 'var(--color-secondary)',
@@ -45,21 +45,21 @@ module.exports = {
         danger: 'var(--color-danger)',
         border: 'var(--color-border)',
         form: {
-          bg: '#ffffff',
+          bg: 'var(--color-body)',
           border: 'var(--color-border)',
-          text: '#111827',
-          darkBg: '#1e293b',
+          text: 'var(--color-body-text)',
+          darkBg: 'var(--color-form-bg-dark)',
           darkBorder: 'var(--color-border-dark)',
-          darkText: '#f8fafc',
+          darkText: 'var(--color-body-text-dark)',
         },
-            table: {
-              border: 'var(--color-border)',
-              headerBg: 'var(--color-primary)',
-              headerText: '#ffffff',
-              hoverBg: '#e5e7eb',
-              darkBorder: 'var(--color-border-dark)',
-              darkHoverBg: '#475569',
-            },
+        table: {
+          border: 'var(--color-border)',
+          headerBg: 'var(--color-primary)',
+          headerText: 'var(--color-body)',
+          hoverBg: 'var(--color-table-hover-bg)',
+          darkBorder: 'var(--color-border-dark)',
+          darkHoverBg: 'var(--color-table-hover-bg-dark)',
+        },
       },
       spacing: {
         '0.5': 'var(--space-0-5)',


### PR DESCRIPTION
## Summary
- use `static/src/tokens.css` as the single source of color tokens
- reference palette variables throughout `tailwind.config.js`
- document how to update colors for both themes

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa26d741148326abfea680c060d229