### PR TITLE
Add sales and stock visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Inventory-App is a Django application for managing restaurant inventory with a P
 
 - Item and supplier management
 - Stock movement logging and history reports
+- Interactive visualizations for historical sales and stock data
 - Indent and purchase order tracking
 - Dashboard showing key metrics such as low-stock items
 - Bulk upload items and stock transactions from CSV files
@@ -150,6 +151,12 @@ page_obj, _ = list_utils.paginate(request, qs)
 
 `list_utils.export_as_csv` can turn any iterable into a downloadable CSV by
 supplying the header row and a function that builds each data row.
+
+## Visualizations
+
+The `/visualizations/` page provides interactive heatmaps and scatter plots of
+sales and stock movements. Use the metric dropdown and date pickers to filter
+the data range rendered by Plotly.
 
 ## API Endpoints
 

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -30,6 +30,7 @@ from .views.purchase_orders import (
 )
 from .views.recipes import RecipesListView, recipe_create, recipe_detail
 from .views.stock import history_reports, stock_movements
+from .views.visualizations import visualizations
 from .views.suppliers import (
     SupplierCreateView,
     SupplierEditView,
@@ -80,6 +81,7 @@ urlpatterns = [
     path("suppliers/search/", SupplierSearchView.as_view(), name="supplier_search"),
     path("stock-movements/", stock_movements, name="stock_movements"),
     path("history-reports/", history_reports, name="history_reports"),
+    path("visualizations/", visualizations, name="visualizations"),
     path("indents/", IndentsListView.as_view(), name="indents_list"),
     path("indents/table/", IndentsTableView.as_view(), name="indents_table"),
     path("indents/create/", IndentCreateView.as_view(), name="indent_create"),

--- a/inventory/views/visualizations.py
+++ b/inventory/views/visualizations.py
@@ -1,0 +1,55 @@
+from django.db.models import Sum
+from django.db.models.functions import TruncDate
+from django.shortcuts import render
+
+from ..models import SaleTransaction, StockTransaction
+
+
+def visualizations(request):
+    metric = request.GET.get("metric", "sales")
+    start_date = request.GET.get("start_date")
+    end_date = request.GET.get("end_date")
+
+    sales_qs = SaleTransaction.objects.all()
+    stock_qs = StockTransaction.objects.all()
+
+    if start_date:
+        sales_qs = sales_qs.filter(sale_date__date__gte=start_date)
+        stock_qs = stock_qs.filter(transaction_date__date__gte=start_date)
+    if end_date:
+        sales_qs = sales_qs.filter(sale_date__date__lte=end_date)
+        stock_qs = stock_qs.filter(transaction_date__date__lte=end_date)
+
+    sales_data = (
+        sales_qs.annotate(date=TruncDate("sale_date"))
+        .values("date")
+        .annotate(total=Sum("quantity"))
+        .order_by("date")
+    )
+    stock_data = (
+        stock_qs.annotate(date=TruncDate("transaction_date"))
+        .values("date")
+        .annotate(total=Sum("quantity_change"))
+        .order_by("date")
+    )
+
+    sales_map = {d["date"].isoformat(): float(d["total"]) for d in sales_data}
+    stock_map = {d["date"].isoformat(): float(d["total"]) for d in stock_data}
+    dates = sorted(set(sales_map) | set(stock_map))
+
+    heatmap_z = [
+        [sales_map.get(d, 0) for d in dates],
+        [stock_map.get(d, 0) for d in dates],
+    ]
+    selected_map = sales_map if metric == "sales" else stock_map
+    scatter_y = [selected_map.get(d, 0) for d in dates]
+
+    context = {
+        "metric": metric,
+        "start_date": start_date,
+        "end_date": end_date,
+        "dates": dates,
+        "heatmap_z": heatmap_z,
+        "scatter_y": scatter_y,
+    }
+    return render(request, "inventory/visualizations.html", context)

--- a/templates/inventory/visualizations.html
+++ b/templates/inventory/visualizations.html
@@ -1,0 +1,40 @@
+{% extends "_base.html" %}
+{% block title %}Visualizations – Inventory App{% endblock %}
+{% block content %}
+  <h1 class="text-h1 font-semibold mb-4">Visualizations</h1>
+  <form method="get" class="flex flex-col md:flex-row gap-2 mb-4">
+    <select name="metric" class="form-control">
+      <option value="sales" {% if metric == 'sales' %}selected{% endif %}>Sales</option>
+      <option value="stock" {% if metric == 'stock' %}selected{% endif %}>Stock</option>
+    </select>
+    <input type="date" name="start_date" value="{{ start_date }}" class="form-control" />
+    <input type="date" name="end_date" value="{{ end_date }}" class="form-control" />
+    <button type="submit" class="btn-primary">Apply</button>
+  </form>
+  <div id="heatmap" class="w-full h-64"></div>
+  <div id="scatter" class="w-full h-64 mt-4"></div>
+  {{ dates|json_script:"viz-dates" }}
+  {{ heatmap_z|json_script:"viz-heatmap" }}
+  {{ scatter_y|json_script:"viz-scatter-y" }}
+  <script src="https://cdn.plot.ly/plotly-2.26.0.min.js"></script>
+  <script>
+    const dates = JSON.parse(document.getElementById('viz-dates').textContent);
+    const heatmapZ = JSON.parse(document.getElementById('viz-heatmap').textContent);
+    const scatterY = JSON.parse(document.getElementById('viz-scatter-y').textContent);
+
+    Plotly.newPlot('heatmap', [{
+      z: heatmapZ,
+      x: dates,
+      y: ['Sales','Stock'],
+      type: 'heatmap',
+      colorscale: 'Viridis'
+    }], {margin: {t: 30}});
+
+    Plotly.newPlot('scatter', [{
+      x: dates,
+      y: scatterY,
+      mode: 'markers',
+      name: '{{ metric|capfirst }}'
+    }], {margin: {t: 30}, xaxis: {title: 'Date'}, yaxis: {title: '{{ metric|capfirst }}'}});
+  </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `visualizations` view aggregating sales and stock history
- plot heatmap and scatter data with Plotly and filter widgets
- document visualization usage in README

## Testing
- `flake8`
- `pytest` *(fails: OperationalError: no such table: items)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7165f210832690c0dc5222564733