### PR TITLE
Handle recipe tags as structured JSON

### DIFF
--- a/inventory/forms/recipe_forms.py
+++ b/inventory/forms/recipe_forms.py
@@ -1,3 +1,5 @@
+import json
+
 from django import forms
 
 from ..models import Recipe, RecipeComponent
@@ -5,6 +7,8 @@ from .base import StyledFormMixin
 
 
 class RecipeForm(StyledFormMixin, forms.ModelForm):
+    tags = forms.CharField(required=False, help_text="Comma-separated tags")
+
     class Meta:
         model = Recipe
         fields = [
@@ -17,6 +21,24 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
             "tags",
             "is_active",
         ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        tags = self.initial.get("tags")
+        if isinstance(tags, list):
+            self.initial["tags"] = ", ".join(tags)
+
+    def clean_tags(self):
+        data = self.cleaned_data.get("tags")
+        if not data:
+            return []
+        try:
+            parsed = json.loads(data)
+            if isinstance(parsed, list):
+                return parsed
+            return [parsed]
+        except (TypeError, ValueError):
+            return [t.strip() for t in str(data).split(",") if t.strip()]
 
 
 class RecipeComponentForm(StyledFormMixin, forms.ModelForm):

--- a/inventory/migrations/0015_alter_recipe_tags.py
+++ b/inventory/migrations/0015_alter_recipe_tags.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("inventory", "0014_alter_item_is_active"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="recipe",
+            name="tags",
+            field=models.JSONField(blank=True, null=True, default=list),
+        ),
+    ]

--- a/inventory/models/__init__.py
+++ b/inventory/models/__init__.py
@@ -44,7 +44,7 @@ class Recipe(models.Model):
     default_yield_qty = CoerceFloatField(default=Decimal("0"), blank=True, null=True)
     default_yield_unit = models.CharField(max_length=50, blank=True, null=True)
     plating_notes = models.TextField(blank=True, null=True)
-    tags = models.CharField(max_length=255, blank=True, null=True)
+    tags = models.JSONField(default=list, blank=True, null=True)
     version = models.IntegerField(blank=True, null=True)
     effective_from = models.DateField(auto_now_add=True)
     effective_to = models.DateField(auto_now=True)

--- a/inventory/services/ui_service.py
+++ b/inventory/services/ui_service.py
@@ -62,7 +62,9 @@ def build_recipe_choice_label(recipe: Any) -> str:
     recipe = _to_dict(recipe)
     name = recipe.get("name", "")
     unit = recipe.get("default_yield_unit") or ""
-    tags = recipe.get("tags") or ""
+    tags = recipe.get("tags") or []
+    if isinstance(tags, list):
+        tags = ", ".join(str(t) for t in tags if str(t).strip())
     return f"{name} | {unit} | {tags}"
 
 

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -199,4 +199,4 @@ def test_recipe_metadata_fields():
     recipe = Recipe.objects.get(pk=rid)
     assert recipe.type == "FOOD"
     assert recipe.default_yield_unit == "plate"
-    assert recipe.tags == "vegan,healthy"
+    assert recipe.tags == ["vegan", "healthy"]

--- a/tests/test_ui_choices.py
+++ b/tests/test_ui_choices.py
@@ -17,7 +17,7 @@ def test_build_component_options_basic():
             "recipe_id": 10,
             "name": "Bread",
             "default_yield_unit": "loaf",
-            "tags": "baked",
+            "tags": ["baked"],
         }
     ]
     options, meta = build_component_options(items, recipes, placeholder="Choose")


### PR DESCRIPTION
## Summary
- store recipe tags as JSONField
- parse comma-separated tag inputs in forms and services
- adjust UI and tests for tag lists

## Testing
- `flake8`
- `pytest` *(fails: 32 failed, 25 passed, 1 skipped, 69 warnings, 49 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab73d329f88326ba7bfe7774e63fd1