### PR TITLE
Use Python 3.13 for lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.13"
       - name: Install dependencies
         run: pip install pre-commit
       - name: Run pre-commit

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,8 +1,10 @@
 import pytest
 from django.contrib.auth.models import Permission
 from django.urls import reverse
+from django.utils import timezone
 
 from inventory.models import Indent, StockTransaction, Supplier
+
 
 @pytest.mark.django_db
 def test_dashboard_low_stock(client, item_factory, django_user_model):


### PR DESCRIPTION
## Summary
- run lint workflow on Python 3.13
- fix missing timezone import in dashboard tests

## Testing
- `flake8`
- `pytest`
- `pre-commit run --files .github/workflows/lint.yml tests/test_dashboard.py`
- ⚠️ `./bin/act -j flake8 -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:full-latest` (failed: Cannot connect to the Docker daemon)


------
https://chatgpt.com/codex/tasks/task_e_68ac236605788326a3c0c64230e4a650