### PR TITLE
Add progress and actions to purchase orders

### DIFF
--- a/inventory/views/purchase_orders.py
+++ b/inventory/views/purchase_orders.py
@@ -45,8 +45,18 @@ def purchase_orders_list(request):
         default_direction="desc",
     )
     page_obj, _ = list_utils.paginate(request, orders, default_page_size=20)
+    progress_map = purchase_order_service.get_orders_progress([o.pk for o in page_obj])
     for o in page_obj:
         o.badge_class = PO_STATUS_BADGES.get(o.status, "")
+        prog = progress_map.get(o.pk)
+        if prog:
+            o.ordered_total = prog["ordered_total"]
+            o.received_total = prog["received_total"]
+            o.progress_percent = prog["percent"]
+        else:
+            o.ordered_total = Decimal("0")
+            o.received_total = Decimal("0")
+            o.progress_percent = 0
     statuses = PurchaseOrder._meta.get_field("status").choices
     suppliers = Supplier.objects.all()
     querystring = list_utils.build_querystring(request)

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -5,6 +5,8 @@
 <th class="px-4 py-2">Supplier</th>
 <th class="px-4 py-2">Order Date</th>
 <th class="px-4 py-2">Status</th>
+<th class="px-4 py-2">Progress</th>
+<th class="px-4 py-2 text-right">Actions</th>
 {% endblock %}
 
 {% block rows %}
@@ -13,11 +15,33 @@
   <td class="px-4 py-2 text-right"><a class="text-primary" href="{% url 'purchase_order_detail' po.pk %}">{{ po.pk }}</a></td>
   <td class="px-4 py-2">{{ po.supplier.name }}</td>
   <td class="px-4 py-2">{{ po.order_date }}</td>
-  <td class="px-4 py-2"><span class="px-2 py-1 rounded text-xs {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
+  <td class="px-4 py-2"><span class="px-2 py-1 rounded-full text-badge {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
+  <td class="px-4 py-2">
+    <div class="w-full bg-gray-200 rounded-full h-2" role="progressbar" aria-valuenow="{{ po.progress_percent }}" aria-valuemin="0" aria-valuemax="100">
+      <div class="h-2 bg-primary rounded-full" style="width: {{ po.progress_percent }}%"></div>
+    </div>
+    <div class="text-xs text-right mt-1">{{ po.received_total }} / {{ po.ordered_total }}</div>
+  </td>
+  <td class="px-4 py-2">
+    <div class="flex justify-end gap-2">
+      <a href="{% url 'purchase_order_detail' po.pk %}" class="text-primary" title="View">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2.036 12.322a1 1 0 010-.644C3.423 7.51 7.373 4.5 12 4.5c4.628 0 8.578 3.01 9.964 7.178a1 1 0 010 .644C20.578 16.49 16.628 19.5 12 19.5c-4.628 0-8.578-3.01-9.964-7.178z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+        <span class="sr-only">View</span>
+      </a>
+      <a href="{% url 'purchase_order_edit' po.pk %}" class="text-primary" title="Edit">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11.25 3.75h-6a1.5 1.5 0 00-1.5 1.5v13.5a1.5 1.5 0 001.5 1.5h13.5a1.5 1.5 0 001.5-1.5v-6"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 3.75L20.25 9M7.5 9h3.75a.75.75 0 01.75.75V13.5"/></svg>
+        <span class="sr-only">Edit</span>
+      </a>
+      <a href="{% url 'purchase_order_receive' po.pk %}" class="text-primary" title="Receive">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7.5 10.5L12 15l4.5-4.5"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 15V3"/></svg>
+        <span class="sr-only">Receive</span>
+      </a>
+    </div>
+  </td>
 </tr>
 {% empty %}
 <tr>
-  <td colspan="4" class="px-4 py-2">
+  <td colspan="6" class="px-4 py-2">
     {% url 'purchase_order_create' as po_create_url %}
     {% include "components/empty_state.html" with title="No Purchase Orders" message="Create a new purchase order to get started." cta_label="New PO" cta_url=po_create_url %}
   </td>

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -6,12 +6,14 @@
   <a href="{% url 'grn_list' %}" class="btn-secondary">GRNs</a>
 {% endblock %}
 {% block filter_bar %}
-  <form method="get" class="mb-4 grid gap-2 grid-cols-5 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
-    <div class="space-y-1">
-      <label class="block text-sm font-medium">Status</label>
-      <input
-        type="text"
-        name="status"
+  <details class="mb-4">
+    <summary class="cursor-pointer px-4 py-2 bg-gray-100 rounded">Filters</summary>
+    <form method="get" class="mt-2 grid gap-2 grid-cols-5 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
+      <div class="space-y-1">
+        <label class="block text-sm font-medium">Status</label>
+        <input
+          type="text"
+          name="status"
         list="po-statuses"
         class="form-control w-full"
         value="{{ current_status }}"
@@ -50,7 +52,8 @@
     <div class="space-y-1">
       <button type="submit" class="btn-primary w-full">Filter</button>
     </div>
-  </form>
+    </form>
+  </details>
 {% endblock %}
 {% block table_container %}
   {% include "inventory/purchase_orders/_table.html" %}

--- a/tests/test_purchase_order_service_django.py
+++ b/tests/test_purchase_order_service_django.py
@@ -1,8 +1,13 @@
 import pytest
 from datetime import date
-from django.db import connection
 
-from inventory.models import Supplier, PurchaseOrder, PurchaseOrderItem
+from inventory.models import (
+    Supplier,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    GoodsReceivedNote,
+    GRNItem,
+)
 from inventory.services import purchase_order_service
 
 
@@ -18,3 +23,34 @@ def test_create_po_and_get_po(item_factory):
     po = purchase_order_service.get_po_by_id(po_id)
     assert po["supplier_id"] == supplier.pk
     assert po["items"][0]["item_id"] == item.item_id
+
+
+@pytest.mark.django_db
+def test_get_orders_progress(item_factory):
+    supplier = Supplier.objects.create(name="Vendor")
+    item = item_factory(name="Widget")
+    po = PurchaseOrder.objects.create(
+        supplier=supplier, order_date=date.today()
+    )
+    poi = PurchaseOrderItem.objects.create(
+        purchase_order=po,
+        item=item,
+        quantity_ordered=10,
+        unit_price=1,
+    )
+    grn = GoodsReceivedNote.objects.create(
+        purchase_order=po,
+        supplier=supplier,
+        received_date=date.today(),
+    )
+    GRNItem.objects.create(
+        grn=grn,
+        po_item=poi,
+        quantity_ordered_on_po=10,
+        quantity_received=4,
+        unit_price_at_receipt=1,
+    )
+    progress = purchase_order_service.get_orders_progress([po.pk])
+    assert progress[po.pk]["ordered_total"] == 10
+    assert progress[po.pk]["received_total"] == 4
+    assert progress[po.pk]["percent"] == 40


### PR DESCRIPTION
## Summary
- Display pill-style status badges, progress bars, and action icons for each purchase order
- Calculate received vs. ordered quantities via `purchase_order_service`
- Move purchase order filters into a collapsible accordion

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0d4c0b8c8326bbcc11156bf56e4c