### PR TITLE
Guard New PO link behind permission

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -5,7 +5,9 @@
 <div id="kpi-cards" hx-get="{% url 'dashboard-kpis' %}" hx-trigger="load"></div>
 
 <div class="flex gap-4">
-  <a href="{% url 'purchase_order_create' %}" class="btn-primary px-4 py-2 rounded">New PO</a>
+  {% if perms.inventory.add_purchaseorder %}
+    <a href="{% url 'purchase_order_create' %}" class="btn-primary px-4 py-2 rounded">New PO</a>
+  {% endif %}
   <a href="{% url 'grn_list' %}" class="btn-secondary px-4 py-2 rounded">Record Receipt</a>
 </div>
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import pytest
+from django.contrib.auth.models import Permission
 from django.urls import reverse
 from django.utils import timezone
 
@@ -8,7 +9,11 @@ from inventory.models import Indent, PurchaseOrder, StockTransaction, Supplier
 
 
 @pytest.mark.django_db
-def test_dashboard_low_stock(client, item_factory):
+def test_dashboard_low_stock(client, item_factory, django_user_model):
+    user = django_user_model.objects.create_user(username="u", password="pw")
+    perm = Permission.objects.get(codename="add_purchaseorder")
+    user.user_permissions.add(perm)
+    client.force_login(user)
     item_factory(name="Foo", reorder_point=10, current_stock=5)
     resp = client.get(reverse("dashboard"))
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Hide dashboard "New PO" link unless user has `inventory.add_purchaseorder` permission
- Ensure dashboard test logs in with `add_purchaseorder` permission

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab67fc7950832699f25cac3abfa676