### PR TITLE
Fix history reports tabs template

### DIFF
--- a/inventory/views/stock.py
+++ b/inventory/views/stock.py
@@ -371,6 +371,19 @@ def history_reports(request):
     chart_labels = [tx.transaction_date.strftime("%Y-%m-%d") for tx in chart_qs]
     chart_data = [float(tx.quantity_change) for tx in chart_qs]
 
+    tabs = [
+        {
+            "id": "history-table-tab",
+            "title": "Table",
+            "template": "inventory/_history_table.html",
+        },
+        {
+            "id": "history-chart-tab",
+            "title": "Chart",
+            "template": "inventory/_history_chart.html",
+        },
+    ]
+
     ctx = {
         "page_obj": page_obj,
         "transaction_types": transaction_types,
@@ -388,6 +401,7 @@ def history_reports(request):
         "filters": filters,
         "chart_labels": chart_labels,
         "chart_data": chart_data,
+        "tabs": tabs,
     }
     template = (
         "inventory/_history_tabs.html"

--- a/templates/inventory/_history_tabs.html
+++ b/templates/inventory/_history_tabs.html
@@ -1,7 +1,2 @@
-{% with tabs_list=[
-  {"id": "history-table-tab", "title": "Table", "template": "inventory/_history_table.html"},
-  {"id": "history-chart-tab", "title": "Chart", "template": "inventory/_history_chart.html"}
-] %}
-  {% include "components/tabs.html" with tabs=tabs_list %}
-{% endwith %}
+{% include "components/tabs.html" with tabs=tabs %}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ if PROJECT_ROOT not in sys.path:
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inventory_app.settings")
 django.setup()
 
-from inventory.models import Item
+from inventory.models import Item  # noqa: E402
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- build tab definitions in `history_reports` view
- simplify history reports tab template
- silence flake8 import-order warning in tests

## Testing
- `flake8`
- `pytest` *(fails: test suite errors and failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6defabfc83268d292f7d724f5511