### PR TITLE
Add searchable indents table with status badges and actions

### DIFF
--- a/templates/components/action_menu.html
+++ b/templates/components/action_menu.html
@@ -1,0 +1,8 @@
+<div class="flex gap-1">
+  <a href="{{ view_url }}" class="btn-tertiary text-xs">View</a>
+  <a href="{{ edit_url }}" class="btn-tertiary text-xs">Edit</a>
+  <form action="{{ approve_url }}" method="post" class="inline">
+    {% csrf_token %}
+    <button type="submit" class="btn-tertiary text-xs">Approve</button>
+  </form>
+</div>

--- a/templates/components/filter_bar.html
+++ b/templates/components/filter_bar.html
@@ -10,7 +10,7 @@
       value="{{ q }}"
       hx-get="{{ hx_get }}"
       hx-target="{{ hx_target }}"
-      hx-trigger="keyup changed delay:300ms"
+      hx-trigger="keyup changed delay:{{ search_delay|default:'300ms' }}"
       hx-include="#filters"
       {% if hx_indicator %}hx-indicator="{{ hx_indicator }}"{% endif %}
     />

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -12,13 +12,17 @@
     </thead>
       <tbody>
       {% for row in page_obj %}
-      <tr class="odd:bg-gray-50 hover:bg-gray-100">
+      <tr class="odd:bg-gray-50 hover:bg-gray-100 {% if row.is_overdue %}border border-danger{% endif %}">
         <td class="px-4 py-2 text-right">{{ row.indent_id }}</td>
         <td class="px-4 py-2 text-right">{{ row.mrn }}</td>
         <td class="px-4 py-2">{{ row.requested_by }}</td>
         <td class="px-4 py-2">{{ row.department }}</td>
-        <td class="px-4 py-2"><span class="px-2 py-1 rounded {{ badges[row.status|upper] }}">{{ row.status }}</span></td>
-        <td class="px-4 py-2"><a href="{% url 'indent_detail' row.indent_id %}" class="text-primary">View</a></td>
+        <td class="px-4 py-2"><span class="{{ badges[row.status|upper]|default:'badge-warning' }}">{{ row.status }}</span></td>
+        <td class="px-4 py-2">
+          {% url 'indent_detail' row.indent_id as view_url %}
+          {% url 'indent_update_status' row.indent_id 'APPROVED' as approve_url %}
+          {% include "components/action_menu.html" with view_url=view_url edit_url=view_url|add:'?edit=1' approve_url=approve_url %}
+        </td>
       </tr>
       {% empty %}
       <tr>

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -6,7 +6,7 @@
 {% endblock %}
 {% block filter_bar %}
   {% url 'indents_table' as indents_table_url %}
-  {% include "components/filter_bar.html" with search_placeholder="Search indents..." hx_get=indents_table_url hx_target="#indents_table" filters=filters %}
+  {% include "components/filter_bar.html" with search_placeholder="Search indents..." hx_get=indents_table_url hx_target="#indents_table" filters=filters search_delay="500ms" %}
 {% endblock %}
 {% block table_id %}indents_table{% endblock %}
 {% block hx_get %}{% url 'indents_table' %}{% endblock %}


### PR DESCRIPTION
## Summary
- add debounced search filter to indents list
- display indent status with tailwind badges and overdue highlighting
- provide row action menu for view, edit and approve links

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab0d4633a8832685f8a9af61fc6496