### PR TITLE
Enforce authentication with default admin account

### DIFF
--- a/core/apps.py
+++ b/core/apps.py
@@ -4,20 +4,14 @@ from django.apps import AppConfig
 from django.db.models.signals import post_migrate
 
 
-def _create_master_user(sender, **kwargs):
-    """Ensure a default superuser exists.
-
-    This creates a ``master`` user with password ``admin`` so the
-    application always has a default login available. The function is
-    attached to Django's ``post_migrate`` signal so it runs after the
-    database schema has been created.
-    """
+def _create_admin_user(sender, **kwargs):
+    """Ensure a default ``admin`` superuser exists."""
 
     from django.contrib.auth import get_user_model
 
     User = get_user_model()
-    if not User.objects.filter(username="master").exists():
-        User.objects.create_superuser("master", email="", password="admin")
+    if not User.objects.filter(username="admin").exists():
+        User.objects.create_superuser("admin", email="", password="admin")
 
 
 class CoreConfig(AppConfig):
@@ -30,5 +24,5 @@ class CoreConfig(AppConfig):
         """Connect signal handlers when the app is ready."""
 
         post_migrate.connect(
-            _create_master_user, dispatch_uid="core.create_master_user"
+            _create_admin_user, dispatch_uid="core.create_admin_user"
         )

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,21 @@
+import re
+
+from django.conf import settings
+from django.contrib.auth.views import redirect_to_login
+
+
+class LoginRequiredMiddleware:
+    """Redirect unauthenticated users to the login page."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.exempt_urls = [re.compile(expr) for expr in getattr(settings, "LOGIN_EXEMPT_URLS", [])]
+
+    def __call__(self, request):
+        if not request.user.is_authenticated:
+            path = request.path_info.lstrip("/")
+            for pattern in self.exempt_urls:
+                if pattern.match(path):
+                    return self.get_response(request)
+            return redirect_to_login(request.get_full_path(), settings.LOGIN_URL)
+        return self.get_response(request)

--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -58,6 +58,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "core.middleware.LoginRequiredMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
@@ -146,12 +147,25 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",
+        "rest_framework.permissions.IsAuthenticated",
     ],
-    "DEFAULT_AUTHENTICATION_CLASSES": [],
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.BasicAuthentication",
+    ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 25,
 }
 
+LOGIN_URL = "/"
 LOGIN_REDIRECT_URL = "/dashboard/"
 LOGOUT_REDIRECT_URL = "/"
+
+LOGIN_EXEMPT_URLS = [
+    r"^$",
+    r"^login/$",
+    r"^accounts/login/$",
+    r"^accounts/logout/$",
+    r"^healthz$",
+    r"^static/",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,3 +29,19 @@ def item_factory():
         return Item.objects.create(**defaults)
 
     return create_item
+
+
+@pytest.fixture(autouse=True)
+def logged_in_client(client, db):
+    """Log in the default admin user for tests that require authentication."""
+
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+    user, _ = User.objects.get_or_create(username="admin")
+    if not user.has_usable_password():
+        user.set_password("admin")
+        user.save()
+    client.force_login(user)
+    yield
+    client.logout()

--- a/tests/test_admin_user.py
+++ b/tests/test_admin_user.py
@@ -1,0 +1,10 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+
+@pytest.mark.django_db
+def test_admin_user_exists_and_can_login(client):
+    User = get_user_model()
+    assert User.objects.filter(username="admin").exists()
+    client.logout()
+    assert client.login(username="admin", password="admin")

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -184,7 +184,7 @@ def test_items_list_view_shows_empty_categories(client):
 
 def test_items_list_view_populates_categories(client, monkeypatch):
     monkeypatch.setattr(
-        "inventory.views.items.get_supabase_categories",
+        "inventory.services.category_filters.get_supabase_categories",
         lambda: {
             None: [{"id": 1, "name": "Food"}],
             "Food": [{"id": 2, "name": "Fruit"}],

--- a/tests/test_master_user.py
+++ b/tests/test_master_user.py
@@ -1,9 +1,0 @@
-import pytest
-from django.contrib.auth import get_user_model
-
-
-@pytest.mark.django_db
-def test_master_user_exists_and_can_login(client):
-    User = get_user_model()
-    assert User.objects.filter(username="master").exists()
-    assert client.login(username="master", password="admin")

--- a/tests/test_root_view.py
+++ b/tests/test_root_view.py
@@ -3,6 +3,7 @@ import pytest
 
 @pytest.mark.django_db
 def test_root_view_shows_login_form_for_anonymous_user(client):
+    client.logout()
     resp = client.get("/")
     assert resp.status_code == 200
     assert b'name="username"' in resp.content
@@ -10,6 +11,7 @@ def test_root_view_shows_login_form_for_anonymous_user(client):
 
 @pytest.mark.django_db
 def test_login_route_redirects_to_root(client):
+    client.logout()
     resp = client.get("/login/")
     assert resp.status_code == 302
     assert resp.url == "/"


### PR DESCRIPTION
## Summary
- require login for all views via LoginRequiredMiddleware and DRF settings
- auto-create an `admin` superuser for immediate access
- adjust tests to authenticate and confirm admin login

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab8163f9688326a4428b0ef7085e3f