### PR TITLE
Cache ML dashboard results

### DIFF
--- a/inventory/views/ml.py
+++ b/inventory/views/ml.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from django.shortcuts import render
 
 from ..models import Item
@@ -5,9 +6,25 @@ from ..services import ml
 
 
 def ml_dashboard(request):
-    """Display forecasting and ABC classification results."""
-    forecasts = ml.train_models(periods=1)
-    classifications = ml.abc_classification()
+    """Display forecasting and ABC classification results.
+
+    The results of :func:`ml.train_models` and :func:`ml.abc_classification` are
+    cached for a short period to avoid repeatedly running relatively expensive
+    operations on every request. Results are recomputed only when the cache is
+    empty or expires.
+    """
+    ttl = 300  # seconds
+
+    forecasts = cache.get("ml_train_models")
+    if forecasts is None:
+        forecasts = ml.train_models(periods=1)
+        cache.set("ml_train_models", forecasts, ttl)
+
+    classifications = cache.get("ml_abc_classification")
+    if classifications is None:
+        classifications = ml.abc_classification()
+        cache.set("ml_abc_classification", classifications, ttl)
+
     results = []
     for item in Item.objects.all():
         forecast = forecasts.get(item.pk, [0.0])[0] if forecasts.get(item.pk) else 0.0


### PR DESCRIPTION
## Summary
- cache training and classification results in `ml_dashboard` view to avoid repeated computation
- test that cached results persist across requests and refresh when cleared

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac5826ab588326902cf849e5b34b64