### PR TITLE
Add interactive dashboard with AJAX data loading

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -19,11 +19,41 @@
   <a href="{% url 'grn_list' %}" class="btn-secondary px-4 py-2 rounded">Record Receipt</a>
 </div>
 
+<form id="dashboard-filters" class="flex flex-wrap gap-2 my-4 items-end">
+  <div>
+    <label for="item" class="block">Item</label>
+    <select id="item" name="item" class="border p-1">
+      <option value="">All</option>
+      {% for item in items %}
+        <option value="{{ item.pk }}">{{ item.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label for="supplier" class="block">Supplier</label>
+    <select id="supplier" name="supplier" class="border p-1">
+      <option value="">All</option>
+      {% for supplier in suppliers %}
+        <option value="{{ supplier.pk }}">{{ supplier.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div>
+    <label for="start" class="block">Start</label>
+    <input type="date" id="start" name="start" class="border p-1" />
+  </div>
+  <div>
+    <label for="end" class="block">End</label>
+    <input type="date" id="end" name="end" class="border p-1" />
+  </div>
+  <button type="button" id="apply-filters" class="btn-primary px-4 py-2 rounded">Apply</button>
+</form>
+
 <div>
   <canvas id="stock-trend-chart" class="w-full h-64"></canvas>
   <script>
     const ctx = document.getElementById('stock-trend-chart').getContext('2d');
-    new Chart(ctx, {
+    const chart = new Chart(ctx, {
       type: 'line',
       data: {
         labels: {{ trend_labels|safe }},
@@ -37,6 +67,18 @@
       },
       options: {responsive: true, maintainAspectRatio: false}
     });
+
+    async function fetchTrend() {
+      const form = document.getElementById('dashboard-filters');
+      const params = new URLSearchParams(new FormData(form));
+      const resp = await fetch('{% url "ajax-dashboard-data" %}?'+params.toString());
+      const data = await resp.json();
+      chart.data.labels = data.labels;
+      chart.data.datasets[0].data = data.values;
+      chart.update();
+    }
+
+    document.getElementById('apply-filters').addEventListener('click', fetchTrend);
   </script>
 </div>
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from .views import ajax_dashboard_data, interactive_dashboard
+
+urlpatterns = [
+    path("dashboard/interactive/", interactive_dashboard, name="interactive-dashboard"),
+    path("dashboard/data/", ajax_dashboard_data, name="ajax-dashboard-data"),
+]

--- a/inventory_app/urls.py
+++ b/inventory_app/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     path("dashboard/kpis/", dashboard_kpis, name="dashboard-kpis"),
     path("healthz", health_check, name="health-check"),
     path("accounts/", include("django.contrib.auth.urls")),
+    path("", include("core.urls")),
     path("api/", include("inventory.urls")),  # DRF API
     path("", include("inventory.ui_urls")),  # HTML UI routes
 ]

--- a/tests/test_interactive_dashboard.py
+++ b/tests/test_interactive_dashboard.py
@@ -1,0 +1,46 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from inventory.models import PurchaseOrder, StockTransaction, Supplier
+
+
+@pytest.mark.django_db
+def test_ajax_dashboard_data_filters(client, item_factory):
+    item = item_factory(name="Filtered")
+    other = item_factory(name="Other")
+    supplier = Supplier.objects.create(name="Supp", is_active=True)
+    po = PurchaseOrder.objects.create(supplier=supplier, order_date=timezone.now().date())
+    StockTransaction.objects.create(
+        item=item,
+        quantity_change=5,
+        transaction_type="RECEIVING",
+        transaction_date=timezone.now(),
+        related_po_id=po.pk,
+    )
+    StockTransaction.objects.create(
+        item=other,
+        quantity_change=3,
+        transaction_type="RECEIVING",
+        transaction_date=timezone.now(),
+    )
+
+    day = timezone.now().date().isoformat()
+    url = (
+        reverse("ajax-dashboard-data")
+        + f"?item={item.pk}&supplier={supplier.pk}&start={day}&end={day}"
+    )
+    resp = client.get(url)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["labels"] == [day]
+    assert data["values"] == [5.0]
+
+
+@pytest.mark.django_db
+def test_interactive_dashboard_template(client, django_user_model):
+    user = django_user_model.objects.create_user(username="u", password="pw")
+    client.force_login(user)
+    resp = client.get(reverse("interactive-dashboard"))
+    assert resp.status_code == 200
+    assert b"dashboard-filters" in resp.content


### PR DESCRIPTION
## Summary
- Add `interactive_dashboard` and AJAX data endpoint to serve chart data via JSON
- Enable dashboard filtering by item, supplier, and date with asynchronous chart updates
- Include URL patterns and unit tests for new dashboard features

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab7150a4b883268e498905fd715c93