### PR TITLE
feat: expand dashboard KPIs

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,30 +1,41 @@
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
-    <div class="flex items-center gap-4">
-      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
-      <h2 class="text-lg font-medium">Stock Value</h2>
-    </div>
-    <span class="text-4xl font-bold">{{ stock_value }}</span>
+  <div class="p-6 rounded-xl text-white bg-gradient-to-r from-primary to-secondary">
+    <h2 class="text-lg font-medium">Low-stock Items</h2>
+    {% if low_stock_items %}
+      <ul class="mt-2 text-sm space-y-1">
+        {% for name in low_stock_items %}
+          <li>{{ name }}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="mt-2 text-sm">None</p>
+    {% endif %}
   </div>
+
   <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
     <div class="flex items-center gap-4">
-      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3"/></svg>
-      <h2 class="text-lg font-medium">7-day Receipts</h2>
+      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h10.127a3 3 0 0 0 2.958-2.502l1.115-7A3 3 0 0 0 19.336 6H4.664a3 3 0 0 0-2.982 3.248l1.115 7a3 3 0 0 0 2.958 2.502H8.25Zm7.5 0a1.5 1.5 0 1 0 3 0m-3 0a1.5 1.5 0 0 1 3 0"/></svg>
+      <h2 class="text-lg font-medium">High-price Purchases</h2>
     </div>
-    <span class="text-4xl font-bold">{{ receipts }}</span>
+    <span class="text-4xl font-bold">{{ high_price_purchases|length }}</span>
   </div>
-  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
-    <div class="flex items-center gap-4">
-      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"/></svg>
-      <h2 class="text-lg font-medium">7-day Issues</h2>
-    </div>
-    <span class="text-4xl font-bold">{{ issues }}</span>
+
+  <div class="p-6 rounded-xl text-white bg-gradient-to-r from-primary to-secondary">
+    <h2 class="text-lg font-medium mb-2">Pending POs</h2>
+    <ul class="text-sm space-y-1">
+      <li>Draft: {{ pending_po_status.DRAFT|default:0 }}</li>
+      <li>Ordered: {{ pending_po_status.ORDERED|default:0 }}</li>
+      <li>Partial: {{ pending_po_status.PARTIAL|default:0 }}</li>
+    </ul>
   </div>
-  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
-    <div class="flex items-center gap-4">
-      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/></svg>
-      <h2 class="text-lg font-medium">Low-stock Count</h2>
-    </div>
-    <span class="text-4xl font-bold">{{ low_stock }}</span>
+
+  <div class="p-6 rounded-xl text-white bg-gradient-to-r from-primary to-secondary">
+    <h2 class="text-lg font-medium mb-2">Pending Indents</h2>
+    <ul class="text-sm space-y-1">
+      <li>Pending: {{ pending_indent_status.PENDING|default:0 }}</li>
+      <li>Submitted: {{ pending_indent_status.SUBMITTED|default:0 }}</li>
+      <li>Processing: {{ pending_indent_status.PROCESSING|default:0 }}</li>
+    </ul>
   </div>
 </div>
+

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -10,9 +10,9 @@
     {% endif %}
   </div>
 
-  {% if user.is_authenticated %}
-    {% include "core/_kpi_cards.html" with stock_value=stock_value receipts=receipts issues=issues low_stock=low_stock %}
-    <div class="grid gap-4 mt-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+    {% if user.is_authenticated %}
+      {% include "core/_kpi_cards.html" with low_stock_items=low_stock_items high_price_purchases=high_price_purchases pending_po_status=pending_po_status pending_indent_status=pending_indent_status %}
+      <div class="grid gap-4 mt-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
       <a href="{% url 'dashboard' %}" class="bg-white rounded shadow hover:shadow-lg transform transition p-6 flex flex-col items-center text-center">
         <svg aria-hidden="true" class="w-8 h-8 text-primary mb-2" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
         <span class="text-primary font-semibold">Dashboard</span>

--- a/core/views.py
+++ b/core/views.py
@@ -5,7 +5,9 @@ from django.contrib.auth.forms import AuthenticationForm
 
 import json
 
-from inventory.services import dashboard_service, kpis, counts
+from decimal import Decimal
+
+from inventory.services import counts, dashboard_service, kpis
 
 
 def root_view(request):
@@ -16,6 +18,10 @@ def root_view(request):
             "receipts": kpis.receipts_last_7_days(),
             "issues": kpis.issues_last_7_days(),
             "low_stock": kpis.low_stock_count(),
+            "low_stock_items": kpis.low_stock_items(),
+            "high_price_purchases": kpis.high_price_purchases(Decimal("0.1")),
+            "pending_po_status": kpis.pending_po_status_counts(),
+            "pending_indent_status": kpis.pending_indent_counts(),
             "item_count": counts.item_count(),
             "supplier_count": counts.supplier_count(),
             "pending_po_count": counts.pending_po_count(),
@@ -48,9 +54,9 @@ def dashboard(request):
 def dashboard_kpis(request):
     """HTMX endpoint returning KPI card values."""
     data = {
-        "stock_value": kpis.stock_value(),
-        "receipts": kpis.receipts_last_7_days(),
-        "issues": kpis.issues_last_7_days(),
-        "low_stock": kpis.low_stock_count(),
+        "low_stock_items": kpis.low_stock_items(),
+        "high_price_purchases": kpis.high_price_purchases(Decimal("0.1")),
+        "pending_po_status": kpis.pending_po_status_counts(),
+        "pending_indent_status": kpis.pending_indent_counts(),
     }
     return render(request, "core/_kpi_cards.html", data)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,7 +1,8 @@
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 
-from inventory.models import StockTransaction
+from inventory.models import Indent, PurchaseOrder, Supplier
 
 
 @pytest.mark.django_db
@@ -14,9 +15,14 @@ def test_dashboard_low_stock(client, item_factory):
 
 @pytest.mark.django_db
 def test_dashboard_kpis_endpoint(client, item_factory):
-    item1 = item_factory(name="Foo", reorder_point=10, current_stock=5)
-    StockTransaction.objects.create(item=item1, quantity_change=1, transaction_type="RECEIVING")
+    item_factory(name="Foo", reorder_point=10, current_stock=5)
+    supplier = Supplier.objects.create(name="Supp")
+    PurchaseOrder.objects.create(supplier=supplier, order_date=timezone.now().date(), status="DRAFT")
+    Indent.objects.create(mrn="1", status="PENDING")
 
     resp = client.get(reverse("dashboard-kpis"))
     assert resp.status_code == 200
-    assert b"Stock Value" in resp.content
+    assert b"Low-stock Items" in resp.content
+    assert b"High-price Purchases" in resp.content
+    assert b"Pending POs" in resp.content
+    assert b"Pending Indents" in resp.content


### PR DESCRIPTION
## Summary
- replace legacy dashboard KPI cards with low-stock summary
- flag purchase receipts priced above historical averages
- expose pending purchase orders and indents by status

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab34e4480083268448839f07e42775