### PR TITLE
Add placeholder and HTMX swap for KPI cards

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -2,7 +2,15 @@
 {% block content %}
 <h1 class="text-h1">Dashboard</h1>
 
-<div id="kpi-cards" hx-get="{% url 'dashboard-kpis' %}" hx-trigger="load"></div>
+<div
+  id="kpi-cards"
+  hx-get="{% url 'dashboard-kpis' %}"
+  hx-trigger="load"
+  hx-target="#kpi-cards"
+  hx-swap="outerHTML"
+>
+  Loading KPI metrics…
+</div>
 
 <div class="flex gap-4">
   <a href="{% url 'purchase_order_create' %}" class="btn-primary px-4 py-2 rounded">New PO</a>


### PR DESCRIPTION
## Summary
- Ensure KPI cards container swaps itself by adding `hx-target` and `hx-swap="outerHTML"`
- Add a "Loading KPI metrics…" fallback for non-JS environments

## Testing
- `flake8`
- `pytest`
- `python manage.py runserver 0.0.0.0:8000` + `curl -s http://localhost:8000/dashboard/ | sed -n '70,90p'`
- `curl -s http://localhost:8000/dashboard/kpis/ | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ab674938f483268129f25e681ef5b2