### PR TITLE
Exclude inactive items from low-stock KPI

### DIFF
--- a/inventory/services/dashboard_service.py
+++ b/inventory/services/dashboard_service.py
@@ -5,8 +5,14 @@ from inventory.models import Item
 
 def get_low_stock_items():
     """Return items whose current stock is below their reorder point."""
-    return (
+    qs = (
         Item.objects.only("name", "current_stock", "reorder_point")
-        .filter(reorder_point__isnull=False, current_stock__lt=F("reorder_point"))
-        .order_by("name")
+        .filter(
+            reorder_point__isnull=False,
+            current_stock__lt=F("reorder_point"),
+            is_active=True,
+        )
     )
+    if hasattr(Item, "is_placeholder"):
+        qs = qs.filter(is_placeholder=False)
+    return qs.order_by("name")

--- a/inventory/services/kpis.py
+++ b/inventory/services/kpis.py
@@ -47,8 +47,13 @@ def low_stock_count():
 def low_stock_items(limit: int = 5) -> List[str]:
     """Return names of items that are below their reorder point."""
     qs = Item.objects.filter(
-        reorder_point__isnull=False, current_stock__lt=F("reorder_point")
-    ).order_by("name")
+        reorder_point__isnull=False,
+        current_stock__lt=F("reorder_point"),
+        is_active=True,
+    )
+    if hasattr(Item, "is_placeholder"):
+        qs = qs.filter(is_placeholder=False)
+    qs = qs.order_by("name")
     return list(qs.values_list("name", flat=True)[:limit])
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,6 @@ import sys
 import django
 import pytest
 
-from inventory.models import Item
-
 # Ensure project root is on sys.path
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if PROJECT_ROOT not in sys.path:
@@ -13,6 +11,8 @@ if PROJECT_ROOT not in sys.path:
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inventory_app.settings")
 django.setup()
+
+from inventory.models import Item
 
 
 @pytest.fixture
@@ -23,6 +23,7 @@ def item_factory():
             "base_unit": "kg",
             "purchase_unit": "g",
             "category_id": 1,
+            "is_active": True,
         }
         defaults.update(kwargs)
         return Item.objects.create(**defaults)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -10,9 +10,11 @@ from inventory.models import Indent, PurchaseOrder, StockTransaction, Supplier
 @pytest.mark.django_db
 def test_dashboard_low_stock(client, item_factory):
     item_factory(name="Foo", reorder_point=10, current_stock=5)
+    item_factory(name="Inactive", reorder_point=10, current_stock=5, is_active=False)
     resp = client.get(reverse("dashboard"))
     assert resp.status_code == 200
     assert b"Foo" in resp.content
+    assert b"Inactive" not in resp.content
 
 
 @pytest.mark.django_db

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -6,6 +6,7 @@ from inventory.services import dashboard_service
 @pytest.mark.django_db
 def test_get_low_stock_items(item_factory):
     item_factory(name="Low", reorder_point=10, current_stock=5)
+    item_factory(name="Inactive", reorder_point=10, current_stock=5, is_active=False)
     item_factory(name="High", reorder_point=10, current_stock=15)
     items = list(dashboard_service.get_low_stock_items())
     assert [item.name for item in items] == ["Low"]

--- a/tests/test_kpis_service.py
+++ b/tests/test_kpis_service.py
@@ -17,6 +17,13 @@ from inventory.services import kpis
 
 
 @pytest.mark.django_db
+def test_low_stock_items_excludes_inactive(item_factory):
+    item_factory(name="Active", reorder_point=10, current_stock=5)
+    item_factory(name="Inactive", reorder_point=10, current_stock=5, is_active=False)
+    assert kpis.low_stock_items() == ["Active"]
+
+
+@pytest.mark.django_db
 def test_kpi_calculations(item_factory):
     item1 = item_factory(name="A", reorder_point=20, current_stock=10)
     item2 = item_factory(name="B", reorder_point=1, current_stock=5)


### PR DESCRIPTION
## Summary
- Ignore inactive and placeholder items when retrieving low-stock entries
- Default test item factory to active items
- Add coverage ensuring inactive items are filtered out

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6807659083268cba7c1c2040d2b2