### PR TITLE
Fix CoerceFloatField import in models package

### DIFF
--- a/inventory/models/__init__.py
+++ b/inventory/models/__init__.py
@@ -1,7 +1,7 @@
 from .items import Item, StockTransaction
 from .orders import GoodsReceivedNote, GRNItem, Indent, IndentItem, PurchaseOrder, PurchaseOrderItem
 from .suppliers import Supplier
-from .recipes import CoerceFloatField, Recipe, RecipeComponent, SaleTransaction
+from .recipes import Recipe, RecipeComponent, SaleTransaction
 from .fields import CoerceFloatField
 
 __all__ = [


### PR DESCRIPTION
## Summary
- remove redundant CoerceFloatField import from recipes
- ensure models __all__ lists the exported fields

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acc36ffcd88326a51719712cd66636