### PR TITLE
feat: add recipe card grid with search

### DIFF
--- a/templates/inventory/recipes/_recipes_cards.html
+++ b/templates/inventory/recipes/_recipes_cards.html
@@ -1,0 +1,7 @@
+<div class="grid gap-4 grid-cols-3 max-lg:grid-cols-2 max-sm:grid-cols-1">
+  {% for recipe in recipes %}
+    {% include "inventory/recipes/recipes_card.html" with recipe=recipe %}
+  {% empty %}
+    <p class="col-span-full">No recipes available.</p>
+  {% endfor %}
+</div>

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -4,12 +4,10 @@
 {% block actions %}
   <a class="btn-primary" href="{% url 'recipe_create' %}">New Recipe</a>
 {% endblock %}
-{% block table_container %}
-<ul class="list-disc pl-5">
-  {% for r in recipes %}
-    <li><a class="text-primary" href="{% url 'recipe_detail' r.recipe_id %}">{{ r.name }}</a></li>
-  {% empty %}
-    <li>No recipes available.</li>
-  {% endfor %}
-</ul>
+{% block filter_bar %}
+  {% url 'recipes_list' as recipes_list_url %}
+  {% include "components/filter_bar.html" with search_placeholder="Search recipes..." hx_get=recipes_list_url hx_target="#recipes_grid" q=q %}
 {% endblock %}
+{% block table_id %}recipes_grid{% endblock %}
+{% block hx_get %}{% url 'recipes_list' %}{% endblock %}
+{% block table_content %}{{ recipes_grid|safe }}{% endblock %}

--- a/templates/inventory/recipes/recipes_card.html
+++ b/templates/inventory/recipes/recipes_card.html
@@ -1,0 +1,9 @@
+<a href="{% url 'recipe_detail' recipe.recipe_id %}" class="block bg-white rounded-lg shadow hover:shadow-xl transition-transform transform hover:-translate-y-1">
+  {% if recipe.image %}
+  <img src="{{ recipe.image }}" alt="{{ recipe.name }}" class="w-full h-40 object-cover rounded-t-lg" />
+  {% endif %}
+  <div class="p-4">
+    <h3 class="text-lg font-semibold mb-2">{{ recipe.name }}</h3>
+    <p class="text-sm text-gray-600">{{ recipe.component_count }} ingredients</p>
+  </div>
+</a>


### PR DESCRIPTION
## Summary
- show recipes as cards with optional images and ingredient counts
- add search bar using shared filter_bar component
- support HTMX grid updates from recipes list view

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0d534b808326a1d02ae3e5c7b359