### PR TITLE
Use shared layouts and components for templates

### DIFF
--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -1,79 +1,78 @@
-<div class="max-md:overflow-x-auto">
-  <table class="table w-full table-auto text-sm">
-    <thead class="bg-primary text-white">
-      <tr>
-        <th class="px-4 py-2 text-right">
-          <a hx-get="{% url 'history_reports' %}?sort=id&direction={% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='id';document.querySelector('#filters input[name=direction]').value='{% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            ID{% if sort == 'id' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2">
-          <a hx-get="{% url 'history_reports' %}?sort=item&direction={% if sort == 'item' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='item';document.querySelector('#filters input[name=direction]').value='{% if sort == 'item' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Item{% if sort == 'item' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2">
-          <a hx-get="{% url 'history_reports' %}?sort=type&direction={% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='type';document.querySelector('#filters input[name=direction]').value='{% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Type{% if sort == 'type' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2 text-right">
-          <a hx-get="{% url 'history_reports' %}?sort=qty&direction={% if sort == 'qty' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='qty';document.querySelector('#filters input[name=direction]').value='{% if sort == 'qty' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Qty{% if sort == 'qty' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2 text-right">
-          <a hx-get="{% url 'history_reports' %}?sort=user&direction={% if sort == 'user' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='user';document.querySelector('#filters input[name=direction]').value='{% if sort == 'user' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            User{% if sort == 'user' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2">
-          <a hx-get="{% url 'history_reports' %}?sort=date&direction={% if sort == 'date' and direction == 'asc' %}desc{% else %}asc{% endif %}"
-             hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
-             hx-on:click="document.querySelector('#filters input[name=sort]').value='date';document.querySelector('#filters input[name=direction]').value='{% if sort == 'date' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
-            Date{% if sort == 'date' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
-          </a>
-        </th>
-        <th class="px-4 py-2">Notes</th>
-      </tr>
-    </thead>
-      <tbody>
-      {% for row in page_obj %}
-      <tr class="odd:bg-gray-50 hover:bg-gray-100">
-        <td class="px-4 py-2 text-right">{{ row.transaction_id }}</td>
-        <td class="px-4 py-2">{{ row.item.name }}</td>
-        <td class="px-4 py-2">{{ row.transaction_type }}</td>
-        <td class="px-4 py-2 text-right">{{ row.quantity_change }}</td>
-        <td class="px-4 py-2 text-right">{{ row.user_id }}</td>
-        <td class="px-4 py-2">{{ row.transaction_date }}</td>
-        <td class="px-4 py-2">{{ row.notes }}</td>
-      </tr>
-      {% empty %}
-      <tr>
-        <td colspan="7" class="px-4 py-2">No transactions found.</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-    <tfoot>
-      <tr>
-        <td colspan="3" class="px-4 py-2 font-semibold text-right">Total</td>
-        <td class="px-4 py-2 font-semibold text-right">{{ total_quantity }}</td>
-        <td colspan="3"></td>
-      </tr>
-    </tfoot>
-  </table>
-</div>
-{% url 'history_reports' as history_url %}
-<div class="mt-4">
-  {% include "components/pagination.html" with page_obj=page_obj base_url=history_url extra_query="" hx_target="#history_table" hx_include="#filters" hx_indicator="#htmx-spinner" %}
-</div>
+{% extends "components/table.html" %}
+
+{% block headers %}
+<th class="px-4 py-2 text-right">
+  <a hx-get="{% url 'history_reports' %}?sort=id&direction={% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='id';document.querySelector('#filters input[name=direction]').value='{% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    ID{% if sort == 'id' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2">
+  <a hx-get="{% url 'history_reports' %}?sort=item&direction={% if sort == 'item' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='item';document.querySelector('#filters input[name=direction]').value='{% if sort == 'item' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Item{% if sort == 'item' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2">
+  <a hx-get="{% url 'history_reports' %}?sort=type&direction={% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='type';document.querySelector('#filters input[name=direction]').value='{% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Type{% if sort == 'type' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2 text-right">
+  <a hx-get="{% url 'history_reports' %}?sort=qty&direction={% if sort == 'qty' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='qty';document.querySelector('#filters input[name=direction]').value='{% if sort == 'qty' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Qty{% if sort == 'qty' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2 text-right">
+  <a hx-get="{% url 'history_reports' %}?sort=user&direction={% if sort == 'user' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='user';document.querySelector('#filters input[name=direction]').value='{% if sort == 'user' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    User{% if sort == 'user' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2">
+  <a hx-get="{% url 'history_reports' %}?sort=date&direction={% if sort == 'date' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+     hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
+     hx-on:click="document.querySelector('#filters input[name=sort]').value='date';document.querySelector('#filters input[name=direction]').value='{% if sort == 'date' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
+    Date{% if sort == 'date' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
+  </a>
+</th>
+<th class="px-4 py-2">Notes</th>
+{% endblock %}
+
+{% block rows %}
+  {% for row in page_obj %}
+  <tr class="odd:bg-gray-50 hover:bg-gray-100">
+    <td class="px-4 py-2 text-right">{{ row.transaction_id }}</td>
+    <td class="px-4 py-2">{{ row.item.name }}</td>
+    <td class="px-4 py-2">{{ row.transaction_type }}</td>
+    <td class="px-4 py-2 text-right">{{ row.quantity_change }}</td>
+    <td class="px-4 py-2 text-right">{{ row.user_id }}</td>
+    <td class="px-4 py-2">{{ row.transaction_date }}</td>
+    <td class="px-4 py-2">{{ row.notes }}</td>
+  </tr>
+  {% empty %}
+  <tr>
+    <td colspan="7" class="px-4 py-2">No transactions found.</td>
+  </tr>
+  {% endfor %}
+  <tr>
+    <td colspan="3" class="px-4 py-2 font-semibold text-right">Total</td>
+    <td class="px-4 py-2 font-semibold text-right">{{ total_quantity }}</td>
+    <td colspan="3"></td>
+  </tr>
+{% endblock %}
+
+{% block footer %}
+  {% url 'history_reports' as history_url %}
+  <div class="mt-4">
+    {% include "components/pagination.html" with page_obj=page_obj base_url=history_url extra_query="" hx_target="#history_table" hx_include="#filters" hx_indicator="#htmx-spinner" %}
+  </div>
+{% endblock %}
+

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -1,58 +1,11 @@
-{% extends "_base.html" %}
+{% extends "components/list_layout.html" %}
 {% block title %}History Reports – Inventory App{% endblock %}
-{% block content %}
-  <h1 class="text-2xl font-semibold mb-4">History Reports</h1>
-    <form id="filters" method="get" class="grid gap-2 mb-4 grid-cols-7 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1"
-          hx-get="{% url 'history_reports' %}"
-          hx-target="#history_table"
-          hx-indicator="#htmx-spinner">
-      <input
-        type="text"
-        name="item"
-        list="history-items"
-        class="form-control w-full"
-        value="{{ item|default:'' }}"
-      />
-      <datalist id="history-items">
-        <option value="" label="All Items"></option>
-        {% for it in items %}
-        <option value="{{ it.item_id }}" label="{{ it.name }}"></option>
-        {% endfor %}
-      </datalist>
-      <input
-        type="text"
-        name="type"
-        list="history-types"
-        class="form-control w-full"
-        value="{{ type }}"
-      />
-      <datalist id="history-types">
-        <option value="" label="All Types"></option>
-        {% for t in transaction_types %}
-        <option value="{{ t }}"></option>
-        {% endfor %}
-      </datalist>
-      <input
-        type="text"
-        name="user"
-        list="history-users"
-        class="form-control w-full"
-        value="{{ user }}"
-      />
-      <datalist id="history-users">
-        <option value="" label="All Users"></option>
-        {% for u in users %}
-        <option value="{{ u }}"></option>
-        {% endfor %}
-      </datalist>
-      <input type="date" name="start_date" value="{{ start_date }}" class="form-control w-full" />
-      <input type="date" name="end_date" value="{{ end_date }}" class="form-control w-full" />
-      <input type="hidden" name="sort" value="{{ sort|default:'date' }}" />
-      <input type="hidden" name="direction" value="{{ direction|default:'desc' }}" />
-      <button type="submit" class="btn-primary w-full">Filter</button>
-      <a href="?{% if query_string %}{{ query_string }}&{% endif %}export=csv" class="btn-outline w-full">Export CSV</a>
-    </form>
-    <div id="history_table">
-      {% include "inventory/_history_table.html" %}
-    </div>
+{% block heading %}History Reports{% endblock %}
+{% block filter_bar %}
+  {% url 'history_reports' as history_url %}
+  {% include "components/filter_bar.html" with hx_get=history_url hx_target="#history_table" hx_indicator="#htmx-spinner" filters=filters export_url=history_url export_param_name="export" export_param_value="csv" sort=sort direction=direction q=item search_placeholder="Item ID" %}
 {% endblock %}
+{% block table_id %}history_table{% endblock %}
+{% block hx_get %}{% url 'history_reports' %}{% endblock %}
+{% block table_content %}{% include "inventory/_history_table.html" %}{% endblock %}
+

--- a/templates/inventory/item_form.html
+++ b/templates/inventory/item_form.html
@@ -1,67 +1,55 @@
-{% extends "_base.html" %}
+{% extends "components/form_layout.html" %}
 {% block title %}{% if is_edit %}Edit Item{% else %}New Item{% endif %} – Inventory App{% endblock %}
-{% block content %}
-<div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">{% if is_edit %}Edit Item{% else %}New Item{% endif %}</h1>
-  {% if form %}
-  <form method="post" id="item-form" hx-post="{% if is_edit %}{% url 'item_edit' item.pk %}{% else %}{% url 'item_create' %}{% endif %}" hx-target="#item-options" class="grid grid-cols-1 gap-4">
-    {% csrf_token %}
-    {% if form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
-    </ul>
-    {% endif %}
-    {% if not form.units_map %}
-    <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
-    {% endif %}
-    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1" style="grid-column: 1 / -1;">
-      <div id="name-field" class="space-y-1 relative">
-        <label for="{{ form.name.id_for_label }}" class="block mb-1 font-medium">{{ form.name.label }}</label>
-        {{ form.name }}
-        {% if form.name.help_text %}
-          <p class="text-sm text-gray-500">{{ form.name.help_text }}</p>
-        {% endif %}
-        {% if form.name.errors %}
-          <ul class="text-sm text-red-600 list-disc pl-5">
-            {% for error in form.name.errors %}
-              <li>{{ error }}</li>
-            {% endfor %}
-          </ul>
-        {% endif %}
-      </div>
-      {% include "components/form_field.html" with field=form.base_unit %}
-      {% include "components/form_field.html" with field=form.purchase_unit %}
-      {% for field in form %}
-        {% if field.name not in excluded_fields %}
-          {% include "components/form_field.html" with field=field %}
-        {% endif %}
-      {% endfor %}
+{% block heading %}{% if is_edit %}Edit Item{% else %}New Item{% endif %}{% endblock %}
+{% block form_attrs %}id="item-form" hx-post="{% if is_edit %}{% url 'item_edit' item.pk %}{% else %}{% url 'item_create' %}{% endif %}" hx-target="#item-options"{% endblock %}
+{% block fields %}
+  {% if not form.units_map %}
+  <p class="text-sm text-red-600">Could not load unit options. Please try again later.</p>
+  {% endif %}
+  <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+    <div id="name-field" class="space-y-1 relative col-span-2">
+      <label for="{{ form.name.id_for_label }}" class="block mb-1 font-medium">{{ form.name.label }}</label>
+      {{ form.name }}
+      {% if form.name.help_text %}
+        <p class="text-sm text-gray-500">{{ form.name.help_text }}</p>
+      {% endif %}
+      {% if form.name.errors %}
+        <ul class="text-sm text-red-600 list-disc pl-5">
+          {% for error in form.name.errors %}<li>{{ error }}</li>{% endfor %}
+        </ul>
+      {% endif %}
     </div>
-    <datalist id="base-unit-options">
-      {% for u in form.base_units %}
-        <option value="{{ u }}"></option>
-      {% endfor %}
-    </datalist>
-    <datalist id="purchase-unit-options">
-      {% for u in form.purchase_units %}
-        <option value="{{ u }}"></option>
-      {% endfor %}
-    </datalist>
-    <datalist id="category-options">
-      {% for c in form.category_options %}
-        <option value="{{ c }}"{% if c == form.category.value %} selected{% endif %}></option>
-      {% endfor %}
-    </datalist>
-    <datalist id="sub-category-options">
-      {% for c in form.sub_category_options %}
-        <option value="{{ c }}"{% if c == form.sub_category.value %} selected{% endif %}></option>
-      {% endfor %}
-    </datalist>
-    <div class="flex gap-2">
-      <button type="submit" class="btn-primary">Save</button>
-      <a href="{% url 'items_list' %}" class="btn-outline">Cancel</a>
-    </div>
-  </form>
+    {% include "components/form_field.html" with field=form.base_unit %}
+    {% include "components/form_field.html" with field=form.purchase_unit %}
+    {% for field in form %}
+      {% if field.name not in excluded_fields %}
+        {% include "components/form_field.html" with field=field %}
+      {% endif %}
+    {% endfor %}
+  </div>
+  <datalist id="base-unit-options">
+    {% for u in form.base_units %}
+      <option value="{{ u }}"></option>
+    {% endfor %}
+  </datalist>
+  <datalist id="purchase-unit-options">
+    {% for u in form.purchase_units %}
+      <option value="{{ u }}"></option>
+    {% endfor %}
+  </datalist>
+  <datalist id="category-options">
+    {% for c in form.category_options %}
+      <option value="{{ c }}"{% if c == form.category.value %} selected{% endif %}></option>
+    {% endfor %}
+  </datalist>
+  <datalist id="sub-category-options">
+    {% for c in form.sub_category_options %}
+      <option value="{{ c }}"{% if c == form.sub_category.value %} selected{% endif %}></option>
+    {% endfor %}
+  </datalist>
+{% endblock %}
+{% block back_url %}{% url 'items_list' %}{% endblock %}
+{% block extra %}
   {{ form.units_map|json_script:"units-data" }}
   {{ form.categories_map|json_script:"categories-data" }}
   <script>
@@ -121,9 +109,5 @@
       });
     });
   </script>
-  {% else %}
-    <p>Unable to load form.</p>
-  {% endif %}
-</div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- refactor item form to extend shared `form_layout` and reuse existing field partials
- modernize history reports page to use `list_layout`, `filter_bar`, and `table` components
- update history report view to support new filter bar structure

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aae076a4d483269decdbcaa9ea2c49