### PR TITLE
chore: tidy recipe models

### DIFF
--- a/inventory/models/__init__.py
+++ b/inventory/models/__init__.py
@@ -1,7 +1,7 @@
 from .items import Item, StockTransaction
 from .orders import GoodsReceivedNote, GRNItem, Indent, IndentItem, PurchaseOrder, PurchaseOrderItem
 from .suppliers import Supplier
-from .recipes import CoerceFloatField, Recipe, RecipeComponent, SaleTransaction
+from .recipes import Recipe, RecipeComponent, SaleTransaction
 from .fields import CoerceFloatField
 
 __all__ = [

--- a/inventory/models/recipes.py
+++ b/inventory/models/recipes.py
@@ -1,28 +1,8 @@
 from decimal import Decimal
 
 from django.db import models
-from .items import Item, StockTransaction
-from .orders import GoodsReceivedNote, GRNItem, Indent, IndentItem, PurchaseOrder, PurchaseOrderItem
-from .suppliers import Supplier
+
 from .fields import CoerceFloatField
-
-
-def __init__(self, *args, **kwargs):
-        kwargs.setdefault("max_digits", 10)
-        kwargs.setdefault("decimal_places", 2)
-        super().__init__(*args, **kwargs)
-
-def to_python(self, value):
-        from decimal import InvalidOperation
-        if value in self.empty_values:
-            return Decimal("0")
-        try:
-            return Decimal(value)
-        except (TypeError, ValueError, InvalidOperation):
-            return Decimal("0")
-
-def from_db_value(self, value, expression, connection):
-        return self.to_python(value)
 
 
 class Recipe(models.Model):


### PR DESCRIPTION
## Summary
- remove unused imports and stray methods from recipe models
- expose only Recipe, RecipeComponent and SaleTransaction

## Testing
- `flake8` *(fails: E302 expected 2 blank lines, F401 imported but unused, E402 module level import not at top of file)*
- `pytest` *(fails: fixture 'client' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc3910ec083269d4399ec7a9ca319