### PR TITLE
Implement tabs component for item detail view

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -296,7 +296,20 @@ class ItemDetailView(View):
             raise Http404("Item not found")
         if not details:
             raise Http404("Item not found")
-        return render(request, self.template_name, {"item": details})
+        tabs = [
+            {
+                "id": "details",
+                "title": "Details",
+                "template": "inventory/_item_details.html",
+            },
+            {
+                "id": "notes",
+                "title": "Notes",
+                "template": "inventory/_item_notes.html",
+            },
+        ]
+        ctx = {"item": details, "tabs": tabs}
+        return render(request, self.template_name, ctx)
 
 
 class ItemDeleteView(View):

--- a/static/js/tabs.js
+++ b/static/js/tabs.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-tabs]').forEach(container => {
+    const tabs = container.querySelectorAll('[data-tab-target]');
+    const panels = container.querySelectorAll('[role="tabpanel"]');
+    tabs.forEach(tab => {
+      tab.addEventListener('click', () => {
+        const target = tab.getAttribute('data-tab-target');
+        tabs.forEach(t => {
+          t.classList.remove('border-primary', 'text-primary');
+          t.setAttribute('aria-selected', 'false');
+        });
+        panels.forEach(p => p.classList.add('hidden'));
+        tab.classList.add('border-primary', 'text-primary');
+        tab.setAttribute('aria-selected', 'true');
+        const panel = container.querySelector(`#${target}`);
+        if (panel) {
+          panel.classList.remove('hidden');
+        }
+      });
+    });
+  });
+});

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -13,6 +13,7 @@
     <script src="{% static 'js/nav.js' %}"></script>
     <script src="{% static 'js/formset.js' %}"></script>
     <script src="{% static 'js/table-sort.js' %}"></script>
+    <script src="{% static 'js/tabs.js' %}"></script>
   </head>
   <body class="min-h-screen text-base">
     {% include "components/nav.html" %}

--- a/templates/components/tabs.html
+++ b/templates/components/tabs.html
@@ -1,0 +1,24 @@
+<div data-tabs class="grid gap-4">
+  <div role="tablist" class="flex border-b">
+    {% for tab in tabs %}
+      <button
+        type="button"
+        role="tab"
+        aria-selected="{% if forloop.first %}true{% else %}false{% endif %}"
+        data-tab-target="{{ tab.id }}"
+        class="px-4 py-2 -mb-px border-b-2 border-transparent text-secondary hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary"
+      >
+        {{ tab.title }}
+      </button>
+    {% endfor %}
+  </div>
+  {% for tab in tabs %}
+    <div
+      id="{{ tab.id }}"
+      role="tabpanel"
+      class="{% if not forloop.first %}hidden{% endif %}"
+    >
+      {% include tab.template %}
+    </div>
+  {% endfor %}
+</div>

--- a/templates/inventory/_item_details.html
+++ b/templates/inventory/_item_details.html
@@ -1,0 +1,12 @@
+<table class="table">
+  <tbody>
+    <tr><th class="text-left pr-4">ID</th><td>{{ item.item_id }}</td></tr>
+    <tr><th class="text-left pr-4">Base Unit</th><td>{{ item.base_unit }}</td></tr>
+    <tr><th class="text-left pr-4">Purchase Unit</th><td>{{ item.purchase_unit }}</td></tr>
+    <tr><th class="text-left pr-4">Category ID</th><td>{{ item.category_id }}</td></tr>
+    <tr><th class="text-left pr-4">Current Stock</th><td>{{ item.current_stock }}</td></tr>
+    <tr><th class="text-left pr-4">Reorder Point</th><td>{{ item.reorder_point }}</td></tr>
+    <tr><th class="text-left pr-4">Notes</th><td>{{ item.notes }}</td></tr>
+    <tr><th class="text-left pr-4">Active</th><td>{{ item.is_active }}</td></tr>
+  </tbody>
+</table>

--- a/templates/inventory/_item_notes.html
+++ b/templates/inventory/_item_notes.html
@@ -1,0 +1,4 @@
+<div>
+  <h2 class="text-xl mb-4">Notes</h2>
+  <p>{{ item.notes }}</p>
+</div>

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -2,18 +2,7 @@
 {% block title %}Item Detail – Inventory App{% endblock %}
 {% block content %}
   <h1 class="text-2xl font-semibold mb-4">{{ item.name }}</h1>
-  <table class="table">
-    <tbody>
-      <tr><th class="text-left pr-4">ID</th><td>{{ item.item_id }}</td></tr>
-      <tr><th class="text-left pr-4">Base Unit</th><td>{{ item.base_unit }}</td></tr>
-      <tr><th class="text-left pr-4">Purchase Unit</th><td>{{ item.purchase_unit }}</td></tr>
-      <tr><th class="text-left pr-4">Category ID</th><td>{{ item.category_id }}</td></tr>
-      <tr><th class="text-left pr-4">Current Stock</th><td>{{ item.current_stock }}</td></tr>
-      <tr><th class="text-left pr-4">Reorder Point</th><td>{{ item.reorder_point }}</td></tr>
-      <tr><th class="text-left pr-4">Notes</th><td>{{ item.notes }}</td></tr>
-      <tr><th class="text-left pr-4">Active</th><td>{{ item.is_active }}</td></tr>
-    </tbody>
-  </table>
+  {% include "components/tabs.html" with tabs=tabs %}
   <div class="mt-4">
     <a href="{% url 'items_list' %}" class="text-primary">Back to list</a>
   </div>


### PR DESCRIPTION
## Summary
- add reusable tabs component and activation script
- load tabs script in base template
- update item detail view to use tabs component

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aad7aaa8388326ab28ca6dee261b9f