### PR TITLE
chore: require Python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Django application using Gunicorn
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 # Disable Python buffering and writing pyc files
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Any `<select>` element with the `predictive` class is automatically enhanced wit
 
 ## Installation
 
-This project requires **Python 3.11 or newer**.
+This project requires **Python 3.13 or newer**.
 
 Install dependencies using `pip`:
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,8 +1,10 @@
 import pytest
 from django.contrib.auth.models import Permission
 from django.urls import reverse
+from django.utils import timezone
 
 from inventory.models import Indent, StockTransaction, Supplier
+
 
 @pytest.mark.django_db
 def test_dashboard_low_stock(client, item_factory, django_user_model):


### PR DESCRIPTION
## Summary
- document requirement for Python 3.13 or newer
- update Docker base image to Python 3.13
- add missing timezone import in dashboard tests

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac235d46448326bf2ec7fbc4266b58