### PR TITLE
Display inventory counts on home dashboard

### DIFF
--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -28,7 +28,7 @@
           <li>
             <a href="{% url 'items_list' %}" class="flex items-center text-primary hover:underline">
               <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/></svg>
-              Items
+              Items ({{ item_count }})
             </a>
           </li>
           <li>
@@ -45,7 +45,7 @@
           <li>
             <a href="{% url 'suppliers_list' %}" class="flex items-center text-primary hover:underline">
               <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h6m-9 0H3.375a1.125 1.125 0 0 1-1.125-1.125V14.25m17.25 4.5a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h1.125c.621 0 1.129-.504 1.09-1.124a17.902 17.902 0 0 0-3.213-9.193 2.056 2.056 0 0 0-1.58-.86H14.25M16.5 18.75h-2.25m0-11.177v-.958c0-.568-.422-1.048-.987-1.106a48.554 48.554 0 0 0-10.026 0 1.106 1.106 0 0 0-.987 1.106v7.635m12-6.677v6.677m0 4.5v-4.5m0 0h-12"/></svg>
-              Suppliers
+              Suppliers ({{ supplier_count }})
             </a>
           </li>
           <li>
@@ -57,7 +57,7 @@
           <li>
             <a href="{% url 'purchase_orders_list' %}" class="flex items-center text-primary hover:underline">
               <svg aria-hidden="true" class="w-5 h-5 mr-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/></svg>
-              Purchase Orders
+              Purchase Orders ({{ pending_po_count }})
             </a>
           </li>
           <li>

--- a/core/views.py
+++ b/core/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import redirect, render
 from django.contrib.auth import login
 from django.contrib.auth.forms import AuthenticationForm
 
-from inventory.services import dashboard_service, kpis
+from inventory.services import dashboard_service, kpis, counts
 
 
 def root_view(request):
@@ -14,6 +14,9 @@ def root_view(request):
             "receipts": kpis.receipts_last_7_days(),
             "issues": kpis.issues_last_7_days(),
             "low_stock": kpis.low_stock_count(),
+            "item_count": counts.item_count(),
+            "supplier_count": counts.supplier_count(),
+            "pending_po_count": counts.pending_po_count(),
         }
         return render(request, "core/home.html", data)
 

--- a/inventory/services/__init__.py
+++ b/inventory/services/__init__.py
@@ -12,6 +12,7 @@ from . import (
     list_utils,
     sale_service,
     kpis,
+    counts,
     supabase_units,
     supabase_categories,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "list_utils",
     "sale_service",
     "kpis",
+    "counts",
     "supabase_units",
     "supabase_categories",
 ]

--- a/inventory/services/counts.py
+++ b/inventory/services/counts.py
@@ -1,0 +1,18 @@
+"""Lightweight count helpers for dashboard navigation."""
+
+from inventory.models import Item, Supplier, PurchaseOrder
+
+
+def item_count() -> int:
+    """Return total number of items."""
+    return Item.objects.count()
+
+
+def supplier_count() -> int:
+    """Return total number of suppliers."""
+    return Supplier.objects.count()
+
+
+def pending_po_count() -> int:
+    """Return count of purchase orders not yet completed or cancelled."""
+    return PurchaseOrder.objects.filter(status__in=["DRAFT", "ORDERED", "PARTIAL"]).count()

--- a/tests/test_root_view.py
+++ b/tests/test_root_view.py
@@ -25,3 +25,29 @@ def test_root_view_includes_kpis_for_authenticated_user(client, django_user_mode
     assert resp.context["issues"] == 3
     assert resp.context["low_stock"] == 4
     assert b"name=\"username\"" not in resp.content
+
+
+@pytest.mark.django_db
+def test_root_view_includes_nav_counts_for_authenticated_user(
+    client, django_user_model, monkeypatch
+):
+    user = django_user_model.objects.create_user(username="u", password="p")
+    client.force_login(user)
+
+    monkeypatch.setattr("inventory.services.kpis.stock_value", lambda: 0)
+    monkeypatch.setattr("inventory.services.kpis.receipts_last_7_days", lambda: 0)
+    monkeypatch.setattr("inventory.services.kpis.issues_last_7_days", lambda: 0)
+    monkeypatch.setattr("inventory.services.kpis.low_stock_count", lambda: 0)
+
+    monkeypatch.setattr("inventory.services.counts.item_count", lambda: 5)
+    monkeypatch.setattr("inventory.services.counts.supplier_count", lambda: 7)
+    monkeypatch.setattr("inventory.services.counts.pending_po_count", lambda: 2)
+
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.context["item_count"] == 5
+    assert resp.context["supplier_count"] == 7
+    assert resp.context["pending_po_count"] == 2
+    assert b"Items (5)" in resp.content
+    assert b"Suppliers (7)" in resp.content
+    assert b"Purchase Orders (2)" in resp.content


### PR DESCRIPTION
## Summary
- add count helpers for items, suppliers, and open purchase orders
- surface these metrics on the home view and template
- test that authenticated users see correct counts in navigation

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aae685dde083268bc395fd7e087a2e