### PR TITLE
Improve dashboard layout and base container

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -1,34 +1,36 @@
 {% extends "_base.html" %}
 {% block content %}
-<h1 class="text-2xl font-semibold mb-4">Dashboard</h1>
+<h1 class="text-h1">Dashboard</h1>
 
 <div id="kpi-cards" hx-get="{% url 'dashboard-kpis' %}" hx-trigger="load"></div>
 
-<div class="flex gap-4 mt-4">
+<div class="flex gap-4">
   <a href="{% url 'purchase_order_create' %}" class="btn-primary px-4 py-2 rounded">New PO</a>
   <a href="{% url 'grn_list' %}" class="btn-secondary px-4 py-2 rounded">Record Receipt</a>
 </div>
 
-<canvas id="stock-trend-chart" class="mt-8 w-full h-64"></canvas>
-<script>
-  const ctx = document.getElementById('stock-trend-chart').getContext('2d');
-  new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: {{ trend_labels|safe }},
-      datasets: [{
-        label: 'Stock Trend',
-        data: {{ trend_values|safe }},
-        borderColor: '#3b82f6',
-        backgroundColor: 'rgba(59,130,246,0.2)',
-        tension: 0.4,
-      }]
-    },
-    options: {responsive: true, maintainAspectRatio: false}
-  });
-</script>
+<div>
+  <canvas id="stock-trend-chart" class="w-full h-64"></canvas>
+  <script>
+    const ctx = document.getElementById('stock-trend-chart').getContext('2d');
+    new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: {{ trend_labels|safe }},
+        datasets: [{
+          label: 'Stock Trend',
+          data: {{ trend_values|safe }},
+          borderColor: '#3b82f6',
+          backgroundColor: 'rgba(59,130,246,0.2)',
+          tension: 0.4,
+        }]
+      },
+      options: {responsive: true, maintainAspectRatio: false}
+    });
+  </script>
+</div>
 
-<h2 class="text-xl mb-2 mt-8">Low Stock Items</h2>
+<h2 class="text-h2 mb-2">Low Stock Items</h2>
 <ul class="space-y-2">
   {% for item in low_stock %}
     <li class="flex items-center justify-between p-4 rounded border">

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -35,7 +35,7 @@
             class="h-12 w-12 border-4 border-primary border-t-transparent rounded-full animate-spin"
           ></div>
         </div>
-        <main class="main-content container grid gap-4 flex-1">
+        <main class="main-content container flex flex-col gap-4 flex-1">
           {% if messages %}
             {% include "components/alert.html" %}
           {% endif %}


### PR DESCRIPTION
## Summary
- Convert base template main container to a flex column for consistent spacing across pages
- Apply style guide headings and wrap chart block for better dashboard spacing

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab11c87c7483269981f4e0fd1f2323