### PR TITLE
Use table component on detail item lists

### DIFF
--- a/templates/inventory/_indent_items_table.html
+++ b/templates/inventory/_indent_items_table.html
@@ -1,0 +1,15 @@
+{% extends "components/table.html" %}
+
+{% block headers %}
+  <th class="px-4 py-2">Item</th>
+  <th class="px-4 py-2">Qty</th>
+{% endblock %}
+
+{% block rows %}
+  {% for row in items %}
+    <tr class="odd:bg-gray-50 hover:bg-gray-100">
+      <td class="px-4 py-2">{{ row.item.name }}</td>
+      <td class="px-4 py-2">{{ row.requested_qty }}</td>
+    </tr>
+  {% endfor %}
+{% endblock %}

--- a/templates/inventory/grns/_items_table.html
+++ b/templates/inventory/grns/_items_table.html
@@ -1,0 +1,17 @@
+{% extends "components/table.html" %}
+
+{% block headers %}
+  <th class="px-4 py-2">Item</th>
+  <th class="px-4 py-2">Ordered</th>
+  <th class="px-4 py-2">Received</th>
+{% endblock %}
+
+{% block rows %}
+  {% for item in items %}
+    <tr class="odd:bg-gray-50 hover:bg-gray-100">
+      <td class="px-4 py-2">{{ item.po_item.item.name }}</td>
+      <td class="px-4 py-2">{{ item.po_item.quantity_ordered }}</td>
+      <td class="px-4 py-2">{{ item.quantity_received }}</td>
+    </tr>
+  {% endfor %}
+{% endblock %}

--- a/templates/inventory/grns/detail.html
+++ b/templates/inventory/grns/detail.html
@@ -8,16 +8,5 @@
   {% include "components/detail_table.html" with rows=rows %}
 {% endblock %}
 {% block extra_tables %}
-  <table class="table">
-    <thead><tr><th>Item</th><th>Ordered</th><th>Received</th></tr></thead>
-    <tbody>
-    {% for item in items %}
-      <tr>
-        <td>{{ item.po_item.item.name }}</td>
-        <td>{{ item.po_item.quantity_ordered }}</td>
-        <td>{{ item.quantity_received }}</td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
+  {% include "inventory/grns/_items_table.html" with items=items %}
 {% endblock %}

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -10,14 +10,7 @@
 {% endblock %}
 {% block extra_tables %}
   <h2 class="text-xl mb-4 mt-8">Items</h2>
-  <table class="table">
-    <thead><tr><th>Item</th><th>Qty</th></tr></thead>
-    <tbody>
-    {% for row in items %}
-      <tr><td>{{ row.item.name }}</td><td>{{ row.requested_qty }}</td></tr>
-    {% endfor %}
-    </tbody>
-  </table>
+  {% include "inventory/_indent_items_table.html" with items=items %}
   <div class="mt-4 flex gap-2">
     <form action="{% url 'indent_update_status' indent.indent_id 'PROCESSING' %}" method="post" class="inline">
       {% csrf_token %}

--- a/templates/inventory/purchase_orders/_items_table.html
+++ b/templates/inventory/purchase_orders/_items_table.html
@@ -1,0 +1,17 @@
+{% extends "components/table.html" %}
+
+{% block headers %}
+  <th class="px-4 py-2">Item</th>
+  <th class="px-4 py-2">Ordered</th>
+  <th class="px-4 py-2">Received</th>
+{% endblock %}
+
+{% block rows %}
+  {% for item in items %}
+    <tr class="odd:bg-gray-50 hover:bg-gray-100">
+      <td class="px-4 py-2">{{ item.item.name }}</td>
+      <td class="px-4 py-2">{{ item.quantity_ordered }}</td>
+      <td class="px-4 py-2">{{ item.received_total }}</td>
+    </tr>
+  {% endfor %}
+{% endblock %}

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -12,16 +12,5 @@
 {% endblock %}
 {% block extra_tables %}
   <h2 class="text-xl mb-4 mt-8">Items</h2>
-  <table class="table mb-4">
-    <thead><tr><th>Item</th><th>Ordered</th><th>Received</th></tr></thead>
-    <tbody>
-    {% for item in items %}
-      <tr>
-        <td>{{ item.item.name }}</td>
-        <td>{{ item.quantity_ordered }}</td>
-        <td>{{ item.received_total }}</td>
-      </tr>
-    {% endfor %}
-    </tbody>
-  </table>
+  {% include "inventory/purchase_orders/_items_table.html" with items=items %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- render indent item lists with table component
- refactor purchase order and GRN item tables to reusable partials

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaf011260c8326a62cf98ceeaa330f