### PR TITLE
refactor: centralize supabase connection

### DIFF
--- a/inventory/services/__init__.py
+++ b/inventory/services/__init__.py
@@ -11,6 +11,7 @@ from . import (
     recipe_service,
     sale_service,
     stock_service,
+    supabase_client,
     supabase_categories,
     supabase_units,
     supplier_service,
@@ -30,6 +31,7 @@ __all__ = [
     "sale_service",
     "kpis",
     "counts",
+    "supabase_client",
     "supabase_units",
     "supabase_categories",
 ]

--- a/inventory/services/supabase_categories.py
+++ b/inventory/services/supabase_categories.py
@@ -1,17 +1,9 @@
 import logging
-import os
 import threading
 import time
 from typing import Dict, List, Optional
 
-try:
-    from supabase import Client, SupabaseException, create_client
-except ModuleNotFoundError:  # pragma: no cover - supabase optional
-    Client = None  # type: ignore
-    create_client = None  # type: ignore
-
-    class SupabaseException(Exception):
-        pass
+from .supabase_client import SupabaseException, get_supabase_client
 
 
 logger = logging.getLogger(__name__)
@@ -31,13 +23,11 @@ def _load_categories_from_supabase() -> Dict[Optional[str], List[dict]]:
     initialised or the request fails, an empty mapping is returned.
     """
 
-    url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_KEY")
-    if not url or not key or create_client is None:
+    client = get_supabase_client()
+    if client is None:
         logger.warning("Supabase is not configured; no categories loaded")
         return {}
     try:  # pragma: no cover - network interaction
-        client: Client = create_client(url, key)
         resp = (
             client.table("category")
             .select("category_id,category,sub_category")

--- a/inventory/services/supabase_client.py
+++ b/inventory/services/supabase_client.py
@@ -1,0 +1,43 @@
+import logging
+import os
+from typing import Optional
+
+try:
+    from supabase import Client, SupabaseException, create_client
+except ModuleNotFoundError:  # pragma: no cover - supabase optional
+    Client = None  # type: ignore
+    create_client = None  # type: ignore
+
+    class SupabaseException(Exception):
+        pass
+
+logger = logging.getLogger(__name__)
+
+_client: Client | None = None
+
+
+def get_supabase_client() -> Optional[Client]:
+    """Return a cached Supabase client if available.
+
+    The client is initialised using the ``SUPABASE_URL`` and ``SUPABASE_KEY``
+    environment variables. If configuration is missing or the connection
+    fails, ``None`` is returned and the error is logged. The initialisation
+    is performed once and the resulting client is cached for subsequent
+    calls.
+    """
+
+    global _client
+    if _client is not None:
+        return _client
+
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_KEY")
+    if not url or not key or create_client is None:
+        logger.warning("Supabase is not configured")
+        return None
+    try:  # pragma: no cover - network interaction
+        _client = create_client(url, key)
+    except SupabaseException:  # pragma: no cover - network interaction
+        logger.exception("Failed to initialise Supabase client")
+        return None
+    return _client

--- a/inventory/services/supabase_units.py
+++ b/inventory/services/supabase_units.py
@@ -1,17 +1,9 @@
 import logging
-import os
 import threading
 import time
 from typing import Dict, List
 
-try:
-    from supabase import Client, SupabaseException, create_client
-except ModuleNotFoundError:  # pragma: no cover - supabase optional
-    Client = None  # type: ignore
-    create_client = None  # type: ignore
-
-    class SupabaseException(Exception):
-        pass
+from .supabase_client import SupabaseException, get_supabase_client
 
 
 logger = logging.getLogger(__name__)
@@ -30,13 +22,11 @@ def _load_units_from_supabase() -> Dict[str, List[str]]:
     mapping is returned.
     """
 
-    url = os.getenv("SUPABASE_URL")
-    key = os.getenv("SUPABASE_KEY")
-    if not url or not key or create_client is None:
+    client = get_supabase_client()
+    if client is None:
         logger.warning("Supabase is not configured; no units loaded")
         return {}
     try:  # pragma: no cover - network interaction
-        client: Client = create_client(url, key)
         resp = client.table("units").select("base_unit,purchase_unit").execute()
     except SupabaseException:  # pragma: no cover - network interaction
         logger.exception("Failed to fetch units from Supabase")

--- a/tests/test_supabase_categories.py
+++ b/tests/test_supabase_categories.py
@@ -1,7 +1,7 @@
 import time
 from concurrent.futures import ThreadPoolExecutor
 
-from inventory.services import supabase_categories
+from inventory.services import supabase_categories, supabase_client
 
 
 class DummyResp:
@@ -58,8 +58,9 @@ class DummyClient:
 def test_load_categories_from_supabase(monkeypatch):
     monkeypatch.setenv("SUPABASE_URL", "url")
     monkeypatch.setenv("SUPABASE_KEY", "key")
+    monkeypatch.setattr(supabase_client, "_client", None)
     monkeypatch.setattr(
-        supabase_categories, "create_client", lambda url, key: DummyClient()
+        supabase_client, "create_client", lambda url, key: DummyClient()
     )
     cats = supabase_categories._load_categories_from_supabase()
     assert cats == {
@@ -71,13 +72,14 @@ def test_load_categories_from_supabase(monkeypatch):
 def test_load_categories_supabase_exception(monkeypatch):
     monkeypatch.setenv("SUPABASE_URL", "url")
     monkeypatch.setenv("SUPABASE_KEY", "key")
+    monkeypatch.setattr(supabase_client, "_client", None)
 
     class FailingClient(DummyClient):
         def table(self, name):
             raise supabase_categories.SupabaseException("fail")
 
     monkeypatch.setattr(
-        supabase_categories, "create_client", lambda u, k: FailingClient()
+        supabase_client, "create_client", lambda u, k: FailingClient()
     )
     cats = supabase_categories._load_categories_from_supabase()
     assert cats == {}


### PR DESCRIPTION
## Summary
- add shared Supabase client helper
- use centralized client in categories and units services
- update unit and category tests for new client

## Testing
- `flake8`
- `pytest tests/test_supabase_units.py tests/test_supabase_categories.py -q`
- `pytest -q` *(fails: no such table: items)*

------
https://chatgpt.com/codex/tasks/task_e_68ab755324c08326b95c5e7d18d52032