### PR TITLE
Simplify sidebar navigation

### DIFF
--- a/templates/components/nav.html
+++ b/templates/components/nav.html
@@ -14,45 +14,21 @@
 </button>
 <aside id="sidebar" class="bg-primary text-gray-300 w-64 space-y-4 py-6 px-2 fixed inset-y-0 left-0 transform -translate-x-full md:relative md:translate-x-0 transition-transform duration-200 flex flex-col">
   <div class="px-4 text-2xl font-bold text-white">Inventory App</div>
-  <nav class="flex-1 overflow-y-auto px-2">
-    <details class="mb-2">
-      <summary class="cursor-pointer px-2 py-2 rounded hover:bg-primary/50 hover:text-white">Overview</summary>
-      <div class="pl-4 flex flex-col space-y-1">
-        <a href="{{ dashboard_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">Dashboard</a>
-        <a href="{{ reports_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">Reports</a>
-      </div>
-    </details>
-    <details class="mb-2">
-      <summary class="cursor-pointer px-2 py-2 rounded hover:bg-primary/50 hover:text-white">Inventory</summary>
-      <div class="pl-4 flex flex-col space-y-1">
-        <a href="{{ items_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">Items</a>
-        <a href="{{ movements_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">Stock Movements</a>
-      </div>
-    </details>
-    <details class="mb-2">
-      <summary class="cursor-pointer px-2 py-2 rounded hover:bg-primary/50 hover:text-white">Procurement</summary>
-      <div class="pl-4 flex flex-col space-y-1">
-        <a href="{{ suppliers_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">Suppliers</a>
-        <a href="{{ indents_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">Indents</a>
-        <a href="{{ po_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">Purchase Orders</a>
-        <a href="{{ grn_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">GRNs</a>
-      </div>
-    </details>
-    <details class="mb-2">
-      <summary class="cursor-pointer px-2 py-2 rounded hover:bg-primary/50 hover:text-white">Production</summary>
-      <div class="pl-4 flex flex-col space-y-1">
-        <a href="{{ recipes_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">Recipes</a>
-      </div>
-    </details>
-    <details>
-      <summary class="cursor-pointer px-2 py-2 rounded hover:bg-primary/50 hover:text-white">Account</summary>
-      <div class="pl-4 flex flex-col space-y-1">
-        {% if user.is_authenticated %}
-          <a href="{{ logout_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">Logout</a>
-        {% else %}
-          <a href="{{ login_url }}" class="block px-2 py-1 rounded hover:bg-primary/50 hover:text-white">Login</a>
-        {% endif %}
-      </div>
-    </details>
+  <nav class="flex-1 overflow-y-auto px-2 flex flex-col space-y-1">
+    <a href="{{ dashboard_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'dashboard' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">🏠</span>Dashboard</a>
+    <a href="{{ reports_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'history_reports' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">📊</span>Reports</a>
+    <a href="{{ items_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'items_list' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">📦</span>Items</a>
+    <a href="{{ movements_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'stock_movements' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">🔄</span>Stock Movements</a>
+    <a href="{{ suppliers_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'suppliers_list' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">🚚</span>Suppliers</a>
+    <a href="{{ indents_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'indents_list' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">📝</span>Indents</a>
+    <a href="{{ po_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'purchase_orders_list' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">🛒</span>Purchase Orders</a>
+    <a href="{{ grn_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'grn_list' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">📥</span>GRNs</a>
+    <a href="{{ recipes_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'recipes_list' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">🍳</span>Recipes</a>
+    {% if user.is_authenticated %}
+    <a href="{{ logout_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'logout' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">👤</span>Logout</a>
+    {% else %}
+    <a href="{{ login_url }}" class="flex items-center px-2 py-2 rounded hover:bg-primary/50 hover:text-white {% if request.resolver_match.url_name == 'root' %}bg-primary/50 text-white font-medium{% endif %}"><span class="mr-2">👤</span>Login</a>
+    {% endif %}
   </nav>
 </aside>
+

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -12,11 +12,6 @@ def test_nav_template_contains_links():
     request.user = AnonymousUser()
     html = render_to_string("components/nav.html", {"request": request})
     expected = [
-        "Overview",
-        "Inventory",
-        "Procurement",
-        "Production",
-        "Account",
         "Dashboard",
         "Reports",
         "Items",
@@ -39,11 +34,6 @@ def test_home_page_contains_nav_links(client, django_user_model):
     resp = client.get(reverse("root"))
     html = resp.content.decode()
     expected = [
-        "Overview",
-        "Inventory",
-        "Procurement",
-        "Production",
-        "Account",
         "Dashboard",
         "Reports",
         "Items",


### PR DESCRIPTION
## Summary
- Replace accordion sidebar with a flat list of links and emoji icons
- Add conditional styling for the active page
- Update navigation tests for new layout

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab483049608326b2f1a481385b7e27