### PR TITLE
Refactor Supabase caching with shared helper

### DIFF
--- a/inventory/services/supabase_cache.py
+++ b/inventory/services/supabase_cache.py
@@ -1,0 +1,60 @@
+"""Generic caching utilities for Supabase-backed services.
+
+This module provides a small helper to wrap data-fetching callables with
+thread-safe caching and time-based invalidation. It centralises the
+previously duplicated cache and lock management used by several Supabase
+service modules.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Generic, TypeVar
+
+
+T = TypeVar("T")
+
+
+@dataclass
+class _CacheState(Generic[T]):
+    """Internal mutable cache container used by ``get_cached``."""
+
+    value: T | None = None
+    time: float | None = None
+
+
+def get_cached(fetch_func: Callable[[], T], ttl: int) -> Callable[[bool], T]:
+    """Return a callable that caches ``fetch_func`` results for ``ttl`` seconds.
+
+    The returned function accepts a ``force`` boolean parameter. When ``force``
+    is ``True`` the cache is bypassed and refreshed immediately. Cache state and
+    the internal lock are exposed via ``_state`` and ``_lock`` attributes to aid
+    testing.
+    """
+
+    lock = threading.Lock()
+    state: _CacheState[T] = _CacheState()
+
+    def wrapper(force: bool = False) -> T:
+        with lock:
+            now = time.time()
+            if (
+                not force
+                and state.value is not None
+                and state.time is not None
+                and now - state.time < ttl
+            ):
+                return state.value
+
+            state.value = fetch_func()
+            state.time = now
+            return state.value
+
+    wrapper._state = state  # type: ignore[attr-defined]
+    wrapper._lock = lock  # type: ignore[attr-defined]
+    return wrapper
+
+
+__all__ = ["get_cached"]

--- a/tests/test_supabase_categories.py
+++ b/tests/test_supabase_categories.py
@@ -86,8 +86,9 @@ def test_load_categories_supabase_exception(monkeypatch):
 
 
 def test_get_categories_thread_safe(monkeypatch):
-    monkeypatch.setattr(supabase_categories, "_cache", None)
-    monkeypatch.setattr(supabase_categories, "_cache_time", None)
+    state = supabase_categories.get_categories._state
+    state.value = None
+    state.time = None
 
     def slow_load():
         time.sleep(0.01)
@@ -100,4 +101,4 @@ def test_get_categories_thread_safe(monkeypatch):
     with ThreadPoolExecutor(max_workers=5) as ex:
         list(ex.map(lambda _: supabase_categories.get_categories(force=True), range(5)))
 
-    assert supabase_categories._cache == {None: [{"id": 1, "name": "Food"}]}
+    assert state.value == {None: [{"id": 1, "name": "Food"}]}

--- a/tests/test_supabase_units.py
+++ b/tests/test_supabase_units.py
@@ -71,8 +71,9 @@ def test_load_units_configuration_error(monkeypatch):
 
 
 def test_get_units_thread_safe(monkeypatch):
-    monkeypatch.setattr(supabase_units, "_cache", None)
-    monkeypatch.setattr(supabase_units, "_cache_time", None)
+    state = supabase_units.get_units._state
+    state.value = None
+    state.time = None
 
     def slow_load():
         time.sleep(0.01)
@@ -83,4 +84,4 @@ def test_get_units_thread_safe(monkeypatch):
     with ThreadPoolExecutor(max_workers=5) as ex:
         list(ex.map(lambda _: supabase_units.get_units(force=True), range(5)))
 
-    assert supabase_units._cache == {"kg": ["g"]}
+    assert state.value == {"kg": ["g"]}


### PR DESCRIPTION
## Summary
- add generic `get_cached` utility for thread-safe TTL caching
- simplify `supabase_categories` and `supabase_units` to use shared helper
- adjust tests for new cache helper

## Testing
- `flake8`
- `pytest` *(fails: tests/test_recipe_service.py::test_create_and_update_components, tests/test_recipe_service.py::test_nested_recipes_and_cycle_prevention, tests/test_recipe_service.py::test_record_sale_reduces_nested_stock, tests/test_recipe_service.py::test_recipe_metadata_fields, tests/test_root_view.py::test_root_view_shows_login_form_for_anonymous_user, tests/test_root_view.py::test_login_route_redirects_to_root, tests/test_root_view.py::test_root_view_includes_kpis_for_authenticated_user, tests/test_root_view.py::test_root_view_includes_nav_counts_for_authenticated_user, tests/test_stock_forms.py::test_stock_movements_page_has_datalist, tests/test_stock_service.py::test_record_stock_transaction_updates_stock_and_logs, tests/test_stock_service.py::test_record_stock_transactions_bulk, tests/test_stock_service.py::test_remove_stock_transactions_bulk, tests/test_stock_service.py::test_record_stock_transactions_bulk_rollback_on_error, tests/test_stock_service.py::test_remove_stock_transactions_bulk_rollback_on_error, tests/test_stock_service.py::test_concurrent_stock_updates, tests/test_supplier_service_django.py::test_suppliers_table_filters, tests/test_supplier_service_django.py::test_suppliers_export, tests/test_supplier_service_django.py::test_toggle_supplier_post, tests/test_what_if_reorder.py::test_what_if_reorder_projection)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7e48784483268cdbcf6b4176b7e9