### PR TITLE
Add reusable list page layout

### DIFF
--- a/templates/components/list_layout.html
+++ b/templates/components/list_layout.html
@@ -1,0 +1,17 @@
+{% extends "_base.html" %}
+{% block title %}List – Inventory App{% endblock %}
+{% block content %}
+  <h1 class="text-2xl font-semibold mb-4">{% block heading %}{% endblock %}</h1>
+  <div class="mb-4 flex justify-end gap-2">{% block actions %}{% endblock %}</div>
+  {% block filter_bar %}{% endblock %}
+  {% block extra %}{% endblock %}
+  {% block table_container %}
+  <div id="{% block table_id %}{% endblock %}"
+       hx-get="{% block hx_get %}{% endblock %}"
+       hx-trigger="load"
+       hx-include="#filters"
+       hx-indicator="#htmx-spinner">
+    {% block table_content %}{% endblock %}
+  </div>
+  {% endblock %}
+{% endblock %}

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -1,7 +1,7 @@
-{% extends "_base.html" %}
+{% extends "components/list_layout.html" %}
 {% block title %}Goods Received Notes – Inventory App{% endblock %}
-{% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Goods Received Notes</h1>
+{% block heading %}Goods Received Notes{% endblock %}
+{% block filter_bar %}
   <form method="get" class="mb-4 grid gap-2 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
       <label class="block text-sm font-medium">Supplier</label>
@@ -31,6 +31,8 @@
       <button type="submit" class="btn-primary w-full">Filter</button>
     </div>
   </form>
+{% endblock %}
+{% block table_container %}
   <table class="table">
     <thead><tr><th>ID</th><th>PO</th><th>Supplier</th><th>Date</th></tr></thead>
     <tbody>

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -1,19 +1,18 @@
-{% extends "_base.html" %}
+{% extends "components/list_layout.html" %}
 {% block title %}Indents – Inventory App{% endblock %}
-{% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Indents ({{ total_indents }})</h1>
-  <div class="mb-4 flex justify-end gap-2">
-    <a href="{% url 'indent_create' %}" class="btn-primary">New Indent</a>
-  </div>
+{% block heading %}Indents ({{ total_indents }}){% endblock %}
+{% block actions %}
+  <a href="{% url 'indent_create' %}" class="btn-primary">New Indent</a>
+{% endblock %}
+{% block filter_bar %}
   {% url 'indents_table' as indents_table_url %}
   {% include "components/filter_bar.html" with search_placeholder="Search indents..." hx_get=indents_table_url hx_target="#indents_table" filters=filters %}
-  <div id="indents_table"
-       hx-get="{% url 'indents_table' %}"
-       hx-trigger="load"
-       hx-include="#filters">
-    {% if total_indents == 0 %}
-      {% url 'indent_create' as indent_create_url %}
-      {% include "components/empty_state.html" with title="No Indents" message="Create your first indent to get started." cta_label="New Indent" cta_url=indent_create_url %}
-    {% endif %}
-  </div>
+{% endblock %}
+{% block table_id %}indents_table{% endblock %}
+{% block hx_get %}{% url 'indents_table' %}{% endblock %}
+{% block table_content %}
+  {% if total_indents == 0 %}
+    {% url 'indent_create' as indent_create_url %}
+    {% include "components/empty_state.html" with title="No Indents" message="Create your first indent to get started." cta_label="New Indent" cta_url=indent_create_url %}
+  {% endif %}
 {% endblock %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -1,13 +1,15 @@
-{% extends "_base.html" %}
+{% extends "components/list_layout.html" %}
 {% block title %}Items – Inventory App{% endblock %}
-{% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Items</h1>
-  <div class="mb-4 flex justify-end gap-2">
-    <a href="{% url 'item_create' %}" class="btn-primary">New Item</a>
-    <a href="{% url 'items_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
-  </div>
+{% block heading %}Items{% endblock %}
+{% block actions %}
+  <a href="{% url 'item_create' %}" class="btn-primary">New Item</a>
+  <a href="{% url 'items_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
+{% endblock %}
+{% block filter_bar %}
   {% url 'items_table' as items_table_url %}
   {% include "components/filter_bar.html" with search_placeholder="Search items..." hx_get=items_table_url hx_target="#items_table" hx_indicator="#htmx-spinner" filters=filters export_url=export_url sort=sort direction=direction %}
+{% endblock %}
+{% block extra %}
   {{ categories_map|json_script:"categories-data" }}
   <script>
     document.addEventListener('DOMContentLoaded', function () {
@@ -46,11 +48,7 @@
       });
     });
   </script>
-  <div id="items_table"
-       hx-get="{% url 'items_table' %}"
-       hx-trigger="load"
-       hx-include="#filters"
-       hx-indicator="#htmx-spinner">
-    {{ items_table|safe }}
-  </div>
 {% endblock %}
+{% block table_id %}items_table{% endblock %}
+{% block hx_get %}{% url 'items_table' %}{% endblock %}
+{% block table_content %}{{ items_table|safe }}{% endblock %}

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -1,11 +1,11 @@
-{% extends "_base.html" %}
+{% extends "components/list_layout.html" %}
 {% block title %}Purchase Orders – Inventory App{% endblock %}
-{% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Purchase Orders</h1>
-  <div class="mb-4 flex justify-end gap-2">
-    <a href="{% url 'purchase_order_create' %}" class="btn-primary">New PO</a>
-    <a href="{% url 'grn_list' %}" class="btn-secondary">GRNs</a>
-  </div>
+{% block heading %}Purchase Orders{% endblock %}
+{% block actions %}
+  <a href="{% url 'purchase_order_create' %}" class="btn-primary">New PO</a>
+  <a href="{% url 'grn_list' %}" class="btn-secondary">GRNs</a>
+{% endblock %}
+{% block filter_bar %}
   <form method="get" class="mb-4 grid gap-2 grid-cols-5 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
       <label class="block text-sm font-medium">Status</label>
@@ -51,5 +51,7 @@
       <button type="submit" class="btn-primary w-full">Filter</button>
     </div>
   </form>
+{% endblock %}
+{% block table_container %}
   {% include "inventory/purchase_orders/_table.html" %}
 {% endblock %}

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -1,8 +1,10 @@
-{% extends "_base.html" %}
+{% extends "components/list_layout.html" %}
 {% block title %}Recipes – Inventory App{% endblock %}
-{% block content %}
-<h1 class="text-2xl font-semibold mb-4">Recipes</h1>
-<p class="mb-4"><a class="text-primary" href="{% url 'recipe_create' %}">Create Recipe</a></p>
+{% block heading %}Recipes{% endblock %}
+{% block actions %}
+  <a class="btn-primary" href="{% url 'recipe_create' %}">New Recipe</a>
+{% endblock %}
+{% block table_container %}
 <ul class="list-disc pl-5">
   {% for r in recipes %}
     <li><a class="text-primary" href="{% url 'recipe_detail' r.recipe_id %}">{{ r.name }}</a></li>

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -1,22 +1,20 @@
-{% extends "_base.html" %}
+{% extends "components/list_layout.html" %}
 {% block title %}Suppliers – Inventory App{% endblock %}
-{% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Suppliers ({{ total_suppliers }})</h1>
-  <div class="mb-4 flex justify-end gap-2">
-    <a href="{% url 'supplier_create' %}" class="btn-primary">New Supplier</a>
-    <a href="{% url 'suppliers_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
-    <a href="{% url 'suppliers_bulk_delete' %}" class="btn-danger">Bulk Delete</a>
-  </div>
+{% block heading %}Suppliers ({{ total_suppliers }}){% endblock %}
+{% block actions %}
+  <a href="{% url 'supplier_create' %}" class="btn-primary">New Supplier</a>
+  <a href="{% url 'suppliers_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
+  <a href="{% url 'suppliers_bulk_delete' %}" class="btn-danger">Bulk Delete</a>
+{% endblock %}
+{% block filter_bar %}
   {% url 'suppliers_table' as suppliers_table_url %}
   {% include "components/filter_bar.html" with search_placeholder="Search suppliers..." hx_get=suppliers_table_url hx_target="#suppliers_table" filters=filters export_url=export_url export_param_name="export" export_param_value="1" page_size=page_size sort=sort direction=direction %}
-  <div id="suppliers_table"
-       hx-get="{% url 'suppliers_table' %}"
-       hx-trigger="load"
-       hx-include="#filters">
-    {% if total_suppliers == 0 %}
-      {% url 'supplier_create' as supplier_create_url %}
-      {% include "components/empty_state.html" with title="No Suppliers" message="Start by adding your first supplier." cta_label="New Supplier" cta_url=supplier_create_url %}
-    {% endif %}
-  </div>
 {% endblock %}
-
+{% block table_id %}suppliers_table{% endblock %}
+{% block hx_get %}{% url 'suppliers_table' %}{% endblock %}
+{% block table_content %}
+  {% if total_suppliers == 0 %}
+    {% url 'supplier_create' as supplier_create_url %}
+    {% include "components/empty_state.html" with title="No Suppliers" message="Start by adding your first supplier." cta_label="New Supplier" cta_url=supplier_create_url %}
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- create reusable `list_layout.html` with slots for headings, actions, filters, and HTMX tables
- refactor list templates to extend new layout fragment

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aad8583d008326aa5ddbc67f7f9d7f