### PR TITLE
Include database error details in purchase order creation

### DIFF
--- a/inventory/services/purchase_order_service.py
+++ b/inventory/services/purchase_order_service.py
@@ -47,10 +47,10 @@ def create_po(
         return False, f"Invalid reference: {exc}", None
     except IntegrityError as exc:
         logger.error("Integrity error creating PO: %s", exc)
-        return False, "Database error creating Purchase Order.", None
+        return False, f"Database error: {exc}", None
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("Error creating PO: %s", exc)
-        return False, "Database error creating Purchase Order.", None
+        return False, f"Database error: {exc}", None
 
 
 def get_po_by_id(po_id: int) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- include underlying database error message in `create_po` failures

## Testing
- `flake8`
- `pytest` *(fails: django.db.utils.OperationalError: no such table: items)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7bd7e068832686e6ae78f99d58cd