### PR TITLE
Add what-if reorder projections

### DIFF
--- a/inventory/forms/reorder_point_form.py
+++ b/inventory/forms/reorder_point_form.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from django import forms
+
+from ..models import Item
+from .base import StyledFormMixin
+
+
+class ReorderPointForm(StyledFormMixin, forms.Form):
+    """Form for updating reorder point on multiple items."""
+
+    items = forms.ModelMultipleChoiceField(
+        queryset=Item.objects.filter(is_active=True),
+        required=True,
+    )
+    reorder_point = forms.DecimalField(min_value=0, required=True)

--- a/inventory/urls.py
+++ b/inventory/urls.py
@@ -18,6 +18,7 @@ from .views import (
     SupplierViewSet,
 )
 from .views.items import ItemsExportView
+from .views.what_if import what_if_reorder
 
 router = DefaultRouter()
 router.register(r"items", ItemViewSet)
@@ -35,4 +36,5 @@ router.register(r"sale-transactions", SaleTransactionViewSet)
 
 urlpatterns = router.urls + [
     path("items/export/", ItemsExportView.as_view(), name="items_export_api"),
+    path("what-if/reorder/", what_if_reorder, name="what_if_reorder"),
 ]

--- a/inventory/views/what_if.py
+++ b/inventory/views/what_if.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from django.shortcuts import render
+
+from ..forms.reorder_point_form import ReorderPointForm
+from ..services import stock_service
+
+
+def what_if_reorder(request):
+    """Adjust reorder points and show projected stock levels."""
+
+    form = ReorderPointForm(request.POST or None)
+    projections = []
+    if request.method == "POST" and form.is_valid():
+        items = form.cleaned_data["items"]
+        reorder_point = form.cleaned_data["reorder_point"]
+        for item in items:
+            item.reorder_point = reorder_point
+            item.save(update_fields=["reorder_point"])
+            history = stock_service.get_stock_history(item.pk)
+            projections.append({"item": item, "history": history})
+    return render(
+        request,
+        "inventory/what_if_reorder.html",
+        {"form": form, "projections": projections},
+    )

--- a/templates/inventory/what_if_reorder.html
+++ b/templates/inventory/what_if_reorder.html
@@ -1,0 +1,44 @@
+{% extends "components/form_layout.html" %}
+{% block title %}What-if Reorder – Inventory App{% endblock %}
+{% block heading %}What-if Reorder{% endblock %}
+{% block fields %}
+  {% include "components/form_field.html" with field=form.items %}
+  {% include "components/form_field.html" with field=form.reorder_point %}
+{% endblock %}
+{% block submit_text %}Recalculate{% endblock %}
+{% block back_url %}{% url 'items_list' %}{% endblock %}
+{% block extra %}
+  {% if projections %}
+  <div class="mt-8 space-y-8">
+    {% for proj in projections %}
+      {% with data_id='data-'|add:proj.item.item_id|stringformat:"s" %}
+      <div>
+        <h2 class="text-h2 mb-2">{{ proj.item.name }}</h2>
+        <canvas id="chart-{{ proj.item.item_id }}" class="w-full h-64"></canvas>
+        {{ proj.history|json_script:data_id }}
+      </div>
+      {% endwith %}
+    {% endfor %}
+  </div>
+  <script>
+  {% for proj in projections %}
+    const data{{ proj.item.item_id }} = JSON.parse(document.getElementById('data-{{ proj.item.item_id }}').textContent);
+    const ctx{{ proj.item.item_id }} = document.getElementById('chart-{{ proj.item.item_id }}').getContext('2d');
+    new Chart(ctx{{ proj.item.item_id }}, {
+      type: 'line',
+      data: {
+        labels: data{{ proj.item.item_id }}.map((_, idx) => idx + 1),
+        datasets: [{
+          label: 'Stock',
+          data: data{{ proj.item.item_id }},
+          borderColor: '#3b82f6',
+          fill: false,
+          tension: 0.1
+        }]
+      },
+      options: {responsive: true, maintainAspectRatio: false}
+    });
+  {% endfor %}
+  </script>
+  {% endif %}
+{% endblock %}

--- a/tests/test_what_if_reorder.py
+++ b/tests/test_what_if_reorder.py
@@ -1,0 +1,21 @@
+import pytest
+from django.urls import reverse
+
+from inventory.services import stock_service
+
+
+@pytest.mark.django_db
+def test_what_if_reorder_projection(client, item_factory):
+    item = item_factory(current_stock=10, reorder_point=5)
+    stock_service.record_stock_transaction(
+        item_id=item.item_id,
+        quantity_change=5,
+        transaction_type="RECEIVING",
+    )
+    url = reverse("what_if_reorder")
+    response = client.post(url, {"items": [item.item_id], "reorder_point": 3})
+    assert response.status_code == 200
+    item.refresh_from_db()
+    assert item.reorder_point == 3
+    expected = stock_service.get_stock_history(item.item_id)
+    assert response.context["projections"][0]["history"] == expected


### PR DESCRIPTION
## Summary
- add form for adjusting reorder point on selected items
- implement view and template to project stock levels with charts
- wire up routing and tests for projection recalculation

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab715b61048326b76c749bba5a4320