### PR TITLE
Use text-h1 and text-h2 for template headings

### DIFF
--- a/templates/components/detail_layout.html
+++ b/templates/components/detail_layout.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block title %}Detail – Inventory App{% endblock %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">{% block heading %}{% endblock %}</h1>
+  <h1 class="text-h1 font-semibold mb-4">{% block heading %}{% endblock %}</h1>
   <div class="mb-4 flex justify-end gap-2">{% block actions %}{% endblock %}</div>
   {% block detail_table %}{% endblock %}
   {% block extra_tables %}{% endblock %}

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -1,6 +1,6 @@
 <div class="p-4 max-sm:p-2 text-center border border-form-border rounded bg-form-bg">
   <svg class="mx-auto w-5 h-5 text-form-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-    <h2 class="text-xl mb-4 mt-8">{{ title }}</h2>
+    <h2 class="text-h2 mb-4 mt-8">{{ title }}</h2>
   <p class="mb-4 text-form-text">{{ message }}</p>
   <a href="{{ cta_url }}" class="btn-primary">{{ cta_label }}</a>
 </div>

--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -2,7 +2,7 @@
 {% block title %}Form – Inventory App{% endblock %}
 {% block content %}
 <div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-2xl font-semibold mb-4">
+  <h1 class="text-h1 font-semibold mb-4">
     {% block heading %}{% endblock %}
   </h1>
   {% if form %}

--- a/templates/components/list_layout.html
+++ b/templates/components/list_layout.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block title %}List – Inventory App{% endblock %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">{% block heading %}{% endblock %}</h1>
+  <h1 class="text-h1 font-semibold mb-4">{% block heading %}{% endblock %}</h1>
   <div class="mb-4 flex justify-end gap-2">{% block actions %}{% endblock %}</div>
   {% block filter_bar %}{% endblock %}
   {% block extra %}{% endblock %}

--- a/templates/inventory/_adjust_form.html
+++ b/templates/inventory/_adjust_form.html
@@ -1,4 +1,4 @@
-<h2 class="text-xl mb-4 mt-8">Stock Adjustment</h2>
+<h2 class="text-h2 mb-4 mt-8">Stock Adjustment</h2>
 <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
   {% csrf_token %}
   {% if adjust_form.non_field_errors %}

--- a/templates/inventory/_item_notes.html
+++ b/templates/inventory/_item_notes.html
@@ -1,4 +1,4 @@
 <div>
-  <h2 class="text-xl mb-4">Notes</h2>
+  <h2 class="text-h2 mb-4">Notes</h2>
   <p>{{ item.notes }}</p>
 </div>

--- a/templates/inventory/_receive_form.html
+++ b/templates/inventory/_receive_form.html
@@ -1,4 +1,4 @@
-<h2 class="text-xl mb-4 mt-8">Goods Received</h2>
+<h2 class="text-h2 mb-4 mt-8">Goods Received</h2>
 <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
   {% csrf_token %}
   {% if receive_form.non_field_errors %}

--- a/templates/inventory/_waste_form.html
+++ b/templates/inventory/_waste_form.html
@@ -1,4 +1,4 @@
-<h2 class="text-xl mb-4 mt-8">Wastage/Spoilage</h2>
+<h2 class="text-h2 mb-4 mt-8">Wastage/Spoilage</h2>
 <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
   {% csrf_token %}
   {% if waste_form.non_field_errors %}

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -9,7 +9,7 @@
   {% include "components/detail_table.html" with rows=rows %}
 {% endblock %}
 {% block extra_tables %}
-  <h2 class="text-xl mb-4 mt-8">Items</h2>
+  <h2 class="text-h2 mb-4 mt-8">Items</h2>
   {% include "inventory/_indent_items_table.html" with items=items %}
   <div class="mt-4 flex gap-2">
     <form action="{% url 'indent_update_status' indent.indent_id 'PROCESSING' %}" method="post" class="inline">

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -11,6 +11,6 @@
   {% include "components/detail_table.html" with rows=rows %}
 {% endblock %}
 {% block extra_tables %}
-  <h2 class="text-xl mb-4 mt-8">Items</h2>
+  <h2 class="text-h2 mb-4 mt-8">Items</h2>
   {% include "inventory/purchase_orders/_items_table.html" with items=items %}
 {% endblock %}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -2,14 +2,14 @@
 {% block title %}Stock Movements – Inventory App{% endblock %}
 {% load static %}
 {% block content %}
-  <h1 class="text-2xl font-semibold mb-4">Stock Movements</h1>
+  <h1 class="text-h1 font-semibold mb-4">Stock Movements</h1>
   {% if messages %}
     {% include "components/alert.html" %}
   {% endif %}
   {% include "components/tabs.html" with tabs=tabs %}
   <datalist id="item-options"></datalist>
   <hr class="my-4"/>
-  <h2 class="text-xl mb-4 mt-8">Bulk Upload Stock Transactions</h2>
+  <h2 class="text-h2 mb-4 mt-8">Bulk Upload Stock Transactions</h2>
   <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary">Download sample CSV</a></p>
   <form method="post" enctype="multipart/form-data" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
     {% csrf_token %}
@@ -38,7 +38,7 @@
     </ul>
   {% endif %}
   <hr class="my-4"/>
-  <h2 class="text-xl mb-4 mt-8">Recent Transactions</h2>
+  <h2 class="text-h2 mb-4 mt-8">Recent Transactions</h2>
   <div class="max-md:overflow-x-auto">
     <table class="table">
       <thead>


### PR DESCRIPTION
## Summary
- replace text-2xl with text-h1 for page titles
- swap text-xl for text-h2 in section headings
- ensure each template has a single text-h1 and appropriate text-h2 sections

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aafa1f6e4483269f1f352e4fafaa47