### PR TITLE
Pin lint hooks to Python 3.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,16 +3,18 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black
-        language_version: python3
+        language_version: python3.11
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
       - id: isort
         args: ["--profile", "black"]
+        language_version: python3.11
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:
       - id: flake8
+        language_version: python3.11
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Any `<select>` element with the `predictive` class is automatically enhanced wit
 
 ## Installation
 
+This project requires **Python 3.11 or newer**.
+
 Install dependencies using `pip`:
 
 ```bash


### PR DESCRIPTION
## Summary
- ensure Black, isort, and Flake8 run under Python 3.11
- document Python 3.11 runtime requirement in README

## Testing
- `pre-commit run --files inventory/__init__.py`
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab745fa0808326aedbc5272eb19972