### PR TITLE
chore: update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@ whitenoise==6.9.0
 gunicorn==23.0.0
 psycopg[binary]==3.2.9
 fpdf2==2.8.4
-sqlalchemy==2.0.43
-pyyaml==6.0.2
 pydantic==2.11.7
 supabase==2.18.1
-statsmodels==0.14.2
+statsmodels==0.14.5


### PR DESCRIPTION
## Summary
- remove unused SQLAlchemy and PyYAML dependencies
- upgrade statsmodels to 0.14.5

## Testing
- `flake8`
- `pytest` *(fails: fixture 'client' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac173e19c88326bd604a51d9e537aa