### PR TITLE
Use CoerceFloatField for stock transaction quantity

### DIFF
--- a/inventory/models/fields.py
+++ b/inventory/models/fields.py
@@ -1,6 +1,7 @@
 from decimal import Decimal, InvalidOperation
 from django.db import models
 
+
 class CoerceFloatField(models.DecimalField):
     """DecimalField that coerces invalid values to Decimal('0')."""
 

--- a/inventory/models/items.py
+++ b/inventory/models/items.py
@@ -38,7 +38,7 @@ class StockTransaction(models.Model):
     item = models.ForeignKey(
         Item, models.DO_NOTHING, db_column="item_id", blank=True, null=True
     )
-    quantity_change = models.DecimalField(
+    quantity_change = CoerceFloatField(
         max_digits=10, decimal_places=2, blank=True, null=True
     )
     transaction_type = models.CharField(max_length=50, blank=True, null=True)

--- a/inventory/models/orders.py
+++ b/inventory/models/orders.py
@@ -5,7 +5,7 @@ from django.db.models import Sum
 
 from .items import Item
 from .suppliers import Supplier
-from .fields import CoerceFloatField
+
 
 class Indent(models.Model):
     """Represents a material requisition from a department."""

--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 import environ
@@ -85,8 +86,6 @@ WSGI_APPLICATION = "inventory_app.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
-
-import os
 
 DATABASE_URL = os.environ.get("DATABASE_URL")  # prefer Codespaces secrets
 DATABASES = {


### PR DESCRIPTION
## Summary
- use `CoerceFloatField` for `StockTransaction.quantity_change`
- clean up imports and formatting to satisfy flake8

## Testing
- `flake8`
- `pytest -q` *(fails: no such table: suppliers)*

------
https://chatgpt.com/codex/tasks/task_e_68acc9a558bc8326ba2841eac4b68cee