### PR TITLE
Add stale items KPI and dashboard card

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,9 +1,22 @@
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
   <div class="p-6 rounded-xl text-white bg-gradient-to-r from-primary to-secondary">
     <h2 class="text-lg font-medium">Low-stock Items</h2>
     {% if low_stock_items %}
       <ul class="mt-2 text-sm space-y-1">
         {% for name in low_stock_items %}
+          <li>{{ name }}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="mt-2 text-sm">None</p>
+    {% endif %}
+  </div>
+
+  <div class="p-6 rounded-xl text-white bg-gradient-to-r from-primary to-secondary">
+    <h2 class="text-lg font-medium">Stale Items</h2>
+    {% if stale_items %}
+      <ul class="mt-2 text-sm space-y-1">
+        {% for name in stale_items %}
           <li>{{ name }}</li>
         {% endfor %}
       </ul>

--- a/core/views.py
+++ b/core/views.py
@@ -55,6 +55,7 @@ def dashboard_kpis(request):
     """HTMX endpoint returning KPI card values."""
     data = {
         "low_stock_items": kpis.low_stock_items(),
+        "stale_items": kpis.stale_items(),
         "high_price_purchases": kpis.high_price_purchases(Decimal("0.1")),
         "pending_po_status": kpis.pending_po_status_counts(),
         "pending_indent_status": kpis.pending_indent_counts(),

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,8 +1,9 @@
 import pytest
+from datetime import timedelta
 from django.urls import reverse
 from django.utils import timezone
 
-from inventory.models import Indent, PurchaseOrder, Supplier
+from inventory.models import Indent, PurchaseOrder, StockTransaction, Supplier
 
 
 @pytest.mark.django_db
@@ -15,7 +16,21 @@ def test_dashboard_low_stock(client, item_factory):
 
 @pytest.mark.django_db
 def test_dashboard_kpis_endpoint(client, item_factory):
-    item_factory(name="Foo", reorder_point=10, current_stock=5)
+    fresh = item_factory(name="Foo", reorder_point=10, current_stock=5)
+    StockTransaction.objects.create(
+        item=fresh,
+        quantity_change=1,
+        transaction_type="RECEIVING",
+        transaction_date=timezone.now(),
+    )
+    stale = item_factory(name="Old")
+    old_tx = StockTransaction.objects.create(
+        item=stale,
+        quantity_change=1,
+        transaction_type="RECEIVING",
+    )
+    old_tx.transaction_date = timezone.now() - timedelta(days=40)
+    old_tx.save(update_fields=["transaction_date"])
     supplier = Supplier.objects.create(name="Supp")
     PurchaseOrder.objects.create(supplier=supplier, order_date=timezone.now().date(), status="DRAFT")
     Indent.objects.create(mrn="1", status="PENDING")
@@ -23,6 +38,8 @@ def test_dashboard_kpis_endpoint(client, item_factory):
     resp = client.get(reverse("dashboard-kpis"))
     assert resp.status_code == 200
     assert b"Low-stock Items" in resp.content
+    assert b"Stale Items" in resp.content
+    assert b"Old" in resp.content
     assert b"High-price Purchases" in resp.content
     assert b"Pending POs" in resp.content
     assert b"Pending Indents" in resp.content


### PR DESCRIPTION
## Summary
- Track items with no stock transactions over a configurable period
- Surface stale item list on dashboard KPI endpoint and card
- Test stale item detection and dashboard display

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab396955288326b56484f80f724477