### PR TITLE
Refactor item list view with category filter helper

### DIFF
--- a/inventory/services/__init__.py
+++ b/inventory/services/__init__.py
@@ -5,6 +5,7 @@ from . import (
     dashboard_service,
     goods_receiving_service,
     item_service,
+    category_filters,
     kpis,
     list_utils,
     purchase_order_service,
@@ -21,6 +22,7 @@ from . import (
 __all__ = [
     "dashboard_service",
     "item_service",
+    "category_filters",
     "supplier_service",
     "stock_service",
     "purchase_order_service",

--- a/inventory/services/category_filters.py
+++ b/inventory/services/category_filters.py
@@ -1,0 +1,64 @@
+import logging
+from typing import Any, Dict, List
+
+from .supabase_categories import get_categories as get_supabase_categories
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_category_filters(request) -> Dict[str, Any]:
+    """Return selected category values and available options."""
+    category = (request.GET.get("category") or "").strip()
+    subcategory = (request.GET.get("subcategory") or "").strip()
+
+    try:
+        categories_map = get_supabase_categories()
+    except Exception:  # pragma: no cover - defensive
+        categories_map = {}
+        logger.exception("Failed to load categories")
+
+    categories = [c["name"] for c in categories_map.get(None, [])]
+    subcategories: List[str] = []
+    if category:
+        subcategories = [c["name"] for c in categories_map.get(category, [])]
+
+    return {
+        "category": category,
+        "subcategory": subcategory,
+        "categories": categories,
+        "subcategories": subcategories,
+        "categories_map": categories_map,
+    }
+
+
+def build_filters(category_ctx: Dict[str, Any], active_value: str | None = None) -> List[dict]:
+    """Return filter definitions combining category data and active status."""
+    category = category_ctx["category"]
+    subcategory = category_ctx["subcategory"]
+    categories = category_ctx["categories"]
+    subcategories = category_ctx["subcategories"]
+
+    return [
+        {
+            "name": "active",
+            "value": active_value or "",
+            "id": "filter-active",
+            "options": [
+                {"value": "", "label": "All"},
+                {"value": "1", "label": "Active"},
+                {"value": "0", "label": "Inactive"},
+            ],
+        },
+        {
+            "name": "category",
+            "value": category,
+            "id": "filter-category",
+            "options": [{"value": "", "label": "All"}] + [{"value": c} for c in categories],
+        },
+        {
+            "name": "subcategory",
+            "value": subcategory,
+            "id": "filter-subcategory",
+            "options": [{"value": "", "label": "All"}] + [{"value": sc} for sc in subcategories],
+        },
+    ]


### PR DESCRIPTION
## Summary
- add category_filters service to resolve categories and build filter definitions
- streamline item list view to orchestrate filtering helpers
- expose new category filter service in service package

## Testing
- `flake8`
- `pytest` *(fails: test_create_and_update_components, test_nested_recipes_and_cycle_prevention, test_record_sale_reduces_nested_stock, test_recipe_metadata_fields, test_root_view_shows_login_form_for_anonymous_user, test_login_route_redirects_to_root, test_root_view_includes_kpis_for_authenticated_user, test_root_view_includes_nav_counts_for_authenticated_user, test_stock_movements_page_has_datalist, test_record_stock_transaction_updates_stock_and_logs, test_record_stock_transactions_bulk, test_remove_stock_transactions_bulk, test_record_stock_transactions_bulk_rollback_on_error, test_remove_stock_transactions_bulk_rollback_on_error, test_concurrent_stock_updates, test_suppliers_table_filters, test_suppliers_export, test_toggle_supplier_post, test_what_if_reorder_projection)*


------
https://chatgpt.com/codex/tasks/task_e_68ab7e9b43008326a4fabd19905ca130