### PR TITLE
Use base layout for form templates

### DIFF
--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -1,15 +1,24 @@
-{% extends "components/form_layout.html" %}
-{% block heading %}{{ title }}{% endblock %}
-{% block form_attrs %}enctype="multipart/form-data"{% endblock %}
-{% block fields %}
-  {% for field in form %}
-    {% include "components/form_field.html" with field=field %}
-  {% endfor %}
-{% endblock %}
-{% block submit_text %}Upload{% endblock %}
-{% block back_url %}{% url back_url %}{% endblock %}
-{% block back_text %}Back{% endblock %}
-{% block extra %}
+{% extends "_base.html" %}
+{% block title %}{{ title }} – Inventory App{% endblock %}
+{% block content %}
+<div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
+  <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
+  {% if form %}
+  <form method="post" enctype="multipart/form-data" class="grid grid-cols-1 gap-4">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
+    <div class="flex gap-2">
+      <button type="submit" class="btn-primary">Upload</button>
+      <a href="{% url back_url %}" class="btn-outline">Back</a>
+    </div>
+  </form>
   {% if inserted %}
   <p class="mt-4 text-green-700">Inserted {{ inserted }} record(s).</p>
   {% endif %}
@@ -23,4 +32,9 @@
     </ul>
   </div>
   {% endif %}
+  {% else %}
+    <p>Unable to load form.</p>
+  {% endif %}
+</div>
 {% endblock %}
+

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -1,57 +1,72 @@
-{% extends "components/form_layout.html" %}
-{% block heading %}New Indent{% endblock %}
-{% block form_attrs %}id="indent-form"{% endblock %}
-{% block fields %}
-  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
-    {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
-    {% endfor %}
-  </div>
-  {{ formset.management_form }}
-  {% if formset.non_form_errors %}
-  <ul class="text-red-600 list-disc pl-5">
-    {% for error in formset.non_form_errors %}
-      <li>{{ error }}</li>
-    {% endfor %}
-  </ul>
-  {% endif %}
-  <table id="items-table" class="table">
-    <thead>
-      <tr>
-        <th>Item</th>
-        <th>Qty</th>
-        <th>Notes</th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-    {% for item_form in formset %}
-      <tr class="form-row">
-        <td>{% include "components/form_field.html" with field=item_form.item %}</td>
-        <td>{% include "components/form_field.html" with field=item_form.requested_qty %}</td>
-        <td>{% include "components/form_field.html" with field=item_form.notes %}</td>
-        <td><button type="button" class="remove-row btn-danger">Remove</button></td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
-  <datalist id="item-options"></datalist>
-  <div>
-    <button type="button" id="add-row" class="btn-secondary mt-2">Add Item</button>
-  </div>
-{% endblock %}
-{% block submit_text %}Submit{% endblock %}
-{% block back_url %}{% url 'indents_list' %}{% endblock %}
-{% block extra %}
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    initFormset({
-      formsetPrefix: 'items',
-      addButtonId: 'add-row',
-      formContainer: '#items-table tbody',
-      formClass: 'form-row',
-      removeButtonClass: 'remove-row'
+{% extends "_base.html" %}
+{% block title %}New Indent – Inventory App{% endblock %}
+{% block content %}
+<div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
+  <h1 class="text-2xl font-semibold mb-4">New Indent</h1>
+  {% if form %}
+  <form method="post" id="indent-form" class="grid grid-cols-1 gap-4">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+      {% for field in form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
+    </div>
+    {{ formset.management_form }}
+    {% if formset.non_form_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in formset.non_form_errors %}
+        <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    <table id="items-table" class="table">
+      <thead>
+        <tr>
+          <th>Item</th>
+          <th>Qty</th>
+          <th>Notes</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for item_form in formset %}
+        <tr class="form-row">
+          <td>{% include "components/form_field.html" with field=item_form.item %}</td>
+          <td>{% include "components/form_field.html" with field=item_form.requested_qty %}</td>
+          <td>{% include "components/form_field.html" with field=item_form.notes %}</td>
+          <td><button type="button" class="remove-row btn-danger">Remove</button></td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    <datalist id="item-options"></datalist>
+    <div>
+      <button type="button" id="add-row" class="btn-secondary mt-2">Add Item</button>
+    </div>
+    <div class="flex gap-2">
+      <button type="submit" class="btn-primary">Submit</button>
+      <a href="{% url 'indents_list' %}" class="btn-outline">Cancel</a>
+    </div>
+  </form>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      initFormset({
+        formsetPrefix: 'items',
+        addButtonId: 'add-row',
+        formContainer: '#items-table tbody',
+        formClass: 'form-row',
+        removeButtonClass: 'remove-row'
+      });
     });
-  });
-</script>
+  </script>
+  {% else %}
+    <p>Unable to load form.</p>
+  {% endif %}
+</div>
 {% endblock %}
+

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -1,60 +1,67 @@
-{% extends "components/form_layout.html" %}
-{% block heading %}{% if is_edit %}Edit Item{% else %}New Item{% endif %}{% endblock %}
-{% block form_attrs %}
-  id="item-form"
-  hx-post="{% if is_edit %}{% url 'item_edit' item.pk %}{% else %}{% url 'item_create' %}{% endif %}"
-  hx-target="#item-options"
-{% endblock %}
-{% block fields %}
-  {% if not form.units_map %}
-  <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
-  {% endif %}
-  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1" style="grid-column: 1 / -1;">
-    <div id="name-field" class="space-y-1 relative">
-      <label for="{{ form.name.id_for_label }}" class="block mb-1 font-medium">{{ form.name.label }}</label>
-      {{ form.name }}
-      {% if form.name.help_text %}
-        <p class="text-sm text-gray-500">{{ form.name.help_text }}</p>
-      {% endif %}
-      {% if form.name.errors %}
-        <ul class="text-sm text-red-600 list-disc pl-5">
-          {% for error in form.name.errors %}
-            <li>{{ error }}</li>
-          {% endfor %}
-        </ul>
-      {% endif %}
+{% extends "_base.html" %}
+{% block title %}{% if is_edit %}Edit Item{% else %}New Item{% endif %} – Inventory App{% endblock %}
+{% block content %}
+<div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
+  <h1 class="text-2xl font-semibold mb-4">{% if is_edit %}Edit Item{% else %}New Item{% endif %}</h1>
+  {% if form %}
+  <form method="post" id="item-form" hx-post="{% if is_edit %}{% url 'item_edit' item.pk %}{% else %}{% url 'item_create' %}{% endif %}" hx-target="#item-options" class="grid grid-cols-1 gap-4">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+    {% if not form.units_map %}
+    <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
+    {% endif %}
+    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1" style="grid-column: 1 / -1;">
+      <div id="name-field" class="space-y-1 relative">
+        <label for="{{ form.name.id_for_label }}" class="block mb-1 font-medium">{{ form.name.label }}</label>
+        {{ form.name }}
+        {% if form.name.help_text %}
+          <p class="text-sm text-gray-500">{{ form.name.help_text }}</p>
+        {% endif %}
+        {% if form.name.errors %}
+          <ul class="text-sm text-red-600 list-disc pl-5">
+            {% for error in form.name.errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+      {% include "components/form_field.html" with field=form.base_unit %}
+      {% include "components/form_field.html" with field=form.purchase_unit %}
+      {% for field in form %}
+        {% if field.name not in excluded_fields %}
+          {% include "components/form_field.html" with field=field %}
+        {% endif %}
+      {% endfor %}
     </div>
-    {% include "components/form_field.html" with field=form.base_unit %}
-    {% include "components/form_field.html" with field=form.purchase_unit %}
-    {% for field in form %}
-      {% if field.name not in excluded_fields %}
-        {% include "components/form_field.html" with field=field %}
-      {% endif %}
-    {% endfor %}
-  </div>
-  <datalist id="base-unit-options">
-    {% for u in form.base_units %}
-      <option value="{{ u }}"></option>
-    {% endfor %}
-  </datalist>
-  <datalist id="purchase-unit-options">
-    {% for u in form.purchase_units %}
-      <option value="{{ u }}"></option>
-    {% endfor %}
-  </datalist>
-  <datalist id="category-options">
-    {% for c in form.category_options %}
-      <option value="{{ c }}"{% if c == form.category.value %} selected{% endif %}></option>
-    {% endfor %}
-  </datalist>
-  <datalist id="sub-category-options">
-    {% for c in form.sub_category_options %}
-      <option value="{{ c }}"{% if c == form.sub_category.value %} selected{% endif %}></option>
-    {% endfor %}
-  </datalist>
-{% endblock %}
-{% block back_url %}{% url 'items_list' %}{% endblock %}
-{% block extra %}
+    <datalist id="base-unit-options">
+      {% for u in form.base_units %}
+        <option value="{{ u }}"></option>
+      {% endfor %}
+    </datalist>
+    <datalist id="purchase-unit-options">
+      {% for u in form.purchase_units %}
+        <option value="{{ u }}"></option>
+      {% endfor %}
+    </datalist>
+    <datalist id="category-options">
+      {% for c in form.category_options %}
+        <option value="{{ c }}"{% if c == form.category.value %} selected{% endif %}></option>
+      {% endfor %}
+    </datalist>
+    <datalist id="sub-category-options">
+      {% for c in form.sub_category_options %}
+        <option value="{{ c }}"{% if c == form.sub_category.value %} selected{% endif %}></option>
+      {% endfor %}
+    </datalist>
+    <div class="flex gap-2">
+      <button type="submit" class="btn-primary">Save</button>
+      <a href="{% url 'items_list' %}" class="btn-outline">Cancel</a>
+    </div>
+  </form>
   {{ form.units_map|json_script:"units-data" }}
   {{ form.categories_map|json_script:"categories-data" }}
   <script>
@@ -114,4 +121,9 @@
       });
     });
   </script>
+  {% else %}
+    <p>Unable to load form.</p>
+  {% endif %}
+</div>
 {% endblock %}
+

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -1,64 +1,80 @@
-{% extends "components/form_layout.html" %}
-{% block heading %}{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order{% endblock %}
-{% block form_attrs %}id="po-form"{% endblock %}
-{% block fields %}
-  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
-    {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
-    {% endfor %}
-  </div>
-  <datalist id="supplier-options"></datalist>
-  <div id="items-formset">
-    {{ formset.management_form }}
-    {% if formset.non_form_errors %}
-      <ul class="text-red-600 list-disc pl-5">
-        {% for error in formset.non_form_errors %}
-          <li>{{ error }}</li>
-        {% endfor %}
-      </ul>
+{% extends "_base.html" %}
+{% block title %}{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order – Inventory App{% endblock %}
+{% block content %}
+<div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
+  <h1 class="text-2xl font-semibold mb-4">{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order</h1>
+  {% if form %}
+  <form method="post" id="po-form" class="grid grid-cols-1 gap-4">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
     {% endif %}
-    {% for f in formset %}
-    <div class="border p-2 item-form">
-      {% if f.non_field_errors %}
-        <ul class="text-red-600 list-disc pl-5">
-          {% for error in f.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-        </ul>
-      {% endif %}
-      {% for field in f %}
+    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+      {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}
     </div>
-    {% endfor %}
-  </div>
-  <datalist id="item-options"></datalist>
-  <div>
-    <button type="button" id="add-item" class="btn-secondary">Add Item</button>
-  </div>
-{% endblock %}
-{% block back_url %}{% url 'purchase_orders_list' %}{% endblock %}
-{% block extra %}
-<template id="item-empty-form">
-  <div class="border p-2 item-form">
-    {% for field in formset.empty_form %}
-      {% include "components/form_field.html" with field=field %}
-    {% endfor %}
-  </div>
-</template>
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    initFormset({
-      formsetPrefix: '{{ formset.prefix }}',
-      addButtonId: 'add-item',
-      formContainer: '#items-formset',
-      formClass: 'item-form',
-      templateId: 'item-empty-form'
+    <datalist id="supplier-options"></datalist>
+    <div id="items-formset">
+      {{ formset.management_form }}
+      {% if formset.non_form_errors %}
+        <ul class="text-red-600 list-disc pl-5">
+          {% for error in formset.non_form_errors %}
+            <li>{{ error }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+      {% for f in formset %}
+      <div class="border p-2 item-form">
+        {% if f.non_field_errors %}
+          <ul class="text-red-600 list-disc pl-5">
+            {% for error in f.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+          </ul>
+        {% endif %}
+        {% for field in f %}
+          {% include "components/form_field.html" with field=field %}
+        {% endfor %}
+      </div>
+      {% endfor %}
+    </div>
+    <datalist id="item-options"></datalist>
+    <div>
+      <button type="button" id="add-item" class="btn-secondary">Add Item</button>
+    </div>
+    <div class="flex gap-2">
+      <button type="submit" class="btn-primary">Save</button>
+      <a href="{% url 'purchase_orders_list' %}" class="btn-outline">Cancel</a>
+    </div>
+  </form>
+  <template id="item-empty-form">
+    <div class="border p-2 item-form">
+      {% for field in formset.empty_form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
+    </div>
+  </template>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      initFormset({
+        formsetPrefix: '{{ formset.prefix }}',
+        addButtonId: 'add-item',
+        formContainer: '#items-formset',
+        formClass: 'item-form',
+        templateId: 'item-empty-form'
+      });
+      document.getElementById('po-form').addEventListener('submit', function (e) {
+        if (!this.checkValidity()) {
+          e.preventDefault();
+          this.reportValidity();
+        }
+      });
     });
-    document.getElementById('po-form').addEventListener('submit', function (e) {
-      if (!this.checkValidity()) {
-        e.preventDefault();
-        this.reportValidity();
-      }
-    });
-  });
-</script>
+  </script>
+  {% else %}
+    <p>Unable to load form.</p>
+  {% endif %}
+</div>
 {% endblock %}
+

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -1,10 +1,29 @@
-{% extends "components/form_layout.html" %}
-{% block heading %}{% if is_edit %}Edit Supplier{% else %}New Supplier{% endif %}{% endblock %}
-{% block fields %}
-  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
-    {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
-    {% endfor %}
-  </div>
+{% extends "_base.html" %}
+{% block title %}{% if is_edit %}Edit Supplier{% else %}New Supplier{% endif %} – Inventory App{% endblock %}
+{% block content %}
+<div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
+  <h1 class="text-2xl font-semibold mb-4">{% if is_edit %}Edit Supplier{% else %}New Supplier{% endif %}</h1>
+  {% if form %}
+  <form method="post" class="grid grid-cols-1 gap-4">
+    {% csrf_token %}
+    {% if form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+      {% for field in form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
+    </div>
+    <div class="flex gap-2">
+      <button type="submit" class="btn-primary">Save</button>
+      <a href="{% url 'suppliers_list' %}" class="btn-outline">Cancel</a>
+    </div>
+  </form>
+  {% else %}
+    <p>Unable to load form.</p>
+  {% endif %}
+</div>
 {% endblock %}
-{% block back_url %}{% url 'suppliers_list' %}{% endblock %}
+


### PR DESCRIPTION
## Summary
- Ensure all inventory form templates extend `_base.html`
- Remove redundant wrapper markup from form pages

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aad8443d288326985e7f0f4b6437d1