### PR TITLE
Run migrations before starting server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ COPY . .
 # Expose the port Gunicorn will listen on
 EXPOSE 8000
 
-# Default command to run the Gunicorn application server
-CMD ["gunicorn", "inventory_app.wsgi:application", "--bind", "0.0.0.0:8000"]
+# Run migrations to initialize the auth_user table and other schema objects required for authentication
+CMD ["sh", "-c", "python manage.py migrate && exec gunicorn inventory_app.wsgi:application --bind 0.0.0.0:8000"]

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -4,11 +4,6 @@ from django.urls import reverse
 from django.utils import timezone
 
 from inventory.models import Indent, StockTransaction, Supplier
-from django.utils import timezone
-
-
-
-
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- run database migrations before launching gunicorn so auth tables exist
- tidy test imports so flake8 passes

## Testing
- `flake8`
- `pytest`
- `python manage.py migrate --noinput`


------
https://chatgpt.com/codex/tasks/task_e_68ac2c14deac8326a8c6bcba2b092215