### PR TITLE
Organize stock movements into collapsible sections and add quick entry modal

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -10,6 +10,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/list.js/2.3.1/list.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+    <link rel="stylesheet" href="https://unpkg.com/dropzone@5/dist/min/dropzone.min.css">
+    <script src="https://unpkg.com/dropzone@5/dist/min/dropzone.min.js"></script>
     <script src="{% static 'js/color.js' %}"></script>
     <script src="{% static 'js/predictive-dropdown.js' %}"></script>
     <script src="{% static 'js/nav.js' %}"></script>

--- a/templates/components/collapsible.html
+++ b/templates/components/collapsible.html
@@ -1,0 +1,8 @@
+<details class="border rounded mb-4" {% block open %}{% endblock %}>
+  <summary class="cursor-pointer px-4 py-2 bg-gray-100">
+    <h2 class="text-h2 font-semibold">{% block title %}{% endblock %}</h2>
+  </summary>
+  <div class="p-4">
+    {% block content %}{% endblock %}
+  </div>
+</details>

--- a/templates/inventory/_bulk_upload_section.html
+++ b/templates/inventory/_bulk_upload_section.html
@@ -1,0 +1,28 @@
+{% extends "components/collapsible.html" %}
+{% load static %}
+{% block title %}Bulk Upload{% endblock %}
+{% block content %}
+  <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary">Download sample CSV</a></p>
+  <form method="post" action="" enctype="multipart/form-data" class="dropzone border-dashed border-2 p-4" id="bulk-upload-form">
+    {% csrf_token %}
+    <input type="hidden" name="bulk_upload" value="1" />
+    {% if bulk_form.non_field_errors %}
+    <ul class="text-red-600 list-disc pl-5">
+      {% for error in bulk_form.non_field_errors %}
+      <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    <div class="dz-message" data-dz-message><span>Drop CSV file here or click to upload.</span></div>
+  </form>
+  {% if bulk_success_count is not None %}
+    <p class="mt-2">{{ bulk_success_count }} transaction(s) recorded successfully.</p>
+  {% endif %}
+  {% if bulk_errors %}
+    <ul class="text-red-700 mt-2">
+      {% for e in bulk_errors %}
+        <li>{{ e }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+{% endblock %}

--- a/templates/inventory/_manual_entry_section.html
+++ b/templates/inventory/_manual_entry_section.html
@@ -1,0 +1,7 @@
+{% extends "components/collapsible.html" %}
+{% block open %}open{% endblock %}
+{% block title %}Manual Entry{% endblock %}
+{% block content %}
+  {% include "components/tabs.html" with tabs=tabs %}
+  <datalist id="item-options"></datalist>
+{% endblock %}

--- a/templates/inventory/_recent_transactions_section.html
+++ b/templates/inventory/_recent_transactions_section.html
@@ -1,0 +1,45 @@
+{% extends "components/collapsible.html" %}
+{% block title %}Recent Transactions{% endblock %}
+{% block content %}
+  <div class="max-md:overflow-x-auto">
+    <table class="table w-full">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Item</th>
+          <th>Type</th>
+          <th>Qty</th>
+          <th>User</th>
+          <th>Date</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for tx in page_obj %}
+        <tr>
+          <td>{{ tx.transaction_id }}</td>
+          <td>{{ tx.item.name }}</td>
+          <td>
+            {% if tx.direction == 'in' %}
+              <span class="badge-success">IN</span>
+            {% else %}
+              <span class="badge-error">OUT</span>
+            {% endif %}
+          </td>
+          <td>{{ tx.quantity_change }}</td>
+          <td>{{ tx.user_id }}</td>
+          <td>{{ tx.transaction_date }}</td>
+          <td>{{ tx.notes }}</td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="7" class="p-2">No transactions found.</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <div class="mt-4">
+    {% include "components/pagination.html" with page_obj=page_obj base_url="" extra_query=query_string %}
+  </div>
+{% endblock %}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -1,77 +1,36 @@
 {% extends "_base.html" %}
-{% block title %}Stock Movements – Inventory App{% endblock %}
 {% load static %}
+{% block title %}Stock Movements – Inventory App{% endblock %}
 {% block content %}
   <h1 class="text-h1 font-semibold mb-4">Stock Movements</h1>
-  {% if messages %}
-    {% include "components/alert.html" %}
-  {% endif %}
-  {% include "components/tabs.html" with tabs=tabs %}
-  <datalist id="item-options"></datalist>
-  <hr class="my-4"/>
-  <h2 class="text-h2 mb-4 mt-8">Bulk Upload Stock Transactions</h2>
-  <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary">Download sample CSV</a></p>
-  <form method="post" enctype="multipart/form-data" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
-    {% csrf_token %}
-    {% if bulk_form.non_field_errors %}
-    <ul class="text-red-600 list-disc pl-5">
-      {% for error in bulk_form.non_field_errors %}
-      <li>{{ error }}</li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    {% for field in bulk_form %}
-      {% include "components/form_field.html" with field=field container_class="col-span-2" %}
-    {% endfor %}
-    <div class="col-span-2">
-      <button type="submit" name="bulk_upload" class="btn-primary">Upload</button>
-    </div>
-  </form>
-  {% if bulk_success_count is not None %}
-    <p>{{ bulk_success_count }} transaction(s) recorded successfully.</p>
-  {% endif %}
-  {% if bulk_errors %}
-    <ul class="text-red-700">
-      {% for e in bulk_errors %}
-        <li>{{ e }}</li>
-      {% endfor %}
-    </ul>
-  {% endif %}
-  <hr class="my-4"/>
-  <h2 class="text-h2 mb-4 mt-8">Recent Transactions</h2>
-  <div class="max-md:overflow-x-auto">
-    <table class="table">
-      <thead>
-        <tr>
-          <th>ID</th>
-          <th>Item</th>
-          <th>Type</th>
-          <th>Qty</th>
-          <th>User</th>
-          <th>Date</th>
-          <th>Notes</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for tx in page_obj %}
-        <tr>
-          <td>{{ tx.transaction_id }}</td>
-          <td>{{ tx.item.name }}</td>
-          <td>{{ tx.transaction_type }}</td>
-          <td>{{ tx.quantity_change }}</td>
-          <td>{{ tx.user_id }}</td>
-          <td>{{ tx.transaction_date }}</td>
-          <td>{{ tx.notes }}</td>
-        </tr>
-        {% empty %}
-        <tr>
-          <td colspan="7" class="p-2">No transactions found.</td>
-        </tr>
+  {% include "inventory/_manual_entry_section.html" %}
+  {% include "inventory/_bulk_upload_section.html" %}
+  {% include "inventory/_recent_transactions_section.html" %}
+  <button id="record-movement-btn" class="btn-primary rounded-full fixed bottom-6 right-6 z-40 px-4 py-2">Record Movement</button>
+  <div id="record-modal" class="fixed inset-0 hidden items-center justify-center bg-black/50 z-50">
+    <div class="bg-white p-6 rounded shadow-lg w-full max-w-md relative">
+      <button type="button" class="absolute top-2 right-2 text-bodyText hover:text-primary" data-close>
+        <span class="sr-only">Close</span>&times;
+      </button>
+      <form method="post" class="grid gap-4">
+        {% csrf_token %}
+        {% for field in quick_form %}
+          {% include "components/form_field.html" with field=field %}
         {% endfor %}
-      </tbody>
-    </table>
+        <button type="submit" name="submit_quick" class="btn-primary w-full">Save</button>
+      </form>
+    </div>
   </div>
-  <div class="mt-4">
-    {% include "components/pagination.html" with page_obj=page_obj base_url="" extra_query=query_string %}
-  </div>
+  <script>
+    (function () {
+      const modal = document.getElementById('record-modal');
+      const openBtn = document.getElementById('record-movement-btn');
+      const closeBtn = modal.querySelector('[data-close]');
+      function open() { modal.classList.remove('hidden'); }
+      function close() { modal.classList.add('hidden'); }
+      openBtn && openBtn.addEventListener('click', open);
+      closeBtn && closeBtn.addEventListener('click', close);
+      modal.addEventListener('click', function (e) { if (e.target === modal) { close(); } });
+    })();
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Introduce reusable `collapsible` component and apply to stock movement page
- Style transaction history with IN/OUT badges and include Dropzone.js for bulk uploads
- Add floating "Record Movement" button with modal quick-entry form

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0fa1e108832699bb77eb224376f0