### PR TITLE
Narrow flake8 ignores and resolve lint violations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 120
-extend-ignore = E501,F401,F821,E722,W291,E741,E402
+extend-ignore = E501

--- a/core/admin.py
+++ b/core/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/core/models.py
+++ b/core/models.py
@@ -1,3 +1,1 @@
-from django.db import models
-
 # Create your models here.

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/inventory/migrations/0008_remove_purchaseorderitem_quantity_received.py
+++ b/inventory/migrations/0008_remove_purchaseorderitem_quantity_received.py
@@ -25,7 +25,7 @@ def migrate_existing_grn(apps, schema_editor):
                 purchase_order_id=poi.purchase_order_id,
                 supplier_id=poi.purchase_order.supplier_id,
                 received_date=now().date(),
-                notes="Migrated from PurchaseOrderItem", 
+                notes="Migrated from PurchaseOrderItem",
             )
             GRNItem.objects.create(
                 grn=grn,

--- a/inventory/models/__init__.py
+++ b/inventory/models/__init__.py
@@ -22,9 +22,9 @@ class CoerceFloatField(models.DecimalField):
         return self.to_python(value)
 
 
-from .items import Item, StockTransaction
-from .suppliers import Supplier
-from .orders import (
+from .items import Item, StockTransaction  # noqa: E402
+from .suppliers import Supplier  # noqa: E402
+from .orders import (  # noqa: E402
     Indent,
     IndentItem,
     PurchaseOrder,

--- a/inventory/services/goods_receiving_service.py
+++ b/inventory/services/goods_receiving_service.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import date
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple
 from django.db import transaction

--- a/inventory/services/item_service.py
+++ b/inventory/services/item_service.py
@@ -18,7 +18,7 @@ from django.db import IntegrityError, transaction
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
 
-from inventory.models import Item, StockTransaction
+from inventory.models import Item
 
 logger = logging.getLogger(__name__)
 

--- a/inventory/services/purchase_order_service.py
+++ b/inventory/services/purchase_order_service.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import date
 from typing import Any, Dict, List, Optional, Tuple
 from decimal import Decimal
 

--- a/inventory/views/suppliers.py
+++ b/inventory/views/suppliers.py
@@ -1,8 +1,8 @@
+import csv
 import io
 import logging
 
 from django.contrib import messages
-from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views import View

--- a/tests/test_aa_views.py
+++ b/tests/test_aa_views.py
@@ -5,7 +5,7 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.db import connection, DatabaseError
 from unittest.mock import patch
 
-from inventory.models import Item, Indent, IndentItem
+from inventory.models import Indent
 from inventory.views.items import ItemEditView
 from inventory.views.indents import IndentCreateView
 

--- a/tests/test_goods_receiving_service_django.py
+++ b/tests/test_goods_receiving_service_django.py
@@ -1,14 +1,10 @@
 import pytest
 from datetime import date
-from django.db import connection
 
 from inventory.models import (
     Supplier,
-    StockTransaction,
     PurchaseOrder,
     PurchaseOrderItem,
-    GoodsReceivedNote,
-    GRNItem,
 )
 from inventory.services import purchase_order_service, goods_receiving_service
 

--- a/tests/test_indent_forms.py
+++ b/tests/test_indent_forms.py
@@ -1,6 +1,3 @@
-import django
-from django.conf import settings
-
 import pytest
 from inventory.forms.indent_forms import IndentForm, IndentItemFormSet, IndentItemForm
 

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -3,11 +3,8 @@ from django import forms
 from django.template.loader import render_to_string
 from django.test import RequestFactory
 
-from django.urls import reverse
-
 from inventory.forms.item_forms import ItemForm
 from inventory.forms import item_forms as forms_module
-from inventory.services import supabase_units
 
 
 @pytest.mark.django_db

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -7,7 +7,6 @@ from inventory.models import (
     Item,
     Recipe,
     RecipeComponent,
-    StockTransaction,
     SaleTransaction,
 )
 from inventory.services.recipe_service import (

--- a/tests/test_stock_service_django.py
+++ b/tests/test_stock_service_django.py
@@ -1,5 +1,4 @@
 import pytest
-from django.db import connection
 
 from inventory.models import StockTransaction
 from inventory.services import stock_service

--- a/tests/test_supabase_categories.py
+++ b/tests/test_supabase_categories.py
@@ -1,8 +1,6 @@
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-import pytest
-
 from inventory.services import supabase_categories
 
 


### PR DESCRIPTION
## Summary
- remove project-wide flake8 ignores for F401, F821, E722, W291, E741, and E402
- clean up or silence the resulting lint errors

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab47e1b3b88326ab07319b75f7ce9c