### PR TITLE
Avoid running migrations during WSGI startup

### DIFF
--- a/inventory_app/wsgi.py
+++ b/inventory_app/wsgi.py
@@ -9,16 +9,9 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/wsgi/
 
 import os
 
-from django.core.management import call_command
 from django.core.wsgi import get_wsgi_application
-from django.db.utils import OperationalError
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inventory_app.settings")
 
-try:
-    call_command("migrate", interactive=False)
-except OperationalError:
-    # Database may be unavailable when the server starts; continue without failing.
-    pass
-
+# Database migrations should be run separately before launching the application.
 application = get_wsgi_application()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -3,6 +3,8 @@ from django.contrib.auth.models import Permission
 from django.urls import reverse
 
 from inventory.models import Indent, StockTransaction, Supplier
+from django.utils import timezone
+
 
 @pytest.mark.django_db
 def test_dashboard_low_stock(client, item_factory, django_user_model):

--- a/tests/test_wsgi_migration.py
+++ b/tests/test_wsgi_migration.py
@@ -2,11 +2,11 @@ from unittest.mock import patch
 import sys
 
 
-def test_wsgi_runs_migrate():
+def test_wsgi_does_not_run_migrate():
     sys.modules.pop("inventory_app.wsgi", None)
     with patch("django.core.management.call_command") as call, patch(
         "django.core.wsgi.get_wsgi_application"
     ):
         import inventory_app.wsgi  # noqa: F401
 
-    call.assert_called_with("migrate", interactive=False)
+    call.assert_not_called()


### PR DESCRIPTION
## Summary
- stop automatic `migrate` call in `inventory_app.wsgi`
- import missing timezone and satisfy flake8 in dashboard tests
- update WSGI migration test to assert migrations aren't run

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac21aae21c832685735fa33e009dcd