### PR TITLE
Configure DEBUG via DJANGO_DEBUG environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 DJANGO_SECRET_KEY=
 DATABASE_URL=
 # For local runs, you can set DATABASE_URL=sqlite:///db.sqlite3
+# Set to True to enable Django's debug mode (default: False)
 DJANGO_DEBUG=True
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ cp .env.example .env
 
 You can also set these values directly in the environment instead of using a `.env` file.
 
+Set `DJANGO_DEBUG` to `True` to enable Django's debug mode (defaults to `False`).
+
 To fetch item categories and unit options from Supabase, configure:
 
 - `SUPABASE_URL`

--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 import environ
 
@@ -32,7 +33,7 @@ SECRET_KEY = env("DJANGO_SECRET_KEY", default="dev-secret-key")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 # Enabled temporarily for debugging
-DEBUG = True
+DEBUG = env.bool("DJANGO_DEBUG", default=False)
 
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["localhost"])
 
@@ -85,8 +86,6 @@ WSGI_APPLICATION = "inventory_app.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
-
-import os
 
 DATABASE_URL = os.environ.get("DATABASE_URL")  # prefer Codespaces secrets
 DATABASES = {


### PR DESCRIPTION
## Summary
- Load DEBUG setting from DJANGO_DEBUG env variable with a safe default
- Document DJANGO_DEBUG in README and .env.example

## Testing
- `flake8` *(fails: F401 etc. in inventory/models)*
- `pytest` *(fails: TransactionManagementError across multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acc3df90b483268275d30f4f6fb917