### PR TITLE
Refactor items list filters and responsive table

### DIFF
--- a/templates/components/filter_bar.html
+++ b/templates/components/filter_bar.html
@@ -18,24 +18,22 @@
   {% for f in filters %}
     <div class="flex flex-col">
       <label for="{{ f.id|default:f.name }}" class="text-sm font-medium">{{ f.label|default:f.name|capfirst }}</label>
-      <input
-        type="text"
+      <select
         name="{{ f.name }}"
-        list="{{ f.list_id }}"
         class="form-control w-full"
-        value="{{ f.value }}"
         hx-get="{{ hx_get }}"
         hx-target="{{ hx_target }}"
         hx-trigger="change"
         hx-include="#filters"
         {% if hx_indicator %}hx-indicator="{{ hx_indicator }}"{% endif %}
         id="{{ f.id|default:f.name }}"
-      />
-      <datalist id="{{ f.list_id }}">
+      >
         {% for opt in f.options %}
-          <option value="{{ opt.value }}"{% if opt.label %} label="{{ opt.label }}"{% endif %}></option>
+          <option value="{{ opt.value }}"{% if opt.value == f.value %} selected{% endif %}>
+            {{ opt.label|default:opt.value }}
+          </option>
         {% endfor %}
-      </datalist>
+      </select>
     </div>
   {% endfor %}
   {% if export_url %}

--- a/templates/components/responsive_table.html
+++ b/templates/components/responsive_table.html
@@ -1,0 +1,17 @@
+{% comment %}
+Responsive table component with sticky headers and row hover states.
+{% endcomment %}
+<div class="max-md:overflow-x-auto">
+  {% block actions %}{% endblock %}
+  <table class="table w-full table-auto text-sm">
+    <thead class="sticky top-0 bg-primary text-white">
+      <tr>
+        {% block headers %}{% endblock %}
+      </tr>
+    </thead>
+    <tbody>
+      {% block rows %}{% endblock %}
+    </tbody>
+  </table>
+</div>
+{% block footer %}{% endblock %}

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,4 +1,4 @@
-{% extends "components/table.html" %}
+{% extends "components/responsive_table.html" %}
 
 {% block headers %}
 <th class="px-4 py-2 text-right">
@@ -41,6 +41,7 @@
     Reorder Point{% if sort == 'reorder_point' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
     </a>
   </th>
+<th class="px-4 py-2">Stock Level</th>
 <th class="px-4 py-2">
   <a href="{% url 'items_list' %}?q={{ q|urlencode }}&active={{ active|urlencode }}&page_size={{ page_size }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-get="{% url 'items_table' %}?sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
@@ -60,6 +61,9 @@
   <td class="px-4 py-2">{{ row.base_unit }}</td>
   <td class="px-4 py-2 text-right">{{ row.current_stock }}</td>
   <td class="px-4 py-2 text-right">{{ row.reorder_point }}</td>
+  <td class="px-4 py-2 text-center">
+    <span class="inline-block w-3 h-3 rounded-full {% if row.stock_ok %}bg-green-600{% else %}bg-red-600{% endif %}" aria-label="{% if row.stock_ok %}In Stock{% else %}Low Stock{% endif %}"></span>
+  </td>
   <td class="px-4 py-2">{{ row.is_active }}</td>
   <td class="px-4 py-2">
     <a href="{% url 'item_detail' row.item_id %}" class="text-primary mr-2">View</a>
@@ -69,7 +73,7 @@
 </tr>
 {% empty %}
 <tr>
-  <td colspan="9" class="px-4 py-2">
+  <td colspan="8" class="px-4 py-2">
     {% url 'item_create' as item_create_url %}
     {% include "components/empty_state.html" with title="No Items" message="No items found." cta_label="New Item" cta_url=item_create_url %}
   </td>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -16,18 +16,18 @@
       const categories = JSON.parse(
         document.getElementById('categories-data').textContent
       );
-      const categoryInput = document.getElementById('filter-category');
-      const subInput = document.getElementById('filter-subcategory');
-      const subDatalist = document.getElementById('item-subcategory');
+      const categorySelect = document.getElementById('filter-category');
+      const subSelect = document.getElementById('filter-subcategory');
 
       function refreshSubcategories(selected) {
-        const cat = categoryInput.value;
+        const cat = categorySelect.value;
         const options = categories[cat] || [];
-        subDatalist.innerHTML = '<option value="" label="All"></option>';
+        subSelect.innerHTML = '<option value="">All</option>';
         options.forEach(function (opt) {
           const o = document.createElement('option');
           o.value = opt.name;
-          subDatalist.appendChild(o);
+          o.textContent = opt.name;
+          subSelect.appendChild(o);
         });
         if (
           selected &&
@@ -35,19 +35,26 @@
             return o.name === selected;
           })
         ) {
-          subInput.value = selected;
+          subSelect.value = selected;
         } else {
-          subInput.value = '';
+          subSelect.value = '';
         }
       }
 
-      const initialSub = subInput.value;
+      const initialSub = subSelect.value;
       refreshSubcategories(initialSub);
-      categoryInput.addEventListener('change', function () {
+      categorySelect.addEventListener('change', function () {
         refreshSubcategories();
       });
     });
   </script>
+  <a
+    href="{% url 'item_create' %}"
+    class="md:hidden fixed bottom-4 right-4 btn-primary rounded-full w-12 h-12 flex items-center justify-center shadow-lg"
+    aria-label="Add Item"
+  >
+    +
+  </a>
 {% endblock %}
 {% block table_id %}items_table{% endblock %}
 {% block hx_get %}{% url 'items_table' %}{% endblock %}


### PR DESCRIPTION
## Summary
- Replace datalist filters with Tailwind selects
- Add responsive table component with stock level indicator
- Add mobile floating action button for new items

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab0bd3b84c832695c1a1e2f15e696a