### PR TITLE
Use Python 3.13 dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Python 3",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.13-bullseye",
   "customizations": {
     "codespaces": {
       "openFiles": [

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,8 +1,10 @@
 import pytest
 from django.contrib.auth.models import Permission
 from django.urls import reverse
+from django.utils import timezone
 
 from inventory.models import Indent, StockTransaction, Supplier
+
 
 @pytest.mark.django_db
 def test_dashboard_low_stock(client, item_factory, django_user_model):


### PR DESCRIPTION
## Summary
- use Python 3.13 image for development container
- fix dashboard test spacing and imports to satisfy linter

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac23533018832694f83f54c792b160