### PR TITLE
Remove dark mode tokens and selectors from CSS

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -3,20 +3,14 @@
 :root {
   /* Color tokens */
   --color-primary: #0D3A99;
-  /* Dark mode variant */
-  --color-primary-dark: #1D4ED8;
   --color-secondary: #024427;
-  /* Dark mode variant */
-  --color-secondary-dark: #165E2D;
   --color-accent: #8C4A02;
   --color-danger: #B91C1C;
   --color-border: #6b7280;
-  --color-border-dark: #64748b;
   /* Body and text colors */
   --color-body: #ffffff;
-  --color-body-dark: #0f172a;
   --color-body-text: #111827;
-  --color-body-text-dark: #f8fafc;
+  --color-table-hover-bg: #e5e7eb;
   /* Spacing tokens */
   --space-0-5: 0.125rem;
   --space-1: 0.25rem;
@@ -31,7 +25,7 @@
   --font-size-badge: 0.8rem;
 }
 
-/* ! tailwindcss v3.4.4 | MIT License | https://tailwindcss.com */
+/* ! tailwindcss v3.4.1 | MIT License | https://tailwindcss.com */
 
 /*
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
@@ -242,8 +236,6 @@ textarea {
   /* 1 */
   line-height: inherit;
   /* 1 */
-  letter-spacing: inherit;
-  /* 1 */
   color: inherit;
   /* 1 */
   margin: 0;
@@ -267,9 +259,9 @@ select {
 */
 
 button,
-input:where([type='button']),
-input:where([type='reset']),
-input:where([type='submit']) {
+[type='button'],
+[type='reset'],
+[type='submit'] {
   -webkit-appearance: button;
   /* 1 */
   background-color: transparent;
@@ -483,11 +475,6 @@ body {
   font-family: Roboto, sans-serif;
 }
 
-.dark {
-  --color-primary: var(--color-primary-dark);
-  --color-secondary: var(--color-secondary-dark);
-}
-
 /* Base link styles: underlined with primary color.
      Button classes (.btn-*) remove the underline. */
 
@@ -498,7 +485,7 @@ a {
 
 a:hover,
   a:focus {
-  color: var(--color-primary-dark);
+  color: #1D4ED8;
 }
 
 *, ::before, ::after{
@@ -549,10 +536,6 @@ a:hover,
   --tw-backdrop-opacity:  ;
   --tw-backdrop-saturate:  ;
   --tw-backdrop-sepia:  ;
-  --tw-contain-size:  ;
-  --tw-contain-layout:  ;
-  --tw-contain-paint:  ;
-  --tw-contain-style:  ;
 }
 
 ::backdrop{
@@ -603,76 +586,6 @@ a:hover,
   --tw-backdrop-opacity:  ;
   --tw-backdrop-saturate:  ;
   --tw-backdrop-sepia:  ;
-  --tw-contain-size:  ;
-  --tw-contain-layout:  ;
-  --tw-contain-paint:  ;
-  --tw-contain-style:  ;
-}
-
-.\!container{
-  width: 100% !important;
-  margin-right: auto !important;
-  margin-left: auto !important;
-  padding-right: var(--space-8) !important;
-  padding-left: var(--space-8) !important;
-}
-
-.container{
-  width: 100%;
-  margin-right: auto;
-  margin-left: auto;
-  padding-right: var(--space-8);
-  padding-left: var(--space-8);
-}
-
-@media (min-width: 640px){
-  .\!container{
-    max-width: 640px !important;
-  }
-
-  .container{
-    max-width: 640px;
-  }
-}
-
-@media (min-width: 768px){
-  .\!container{
-    max-width: 768px !important;
-  }
-
-  .container{
-    max-width: 768px;
-  }
-}
-
-@media (min-width: 1024px){
-  .\!container{
-    max-width: 1024px !important;
-  }
-
-  .container{
-    max-width: 1024px;
-  }
-}
-
-@media (min-width: 1280px){
-  .\!container{
-    max-width: 1280px !important;
-  }
-
-  .container{
-    max-width: 1280px;
-  }
-}
-
-@media (min-width: 1536px){
-  .\!container{
-    max-width: 1536px !important;
-  }
-
-  .container{
-    max-width: 1536px;
-  }
 }
 
 .active{
@@ -682,23 +595,33 @@ a:hover,
 
 /* Badge component styles */
 
-.dark .badge-success{
+.badge-success,
+  .badge-warning,
+  .badge-error{
+  border-radius: 0.25rem;
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
+  padding-top: var(--space-0-5);
+  padding-bottom: var(--space-0-5);
+}
+
+.badge-success{
   --tw-bg-opacity: 1;
-  background-color: rgb(22 101 52 / var(--tw-bg-opacity));
+  background-color: rgb(21 128 61 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
-.dark .badge-warning{
+.badge-warning{
   --tw-bg-opacity: 1;
-  background-color: rgb(217 119 6 / var(--tw-bg-opacity));
+  background-color: rgb(245 158 11 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
 }
 
-.dark .badge-error{
+.badge-error{
   --tw-bg-opacity: 1;
-  background-color: rgb(185 28 28 / var(--tw-bg-opacity));
+  background-color: rgb(220 38 38 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
@@ -731,7 +654,7 @@ a:hover,
 }
 
 .btn-primary:hover {
-  background-color: var(--color-primary-dark);
+  background-color: #1D4ED8;
 }
 
 .btn-primary:focus{
@@ -765,7 +688,7 @@ a:hover,
 }
 
 .btn-secondary:hover {
-  background-color: var(--color-secondary-dark);
+  background-color: #165E2D;
 }
 
 .btn-secondary:focus{
@@ -794,8 +717,8 @@ a:hover,
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
-  background-color: #ffffff;
-  color: #111827;
+  background-color: var(--color-body);
+  color: var(--color-body-text);
   border-color: var(--color-border);
 }
 
@@ -817,21 +740,6 @@ a:hover,
 .btn-tertiary:disabled{
   cursor: not-allowed;
   opacity: 0.5;
-}
-
-.dark .btn-tertiary {
-  background-color: #1e293b;
-  color: #f8fafc;
-  border-color: var(--color-border-dark);
-}
-
-.dark .btn-tertiary:hover{
-  --tw-bg-opacity: 1;
-  background-color: rgb(55 65 81 / var(--tw-bg-opacity));
-}
-
-.dark .btn-tertiary:focus {
-  --tw-ring-color: var(--color-border-dark);
 }
 
 .btn-danger {
@@ -880,7 +788,7 @@ a:hover,
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
   background-color: transparent;
-  color: #111827;
+  color: var(--color-body-text);
   border-color: var(--color-border);
 }
 
@@ -902,20 +810,6 @@ a:hover,
 .btn-outline:disabled{
   cursor: not-allowed;
   opacity: 0.5;
-}
-
-.dark .btn-outline {
-  color: #f8fafc;
-  border-color: var(--color-border-dark);
-}
-
-.dark .btn-outline:hover{
-  --tw-bg-opacity: 1;
-  background-color: rgb(55 65 81 / var(--tw-bg-opacity));
-}
-
-.dark .btn-outline:focus {
-  --tw-ring-color: var(--color-border-dark);
 }
 
 /* Navigation button styles */
@@ -944,7 +838,7 @@ a:hover,
 
 .nav-btn:hover,
   .nav-btn:focus {
-  background-color: var(--color-primary-dark);
+  background-color: #1D4ED8;
   color: #ffffff;
 }
 
@@ -953,21 +847,7 @@ a:hover,
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
   --tw-ring-offset-width: 2px;
-  --tw-ring-color: var(--color-primary-dark);
-}
-
-.dark .nav-btn {
-  color: var(--color-primary-dark);
-}
-
-.dark .nav-btn:hover,
-  .dark .nav-btn:focus {
-  background-color: var(--color-primary);
-  color: #ffffff;
-}
-
-.dark .nav-btn:focus {
-  --tw-ring-color: var(--color-primary);
+  --tw-ring-color: #1D4ED8;
 }
 
 /* Alert component styles */
@@ -1005,15 +885,6 @@ a:hover,
   color: rgb(21 128 61 / var(--tw-text-opacity));
 }
 
-.alert-success:is(.dark *){
-  --tw-border-opacity: 1;
-  border-color: rgb(21 128 61 / var(--tw-border-opacity));
-  --tw-bg-opacity: 1;
-  background-color: rgb(20 83 45 / var(--tw-bg-opacity));
-  --tw-text-opacity: 1;
-  color: rgb(134 239 172 / var(--tw-text-opacity));
-}
-
 .alert-warning{
   --tw-border-opacity: 1;
   border-color: rgb(234 179 8 / var(--tw-border-opacity));
@@ -1021,15 +892,6 @@ a:hover,
   background-color: rgb(254 249 195 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
   color: rgb(161 98 7 / var(--tw-text-opacity));
-}
-
-.alert-warning:is(.dark *){
-  --tw-border-opacity: 1;
-  border-color: rgb(161 98 7 / var(--tw-border-opacity));
-  --tw-bg-opacity: 1;
-  background-color: rgb(113 63 18 / var(--tw-bg-opacity));
-  --tw-text-opacity: 1;
-  color: rgb(253 224 71 / var(--tw-text-opacity));
 }
 
 .alert-error{
@@ -1041,15 +903,6 @@ a:hover,
   color: rgb(185 28 28 / var(--tw-text-opacity));
 }
 
-.alert-error:is(.dark *){
-  --tw-border-opacity: 1;
-  border-color: rgb(185 28 28 / var(--tw-border-opacity));
-  --tw-bg-opacity: 1;
-  background-color: rgb(127 29 29 / var(--tw-bg-opacity));
-  --tw-text-opacity: 1;
-  color: rgb(252 165 165 / var(--tw-text-opacity));
-}
-
 .alert-info{
   --tw-border-opacity: 1;
   border-color: rgb(59 130 246 / var(--tw-border-opacity));
@@ -1057,15 +910,6 @@ a:hover,
   background-color: rgb(219 234 254 / var(--tw-bg-opacity));
   --tw-text-opacity: 1;
   color: rgb(29 78 216 / var(--tw-text-opacity));
-}
-
-.alert-info:is(.dark *){
-  --tw-border-opacity: 1;
-  border-color: rgb(29 78 216 / var(--tw-border-opacity));
-  --tw-bg-opacity: 1;
-  background-color: rgb(30 58 138 / var(--tw-bg-opacity));
-  --tw-text-opacity: 1;
-  color: rgb(147 197 253 / var(--tw-text-opacity));
 }
 
 /* Form component styles */
@@ -1081,8 +925,8 @@ form input:not([type='checkbox']):not([type='radio']),
   .form-control {
   font-family: Roboto, sans-serif;
   border: 1px solid var(--color-border);
-  background-color: #ffffff;
-  color: #111827;
+  background-color: var(--color-body);
+  color: var(--color-body-text);
   padding: var(--space-2);
   border-radius: var(--space-1);
   width: 100%;
@@ -1101,49 +945,15 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 
 .form-checkbox {
   border: 1px solid var(--color-border);
-  background-color: #ffffff;
-  color: #111827;
+  background-color: var(--color-body);
+  color: var(--color-body-text);
   border-radius: var(--space-1);
 }
 
 .form-radio {
   border: 1px solid var(--color-border);
-  background-color: #ffffff;
-  color: #111827;
-  border-radius: 9999px;
-  accent-color: var(--color-primary);
-}
-
-.dark form input:not([type='checkbox']):not([type='radio']),
-  .dark form select,
-  .dark form textarea,
-  .dark .form-control {
-  border: 1px solid var(--color-border-dark);
-  background-color: #1e293b;
-  color: #f8fafc;
-}
-
-.dark form input:not([type='checkbox']):not([type='radio']):focus,
-  .dark form select:focus,
-  .dark form textarea:focus,
-  .dark .form-control:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  --tw-shadow: 0 0 0 2px rgba(29, 78, 216, 0.6);
-  --tw-shadow-colored: 0 0 0 2px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
-}
-
-.dark .form-checkbox {
-  border: 1px solid var(--color-border-dark);
-  background-color: #1e293b;
-  color: #f8fafc;
-}
-
-.dark .form-radio {
-  border: 1px solid var(--color-border-dark);
-  background-color: #1e293b;
-  color: #f8fafc;
+  background-color: var(--color-body);
+  color: var(--color-body-text);
   border-radius: 9999px;
   accent-color: var(--color-primary);
 }
@@ -1165,34 +975,16 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 
 .table thead {
   background-color: var(--color-primary);
-  color: #ffffff;
+  color: var(--color-body);
 }
 
 .table tbody tr {
-  background-color: #ffffff;
+  background-color: var(--color-body);
   transition: background-color 0.15s ease-in-out;
 }
 
 .table tbody tr:hover {
-  background-color: #e5e7eb;
-}
-
-.dark .table th,
-  .dark .table td {
-  border: 1px solid var(--color-border-dark);
-}
-
-.dark .table thead {
-  background-color: var(--color-primary);
-  color: #ffffff;
-}
-
-.dark .table tbody tr {
-  background-color: #0f172a;
-}
-
-.dark .table tbody tr:hover {
-  background-color: #475569;
+  background-color: var(--color-table-hover-bg);
 }
 
 /* Pagination controls */
@@ -1225,124 +1017,28 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   --tw-ring-color: var(--color-primary);
 }
 
-.dark .pagination-active{
-  border-color: var(--color-border-dark);
-  --tw-bg-opacity: 1;
-  background-color: rgb(55 65 81 / var(--tw-bg-opacity));
-}
-
-.dark .pagination-input{
-  border-color: var(--color-border-dark);
-  --tw-bg-opacity: 1;
-  background-color: rgb(30 41 59 / var(--tw-bg-opacity));
-  --tw-text-opacity: 1;
-  color: rgb(248 250 252 / var(--tw-text-opacity));
-}
-
-.static{
-  position: static;
-}
-
-.fixed{
-  position: fixed;
-}
-
 .absolute{
   position: absolute;
 }
 
-.relative{
-  position: relative;
+.left-0{
+  left: 0px;
 }
 
-.sticky{
-  position: sticky;
-}
-
-.inset-0{
-  inset: 0px;
-}
-
-.bottom-4{
-  bottom: var(--space-4);
-}
-
-.right-4{
-  right: var(--space-4);
-}
-
-.top-0{
-  top: 0px;
-}
-
-.col-span-2{
-  grid-column: span 2 / span 2;
-}
-
-.mx-auto{
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.my-4{
-  margin-top: var(--space-4);
-  margin-bottom: var(--space-4);
-}
-
-.mb-1{
-  margin-bottom: var(--space-1);
-}
-
-.mb-2{
-  margin-bottom: var(--space-2);
+.top-full{
+  top: 100%;
 }
 
 .mb-4{
   margin-bottom: var(--space-4);
 }
 
-.ml-2{
-  margin-left: var(--space-2);
-}
-
-.ml-4{
-  margin-left: var(--space-4);
-}
-
-.ml-auto{
-  margin-left: auto;
-}
-
-.mr-1{
-  margin-right: var(--space-1);
-}
-
-.mr-2{
-  margin-right: var(--space-2);
-}
-
-.mr-4{
-  margin-right: var(--space-4);
-}
-
-.mt-2{
-  margin-top: var(--space-2);
-}
-
-.mt-4{
-  margin-top: var(--space-4);
-}
-
-.mt-8{
-  margin-top: var(--space-8);
+.mt-1{
+  margin-top: var(--space-1);
 }
 
 .block{
   display: block;
-}
-
-.inline{
-  display: inline;
 }
 
 .flex{
@@ -1353,183 +1049,20 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   display: table;
 }
 
-.grid{
-  display: grid;
-}
-
-.hidden{
-  display: none;
-}
-
-.h-12{
-  height: 3rem;
-}
-
-.h-16{
-  height: 4rem;
-}
-
-.h-5{
-  height: 1.25rem;
-}
-
-.max-h-screen{
-  max-height: 100vh;
-}
-
-.min-h-screen{
-  min-height: 100vh;
-}
-
-.w-12{
-  width: 3rem;
-}
-
-.w-24{
-  width: 6rem;
-}
-
-.w-5{
-  width: 1.25rem;
-}
-
-.w-full{
-  width: 100%;
-}
-
-.w-max{
-  width: -moz-max-content;
-  width: max-content;
-}
-
-.max-w-2xl{
-  max-width: 42rem;
-}
-
-.max-w-sm{
-  max-width: 24rem;
-}
-
-.max-w-xs{
-  max-width: 20rem;
-}
-
-.flex-1{
-  flex: 1 1 0%;
-}
-
-.flex-shrink-0{
-  flex-shrink: 0;
-}
-
-.table-auto{
-  table-layout: auto;
-}
-
-@keyframes spin{
-  to{
-    transform: rotate(360deg);
-  }
-}
-
-.animate-spin{
-  animation: spin 1s linear infinite;
-}
-
-.list-disc{
-  list-style-type: disc;
-}
-
-.grid-cols-2{
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.grid-cols-4{
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.grid-cols-5{
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-}
-
-.grid-cols-7{
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-}
-
-.flex-col{
-  flex-direction: column;
-}
-
-.flex-wrap{
-  flex-wrap: wrap;
-}
-
-.items-start{
-  align-items: flex-start;
-}
-
-.items-end{
-  align-items: flex-end;
+.border-collapse{
+  border-collapse: collapse;
 }
 
 .items-center{
   align-items: center;
 }
 
-.justify-end{
-  justify-content: flex-end;
-}
-
-.justify-center{
-  justify-content: center;
-}
-
 .justify-between{
   justify-content: space-between;
 }
 
-.gap-2{
-  gap: var(--space-2);
-}
-
-.gap-4{
-  gap: var(--space-4);
-}
-
-.space-x-4 > :not([hidden]) ~ :not([hidden]){
-  --tw-space-x-reverse: 0;
-  margin-right: calc(var(--space-4) * var(--tw-space-x-reverse));
-  margin-left: calc(var(--space-4) * calc(1 - var(--tw-space-x-reverse)));
-}
-
-.space-y-1 > :not([hidden]) ~ :not([hidden]){
-  --tw-space-y-reverse: 0;
-  margin-top: calc(var(--space-1) * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(var(--space-1) * var(--tw-space-y-reverse));
-}
-
-.space-y-2 > :not([hidden]) ~ :not([hidden]){
-  --tw-space-y-reverse: 0;
-  margin-top: calc(var(--space-2) * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(var(--space-2) * var(--tw-space-y-reverse));
-}
-
-.space-y-4 > :not([hidden]) ~ :not([hidden]){
-  --tw-space-y-reverse: 0;
-  margin-top: calc(var(--space-4) * calc(1 - var(--tw-space-y-reverse)));
-  margin-bottom: calc(var(--space-4) * var(--tw-space-y-reverse));
-}
-
-.overflow-y-auto{
-  overflow-y: auto;
-}
-
 .rounded{
   border-radius: 0.25rem;
-}
-
-.rounded-full{
-  border-radius: 9999px;
 }
 
 .rounded-md{
@@ -1540,24 +1073,13 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   border-width: 1px;
 }
 
-.border-4{
-  border-width: 4px;
+.border-l-4{
+  border-left-width: 4px;
 }
 
-.border-form-border{
-  border-color: var(--color-border);
-}
-
-.border-primary{
-  border-color: var(--color-primary);
-}
-
-.border-t-transparent{
-  border-top-color: transparent;
-}
-
-.bg-black\/25{
-  background-color: rgb(0 0 0 / 0.25);
+.bg-amber-500{
+  --tw-bg-opacity: 1;
+  background-color: rgb(245 158 11 / var(--tw-bg-opacity));
 }
 
 .bg-blue-100{
@@ -1565,35 +1087,39 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   background-color: rgb(219 234 254 / var(--tw-bg-opacity));
 }
 
-.bg-form-bg{
+.bg-green-100{
   --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  background-color: rgb(220 252 231 / var(--tw-bg-opacity));
 }
 
-.bg-primary{
-  background-color: var(--color-primary);
-}
-
-.bg-white{
+.bg-green-700{
   --tw-bg-opacity: 1;
-  background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+  background-color: rgb(21 128 61 / var(--tw-bg-opacity));
 }
 
-.p-2{
-  padding: var(--space-2);
+.bg-red-100{
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 226 226 / var(--tw-bg-opacity));
 }
 
-.p-4{
-  padding: var(--space-4);
+.bg-red-600{
+  --tw-bg-opacity: 1;
+  background-color: rgb(220 38 38 / var(--tw-bg-opacity));
 }
 
-.p-8{
-  padding: var(--space-8);
+.bg-yellow-100{
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 249 195 / var(--tw-bg-opacity));
 }
 
-.px-2{
-  padding-left: var(--space-2);
-  padding-right: var(--space-2);
+.px-1{
+  padding-left: var(--space-1);
+  padding-right: var(--space-1);
+}
+
+.px-1\.5{
+  padding-left: 0.375rem;
+  padding-right: 0.375rem;
 }
 
 .px-3{
@@ -1611,6 +1137,16 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   padding-right: var(--space-8);
 }
 
+.py-0{
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.py-0\.5{
+  padding-top: var(--space-0-5);
+  padding-bottom: var(--space-0-5);
+}
+
 .py-1{
   padding-top: var(--space-1);
   padding-bottom: var(--space-1);
@@ -1621,49 +1157,14 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   padding-bottom: var(--space-2);
 }
 
-.pl-5{
-  padding-left: 1.25rem;
-}
-
-.pr-4{
-  padding-right: var(--space-4);
-}
-
-.text-left{
-  text-align: left;
-}
-
-.text-center{
-  text-align: center;
-}
-
-.text-right{
-  text-align: right;
-}
-
-.text-2xl{
-  font-size: 1.5rem;
-  line-height: 2rem;
-}
-
-.text-base{
-  font-size: var(--font-size-base);
-  line-height: 1.5;
+.py-4{
+  padding-top: var(--space-4);
+  padding-bottom: var(--space-4);
 }
 
 .text-sm{
   font-size: 0.875rem;
   line-height: 1.25rem;
-}
-
-.text-xl{
-  font-size: 1.25rem;
-  line-height: 1.75rem;
-}
-
-.text-xs{
-  font-size: 0.75rem;
-  line-height: 1rem;
 }
 
 .font-bold{
@@ -1674,42 +1175,14 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   font-weight: 500;
 }
 
-.font-semibold{
-  font-weight: 600;
-}
-
-.text-blue-800{
+.text-blue-700{
   --tw-text-opacity: 1;
-  color: rgb(30 64 175 / var(--tw-text-opacity));
-}
-
-.text-form-text{
-  --tw-text-opacity: 1;
-  color: rgb(17 24 39 / var(--tw-text-opacity));
-}
-
-.text-gray-500{
-  --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity));
+  color: rgb(29 78 216 / var(--tw-text-opacity));
 }
 
 .text-green-700{
   --tw-text-opacity: 1;
   color: rgb(21 128 61 / var(--tw-text-opacity));
-}
-
-.text-primary{
-  color: var(--color-primary);
-}
-
-.text-red-400{
-  --tw-text-opacity: 1;
-  color: rgb(248 113 113 / var(--tw-text-opacity));
-}
-
-.text-red-600{
-  --tw-text-opacity: 1;
-  color: rgb(220 38 38 / var(--tw-text-opacity));
 }
 
 .text-red-700{
@@ -1722,10 +1195,46 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
-.shadow{
-  --tw-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-  --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
-  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+.text-yellow-700{
+  --tw-text-opacity: 1;
+  color: rgb(161 98 7 / var(--tw-text-opacity));
+}
+
+.underline{
+  text-decoration-line: underline;
+}
+
+.opacity-50{
+  opacity: 0.5;
+}
+
+.outline-none{
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+
+.outline{
+  outline-style: solid;
+}
+
+.ring-2{
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.transition{
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-colors{
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
 }
 
 /* Utilities rely on CSS variables for theming */
@@ -1747,137 +1256,7 @@ form input:not([type='checkbox']):not([type='radio']):focus,
   }
 }
 
-.odd\:bg-gray-50:nth-child(odd){
-  --tw-bg-opacity: 1;
-  background-color: rgb(249 250 251 / var(--tw-bg-opacity));
-}
-
-.hover\:bg-gray-100:hover{
-  --tw-bg-opacity: 1;
-  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
-}
-
-.hover\:text-white:hover{
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
-.dark\:block:is(.dark *){
-  display: block;
-}
-
-.dark\:hidden:is(.dark *){
-  display: none;
-}
-
-.dark\:border-form-darkBorder:is(.dark *){
-  border-color: var(--color-border-dark);
-}
-
-.dark\:border-primary:is(.dark *){
-  border-color: var(--color-primary);
-}
-
-.dark\:bg-blue-900:is(.dark *){
-  --tw-bg-opacity: 1;
-  background-color: rgb(30 58 138 / var(--tw-bg-opacity));
-}
-
-.dark\:bg-form-darkBg:is(.dark *){
-  --tw-bg-opacity: 1;
-  background-color: rgb(30 41 59 / var(--tw-bg-opacity));
-}
-
-.dark\:bg-primary:is(.dark *){
-  background-color: var(--color-primary);
-}
-
-.dark\:bg-slate-800:is(.dark *){
-  --tw-bg-opacity: 1;
-  background-color: rgb(30 41 59 / var(--tw-bg-opacity));
-}
-
-.dark\:text-blue-100:is(.dark *){
-  --tw-text-opacity: 1;
-  color: rgb(219 234 254 / var(--tw-text-opacity));
-}
-
-.dark\:text-form-darkText:is(.dark *){
-  --tw-text-opacity: 1;
-  color: rgb(248 250 252 / var(--tw-text-opacity));
-}
-
-.dark\:text-gray-200:is(.dark *){
-  --tw-text-opacity: 1;
-  color: rgb(229 231 235 / var(--tw-text-opacity));
-}
-
-.dark\:text-gray-400:is(.dark *){
-  --tw-text-opacity: 1;
-  color: rgb(156 163 175 / var(--tw-text-opacity));
-}
-
-.dark\:text-green-400:is(.dark *){
-  --tw-text-opacity: 1;
-  color: rgb(74 222 128 / var(--tw-text-opacity));
-}
-
-.dark\:text-red-400:is(.dark *){
-  --tw-text-opacity: 1;
-  color: rgb(248 113 113 / var(--tw-text-opacity));
-}
-
-.dark\:text-white:is(.dark *){
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
-.dark\:hover\:text-white:hover:is(.dark *){
-  --tw-text-opacity: 1;
-  color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
 @media (max-width: 639px){
-  .max-sm\:static{
-    position: static;
-  }
-
-  .max-sm\:mt-0{
-    margin-top: 0px;
-  }
-
-  .max-sm\:block{
-    display: block;
-  }
-
-  .max-sm\:hidden{
-    display: none;
-  }
-
-  .max-sm\:max-w-md{
-    max-width: 28rem;
-  }
-
-  .max-sm\:grid-cols-1{
-    grid-template-columns: repeat(1, minmax(0, 1fr));
-  }
-
-  .max-sm\:rounded-none{
-    border-radius: 0px;
-  }
-
-  .max-sm\:bg-transparent{
-    background-color: transparent;
-  }
-
-  .max-sm\:p-2{
-    padding: var(--space-2);
-  }
-
-  .max-sm\:p-4{
-    padding: var(--space-4);
-  }
-
   .max-sm\:px-4{
     padding-left: var(--space-4);
     padding-right: var(--space-4);
@@ -1885,30 +1264,8 @@ form input:not([type='checkbox']):not([type='radio']):focus,
 }
 
 @media (max-width: 767px){
-  .max-md\:max-w-xl{
-    max-width: 36rem;
-  }
-
-  .max-md\:grid-cols-2{
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .max-md\:overflow-x-auto{
-    overflow-x: auto;
-  }
-
-  .max-md\:p-4{
-    padding: var(--space-4);
-  }
-
   .max-md\:px-6{
     padding-left: var(--space-6);
     padding-right: var(--space-6);
-  }
-}
-
-@media (max-width: 1023px){
-  .max-lg\:grid-cols-4{
-    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -12,11 +12,6 @@
     font-family: theme('fontFamily.sans');
   }
 
-  .dark {
-    --color-primary: var(--color-primary-dark);
-    --color-secondary: var(--color-secondary-dark);
-  }
-
   /* Base link styles: underlined with primary color.
      Button classes (.btn-*) remove the underline. */
   a {
@@ -25,7 +20,7 @@
   }
   a:hover,
   a:focus {
-    color: var(--color-primary-dark);
+    color: #1D4ED8;
   }
 }
 
@@ -41,9 +36,6 @@
   .badge-warning { @apply bg-amber-500 text-gray-900; }
   .badge-error { @apply bg-red-600 text-white; }
 
-  .dark .badge-success { @apply bg-green-800 text-white; }
-  .dark .badge-warning { @apply bg-amber-600 text-gray-900; }
-  .dark .badge-error { @apply bg-red-700 text-white; }
 
   /* Toast component styles */
   .toast { @apply absolute left-0 top-full mt-1 z-10; }
@@ -54,7 +46,7 @@
     @apply text-white px-4 py-2 rounded transition-colors no-underline;
   }
   .btn-primary:hover {
-    background-color: var(--color-primary-dark);
+    background-color: #1D4ED8;
   }
   .btn-primary:focus {
     @apply outline-none ring-2 ring-offset-2;
@@ -67,7 +59,7 @@
     @apply text-white px-4 py-2 rounded transition-colors no-underline;
   }
   .btn-secondary:hover {
-    background-color: var(--color-secondary-dark);
+    background-color: #165E2D;
   }
   .btn-secondary:focus {
     @apply outline-none ring-2 ring-offset-2;
@@ -87,13 +79,6 @@
     --tw-ring-color: theme('colors.form.border');
   }
   .btn-tertiary:disabled { @apply opacity-50 cursor-not-allowed; }
-  .dark .btn-tertiary {
-    background-color: theme('colors.form.darkBg');
-    color: theme('colors.bodyText.dark');
-    border-color: theme('colors.form.darkBorder');
-  }
-  .dark .btn-tertiary:hover { @apply bg-gray-700; }
-  .dark .btn-tertiary:focus { --tw-ring-color: theme('colors.form.darkBorder'); }
 
   .btn-danger {
     background-color: theme('colors.danger');
@@ -120,12 +105,6 @@
     --tw-ring-color: theme('colors.form.border');
   }
   .btn-outline:disabled { @apply opacity-50 cursor-not-allowed; }
-  .dark .btn-outline {
-    color: theme('colors.bodyText.dark');
-    border-color: theme('colors.form.darkBorder');
-  }
-  .dark .btn-outline:hover { @apply bg-gray-700; }
-  .dark .btn-outline:focus { --tw-ring-color: theme('colors.form.darkBorder'); }
 
   /* Navigation button styles */
   .nav-btn {
@@ -134,38 +113,29 @@
   }
   .nav-btn:hover,
   .nav-btn:focus {
-    background-color: var(--color-primary-dark);
+    background-color: #1D4ED8;
     color: #ffffff;
   }
   .nav-btn:focus {
     @apply ring-2 ring-offset-2;
-    --tw-ring-color: var(--color-primary-dark);
+    --tw-ring-color: #1D4ED8;
   }
-  .dark .nav-btn {
-    color: var(--color-primary-dark);
-  }
-  .dark .nav-btn:hover,
-  .dark .nav-btn:focus {
-    background-color: var(--color-primary);
-    color: #ffffff;
-  }
-  .dark .nav-btn:focus { --tw-ring-color: var(--color-primary); }
 
   /* Alert component styles */
   .alert {
     @apply px-8 max-md:px-6 max-sm:px-4 py-4 mb-4 border-l-4 rounded;
   }
   .alert-success {
-    @apply bg-green-100 text-green-700 border-green-500 dark:bg-green-900 dark:text-green-300 dark:border-green-700;
+    @apply bg-green-100 text-green-700 border-green-500;
   }
   .alert-warning {
-    @apply bg-yellow-100 text-yellow-700 border-yellow-500 dark:bg-yellow-900 dark:text-yellow-300 dark:border-yellow-700;
+    @apply bg-yellow-100 text-yellow-700 border-yellow-500;
   }
   .alert-error {
-    @apply bg-red-100 text-red-700 border-red-500 dark:bg-red-900 dark:text-red-300 dark:border-red-700;
+    @apply bg-red-100 text-red-700 border-red-500;
   }
   .alert-info {
-    @apply bg-blue-100 text-blue-700 border-blue-500 dark:bg-blue-900 dark:text-blue-300 dark:border-blue-700;
+    @apply bg-blue-100 text-blue-700 border-blue-500;
   }
 
   /* Form component styles */
@@ -206,38 +176,6 @@
     accent-color: var(--color-primary);
   }
 
-  .dark form input:not([type='checkbox']):not([type='radio']),
-  .dark form select,
-  .dark form textarea,
-  .dark .form-control {
-    border: 1px solid theme('colors.form.darkBorder');
-    background-color: theme('colors.form.darkBg');
-    color: theme('colors.form.darkText');
-  }
-
-  .dark form input:not([type='checkbox']):not([type='radio']):focus,
-  .dark form select:focus,
-  .dark form textarea:focus,
-  .dark .form-control:focus {
-    outline: none;
-    border-color: var(--color-primary);
-    @apply shadow-form-focus-dark;
-  }
-
-  .dark .form-checkbox {
-    border: 1px solid theme('colors.form.darkBorder');
-    background-color: theme('colors.form.darkBg');
-    color: theme('colors.form.darkText');
-  }
-
-  .dark .form-radio {
-    border: 1px solid theme('colors.form.darkBorder');
-    background-color: theme('colors.form.darkBg');
-    color: theme('colors.form.darkText');
-    border-radius: 9999px;
-    accent-color: var(--color-primary);
-  }
-
   /* Table component styles */
   .table {
     width: 100%;
@@ -262,16 +200,6 @@
     background-color: theme('colors.table.hoverBg');
   }
 
-  .dark .table th,
-  .dark .table td { border: 1px solid theme('colors.table.darkBorder'); }
-  .dark .table thead {
-    background-color: var(--color-primary);
-    color: theme('colors.table.headerText');
-  }
-  .dark .table tbody tr { background-color: theme('colors.body.dark'); }
-  .dark .table tbody tr:hover {
-    background-color: theme('colors.table.darkHoverBg');
-  }
 
   /* Pagination controls */
   .pagination-active { @apply px-3 py-1 border rounded bg-gray-200; }
@@ -281,8 +209,6 @@
     @apply outline-none ring-2 ring-offset-2;
     --tw-ring-color: var(--color-primary);
   }
-  .dark .pagination-active { @apply border-form-darkBorder bg-gray-700; }
-  .dark .pagination-input { @apply border-form-darkBorder bg-form-darkBg text-form-darkText; }
 }
 
 @layer utilities {

--- a/static/src/tokens.css
+++ b/static/src/tokens.css
@@ -1,24 +1,15 @@
 :root {
   /* Color tokens */
   --color-primary: #0D3A99;
-  /* Dark mode variant */
-  --color-primary-dark: #1D4ED8;
   --color-secondary: #024427;
-  /* Dark mode variant */
-  --color-secondary-dark: #165E2D;
   --color-accent: #8C4A02;
   --color-danger: #B91C1C;
   --color-border: #6b7280;
-  --color-border-dark: #64748b;
 
   /* Body and text colors */
   --color-body: #ffffff;
-  --color-body-dark: #0f172a;
   --color-body-text: #111827;
-  --color-body-text-dark: #f8fafc;
-  --color-form-bg-dark: #1e293b;
   --color-table-hover-bg: #e5e7eb;
-  --color-table-hover-bg-dark: #475569;
 
   /* Spacing tokens */
   --space-0-5: 0.125rem;


### PR DESCRIPTION
## Summary
- drop dark variant color tokens
- remove `.dark` utilities and use light tokens for components
- rebuild app.css without dark selectors

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aac8920fac8326adc695e6e37a9773