### PR TITLE
Ensure dev requirements install project dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,4 @@
+-r requirements.txt
+flake8==7.3.0
 pytest==8.4.1
 pytest-django==4.11.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ if PROJECT_ROOT not in sys.path:
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inventory_app.settings")
 django.setup()
 
-from inventory.models import Item
+from inventory.models import Item  # noqa: E402
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Include project dependencies and linting tools in development requirements
- Silence flake8 import-order warning in test configuration

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab6f44aab4832695f2654f9424c3eb