### PR TITLE
Add formatting hooks to pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,19 @@
 repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:
       - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        files: "\\.(js|jsx|ts|tsx|html)$"


### PR DESCRIPTION
## Summary
- add black and isort hooks for Python formatting
- run prettier hook for templates and JS assets

## Testing
- `pre-commit run --files .pre-commit-config.yaml`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab47f421ac8326b182966b807be584