### PR TITLE
Enforce trailing whitespace checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 120
-extend-ignore = E501,F401,F821,E722,W291,E741,E402
+extend-ignore = E501,F401,F821,E722,E741,E402

--- a/inventory/migrations/0008_remove_purchaseorderitem_quantity_received.py
+++ b/inventory/migrations/0008_remove_purchaseorderitem_quantity_received.py
@@ -25,7 +25,7 @@ def migrate_existing_grn(apps, schema_editor):
                 purchase_order_id=poi.purchase_order_id,
                 supplier_id=poi.purchase_order.supplier_id,
                 received_date=now().date(),
-                notes="Migrated from PurchaseOrderItem", 
+                notes="Migrated from PurchaseOrderItem",
             )
             GRNItem.objects.create(
                 grn=grn,


### PR DESCRIPTION
## Summary
- remove trailing whitespace from migration
- re-enable flake8 W291 to flag trailing spaces

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab47fcc81083268bf85630d5052270