### PR TITLE
Add reusable detail layout for detail pages

### DIFF
--- a/templates/components/detail_layout.html
+++ b/templates/components/detail_layout.html
@@ -1,0 +1,8 @@
+{% extends "_base.html" %}
+{% block title %}Detail – Inventory App{% endblock %}
+{% block content %}
+  <h1 class="text-2xl font-semibold mb-4">{% block heading %}{% endblock %}</h1>
+  <div class="mb-4 flex justify-end gap-2">{% block actions %}{% endblock %}</div>
+  {% block detail_table %}{% endblock %}
+  {% block extra_tables %}{% endblock %}
+{% endblock %}

--- a/templates/inventory/grns/detail.html
+++ b/templates/inventory/grns/detail.html
@@ -1,8 +1,13 @@
-{% extends "_base.html" %}
+{% extends "components/detail_layout.html" %}
 {% block title %}GRN Detail – Inventory App{% endblock %}
-{% block content %}
-  <h1 class="text-2xl font-semibold mb-4">GRN {{ grn.pk }}</h1>
+{% block heading %}GRN {{ grn.pk }}{% endblock %}
+{% block actions %}
+  <a href="{% url 'grn_list' %}" class="btn-outline">Back</a>
+{% endblock %}
+{% block detail_table %}
   {% include "components/detail_table.html" with rows=rows %}
+{% endblock %}
+{% block extra_tables %}
   <table class="table">
     <thead><tr><th>Item</th><th>Ordered</th><th>Received</th></tr></thead>
     <tbody>
@@ -15,7 +20,4 @@
     {% endfor %}
     </tbody>
   </table>
-  <div class="mt-4">
-    <a href="{% url 'grn_list' %}" class="btn-outline">Back</a>
-  </div>
 {% endblock %}

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -1,11 +1,14 @@
-{% extends "_base.html" %}
+{% extends "components/detail_layout.html" %}
 {% block title %}Indent Detail – Inventory App{% endblock %}
-{% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Indent {{ indent.indent_id }}</h1>
+{% block heading %}Indent {{ indent.indent_id }}{% endblock %}
+{% block actions %}
+  <a href="{% url 'indent_pdf' indent.indent_id %}" class="btn-outline">Download PDF</a>
+  <a href="{% url 'indents_list' %}" class="btn-outline">Back</a>
+{% endblock %}
+{% block detail_table %}
   {% include "components/detail_table.html" with rows=rows %}
-  <div class="mb-4">
-    <a href="{% url 'indent_pdf' indent.indent_id %}" class="btn-outline">Download PDF</a>
-  </div>
+{% endblock %}
+{% block extra_tables %}
   <h2 class="text-xl mb-4 mt-8">Items</h2>
   <table class="table">
     <thead><tr><th>Item</th><th>Qty</th></tr></thead>
@@ -28,8 +31,5 @@
       {% csrf_token %}
       <button type="submit" class="btn-danger">Cancel</button>
     </form>
-  </div>
-  <div class="mt-4">
-    <a href="{% url 'indents_list' %}" class="btn-outline">Back</a>
   </div>
 {% endblock %}

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -1,9 +1,9 @@
-{% extends "_base.html" %}
+{% extends "components/detail_layout.html" %}
 {% block title %}Item Detail – Inventory App{% endblock %}
-{% block content %}
-  <h1 class="text-2xl font-semibold mb-4">{{ item.name }}</h1>
+{% block heading %}{{ item.name }}{% endblock %}
+{% block actions %}
+  <a href="{% url 'items_list' %}" class="btn-outline">Back</a>
+{% endblock %}
+{% block detail_table %}
   {% include "components/detail_table.html" with rows=rows %}
-  <div class="mt-4">
-    <a href="{% url 'items_list' %}" class="btn-outline">Back</a>
-  </div>
 {% endblock %}

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -1,8 +1,16 @@
-{% extends "_base.html" %}
+{% extends "components/detail_layout.html" %}
 {% block title %}Purchase Order Detail – Inventory App{% endblock %}
-{% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Purchase Order {{ po.pk }}</h1>
+{% block heading %}Purchase Order {{ po.pk }}{% endblock %}
+{% block actions %}
+  <a href="{% url 'purchase_order_edit' po.pk %}" class="btn-primary">Edit</a>
+  <a href="{% url 'purchase_order_receive' po.pk %}" class="btn-primary">Receive Goods</a>
+  <a href="{% url 'grn_list' %}" class="btn-primary">View GRNs</a>
+  <a href="{% url 'purchase_orders_list' %}" class="btn-outline">Back</a>
+{% endblock %}
+{% block detail_table %}
   {% include "components/detail_table.html" with rows=rows %}
+{% endblock %}
+{% block extra_tables %}
   <h2 class="text-xl mb-4 mt-8">Items</h2>
   <table class="table mb-4">
     <thead><tr><th>Item</th><th>Ordered</th><th>Received</th></tr></thead>
@@ -16,12 +24,4 @@
     {% endfor %}
     </tbody>
   </table>
-  <div class="flex gap-2">
-    <a href="{% url 'purchase_order_edit' po.pk %}" class="btn-primary">Edit</a>
-    <a href="{% url 'purchase_order_receive' po.pk %}" class="btn-primary">Receive Goods</a>
-    <a href="{% url 'grn_list' %}" class="btn-primary">View GRNs</a>
-  </div>
-  <div class="mt-4">
-    <a href="{% url 'purchase_orders_list' %}" class="btn-outline">Back</a>
-  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add reusable `detail_layout.html` extending `_base.html`
- update item, indent, purchase order, and GRN detail templates to use new layout and move actions to shared blocks

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaeada82848326b0afa7dbf54de30c