### PR TITLE
Enhance dashboard with stock chart and quick actions

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,30 +1,30 @@
-<div class="grid grid-cols-4 max-md:grid-cols-1 gap-4">
-  <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
-    <div class="flex items-center gap-2">
-      <svg aria-hidden="true" class="w-6 h-6 text-secondary" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
-      <h2 class="text-sm font-medium text-primary">Stock Value</h2>
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
+    <div class="flex items-center gap-4">
+      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
+      <h2 class="text-lg font-medium">Stock Value</h2>
     </div>
-    <span class="text-3xl font-bold">{{ stock_value }}</span>
+    <span class="text-4xl font-bold">{{ stock_value }}</span>
   </div>
-  <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
-    <div class="flex items-center gap-2">
-      <svg aria-hidden="true" class="w-6 h-6 text-secondary" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/></svg>
-      <h2 class="text-sm font-medium text-primary">7-day Receipts</h2>
+  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
+    <div class="flex items-center gap-4">
+      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/></svg>
+      <h2 class="text-lg font-medium">7-day Receipts</h2>
     </div>
-    <span class="text-3xl font-bold">{{ receipts }}</span>
+    <span class="text-4xl font-bold">{{ receipts }}</span>
   </div>
-  <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
-    <div class="flex items-center gap-2">
-      <svg aria-hidden="true" class="w-6 h-6 text-secondary" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"/></svg>
-      <h2 class="text-sm font-medium text-primary">7-day Issues</h2>
+  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
+    <div class="flex items-center gap-4">
+      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"/></svg>
+      <h2 class="text-lg font-medium">7-day Issues</h2>
     </div>
-    <span class="text-3xl font-bold">{{ issues }}</span>
+    <span class="text-4xl font-bold">{{ issues }}</span>
   </div>
-  <div class="rounded-xl shadow px-8 max-md:px-6 max-sm:px-4 py-4 flex items-center justify-between bg-white border-l-4 border-secondary">
-    <div class="flex items-center gap-2">
-      <svg aria-hidden="true" class="w-6 h-6 text-secondary" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/></svg>
-      <h2 class="text-sm font-medium text-primary">Low-stock Count</h2>
+  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
+    <div class="flex items-center gap-4">
+      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/></svg>
+      <h2 class="text-lg font-medium">Low-stock Count</h2>
     </div>
-    <span class="text-3xl font-bold">{{ low_stock }}</span>
+    <span class="text-4xl font-bold">{{ low_stock }}</span>
   </div>
 </div>

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -4,20 +4,42 @@
 
 <div id="kpi-cards" hx-get="{% url 'dashboard-kpis' %}" hx-trigger="load"></div>
 
+<div class="flex gap-4 mt-4">
+  <a href="{% url 'purchase_order_create' %}" class="btn-primary px-4 py-2 rounded">New PO</a>
+  <a href="{% url 'grn_list' %}" class="btn-secondary px-4 py-2 rounded">Record Receipt</a>
+</div>
+
+<canvas id="stock-trend-chart" class="mt-8 w-full h-64"></canvas>
+<script>
+  const ctx = document.getElementById('stock-trend-chart').getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: {{ trend_labels|safe }},
+      datasets: [{
+        label: 'Stock Trend',
+        data: {{ trend_values|safe }},
+        borderColor: '#3b82f6',
+        backgroundColor: 'rgba(59,130,246,0.2)',
+        tension: 0.4,
+      }]
+    },
+    options: {responsive: true, maintainAspectRatio: false}
+  });
+</script>
+
 <h2 class="text-xl mb-2 mt-8">Low Stock Items</h2>
-<table class="table">
-  <thead><tr><th>Item</th><th>Stock</th><th>Reorder Point</th><th>Actions</th></tr></thead>
-  <tbody>
+<ul class="space-y-2">
   {% for item in low_stock %}
-    <tr>
-      <td>{{ item.name }}</td>
-      <td>{{ item.current_stock }}</td>
-      <td>{{ item.reorder_point }}</td>
-      <td><a href="{% url 'item_detail' item.pk %}" class="text-primary hover:underline">View Item</a></td>
-    </tr>
+    <li class="flex items-center justify-between p-4 rounded border">
+      <div class="flex items-center gap-2">
+        <svg aria-hidden="true" class="w-5 h-5 text-danger" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/></svg>
+        <span>{{ item.name }}</span>
+      </div>
+      <span class="badge-warning">{{ item.current_stock }} / {{ item.reorder_point }}</span>
+    </li>
   {% empty %}
-    <tr><td colspan="4">No low stock items.</td></tr>
+    <li class="p-4 border rounded">No low stock items.</li>
   {% endfor %}
-  </tbody>
-</table>
+</ul>
 {% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -3,6 +3,8 @@ from django.shortcuts import redirect, render
 from django.contrib.auth import login
 from django.contrib.auth.forms import AuthenticationForm
 
+import json
+
 from inventory.services import dashboard_service, kpis, counts
 
 
@@ -34,7 +36,12 @@ def health_check(request):
 
 def dashboard(request):
     """Render dashboard shell; KPI cards are loaded asynchronously."""
-    context = {"low_stock": dashboard_service.get_low_stock_items()}
+    labels, values = kpis.stock_trend_last_7_days()
+    context = {
+        "low_stock": dashboard_service.get_low_stock_items(),
+        "trend_labels": json.dumps(labels),
+        "trend_values": json.dumps(values),
+    }
     return render(request, "core/dashboard.html", context)
 
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -8,6 +8,7 @@
     <link href="{% static 'css/app.css' %}" rel="stylesheet">
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/2.3.1/list.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="{% static 'js/color.js' %}"></script>
     <script src="{% static 'js/predictive-dropdown.js' %}"></script>
     <script src="{% static 'js/nav.js' %}"></script>

--- a/tests/test_kpis_service.py
+++ b/tests/test_kpis_service.py
@@ -18,3 +18,6 @@ def test_kpi_calculations(item_factory):
     assert kpis.receipts_last_7_days() == 5
     assert kpis.issues_last_7_days() == 2
     assert kpis.low_stock_count() == 1
+    labels, values = kpis.stock_trend_last_7_days()
+    assert labels and len(labels) == 7
+    assert values[-1] == 3.0


### PR DESCRIPTION
## Summary
- Replace low-stock table with icon/badge list
- Wrap KPI cards in gradient grid with larger icons
- Add Chart.js line chart of recent stock trends
- Link Chart.js in base template and add quick action buttons

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab0bc442848326ac12e67baf061e87