### PR TITLE
Ensure purchase unit required when creating items

### DIFF
--- a/inventory/services/item_service.py
+++ b/inventory/services/item_service.py
@@ -91,7 +91,7 @@ get_distinct_departments_from_items.clear = (
 def add_new_item(details: Dict[str, Any]) -> Tuple[bool, str]:
     """Insert a single item into the database."""
 
-    valid, missing = _validate_required(details, ["name", "base_unit"])
+    valid, missing = _validate_required(details, ["name", "base_unit", "purchase_unit"])
     if not valid:
         return False, f"Missing or empty required fields: {', '.join(missing)}"
     params = _clean_create_params(details)
@@ -136,14 +136,10 @@ def _clean_create_params(details: Dict[str, Any]) -> Dict[str, Any]:
         else None
     )
 
-    purchase_unit_val = details.get("purchase_unit")
-    if isinstance(purchase_unit_val, str):
-        purchase_unit_val = purchase_unit_val.strip() or None
-
     return dict(
         name=details["name"].strip(),
         base_unit=details["base_unit"].strip(),
-        purchase_unit=purchase_unit_val,
+        purchase_unit=details["purchase_unit"].strip(),
         category_id=details.get("category_id"),
         permitted_departments=cleaned_permitted,
         reorder_point=details.get("reorder_point", Decimal("0")),
@@ -162,7 +158,7 @@ def add_items_bulk(items: List[Dict[str, Any]]) -> Tuple[int, List[str]]:
     processed: List[Dict[str, Any]] = []
     errors: List[str] = []
     for idx, details in enumerate(items):
-        required = ["name", "base_unit"]
+        required = ["name", "base_unit", "purchase_unit"]
         if not all(details.get(k) and str(details.get(k)).strip() for k in required):
             missing = [
                 k
@@ -184,15 +180,11 @@ def add_items_bulk(items: List[Dict[str, Any]]) -> Tuple[int, List[str]]:
             else None
         )
 
-        purchase_unit_val = details.get("purchase_unit")
-        if isinstance(purchase_unit_val, str):
-            purchase_unit_val = purchase_unit_val.strip() or None
-
         processed.append(
             dict(
                 name=details["name"].strip(),
                 base_unit=details["base_unit"].strip(),
-                purchase_unit=purchase_unit_val,
+                purchase_unit=details["purchase_unit"].strip(),
                 category_id=details.get("category_id"),
                 permitted_departments=cleaned_permitted,
                 reorder_point=details.get("reorder_point", Decimal("0")),

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -115,12 +115,19 @@ def test_add_items_bulk_inserts_rows():
 def test_add_items_bulk_validation_failure():
     items = [
         {"name": "Widget", "base_unit": "pcs", "purchase_unit": "box", "category_id": 1},
-        {"name": "", "base_unit": "pcs", "purchase_unit": "box", "category_id": 1},
+        {"name": "Gadget", "base_unit": "pcs", "purchase_unit": "", "category_id": 1},
     ]
     inserted, errors = item_service.add_items_bulk(items)
     assert inserted == 0
     assert errors
     assert Item.objects.count() == 0
+
+
+def test_add_new_item_requires_purchase_unit():
+    details = {"name": "Widget", "base_unit": "pcs"}
+    success, message = item_service.add_new_item(details)
+    assert not success
+    assert "purchase_unit" in message
 
 
 def test_remove_items_bulk_marks_inactive():


### PR DESCRIPTION
## Summary
- require `purchase_unit` when adding items
- validate `purchase_unit` during bulk creation
- add tests for missing `purchase_unit`

## Testing
- `python -m flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab48050f0c8326baf28a6fd261109d