### PR TITLE
Enable client-side table sorting with List.js

### DIFF
--- a/inventory/views/purchase_orders.py
+++ b/inventory/views/purchase_orders.py
@@ -55,6 +55,7 @@ def purchase_orders_list(request):
         "statuses": statuses,
         "suppliers": suppliers,
         "querystring": querystring,
+        "sortable": True,
     }
     ctx.update(params)
     ctx["current_status"] = params.get("status")

--- a/static/js/table-sort.js
+++ b/static/js/table-sort.js
@@ -1,0 +1,20 @@
+// Initialize sortable tables using List.js
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('table[data-sortable]').forEach((table) => {
+    const container = table.parentElement; // div wrapping table
+    const headers = table.querySelectorAll('thead th');
+    const valueNames = [];
+    headers.forEach((th, index) => {
+      const key = `col${index}`;
+      valueNames.push(key);
+      const text = th.textContent.trim();
+      th.innerHTML = `<button class="sort flex items-center" data-sort="${key}">${text}<span class="ml-1">⇅</span></button>`;
+    });
+    table.querySelectorAll('tbody tr').forEach((tr) => {
+      tr.querySelectorAll('td').forEach((td, index) => {
+        td.classList.add(`col${index}`);
+      });
+    });
+    new List(container, { valueNames });
+  });
+});

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -7,10 +7,12 @@
     <title>{% block title %}Inventory App{% endblock %}</title>
     <link href="{% static 'css/app.css' %}" rel="stylesheet">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/2.3.1/list.min.js"></script>
     <script src="{% static 'js/color.js' %}"></script>
     <script src="{% static 'js/predictive-dropdown.js' %}"></script>
     <script src="{% static 'js/nav.js' %}"></script>
     <script src="{% static 'js/formset.js' %}"></script>
+    <script src="{% static 'js/table-sort.js' %}"></script>
   </head>
   <body class="min-h-screen text-base">
     {% include "components/nav.html" %}

--- a/templates/components/table.html
+++ b/templates/components/table.html
@@ -1,13 +1,17 @@
-{% comment %}Reusable table component with sticky headers and optional actions and footer slots{% endcomment %}
+{% comment %}
+Reusable table component with sticky headers and optional actions and footer
+slots. Pass `sortable=True` in the context to enable in-browser sorting via
+List.js; header buttons and cell classes are applied automatically.
+{% endcomment %}
 <div class="max-md:overflow-x-auto">
   {% block actions %}{% endblock %}
-    <table class="table w-full table-auto text-sm">
+    <table class="table w-full table-auto text-sm" {% if sortable %}data-sortable{% endif %}>
       <thead class="sticky top-0 bg-primary text-white">
         <tr>
           {% block headers %}{% endblock %}
         </tr>
       </thead>
-      <tbody>
+      <tbody {% if sortable %}class="list"{% endif %}>
         {% block rows %}{% endblock %}
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- add List.js and table-sort script to base template
- document new `sortable` flag and wire table component for JS sorting
- enable sorting on purchase order tables

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aad5b33f4883268dbbe64994d114e5