### PR TITLE
Adopt shared form layout across templates

### DIFF
--- a/templates/inventory/bulk_delete.html
+++ b/templates/inventory/bulk_delete.html
@@ -1,23 +1,16 @@
-{% extends "_base.html" %}
+{% extends "components/form_layout.html" %}
 {% block title %}Bulk Delete – Inventory App{% endblock %}
-{% block content %}
-<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
-  <form method="post" enctype="multipart/form-data" class="space-y-4">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-    </ul>
-    {% endif %}
-    {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
-    {% endfor %}
-    <div class="flex gap-2">
-      <button type="submit" class="btn-danger">Delete</button>
-      <a href="{% url back_url %}" class="btn-outline">Back</a>
-    </div>
-  </form>
+{% block heading %}{{ title }}{% endblock %}
+{% block form_attrs %}enctype="multipart/form-data"{% endblock %}
+{% block fields %}
+  {% for field in form %}
+    {% include "components/form_field.html" with field=field %}
+  {% endfor %}
+{% endblock %}
+{% block submit_text %}Delete{% endblock %}
+{% block back_url %}{% url back_url %}{% endblock %}
+{% block back_text %}Back{% endblock %}
+{% block extra %}
   {% if deleted %}
   <p class="mt-4 text-green-700">Deleted {{ deleted }} supplier(s).</p>
   {% endif %}
@@ -31,5 +24,4 @@
     </ul>
   </div>
   {% endif %}
-</div>
 {% endblock %}

--- a/templates/inventory/bulk_upload.html
+++ b/templates/inventory/bulk_upload.html
@@ -1,24 +1,16 @@
-{% extends "_base.html" %}
+{% extends "components/form_layout.html" %}
 {% block title %}{{ title }} – Inventory App{% endblock %}
-{% block content %}
-<div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">{{ title }}</h1>
-  {% if form %}
-  <form method="post" enctype="multipart/form-data" class="grid grid-cols-1 gap-4">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-    </ul>
-    {% endif %}
-    {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
-    {% endfor %}
-    <div class="flex gap-2">
-      <button type="submit" class="btn-primary">Upload</button>
-      <a href="{% url back_url %}" class="btn-outline">Back</a>
-    </div>
-  </form>
+{% block heading %}{{ title }}{% endblock %}
+{% block form_attrs %}enctype="multipart/form-data"{% endblock %}
+{% block fields %}
+  {% for field in form %}
+    {% include "components/form_field.html" with field=field %}
+  {% endfor %}
+{% endblock %}
+{% block submit_text %}Upload{% endblock %}
+{% block back_url %}{% url back_url %}{% endblock %}
+{% block back_text %}Back{% endblock %}
+{% block extra %}
   {% if inserted %}
   <p class="mt-4 text-green-700">Inserted {{ inserted }} record(s).</p>
   {% endif %}
@@ -32,9 +24,5 @@
     </ul>
   </div>
   {% endif %}
-  {% else %}
-    <p>Unable to load form.</p>
-  {% endif %}
-</div>
 {% endblock %}
 

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -1,58 +1,50 @@
-{% extends "_base.html" %}
+{% extends "components/form_layout.html" %}
 {% block title %}New Indent – Inventory App{% endblock %}
-{% block content %}
-<div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">New Indent</h1>
-  {% if form %}
-  <form method="post" id="indent-form" class="grid grid-cols-1 gap-4">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-    </ul>
-    {% endif %}
-    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
-      {% for field in form %}
-        {% include "components/form_field.html" with field=field %}
-      {% endfor %}
-    </div>
-    {{ formset.management_form }}
-    {% if formset.non_form_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in formset.non_form_errors %}
-        <li>{{ error }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    <table id="items-table" class="table">
-      <thead>
-        <tr>
-          <th>Item</th>
-          <th>Qty</th>
-          <th>Notes</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-      {% for item_form in formset %}
-        <tr class="form-row">
-          <td>{% include "components/form_field.html" with field=item_form.item %}</td>
-          <td>{% include "components/form_field.html" with field=item_form.requested_qty %}</td>
-          <td>{% include "components/form_field.html" with field=item_form.notes %}</td>
-          <td><button type="button" class="remove-row btn-danger">Remove</button></td>
-        </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-    <datalist id="item-options"></datalist>
-    <div>
-      <button type="button" id="add-row" class="btn-secondary mt-2">Add Item</button>
-    </div>
-    <div class="flex gap-2">
-      <button type="submit" class="btn-primary">Submit</button>
-      <a href="{% url 'indents_list' %}" class="btn-outline">Cancel</a>
-    </div>
-  </form>
+{% block heading %}New Indent{% endblock %}
+{% block form_attrs %}id="indent-form"{% endblock %}
+{% block fields %}
+  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
+  </div>
+  {{ formset.management_form }}
+  {% if formset.non_form_errors %}
+  <ul class="text-red-600 list-disc pl-5">
+    {% for error in formset.non_form_errors %}
+      <li>{{ error }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+  <table id="items-table" class="table">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Qty</th>
+        <th>Notes</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for item_form in formset %}
+      <tr class="form-row">
+        <td>{% include "components/form_field.html" with field=item_form.item %}</td>
+        <td>{% include "components/form_field.html" with field=item_form.requested_qty %}</td>
+        <td>{% include "components/form_field.html" with field=item_form.notes %}</td>
+        <td><button type="button" class="remove-row btn-danger">Remove</button></td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <datalist id="item-options"></datalist>
+  <div>
+    <button type="button" id="add-row" class="btn-secondary mt-2">Add Item</button>
+  </div>
+{% endblock %}
+{% block submit_text %}Submit{% endblock %}
+{% block back_url %}{% url 'indents_list' %}{% endblock %}
+{% block back_text %}Cancel{% endblock %}
+{% block extra %}
   <script>
     document.addEventListener('DOMContentLoaded', function () {
       initFormset({
@@ -64,9 +56,6 @@
       });
     });
   </script>
-  {% else %}
-    <p>Unable to load form.</p>
-  {% endif %}
-</div>
 {% endblock %}
+{% block no_form %}<p>Unable to load form.</p>{% endblock %}
 

--- a/templates/inventory/item_confirm_delete.html
+++ b/templates/inventory/item_confirm_delete.html
@@ -1,13 +1,9 @@
-{% extends "_base.html" %}
+{% extends "components/form_layout.html" %}
 {% block title %}Delete Item – Inventory App{% endblock %}
-{% block content %}
-<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">Delete/Deactivate Item</h1>
+{% block heading %}Delete/Deactivate Item{% endblock %}
+{% block fields %}
   <p class="mb-4">Are you sure you want to delete or deactivate "{{ item.name }}"?</p>
-  <form method="post" class="flex gap-2">
-    {% csrf_token %}
-    <button type="submit" class="btn-danger">Confirm</button>
-    <a href="{% url 'items_list' %}" class="btn-outline">Cancel</a>
-  </form>
-</div>
 {% endblock %}
+{% block submit_text %}Confirm{% endblock %}
+{% block back_url %}{% url 'items_list' %}{% endblock %}
+{% block back_text %}Cancel{% endblock %}

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -1,53 +1,45 @@
-{% extends "_base.html" %}
+{% extends "components/form_layout.html" %}
 {% block title %}{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order – Inventory App{% endblock %}
-{% block content %}
-<div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order</h1>
-  {% if form %}
-  <form method="post" id="po-form" class="grid grid-cols-1 gap-4">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-    </ul>
+{% block heading %}{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order{% endblock %}
+{% block form_attrs %}id="po-form"{% endblock %}
+{% block fields %}
+  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
+  </div>
+  <datalist id="supplier-options"></datalist>
+  <div id="items-formset">
+    {{ formset.management_form }}
+    {% if formset.non_form_errors %}
+      <ul class="text-red-600 list-disc pl-5">
+        {% for error in formset.non_form_errors %}
+          <li>{{ error }}</li>
+        {% endfor %}
+      </ul>
     {% endif %}
-    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
-      {% for field in form %}
+    {% for f in formset %}
+    <div class="border p-2 item-form">
+      {% if f.non_field_errors %}
+        <ul class="text-red-600 list-disc pl-5">
+          {% for error in f.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+      {% endif %}
+      {% for field in f %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}
     </div>
-    <datalist id="supplier-options"></datalist>
-    <div id="items-formset">
-      {{ formset.management_form }}
-      {% if formset.non_form_errors %}
-        <ul class="text-red-600 list-disc pl-5">
-          {% for error in formset.non_form_errors %}
-            <li>{{ error }}</li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-      {% for f in formset %}
-      <div class="border p-2 item-form">
-        {% if f.non_field_errors %}
-          <ul class="text-red-600 list-disc pl-5">
-            {% for error in f.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-          </ul>
-        {% endif %}
-        {% for field in f %}
-          {% include "components/form_field.html" with field=field %}
-        {% endfor %}
-      </div>
-      {% endfor %}
-    </div>
-    <datalist id="item-options"></datalist>
-    <div>
-      <button type="button" id="add-item" class="btn-secondary">Add Item</button>
-    </div>
-    <div class="flex gap-2">
-      <button type="submit" class="btn-primary">Save</button>
-      <a href="{% url 'purchase_orders_list' %}" class="btn-outline">Cancel</a>
-    </div>
-  </form>
+    {% endfor %}
+  </div>
+  <datalist id="item-options"></datalist>
+  <div>
+    <button type="button" id="add-item" class="btn-secondary">Add Item</button>
+  </div>
+{% endblock %}
+{% block submit_text %}Save{% endblock %}
+{% block back_url %}{% url 'purchase_orders_list' %}{% endblock %}
+{% block back_text %}Cancel{% endblock %}
+{% block extra %}
   <template id="item-empty-form">
     <div class="border p-2 item-form">
       {% for field in formset.empty_form %}
@@ -72,9 +64,6 @@
       });
     });
   </script>
-  {% else %}
-    <p>Unable to load form.</p>
-  {% endif %}
-</div>
 {% endblock %}
+{% block no_form %}<p>Unable to load form.</p>{% endblock %}
 

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -1,34 +1,26 @@
-{% extends "_base.html" %}
+{% extends "components/form_layout.html" %}
 {% block title %}Receive Purchase Order – Inventory App{% endblock %}
-{% block content %}
-<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">Receive Goods for PO {{ po.pk }}</h1>
-  <form method="post" class="space-y-4">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-    </ul>
-    {% endif %}
-    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
-      {% for field in form %}
-        {% include "components/form_field.html" with field=field %}
-      {% endfor %}
-    </div>
-    <table class="table">
-      <thead><tr><th>Item</th><th>Ordered</th><th>Received</th><th>Receive Now</th></tr></thead>
-      <tbody>
-      {% for item in items %}
-        <tr>
-          <td>{{ item.item.name }}</td>
-          <td>{{ item.quantity_ordered }}</td>
-          <td>{{ item.received_total }}</td>
-          <td><input type="number" step="any" name="item_{{ item.pk }}" class="form-control w-24" /></td>
-        </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-    <button type="submit" class="btn-primary">Submit GRN</button>
-  </form>
-</div>
+{% block heading %}Receive Goods for PO {{ po.pk }}{% endblock %}
+{% block fields %}
+  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
+  </div>
+  <table class="table">
+    <thead><tr><th>Item</th><th>Ordered</th><th>Received</th><th>Receive Now</th></tr></thead>
+    <tbody>
+    {% for item in items %}
+      <tr>
+        <td>{{ item.item.name }}</td>
+        <td>{{ item.quantity_ordered }}</td>
+        <td>{{ item.received_total }}</td>
+        <td><input type="number" step="any" name="item_{{ item.pk }}" class="form-control w-24" /></td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
 {% endblock %}
+{% block submit_text %}Submit GRN{% endblock %}
+{% block back_url %}{% url 'purchase_orders_list' %}{% endblock %}
+{% block back_text %}Back{% endblock %}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -1,68 +1,59 @@
-{% extends "_base.html" %}
+{% extends "components/form_layout.html" %}
 {% block title %}Recipe Detail – Inventory App{% endblock %}
-{% block content %}
-<div class="w-full max-w-2xl max-md:max-w-xl max-sm:max-w-md mx-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">{% if recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}</h1>
-  <form method="post" id="recipe-form">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}
-      <li>{{ error }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    <div class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
-      {% for field in form %}
-        {% if field.name in ['description', 'plating_notes'] %}
-          {% include "components/form_field.html" with field=field container_class="col-span-2" %}
-        {% else %}
-          {% include "components/form_field.html" with field=field %}
-        {% endif %}
-      {% endfor %}
-    </div>
-    {{ formset.management_form }}
-    {% if formset.non_form_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in formset.non_form_errors %}
-      <li>{{ error }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    <table id="components-table" class="table w-full">
-      <thead>
-        <tr>
-          <th>Kind</th>
-          <th>ID</th>
-          <th>Qty</th>
-          <th>Unit</th>
-          <th>Loss %</th>
-          <th></th>
-        </tr>
-      </thead>
-      <tbody>
-      {% for cform in formset %}
-        <tr class="form-row">
-          <td>{% include "components/form_field.html" with field=cform.component_kind %}</td>
-          <td>{% include "components/form_field.html" with field=cform.component_id %}</td>
-          <td>{% include "components/form_field.html" with field=cform.quantity %}</td>
-          <td>{% include "components/form_field.html" with field=cform.unit %}</td>
-          <td>{% include "components/form_field.html" with field=cform.loss_pct %}</td>
-          <td>
-            {{ cform.DELETE }}<button type="button" class="remove-row btn-danger">Remove</button>
-          </td>
-        </tr>
-      {% endfor %}
-      </tbody>
-    </table>
-    <div class="mt-2">
-      <button type="button" id="add-row" class="btn-secondary">Add Component</button>
-    </div>
-    <div class="mt-4">
-      <button type="submit" class="btn-primary">Save</button>
-    </div>
-  </form>
-</div>
+{% block heading %}{% if recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}{% endblock %}
+{% block form_attrs %}id="recipe-form"{% endblock %}
+{% block fields %}
+  <div class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
+    {% for field in form %}
+      {% if field.name in ['description', 'plating_notes'] %}
+        {% include "components/form_field.html" with field=field container_class="col-span-2" %}
+      {% else %}
+        {% include "components/form_field.html" with field=field %}
+      {% endif %}
+    {% endfor %}
+  </div>
+  {{ formset.management_form }}
+  {% if formset.non_form_errors %}
+  <ul class="text-red-600 list-disc pl-5">
+    {% for error in formset.non_form_errors %}
+    <li>{{ error }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+  <table id="components-table" class="table w-full">
+    <thead>
+      <tr>
+        <th>Kind</th>
+        <th>ID</th>
+        <th>Qty</th>
+        <th>Unit</th>
+        <th>Loss %</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for cform in formset %}
+      <tr class="form-row">
+        <td>{% include "components/form_field.html" with field=cform.component_kind %}</td>
+        <td>{% include "components/form_field.html" with field=cform.component_id %}</td>
+        <td>{% include "components/form_field.html" with field=cform.quantity %}</td>
+        <td>{% include "components/form_field.html" with field=cform.unit %}</td>
+        <td>{% include "components/form_field.html" with field=cform.loss_pct %}</td>
+        <td>
+          {{ cform.DELETE }}<button type="button" class="remove-row btn-danger">Remove</button>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <div class="mt-2">
+    <button type="button" id="add-row" class="btn-secondary">Add Component</button>
+  </div>
+{% endblock %}
+{% block submit_text %}Save{% endblock %}
+{% block back_url %}{% url 'recipes_list' %}{% endblock %}
+{% block back_text %}Cancel{% endblock %}
+{% block extra %}
 <script>
 (function() {
   const addBtn = document.getElementById('add-row');

--- a/templates/inventory/supplier_form.html
+++ b/templates/inventory/supplier_form.html
@@ -1,29 +1,15 @@
-{% extends "_base.html" %}
+{% extends "components/form_layout.html" %}
 {% block title %}{% if is_edit %}Edit Supplier{% else %}New Supplier{% endif %} – Inventory App{% endblock %}
-{% block content %}
-<div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">{% if is_edit %}Edit Supplier{% else %}New Supplier{% endif %}</h1>
-  {% if form %}
-  <form method="post" class="grid grid-cols-1 gap-4">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-    </ul>
-    {% endif %}
-    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
-      {% for field in form %}
-        {% include "components/form_field.html" with field=field %}
-      {% endfor %}
-    </div>
-    <div class="flex gap-2">
-      <button type="submit" class="btn-primary">Save</button>
-      <a href="{% url 'suppliers_list' %}" class="btn-outline">Cancel</a>
-    </div>
-  </form>
-  {% else %}
-    <p>Unable to load form.</p>
-  {% endif %}
-</div>
+{% block heading %}{% if is_edit %}Edit Supplier{% else %}New Supplier{% endif %}{% endblock %}
+{% block fields %}
+  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+    {% for field in form %}
+      {% include "components/form_field.html" with field=field %}
+    {% endfor %}
+  </div>
 {% endblock %}
+{% block submit_text %}Save{% endblock %}
+{% block back_url %}{% url 'suppliers_list' %}{% endblock %}
+{% block back_text %}Cancel{% endblock %}
+{% block no_form %}<p>Unable to load form.</p>{% endblock %}
 

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,21 +1,11 @@
-{% extends "_base.html" %}
+{% extends "components/form_layout.html" %}
 {% block title %}Login – Inventory App{% endblock %}
-{% block content %}
-<div class="max-w-sm mx-auto space-y-4">
-  <h1 class="text-2xl font-semibold">Login</h1>
-  <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-    </ul>
-    {% endif %}
-    {% for field in form %}
-      {% include "components/form_field.html" with field=field container_class="col-span-2" %}
-    {% endfor %}
-    <div class="col-span-2">
-      <button type="submit" class="btn-primary">Login</button>
-    </div>
-  </form>
-</div>
+{% block heading %}Login{% endblock %}
+{% block fields %}
+  {% for field in form %}
+    {% include "components/form_field.html" with field=field container_class="col-span-2" %}
+  {% endfor %}
 {% endblock %}
+{% block submit_text %}Login{% endblock %}
+{% block back_url %}{% url 'root' %}{% endblock %}
+{% block back_text %}Cancel{% endblock %}


### PR DESCRIPTION
## Summary
- Refactor login page to extend components/form_layout.html
- Update inventory forms to use form_layout with block-based headings and buttons

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aadd1fcab0832687a695a73581d270