### PR TITLE
Use reusable detail table and unify detail view navigation

### DIFF
--- a/inventory/views/goods_received.py
+++ b/inventory/views/goods_received.py
@@ -3,6 +3,8 @@ import logging
 
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.html import format_html
 from django.views.generic import TemplateView
 
 from fpdf import FPDF
@@ -72,7 +74,19 @@ class GRNDetailView(TemplateView):
         ctx = super().get_context_data(**kwargs)
         grn = get_object_or_404(GoodsReceivedNote, pk=self.kwargs["pk"])
         items = grn.grnitem_set.select_related("po_item", "po_item__item")
-        ctx.update({"grn": grn, "items": items})
+        rows = [
+            (
+                "PO",
+                format_html(
+                    '<a class="text-primary" href="{}">{}</a>',
+                    reverse("purchase_order_detail", args=[grn.purchase_order_id]),
+                    grn.purchase_order_id,
+                ),
+            ),
+            ("Supplier", grn.supplier.name),
+            ("Date", grn.received_date),
+        ]
+        ctx.update({"grn": grn, "items": items, "rows": rows})
         return ctx
 
 

--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -7,6 +7,7 @@ from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils.html import format_html
 from django.views import View
 from django.views.generic import TemplateView
 from django.views.decorators.http import require_POST
@@ -140,11 +141,14 @@ class IndentCreateView(View):
 def indent_detail(request, pk: int):
     indent = get_object_or_404(Indent, pk=pk)
     items = indent.indentitem_set.select_related("item").all()
-    return render(
-        request,
-        "inventory/indent_detail.html",
-        {"indent": indent, "items": items, "badges": INDENT_STATUS_BADGES},
-    )
+    badge_class = INDENT_STATUS_BADGES.get(indent.status.upper(), "")
+    rows = [
+        ("Status", format_html('<span class="px-2 py-1 rounded {}">{}</span>', badge_class, indent.status)),
+        ("Requested By", indent.requested_by),
+        ("Department", indent.department),
+    ]
+    ctx = {"indent": indent, "items": items, "rows": rows}
+    return render(request, "inventory/indent_detail.html", ctx)
 
 
 @require_POST

--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -296,7 +296,18 @@ class ItemDetailView(View):
             raise Http404("Item not found")
         if not details:
             raise Http404("Item not found")
-        return render(request, self.template_name, {"item": details})
+        rows = [
+            ("ID", details["item_id"]),
+            ("Base Unit", details["base_unit"]),
+            ("Purchase Unit", details["purchase_unit"]),
+            ("Category ID", details["category_id"]),
+            ("Current Stock", details["current_stock"]),
+            ("Reorder Point", details["reorder_point"]),
+            ("Notes", details["notes"]),
+            ("Active", details["is_active"]),
+        ]
+        ctx = {"item": details, "rows": rows}
+        return render(request, self.template_name, ctx)
 
 
 class ItemDeleteView(View):

--- a/inventory/views/purchase_orders.py
+++ b/inventory/views/purchase_orders.py
@@ -5,6 +5,7 @@ from django.contrib import messages
 from decimal import Decimal
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils.html import format_html
 from django.db.models import Sum
 
 from ..forms.purchase_forms import (
@@ -143,11 +144,16 @@ def purchase_order_detail(request, pk: int):
         .all()
     )
     badge_class = PO_STATUS_BADGES.get(po.status, "")
-    return render(
-        request,
-        "inventory/purchase_orders/detail.html",
-        {"po": po, "items": items, "badge_class": badge_class},
-    )
+    rows = [
+        ("Supplier", po.supplier.name),
+        ("Order Date", po.order_date),
+        (
+            "Status",
+            format_html('<span class="px-2 py-1 rounded text-xs {}">{}</span>', badge_class, po.get_status_display()),
+        ),
+    ]
+    ctx = {"po": po, "items": items, "badge_class": badge_class, "rows": rows}
+    return render(request, "inventory/purchase_orders/detail.html", ctx)
 
 
 def purchase_order_receive(request, pk: int):

--- a/templates/components/detail_table.html
+++ b/templates/components/detail_table.html
@@ -1,0 +1,10 @@
+<table class="table">
+  <tbody>
+    {% for label, value in rows %}
+    <tr>
+      <th class="text-left pr-4">{{ label }}</th>
+      <td>{{ value }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/templates/inventory/grns/detail.html
+++ b/templates/inventory/grns/detail.html
@@ -2,9 +2,7 @@
 {% block title %}GRN Detail – Inventory App{% endblock %}
 {% block content %}
   <h1 class="text-2xl font-semibold mb-4">GRN {{ grn.pk }}</h1>
-  <p class="mb-2"><strong>PO:</strong> <a class="text-primary" href="{% url 'purchase_order_detail' grn.purchase_order_id %}">{{ grn.purchase_order_id }}</a></p>
-  <p class="mb-2"><strong>Supplier:</strong> {{ grn.supplier.name }}</p>
-  <p class="mb-4"><strong>Date:</strong> {{ grn.received_date }}</p>
+  {% include "components/detail_table.html" with rows=rows %}
   <table class="table">
     <thead><tr><th>Item</th><th>Ordered</th><th>Received</th></tr></thead>
     <tbody>
@@ -17,4 +15,7 @@
     {% endfor %}
     </tbody>
   </table>
+  <div class="mt-4">
+    <a href="{% url 'grn_list' %}" class="btn-outline">Back</a>
+  </div>
 {% endblock %}

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -2,9 +2,7 @@
 {% block title %}Indent Detail – Inventory App{% endblock %}
 {% block content %}
   <h1 class="text-2xl font-semibold mb-4">Indent {{ indent.indent_id }}</h1>
-  <div class="mb-2">Status: <span class="px-2 py-1 rounded {{ badges[indent.status|upper] }}">{{ indent.status }}</span></div>
-  <div class="mb-2">Requested By: {{ indent.requested_by }}</div>
-  <div class="mb-2">Department: {{ indent.department }}</div>
+  {% include "components/detail_table.html" with rows=rows %}
   <div class="mb-4">
     <a href="{% url 'indent_pdf' indent.indent_id %}" class="btn-outline">Download PDF</a>
   </div>
@@ -30,5 +28,8 @@
       {% csrf_token %}
       <button type="submit" class="btn-danger">Cancel</button>
     </form>
+  </div>
+  <div class="mt-4">
+    <a href="{% url 'indents_list' %}" class="btn-outline">Back</a>
   </div>
 {% endblock %}

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -2,19 +2,8 @@
 {% block title %}Item Detail – Inventory App{% endblock %}
 {% block content %}
   <h1 class="text-2xl font-semibold mb-4">{{ item.name }}</h1>
-  <table class="table">
-    <tbody>
-      <tr><th class="text-left pr-4">ID</th><td>{{ item.item_id }}</td></tr>
-      <tr><th class="text-left pr-4">Base Unit</th><td>{{ item.base_unit }}</td></tr>
-      <tr><th class="text-left pr-4">Purchase Unit</th><td>{{ item.purchase_unit }}</td></tr>
-      <tr><th class="text-left pr-4">Category ID</th><td>{{ item.category_id }}</td></tr>
-      <tr><th class="text-left pr-4">Current Stock</th><td>{{ item.current_stock }}</td></tr>
-      <tr><th class="text-left pr-4">Reorder Point</th><td>{{ item.reorder_point }}</td></tr>
-      <tr><th class="text-left pr-4">Notes</th><td>{{ item.notes }}</td></tr>
-      <tr><th class="text-left pr-4">Active</th><td>{{ item.is_active }}</td></tr>
-    </tbody>
-  </table>
+  {% include "components/detail_table.html" with rows=rows %}
   <div class="mt-4">
-    <a href="{% url 'items_list' %}" class="text-primary">Back to list</a>
+    <a href="{% url 'items_list' %}" class="btn-outline">Back</a>
   </div>
 {% endblock %}

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -2,9 +2,7 @@
 {% block title %}Purchase Order Detail – Inventory App{% endblock %}
 {% block content %}
   <h1 class="text-2xl font-semibold mb-4">Purchase Order {{ po.pk }}</h1>
-  <p class="mb-2"><strong>Supplier:</strong> {{ po.supplier.name }}</p>
-  <p class="mb-2"><strong>Order Date:</strong> {{ po.order_date }}</p>
-  <p class="mb-4"><span class="px-2 py-1 rounded text-xs {{ badge_class }}">{{ po.get_status_display }}</span></p>
+  {% include "components/detail_table.html" with rows=rows %}
   <h2 class="text-xl mb-4 mt-8">Items</h2>
   <table class="table mb-4">
     <thead><tr><th>Item</th><th>Ordered</th><th>Received</th></tr></thead>
@@ -22,5 +20,8 @@
     <a href="{% url 'purchase_order_edit' po.pk %}" class="btn-primary">Edit</a>
     <a href="{% url 'purchase_order_receive' po.pk %}" class="btn-primary">Receive Goods</a>
     <a href="{% url 'grn_list' %}" class="btn-primary">View GRNs</a>
+  </div>
+  <div class="mt-4">
+    <a href="{% url 'purchase_orders_list' %}" class="btn-outline">Back</a>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `detail_table` component for label/value tables
- refactor item, indent, PO and GRN detail templates to use the component
- include consistent Back button on detail pages

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aad8636ba48326a56bf4884825d942