### PR TITLE
Add suppliers card view and export options

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -14,6 +14,7 @@ from .views.items import (
 from .views.suppliers import (
     SuppliersListView,
     SuppliersTableView,
+    SuppliersCardView,
     SupplierCreateView,
     SupplierEditView,
     SupplierToggleActiveView,
@@ -61,6 +62,7 @@ urlpatterns = [
 
     path("suppliers/", SuppliersListView.as_view(), name="suppliers_list"),
     path("suppliers/table/", SuppliersTableView.as_view(), name="suppliers_table"),
+    path("suppliers/cards/", SuppliersCardView.as_view(), name="suppliers_cards"),
     path("suppliers/create/", SupplierCreateView.as_view(), name="supplier_create"),
     path("suppliers/<int:pk>/edit/", SupplierEditView.as_view(), name="supplier_edit"),
     path("suppliers/<int:pk>/toggle/", SupplierToggleActiveView.as_view(), name="supplier_toggle_active"),

--- a/static/img/no_suppliers.svg
+++ b/static/img/no_suppliers.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#f3f4f6"/>
+  <text x="50" y="55" text-anchor="middle" fill="#9ca3af" font-size="14">No Suppliers</text>
+</svg>

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -1,6 +1,11 @@
+{% load static %}
 <div class="p-4 max-sm:p-2 text-center border border-form-border rounded bg-form-bg">
-  <svg class="mx-auto w-5 h-5 text-form-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
-    <h2 class="text-h2 mb-4 mt-8">{{ title }}</h2>
+  {% if img %}
+    <img src="{% static img %}" alt="" class="mx-auto mb-4 w-32 h-32" />
+  {% else %}
+    <svg class="mx-auto w-5 h-5 text-form-text" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+  {% endif %}
+  <h2 class="text-h2 mb-4 mt-8">{{ title }}</h2>
   <p class="mb-4 text-form-text">{{ message }}</p>
   <a href="{{ cta_url }}" class="btn-primary">{{ cta_label }}</a>
 </div>

--- a/templates/inventory/suppliers_card.html
+++ b/templates/inventory/suppliers_card.html
@@ -1,0 +1,43 @@
+{% load static %}
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+  {% for row in page_obj %}
+  <div class="bg-white rounded shadow p-4 flex justify-between items-start">
+    <div>
+      <h3 class="text-lg font-semibold">{{ row.name }}</h3>
+      <p class="text-sm text-gray-600">{{ row.contact_person }}</p>
+    </div>
+    <div class="flex gap-2">
+      <a href="{% url 'supplier_edit' row.supplier_id %}" class="text-primary" title="Edit">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L7.5 21H3v-4.5L16.732 3.732z"/></svg>
+      </a>
+      <form
+        hx-post="{% url 'supplier_toggle_active' row.supplier_id %}"
+        hx-target="#suppliers_cards"
+        hx-confirm="Are you sure you want to delete this supplier?"
+        method="post"
+        class="inline"
+      >
+        {% csrf_token %}
+        <input type="hidden" name="q" value="{{ q }}" />
+        <input type="hidden" name="page" value="{{ page_obj.number }}" />
+        <input type="hidden" name="active" value="{{ active }}" />
+        <input type="hidden" name="page_size" value="{{ page_size }}" />
+        <input type="hidden" name="sort" value="{{ sort }}" />
+        <input type="hidden" name="direction" value="{{ direction }}" />
+        <input type="hidden" name="view" value="cards" />
+        <button type="submit" class="text-red-600">
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5-4h4a1 1 0 011 1v1h3m-12 0h3v1a1 1 0 001 1h4a1 1 0 001-1V5h3M4 7h16"/></svg>
+        </button>
+      </form>
+    </div>
+  </div>
+  {% empty %}
+  <p class="col-span-full text-center text-form-text">No suppliers found.</p>
+  {% endfor %}
+</div>
+{% url 'suppliers_cards' as cards_url %}
+{% with extra_query='q='|add:q|urlencode|add:'&active='|add:active|urlencode|add:'&page_size='|add:page_size|add:'&sort='|add:sort|urlencode|add:'&direction='|add:direction|urlencode|add:'&view=cards' %}
+<div class="mt-4">
+  {% include "components/pagination.html" with page_obj=page_obj base_url=cards_url extra_query=extra_query hx_target="#suppliers_cards" %}
+</div>
+{% endwith %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -5,16 +5,22 @@
   <a href="{% url 'supplier_create' %}" class="btn-primary">New Supplier</a>
   <a href="{% url 'suppliers_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
   <a href="{% url 'suppliers_bulk_delete' %}" class="btn-danger">Bulk Delete</a>
+  <a href="{% url 'suppliers_table' %}?export=1" class="btn-secondary">Export CSV</a>
+  {% if view == 'cards' %}
+    <a href="{% url 'suppliers_list' %}" class="btn-secondary">Table View</a>
+  {% else %}
+    <a href="{% url 'suppliers_list' %}?view=cards" class="btn-secondary">Card View</a>
+  {% endif %}
 {% endblock %}
 {% block filter_bar %}
-  {% url 'suppliers_table' as suppliers_table_url %}
-  {% include "components/filter_bar.html" with search_placeholder="Search suppliers..." hx_get=suppliers_table_url hx_target="#suppliers_table" filters=filters export_url=export_url export_param_name="export" export_param_value="1" page_size=page_size sort=sort direction=direction %}
+  {% url hx_view_name as suppliers_view_url %}
+  {% include "components/filter_bar.html" with search_placeholder="Search suppliers..." hx_get=suppliers_view_url hx_target='#'|add:container_id filters=filters export_url=export_url export_param_name="export" export_param_value="1" page_size=page_size sort=sort direction=direction %}
 {% endblock %}
-{% block table_id %}suppliers_table{% endblock %}
-{% block hx_get %}{% url 'suppliers_table' %}{% endblock %}
+{% block table_id %}{{ container_id }}{% endblock %}
+{% block hx_get %}{% url hx_view_name %}{% endblock %}
 {% block table_content %}
   {% if total_suppliers == 0 %}
     {% url 'supplier_create' as supplier_create_url %}
-    {% include "components/empty_state.html" with title="No Suppliers" message="Start by adding your first supplier." cta_label="New Supplier" cta_url=supplier_create_url %}
+    {% include "components/empty_state.html" with title="No Suppliers" message="Start by adding your first supplier." cta_label="New Supplier" cta_url=supplier_create_url img='img/no_suppliers.svg' %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Allow toggling between supplier table and card views
- Add card-based supplier listing with edit/delete actions
- Show SVG illustration for empty supplier state and add CSV export button

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab0faa27e88326a79b1dde8c4dc5cd