### PR TITLE
Add date range picker and chart to history reports

### DIFF
--- a/templates/inventory/_history_chart.html
+++ b/templates/inventory/_history_chart.html
@@ -1,0 +1,26 @@
+<canvas id="history-chart" class="w-full h-64"></canvas>
+{{ chart_labels|json_script:"history-chart-labels" }}
+{{ chart_data|json_script:"history-chart-data" }}
+<script>
+  const labels = JSON.parse(document.getElementById('history-chart-labels').textContent);
+  const data = JSON.parse(document.getElementById('history-chart-data').textContent);
+  const ctx = document.getElementById('history-chart').getContext('2d');
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: labels,
+      datasets: [{
+        label: 'Stock Change',
+        data: data,
+        borderColor: '#3b82f6',
+        fill: false,
+        tension: 0.1
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false
+    }
+  });
+</script>
+

--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -48,7 +48,7 @@
 
 {% block rows %}
   {% for row in page_obj %}
-  <tr class="odd:bg-gray-50 hover:bg-gray-100">
+  <tr class="odd:bg-white even:bg-gray-50 hover:bg-gray-100">
     <td class="px-4 py-2 text-right">{{ row.transaction_id }}</td>
     <td class="px-4 py-2">{{ row.item.name }}</td>
     <td class="px-4 py-2">{{ row.transaction_type }}</td>

--- a/templates/inventory/_history_tabs.html
+++ b/templates/inventory/_history_tabs.html
@@ -1,0 +1,7 @@
+{% with tabs_list=[
+  {"id": "history-table-tab", "title": "Table", "template": "inventory/_history_table.html"},
+  {"id": "history-chart-tab", "title": "Chart", "template": "inventory/_history_chart.html"}
+] %}
+  {% include "components/tabs.html" with tabs=tabs_list %}
+{% endwith %}
+

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -3,9 +3,63 @@
 {% block heading %}History Reports{% endblock %}
 {% block filter_bar %}
   {% url 'history_reports' as history_url %}
-  {% include "components/filter_bar.html" with hx_get=history_url hx_target="#history_table" hx_indicator="#htmx-spinner" filters=filters export_url=history_url export_param_name="export" export_param_value="csv" sort=sort direction=direction q=item search_placeholder="Item ID" %}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <div class="flex flex-col gap-2 mb-4">
+    <input
+      id="date-range"
+      type="text"
+      class="form-control w-full md:w-64"
+      placeholder="Select Date Range"
+      value="{% if start_date and end_date %}{{ start_date }} to {{ end_date }}{% endif %}"
+    />
+    <div class="flex flex-col md:flex-row md:items-end gap-2">
+      <div class="flex-1">
+        {% include "components/filter_bar.html" with hx_get=history_url hx_target="#history_table" hx_indicator="#htmx-spinner" filters=filters sort=sort direction=direction q=item search_placeholder="Item ID" %}
+      </div>
+      <div class="flex gap-2">
+        <a
+          href="{{ history_url }}{% if query_string %}?{{ query_string }}&{% else %}?{% endif %}export=csv"
+          class="btn-tertiary"
+          >Download CSV</a
+        >
+        <a
+          href="{{ history_url }}{% if query_string %}?{{ query_string }}&{% else %}?{% endif %}export=pdf"
+          class="btn-tertiary"
+          >Download PDF</a
+        >
+      </div>
+    </div>
+  </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const form = document.getElementById('filters');
+      const historyUrl = '{{ history_url }}';
+      ['start_date', 'end_date'].forEach(name => {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = name;
+        input.setAttribute('hx-get', historyUrl);
+        input.setAttribute('hx-target', '#history_table');
+        input.setAttribute('hx-trigger', 'change');
+        input.setAttribute('hx-include', '#filters');
+        input.setAttribute('hx-indicator', '#htmx-spinner');
+        form.appendChild(input);
+      });
+      flatpickr('#date-range', {
+        mode: 'range',
+        dateFormat: 'Y-m-d',
+        onClose: function(selectedDates, dateStr) {
+          const [start, end] = dateStr.split(' to ');
+          form.querySelector('input[name="start_date"]').value = start || '';
+          form.querySelector('input[name="end_date"]').value = end || '';
+          form.querySelector('input[name="end_date"]').dispatchEvent(new Event('change'));
+        }
+      });
+    });
+  </script>
 {% endblock %}
 {% block table_id %}history_table{% endblock %}
 {% block hx_get %}{% url 'history_reports' %}{% endblock %}
-{% block table_content %}{% include "inventory/_history_table.html" %}{% endblock %}
+{% block table_content %}{% include "inventory/_history_tabs.html" %}{% endblock %}
 


### PR DESCRIPTION
## Summary
- add flatpickr date range selector with CSV/PDF export buttons on history reports
- replace history report table with tabbed table/chart view
- support PDF export and chart data in history report view

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab0fd4e85c8326a5475bc61fbbef0f