### PR TITLE
Simplify dashboard KPI cards

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,54 +1,33 @@
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
-  <div class="p-6 rounded-xl text-white bg-gradient-to-r from-primary to-secondary">
-    <h2 class="text-lg font-medium">Low-stock Items</h2>
-    {% if low_stock_items %}
-      <ul class="mt-2 text-sm space-y-1">
-        {% for name in low_stock_items %}
-          <li>{{ name }}</li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p class="mt-2 text-sm">None</p>
-    {% endif %}
-  </div>
-
-  <div class="p-6 rounded-xl text-white bg-gradient-to-r from-primary to-secondary">
-    <h2 class="text-lg font-medium">Stale Items</h2>
-    {% if stale_items %}
-      <ul class="mt-2 text-sm space-y-1">
-        {% for name in stale_items %}
-          <li>{{ name }}</li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p class="mt-2 text-sm">None</p>
-    {% endif %}
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
+    <div class="flex items-center gap-4">
+      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.5c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v4.5h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
+      <h2 class="text-lg font-medium">Items</h2>
+    </div>
+    <span class="text-4xl font-bold">{{ items }}</span>
   </div>
 
   <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
     <div class="flex items-center gap-4">
-      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 18.75a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 0 0-3 0m3 0h10.127a3 3 0 0 0 2.958-2.502l1.115-7A3 3 0 0 0 19.336 6H4.664a3 3 0 0 0-2.982 3.248l1.115 7a3 3 0 0 0 2.958 2.502H8.25Zm7.5 0a1.5 1.5 0 1 0 3 0m-3 0a1.5 1.5 0 0 1 3 0"/></svg>
-      <h2 class="text-lg font-medium">High-price Purchases</h2>
+      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9.303 3.376c.866 1.5-.217 3.374-1.948 3.374H4.645c-1.73 0-2.813-1.874-1.948-3.374L10.052 3.378c.866-1.5 3.032-1.5 3.898 0l7.303 12.748ZM12 15.75h.007v.008H12v-.008Z"/></svg>
+      <h2 class="text-lg font-medium">Low-stock Items</h2>
     </div>
-    <span class="text-4xl font-bold">{{ high_price_purchases|length }}</span>
+    <span class="text-4xl font-bold">{{ low_stock }}</span>
   </div>
 
-  <div class="p-6 rounded-xl text-white bg-gradient-to-r from-primary to-secondary">
-    <h2 class="text-lg font-medium mb-2">Pending POs</h2>
-    <ul class="text-sm space-y-1">
-      <li>Draft: {{ pending_po_status.DRAFT|default:0 }}</li>
-      <li>Ordered: {{ pending_po_status.ORDERED|default:0 }}</li>
-      <li>Partial: {{ pending_po_status.PARTIAL|default:0 }}</li>
-    </ul>
+  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
+    <div class="flex items-center gap-4">
+      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7.5l7.5-4.5 7.5 4.5M21 7.5v9l-7.5 4.5m0-9l7.5-4.5M12 12v9m0 0L3 16.5v-9"/></svg>
+      <h2 class="text-lg font-medium">Suppliers</h2>
+    </div>
+    <span class="text-4xl font-bold">{{ suppliers }}</span>
   </div>
 
-  <div class="p-6 rounded-xl text-white bg-gradient-to-r from-primary to-secondary">
-    <h2 class="text-lg font-medium mb-2">Pending Indents</h2>
-    <ul class="text-sm space-y-1">
-      <li>Pending: {{ pending_indent_status.PENDING|default:0 }}</li>
-      <li>Submitted: {{ pending_indent_status.SUBMITTED|default:0 }}</li>
-      <li>Processing: {{ pending_indent_status.PROCESSING|default:0 }}</li>
-    </ul>
+  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
+    <div class="flex items-center gap-4">
+      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a2 2 0 011.414.586l5.414 5.414A2 2 0 0120 9.414V19a2 2 0 01-2 2z"/></svg>
+      <h2 class="text-lg font-medium">Pending Indents</h2>
+    </div>
+    <span class="text-4xl font-bold">{{ pending_indents }}</span>
   </div>
 </div>
-

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -1,15 +1,16 @@
 {% extends "_base.html" %}
 {% block content %}
-<h1 class="text-h1">Dashboard</h1>
+<h1 class="text-h1 mb-4">Dashboard</h1>
 
 <div
   id="kpi-cards"
+  class="mb-6"
   hx-get="{% url 'dashboard-kpis' %}"
   hx-trigger="load"
   hx-target="#kpi-cards"
   hx-swap="outerHTML"
 >
-  Loading KPI metrics…
+  Loading KPIs…
 </div>
 
 <div class="flex gap-4">

--- a/core/views.py
+++ b/core/views.py
@@ -57,11 +57,10 @@ def dashboard(request):
 def dashboard_kpis(request):
     """HTMX endpoint returning KPI card values."""
     data = {
-        "low_stock_items": kpis.low_stock_items(),
-        "stale_items": kpis.stale_items(),
-        "high_price_purchases": kpis.high_price_purchases(Decimal("0.1")),
-        "pending_po_status": kpis.pending_po_status_counts(),
-        "pending_indent_status": kpis.pending_indent_counts(),
+        "items": counts.item_count(),
+        "low_stock": kpis.low_stock_count(),
+        "suppliers": counts.supplier_count(),
+        "pending_indents": sum(kpis.pending_indent_counts().values()),
     }
     return render(request, "core/_kpi_cards.html", data)
 


### PR DESCRIPTION
## Summary
- Load overall inventory counts for dashboard KPIs
- Redesign KPI cards with four concise stats
- Show KPI card grid at top of dashboard

## Testing
- `flake8`
- `pytest` *(fails: no such table: items)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0fea1f908326a7d266689f7b820f