### PR TITLE
Add explore view with filtering and CSV export

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -41,8 +41,11 @@ from .views.suppliers import (
     SuppliersTableView,
     SupplierToggleActiveView,
 )
+from .views.explore import explore, explore_export
 
 urlpatterns = [
+    path("explore/", explore, name="explore"),
+    path("explore/export/", explore_export, name="explore_export"),
     path("items/", ItemsListView.as_view(), name="items_list"),
     path("items/table/", ItemsTableView.as_view(), name="items_table"),
     path("items/export/", ItemsExportView.as_view(), name="items_export"),

--- a/inventory/views/explore.py
+++ b/inventory/views/explore.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from django.shortcuts import render
+from django.urls import reverse
+
+from ..models import items as models_items
+from ..services import list_utils
+
+Item = models_items.Item
+
+
+def _filter_items(request):
+    """Return filtered and sorted queryset of items."""
+    qs = Item.objects.all()
+    qs, params = list_utils.apply_filters_sort(
+        request,
+        qs,
+        search_fields=["name"],
+        filter_fields={"active": "is_active"},
+        default_sort="name",
+    )
+    return qs, params
+
+
+def explore(request):
+    """Display items with optional filters and pagination."""
+    qs, params = _filter_items(request)
+    page_obj, per_page = list_utils.paginate(request, qs)
+    ctx = {
+        **params,
+        "page_obj": page_obj,
+        "page_size": per_page,
+        "querystring": list_utils.build_querystring(request),
+        "export_url": reverse("explore_export"),
+    }
+    return render(request, "inventory/explore.html", ctx)
+
+
+def explore_export(request):
+    """Export the filtered items as CSV."""
+    qs, _ = _filter_items(request)
+    headers = ["ID", "Name", "Base Unit", "Current Stock", "Active"]
+
+    def row(item: Item):
+        return [
+            item.item_id,
+            item.name,
+            item.base_unit,
+            item.current_stock,
+            item.is_active,
+        ]
+
+    return list_utils.export_as_csv(qs, headers, row, "items.csv")

--- a/templates/inventory/explore.html
+++ b/templates/inventory/explore.html
@@ -1,0 +1,30 @@
+{% extends "_base.html" %}
+{% block content %}
+<h1>Explore Items</h1>
+<form method="get">
+  <input type="text" name="q" value="{{ q }}" placeholder="Search" />
+  <select name="active">
+    <option value="" {% if not active %}selected{% endif %}>All</option>
+    <option value="1" {% if active == '1' %}selected{% endif %}>Active</option>
+    <option value="0" {% if active == '0' %}selected{% endif %}>Inactive</option>
+  </select>
+  <button type="submit">Filter</button>
+</form>
+<a href="{{ export_url }}?{{ querystring }}">Export CSV</a>
+<ul>
+{% for item in page_obj.object_list %}
+  <li>{{ item.name }}</li>
+{% empty %}
+  <li>No results</li>
+{% endfor %}
+</ul>
+<div class="pagination">
+  {% if page_obj.has_previous %}
+    <a href="?{{ querystring }}&page={{ page_obj.previous_page_number }}">Prev</a>
+  {% endif %}
+  <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+  {% if page_obj.has_next %}
+    <a href="?{{ querystring }}&page={{ page_obj.next_page_number }}">Next</a>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_explore_view.py
+++ b/tests/test_explore_view.py
@@ -1,0 +1,42 @@
+import csv
+import pytest
+from django.urls import reverse
+
+from inventory.models import Item
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_item(name="Widget", active=True):
+    return Item.objects.create(
+        name=name,
+        base_unit="pcs",
+        purchase_unit="box",
+        permitted_departments="dept",
+        reorder_point=1,
+        notes="n",
+        is_active=active,
+    )
+
+
+def test_explore_filters_by_query_and_active(client):
+    _create_item("Apple", True)
+    _create_item("Banana", False)
+    url = reverse("explore") + "?q=Banana&active=0"
+    resp = client.get(url)
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    assert "Banana" in content
+    assert "Apple" not in content
+
+
+def test_explore_export_csv(client):
+    _create_item("Apple", True)
+    url = reverse("explore_export")
+    resp = client.get(url)
+    assert resp.status_code == 200
+    assert resp["Content-Type"] == "text/csv"
+    assert "attachment; filename=items.csv" in resp["Content-Disposition"]
+    rows = list(csv.reader(resp.content.decode().splitlines()))
+    assert rows[0] == ["ID", "Name", "Base Unit", "Current Stock", "Active"]
+    assert rows[1][1] == "Apple"


### PR DESCRIPTION
## Summary
- add explore view with filtering, pagination and CSV export
- expose explore routes and template for item exploration
- test filtering and CSV export for explore view

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab717afefc8326b197fa58015f4363