### PR TITLE
Add item detail enhancements

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -9,6 +9,7 @@
     <script src="https://unpkg.com/htmx.org@1.9.12"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/2.3.1/list.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
     <script src="{% static 'js/color.js' %}"></script>
     <script src="{% static 'js/predictive-dropdown.js' %}"></script>
     <script src="{% static 'js/nav.js' %}"></script>

--- a/templates/components/image_uploader.html
+++ b/templates/components/image_uploader.html
@@ -1,0 +1,9 @@
+<form method="post" enctype="multipart/form-data" class="mb-4 flex flex-col gap-2">
+  {% csrf_token %}
+  <label for="id_thumbnail" class="font-semibold">Thumbnail</label>
+  {% if image_url %}
+    <img src="{{ image_url }}" alt="Current thumbnail" class="h-24 w-24 object-cover rounded" />
+  {% endif %}
+  <input type="file" name="thumbnail" id="id_thumbnail" accept="image/*" class="block" />
+  <button type="submit" class="btn-secondary">Upload</button>
+</form>

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -2,8 +2,58 @@
 {% block title %}Item Detail – Inventory App{% endblock %}
 {% block heading %}{{ item.name }}{% endblock %}
 {% block actions %}
-  <a href="{% url 'items_list' %}" class="btn-outline">Back</a>
+  <div x-data>
+    <a href="{% url 'items_list' %}" class="btn-outline">Back</a>
+    <a href="{% url 'item_edit' item.item_id %}" class="btn-primary">Edit</a>
+    <form x-ref="delForm" method="post" action="{% url 'item_delete' item.item_id %}" class="inline">
+      {% csrf_token %}
+      <button type="submit" class="btn-danger" @click.prevent="if(confirm('Delete this item?')) $refs.delForm.submit()">Delete</button>
+    </form>
+  </div>
 {% endblock %}
 {% block detail_table %}
-  {% include "components/detail_table.html" with rows=rows %}
+  <div class="grid grid-cols-2 gap-4 max-md:grid-cols-1">
+    <div>
+      {% include "components/image_uploader.html" %}
+      {% include "components/detail_table.html" with rows=rows %}
+    </div>
+    <div>
+      <h2 class="text-h2 mb-2">Recent Activity</h2>
+      <canvas id="stockSparkline" class="w-full h-24 mb-4"></canvas>
+      <ul class="space-y-1">
+        {% for tx in recent_activity %}
+        <li class="flex justify-between text-sm">
+          <span>{{ tx.transaction_date }}</span>
+          <span>{{ tx.quantity_change }}</span>
+        </li>
+        {% empty %}
+        <li>No recent activity.</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const ctx = document.getElementById('stockSparkline');
+      const data = {{ stock_history|safe }};
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: data.map((_, idx) => idx + 1),
+          datasets: [{
+            data: data,
+            borderColor: '#3b82f6',
+            fill: false,
+            tension: 0.4,
+            pointRadius: 0
+          }]
+        },
+        options: {
+          responsive: true,
+          plugins: { legend: { display: false }, tooltip: { enabled: false } },
+          scales: { x: { display: false }, y: { display: false } }
+        }
+      });
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- build two-column item detail layout with image uploader, recent activity, and stock sparkline
- add stock history helper and integrate recent activity into item detail view
- load Alpine.js for interactive edit/delete buttons

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0d379cf0832693e6130c92b96d29