### PR TITLE
Remove dark mode styling from templates

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -23,7 +23,7 @@
     >
       <div
         aria-hidden="true"
-        class="h-12 w-12 border-4 border-primary dark:border-primary border-t-transparent rounded-full animate-spin"
+        class="h-12 w-12 border-4 border-primary border-t-transparent rounded-full animate-spin"
       ></div>
     </div>
     <div class="container p-8 max-md:p-4 max-sm:p-2 grid gap-4">

--- a/templates/components/colour_customizer.html
+++ b/templates/components/colour_customizer.html
@@ -1,16 +1,16 @@
-<div id="colour-customizer" class="fixed bottom-4 right-4 bg-white dark:bg-slate-800 p-4 rounded shadow space-y-2">
+<div id="colour-customizer" class="fixed bottom-4 right-4 bg-white p-4 rounded shadow space-y-2">
   <label class="block text-sm font-medium">
     Primary
-    <input type="color" id="picker-primary" value="#1a46c2" class="ml-2 border dark:border-form-darkBorder dark:bg-form-darkBg dark:text-form-darkText rounded">
+    <input type="color" id="picker-primary" value="#1a46c2" class="ml-2 border rounded">
   </label>
   <label class="block text-sm font-medium">
     Secondary
-    <input type="color" id="picker-secondary" value="#036045" class="ml-2 border dark:border-form-darkBorder dark:bg-form-darkBg dark:text-form-darkText rounded">
+    <input type="color" id="picker-secondary" value="#036045" class="ml-2 border rounded">
   </label>
   <label class="block text-sm font-medium">
     Accent
-    <input type="color" id="picker-accent" value="#ad5f04" class="ml-2 border dark:border-form-darkBorder dark:bg-form-darkBg dark:text-form-darkText rounded">
+    <input type="color" id="picker-accent" value="#ad5f04" class="ml-2 border rounded">
   </label>
-  <p id="colour-feedback" class="text-xs text-red-600 dark:text-red-400 hidden"></p>
+  <p id="colour-feedback" class="text-xs text-red-600 hidden"></p>
   <button id="colour-reset" type="button" class="btn-secondary w-full mt-2">Reset to default</button>
 </div>

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -1,6 +1,6 @@
-<div class="p-4 max-sm:p-2 text-center border border-form-border rounded bg-form-bg dark:bg-form-darkBg dark:border-form-darkBorder">
-  <svg class="mx-auto w-5 h-5 text-form-text dark:text-form-darkText" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+<div class="p-4 max-sm:p-2 text-center border border-form-border rounded bg-form-bg">
+  <svg class="mx-auto w-5 h-5 text-form-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
     <h2 class="text-xl mb-4 mt-8">{{ title }}</h2>
-  <p class="mb-4 text-form-text dark:text-form-darkText">{{ message }}</p>
+  <p class="mb-4 text-form-text">{{ message }}</p>
   <a href="{{ cta_url }}" class="btn-primary">{{ cta_label }}</a>
 </div>

--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -11,10 +11,10 @@
     {{ field|add_class:"form-control" }}
   {% endif %}
   {% if field.help_text %}
-    <p class="text-sm text-gray-500 dark:text-gray-400">{{ field.help_text }}</p>
+    <p class="text-sm text-gray-500">{{ field.help_text }}</p>
   {% endif %}
   {% if field.errors %}
-    <ul class="text-sm text-red-600 dark:text-red-400 list-disc pl-5">
+    <ul class="text-sm text-red-600 list-disc pl-5">
       {% for error in field.errors %}
         <li>{{ error }}</li>
       {% endfor %}

--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -9,7 +9,7 @@
   <form method="post" {% block form_attrs %}{% endblock %} class="grid grid-cols-1 gap-4">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+    <ul class="text-red-600 list-disc pl-5">
       {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
     </ul>
     {% endif %}

--- a/templates/components/nav.html
+++ b/templates/components/nav.html
@@ -13,12 +13,12 @@
               <button data-dropdown="overview-menu" class="nav-btn">Overview</button>
             <div id="overview-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
               {% url 'dashboard' as dashboard_url %}
-              <a href="{{ dashboard_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == dashboard_url %}active{% endif %}">
+              <a href="{{ dashboard_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == dashboard_url %}active{% endif %}">
                 <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
                 Dashboard
               </a>
               {% url 'history_reports' as reports_url %}
-              <a href="{{ reports_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == reports_url %}active{% endif %}">
+              <a href="{{ reports_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == reports_url %}active{% endif %}">
                 <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></svg>
                 Reports
               </a>
@@ -28,12 +28,12 @@
               <button data-dropdown="inventory-menu" class="nav-btn">Inventory</button>
             <div id="inventory-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
               {% url 'items_list' as items_url %}
-              <a href="{{ items_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == items_url %}active{% endif %}">
+              <a href="{{ items_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == items_url %}active{% endif %}">
                 <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/></svg>
                 Items
               </a>
               {% url 'stock_movements' as movements_url %}
-              <a href="{{ movements_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == movements_url %}active{% endif %}">
+              <a href="{{ movements_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == movements_url %}active{% endif %}">
                 <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5"/></svg>
                 Stock Movements
               </a>
@@ -43,22 +43,22 @@
               <button data-dropdown="procurement-menu" class="nav-btn">Procurement</button>
             <div id="procurement-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
               {% url 'suppliers_list' as suppliers_url %}
-              <a href="{{ suppliers_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == suppliers_url %}active{% endif %}">
+              <a href="{{ suppliers_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == suppliers_url %}active{% endif %}">
                 <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 0 1-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.213-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"/></svg>
                 Suppliers
               </a>
               {% url 'indents_list' as indents_url %}
-              <a href="{{ indents_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == indents_url %}active{% endif %}">
+              <a href="{{ indents_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == indents_url %}active{% endif %}">
                 <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25ZM6.75 12h.008v.008H6.75V12Zm0 3h.008v.008H6.75V15Zm0 3h.008v.008H6.75V18Z"/></svg>
                 Indents
               </a>
               {% url 'purchase_orders_list' as po_url %}
-              <a href="{{ po_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == po_url %}active{% endif %}">
+              <a href="{{ po_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == po_url %}active{% endif %}">
                 <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/></svg>
                 Purchase Orders
               </a>
               {% url 'grn_list' as grn_url %}
-              <a href="{{ grn_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == grn_url %}active{% endif %}">
+              <a href="{{ grn_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == grn_url %}active{% endif %}">
                 <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M10.125 2.25h-4.5c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125v-9M10.125 2.25h.375a9 9 0 0 1 9 9v.375M10.125 2.25A3.375 3.375 0 0 1 13.5 5.625v1.5c0 .621.504 1.125 1.125 1.125h1.5a3.375 3.375 0 0 1 3.375 3.375M9 15l2.25 2.25L15 12"/></svg>
                 GRNs
               </a>
@@ -68,7 +68,7 @@
               <button data-dropdown="production-menu" class="nav-btn">Production</button>
             <div id="production-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
               {% url 'recipes_list' as recipes_url %}
-              <a href="{{ recipes_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == recipes_url %}active{% endif %}">
+              <a href="{{ recipes_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == recipes_url %}active{% endif %}">
                 <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"/></svg>
                 Recipes
               </a>
@@ -79,13 +79,13 @@
             <div id="account-menu" class="hidden flex-col absolute bg-primary mt-2 rounded-md max-sm:static max-sm:bg-transparent max-sm:mt-0 max-sm:rounded-none">
               {% if user.is_authenticated %}
                 {% url 'logout' as logout_url %}
-                <a href="{{ logout_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == logout_url %}active{% endif %}">
+                <a href="{{ logout_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == logout_url %}active{% endif %}">
                   <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15M12 9l-3 3m0 0 3 3m-3-3h12.75"/></svg>
                   Logout
                 </a>
               {% else %}
                 {% url 'login' as login_url %}
-                <a href="{{ login_url }}" class="flex items-center text-white hover:text-white dark:text-gray-200 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == login_url %}active{% endif %}">
+                <a href="{{ login_url }}" class="flex items-center text-white hover:text-white px-3 py-2 rounded-md text-sm font-medium {% if request.path == login_url %}active{% endif %}">
                   <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"/></svg>
                   Login
                 </a>

--- a/templates/components/table.html
+++ b/templates/components/table.html
@@ -1,8 +1,8 @@
 {% comment %}Reusable table component with sticky headers and optional actions and footer slots{% endcomment %}
 <div class="max-md:overflow-x-auto">
   {% block actions %}{% endblock %}
-    <table class="table w-full table-auto text-sm dark:text-white">
-      <thead class="sticky top-0 bg-primary text-white dark:bg-primary dark:text-white">
+    <table class="table w-full table-auto text-sm">
+      <thead class="sticky top-0 bg-primary text-white">
         <tr>
           {% block headers %}{% endblock %}
         </tr>

--- a/templates/components/toast.html
+++ b/templates/components/toast.html
@@ -1,7 +1,7 @@
 {% if message %}
-<div id="{{ toast_id|default:'toast' }}" class="toast w-max max-w-xs bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100 text-sm px-3 py-2 rounded shadow flex items-start gap-2" role="status" aria-live="polite">
+<div id="{{ toast_id|default:'toast' }}" class="toast w-max max-w-xs bg-blue-100 text-blue-800 text-sm px-3 py-2 rounded shadow flex items-start gap-2" role="status" aria-live="polite">
   <span class="flex-1">{{ message }}</span>
-  <button type="button" class="text-blue-800 dark:bg-blue-900 dark:text-blue-100" aria-label="Dismiss" onclick="this.parentElement.remove()">&times;</button>
+  <button type="button" class="text-blue-800" aria-label="Dismiss" onclick="this.parentElement.remove()">&times;</button>
 </div>
 <script>
   setTimeout(() => document.getElementById('{{ toast_id|default:'toast' }}')?.remove(), 5000);

--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -6,7 +6,7 @@
   <form method="post" enctype="multipart/form-data" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+    <ul class="text-red-600 list-disc pl-5">
       {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
     </ul>
     {% endif %}
@@ -19,12 +19,12 @@
     </div>
   </form>
   {% if deleted %}
-  <p class="mt-4 text-green-700 dark:text-green-400">Deleted {{ deleted }} supplier(s).</p>
+  <p class="mt-4 text-green-700">Deleted {{ deleted }} supplier(s).</p>
   {% endif %}
   {% if errors %}
   <div class="mt-4">
-    <p class="text-red-700 dark:text-red-400">Errors:</p>
-    <ul class="list-disc pl-5 dark:text-red-400">
+    <p class="text-red-700">Errors:</p>
+    <ul class="list-disc pl-5">
       {% for err in errors %}
       <li>{{ err }}</li>
       {% endfor %}

--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -11,12 +11,12 @@
 {% block back_text %}Back{% endblock %}
 {% block extra %}
   {% if inserted %}
-  <p class="mt-4 text-green-700 dark:text-green-400">Inserted {{ inserted }} record(s).</p>
+  <p class="mt-4 text-green-700">Inserted {{ inserted }} record(s).</p>
   {% endif %}
   {% if errors %}
   <div class="mt-4">
-    <p class="text-red-700 dark:text-red-400">Errors:</p>
-    <ul class="list-disc pl-5 dark:text-red-400">
+    <p class="text-red-700">Errors:</p>
+    <ul class="list-disc pl-5">
       {% for err in errors %}
       <li>{{ err }}</li>
       {% endfor %}

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -9,7 +9,7 @@
   </div>
   {{ formset.management_form }}
   {% if formset.non_form_errors %}
-  <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+  <ul class="text-red-600 list-disc pl-5">
     {% for error in formset.non_form_errors %}
       <li>{{ error }}</li>
     {% endfor %}

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -7,17 +7,17 @@
 {% endblock %}
 {% block fields %}
   {% if not form.units_map %}
-  <p class="text-sm text-red-600 dark:text-red-400">Could not load unit options. Please try again later.</p>
+  <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
   {% endif %}
   <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1" style="grid-column: 1 / -1;">
     <div id="name-field" class="space-y-1 relative">
       <label for="{{ form.name.id_for_label }}" class="block mb-1 font-medium">{{ form.name.label }}</label>
       {{ form.name }}
       {% if form.name.help_text %}
-        <p class="text-sm text-gray-500 dark:text-gray-400">{{ form.name.help_text }}</p>
+        <p class="text-sm text-gray-500">{{ form.name.help_text }}</p>
       {% endif %}
       {% if form.name.errors %}
-        <ul class="text-sm text-red-600 dark:text-red-400 list-disc pl-5">
+        <ul class="text-sm text-red-600 list-disc pl-5">
           {% for error in form.name.errors %}
             <li>{{ error }}</li>
           {% endfor %}

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -11,16 +11,16 @@
   <div id="items-formset">
     {{ formset.management_form }}
     {% if formset.non_form_errors %}
-      <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+      <ul class="text-red-600 list-disc pl-5">
         {% for error in formset.non_form_errors %}
           <li>{{ error }}</li>
         {% endfor %}
       </ul>
     {% endif %}
     {% for f in formset %}
-    <div class="border dark:border-form-darkBorder p-2 item-form">
+    <div class="border p-2 item-form">
       {% if f.non_field_errors %}
-        <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+        <ul class="text-red-600 list-disc pl-5">
           {% for error in f.non_field_errors %}<li>{{ error }}</li>{% endfor %}
         </ul>
       {% endif %}
@@ -38,7 +38,7 @@
 {% block back_url %}{% url 'purchase_orders_list' %}{% endblock %}
 {% block extra %}
 <template id="item-empty-form">
-  <div class="border dark:border-form-darkBorder p-2 item-form">
+  <div class="border p-2 item-form">
     {% for field in formset.empty_form %}
       {% include "components/form_field.html" with field=field %}
     {% endfor %}

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -6,7 +6,7 @@
   <form method="post" class="space-y-4">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+    <ul class="text-red-600 list-disc pl-5">
       {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
     </ul>
     {% endif %}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -6,7 +6,7 @@
   <form method="post" id="recipe-form">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+    <ul class="text-red-600 list-disc pl-5">
       {% for error in form.non_field_errors %}
       <li>{{ error }}</li>
       {% endfor %}
@@ -23,7 +23,7 @@
     </div>
     {{ formset.management_form }}
     {% if formset.non_form_errors %}
-    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+    <ul class="text-red-600 list-disc pl-5">
       {% for error in formset.non_form_errors %}
       <li>{{ error }}</li>
       {% endfor %}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -18,7 +18,7 @@
     <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
       {% csrf_token %}
       {% if receive_form.non_field_errors %}
-      <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+      <ul class="text-red-600 list-disc pl-5">
         {% for error in receive_form.non_field_errors %}
         <li>{{ error }}</li>
         {% endfor %}
@@ -40,7 +40,7 @@
     <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
       {% csrf_token %}
       {% if adjust_form.non_field_errors %}
-      <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+      <ul class="text-red-600 list-disc pl-5">
         {% for error in adjust_form.non_field_errors %}
         <li>{{ error }}</li>
         {% endfor %}
@@ -62,7 +62,7 @@
     <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
       {% csrf_token %}
       {% if waste_form.non_field_errors %}
-      <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+      <ul class="text-red-600 list-disc pl-5">
         {% for error in waste_form.non_field_errors %}
         <li>{{ error }}</li>
         {% endfor %}
@@ -87,7 +87,7 @@
   <form method="post" enctype="multipart/form-data" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
     {% csrf_token %}
     {% if bulk_form.non_field_errors %}
-    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+    <ul class="text-red-600 list-disc pl-5">
       {% for error in bulk_form.non_field_errors %}
       <li>{{ error }}</li>
       {% endfor %}
@@ -104,7 +104,7 @@
     <p>{{ bulk_success_count }} transaction(s) recorded successfully.</p>
   {% endif %}
   {% if bulk_errors %}
-    <ul class="text-red-700 dark:text-red-400">
+    <ul class="text-red-700">
       {% for e in bulk_errors %}
         <li>{{ e }}</li>
       {% endfor %}

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -6,7 +6,7 @@
   <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
     {% csrf_token %}
     {% if form.non_field_errors %}
-    <ul class="text-red-600 dark:text-red-400 list-disc pl-5">
+    <ul class="text-red-600 list-disc pl-5">
       {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
     </ul>
     {% endif %}


### PR DESCRIPTION
## Summary
- strip `dark:` classes from all templates and remove dark-mode toggle artifacts
- keep navigation and components styled for light theme only

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad3de6e308326940d44d563d4bcc2