### PR TITLE
Display unit for low stock items

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -83,17 +83,28 @@
 </div>
 
 <h2 class="text-h2 mb-2">Low Stock Items</h2>
-<ul class="space-y-2">
-  {% for item in low_stock %}
-    <li class="flex items-center justify-between p-4 rounded border">
-      <div class="flex items-center gap-2">
-        <svg aria-hidden="true" class="w-5 h-5 text-danger" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"/></svg>
-        <span>{{ item.name }}</span>
-      </div>
-      <span class="badge-warning">{{ item.current_stock }} / {{ item.reorder_point }}</span>
-    </li>
-  {% empty %}
-    <li class="p-4 border rounded">No low stock items.</li>
-  {% endfor %}
-</ul>
+<table class="min-w-full text-left border rounded">
+  <thead class="bg-gray-50">
+    <tr>
+      <th class="px-4 py-2">Item Name</th>
+      <th class="px-4 py-2">UoM</th>
+      <th class="px-4 py-2">Current Stock</th>
+      <th class="px-4 py-2">Reorder At</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in low_stock %}
+      <tr class="border-t">
+        <td class="px-4 py-2">{{ item.name }}</td>
+        <td class="px-4 py-2">{{ item.uom|default:item.unit }}</td>
+        <td class="px-4 py-2">{{ item.current_stock }}</td>
+        <td class="px-4 py-2">{{ item.reorder_point }}</td>
+      </tr>
+    {% empty %}
+      <tr>
+        <td colspan="4" class="px-4 py-2">No low stock items.</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/inventory/services/dashboard_service.py
+++ b/inventory/services/dashboard_service.py
@@ -6,7 +6,8 @@ from inventory.models import Item
 def get_low_stock_items():
     """Return items whose current stock is below their reorder point."""
     qs = (
-        Item.objects.only("name", "current_stock", "reorder_point")
+        Item.objects.annotate(uom=F("base_unit"), unit=F("base_unit"))
+        .only("name", "base_unit", "current_stock", "reorder_point")
         .filter(
             reorder_point__isnull=False,
             current_stock__lt=F("reorder_point"),

--- a/tests/test_dashboard_service.py
+++ b/tests/test_dashboard_service.py
@@ -9,4 +9,9 @@ def test_get_low_stock_items(item_factory):
     item_factory(name="Inactive", reorder_point=10, current_stock=5, is_active=False)
     item_factory(name="High", reorder_point=10, current_stock=15)
     items = list(dashboard_service.get_low_stock_items())
-    assert [item.name for item in items] == ["Low"]
+    assert len(items) == 1
+    item = items[0]
+    assert item.name == "Low"
+    assert item.uom == "kg"
+    assert item.current_stock == 5
+    assert item.reorder_point == 10


### PR DESCRIPTION
## Summary
- include base unit annotation in low-stock service query
- show low-stock items in a table with unit, current stock, and reorder point
- test low-stock service returns item, unit, stock, and reorder details

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac154e48dc83268750a32a6b56e8b7