### PR TITLE
Remove dark mode toggle and simplify color contrast checks

### DIFF
--- a/static/js/color.js
+++ b/static/js/color.js
@@ -1,19 +1,4 @@
 (function() {
-  function applyTheme(theme) {
-    if (theme === 'dark') {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-    }
-  }
-
-  // Apply the user's preferred theme immediately to avoid flashes of incorrect styling
-  const stored = localStorage.getItem('theme');
-  if (stored) {
-    applyTheme(stored);
-  } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    applyTheme('dark');
-  }
 
   function hexToRgb(hex) {
     const res = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
@@ -38,20 +23,10 @@
 
   function passesContrast(color) {
     const lightBg = '#ffffff';
-    const darkBg = '#0f172a';
-    return contrast(color, lightBg) >= 4.5 && contrast(color, darkBg) >= 4.5;
+    return contrast(color, lightBg) >= 4.5;
   }
 
   document.addEventListener('DOMContentLoaded', function() {
-    const toggle = document.getElementById('theme-toggle');
-    if (toggle) {
-      toggle.addEventListener('click', function() {
-        const newTheme = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
-        applyTheme(newTheme);
-        localStorage.setItem('theme', newTheme);
-      });
-    }
-
     const feedback = document.getElementById('colour-feedback');
     const lastColors = {};
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -7,7 +7,7 @@
     <title>{% block title %}Inventory App{% endblock %}</title>
     <link href="{% static 'css/app.css' %}" rel="stylesheet">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
-    <script src="{% static 'js/theme.js' %}"></script>
+    <script src="{% static 'js/color.js' %}"></script>
     <script src="{% static 'js/predictive-dropdown.js' %}"></script>
     <script src="{% static 'js/nav.js' %}"></script>
     <script src="{% static 'js/formset.js' %}"></script>

--- a/templates/components/nav.html
+++ b/templates/components/nav.html
@@ -93,10 +93,6 @@
             </div>
           </div>
         </div>
-          <button id="theme-toggle" class="nav-btn ml-4" aria-label="Toggle theme">
-            <svg aria-hidden="true" class="w-5 h-5 dark:hidden" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" /></svg>
-            <svg aria-hidden="true" class="w-5 h-5 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /></svg>
-          </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- drop dark theme apply logic and theme preference storage
- only check color contrast against light background
- remove theme toggle button from navigation and load updated color script

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aad201961c832692dbede56a03c466