### PR TITLE
chore: update base Python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Django application using Gunicorn
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 # Disable Python buffering and writing pyc files
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,8 +1,10 @@
 import pytest
 from django.contrib.auth.models import Permission
 from django.urls import reverse
+from django.utils import timezone
 
 from inventory.models import Indent, StockTransaction, Supplier
+
 
 @pytest.mark.django_db
 def test_dashboard_low_stock(client, item_factory, django_user_model):


### PR DESCRIPTION
## Summary
- upgrade Dockerfile base image to `python:3.13-slim`
- add missing `timezone` import for dashboard tests

## Testing
- `flake8`
- `pytest` *(fails: fixture 'client' not found and multiple other errors)*
- `docker build -t inventory-app:latest .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac237700b883269926b960cb90ec2e