### PR TITLE
Enable asynchronous item creation with HTMX

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -14,6 +14,7 @@
   </head>
   <body class="min-h-screen text-base">
     {% include "components/nav.html" %}
+    <div id="toast-container" class="fixed top-4 right-4 space-y-2 z-50"></div>
     <div
       id="htmx-spinner"
       role="status"

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -1,5 +1,10 @@
 {% extends "components/form_layout.html" %}
 {% block heading %}{% if is_edit %}Edit Item{% else %}New Item{% endif %}{% endblock %}
+{% block form_attrs %}
+  id="item-form"
+  hx-post="{% if is_edit %}{% url 'item_edit' item.pk %}{% else %}{% url 'item_create' %}{% endif %}"
+  hx-target="#item-options"
+{% endblock %}
 {% block fields %}
   {% if not form.units_map %}
   <p class="text-sm text-red-600 dark:text-red-400">Could not load unit options. Please try again later.</p>


### PR DESCRIPTION
## Summary
- enable HTMX submission on the item form
- return partials for HTMX item creation with inline errors and toast
- test HTMX item creation success and failure

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa2fe4fa788326ab9534df61ea80e0