### PR TITLE
Clear item caches after creating an item

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -210,6 +210,8 @@ class ItemCreateView(View):
         form = ItemForm(request.POST)
         if form.is_valid():
             form.save()
+            item_service.get_all_items_with_stock.clear()
+            item_service.get_distinct_departments_from_items.clear()
             if request.headers.get("HX-Request"):
                 items = Item.objects.order_by("name")[:20]
                 options_html = render_to_string(


### PR DESCRIPTION
## Summary
- clear item cache when creating new items so lists and departments stay up to date

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab6fbf13f883268906ec7bc91158f9