### PR TITLE
Redirect to original page after login

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import redirect, render
 from django.utils.dateparse import parse_date
 from django.db.models import Sum
 from django.db.models.functions import TruncDate
+from django.conf import settings
 
 from inventory.models import Item, Supplier, StockTransaction, PurchaseOrder
 from inventory.services import counts, dashboard_service, kpis
@@ -32,11 +33,13 @@ def root_view(request):
         return render(request, "core/home.html", data)
 
     form = AuthenticationForm(request, data=request.POST or None)
+    next_url = request.POST.get("next") or request.GET.get("next", "")
     if request.method == "POST" and form.is_valid():
         login(request, form.get_user())
-        return redirect("root")
+        redirect_to = next_url or settings.LOGIN_REDIRECT_URL
+        return redirect(redirect_to)
 
-    return render(request, "core/home.html", {"form": form})
+    return render(request, "core/home.html", {"form": form, "next": next_url})
 
 
 def health_check(request):

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -6,6 +6,7 @@
     </button>
     <form method="post" class="grid gap-4">
       {% csrf_token %}
+      <input type="hidden" name="next" value="{{ next }}">
       {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}


### PR DESCRIPTION
## Summary
- Redirect authenticated users to the `next` URL or `LOGIN_REDIRECT_URL`
- Add hidden `next` field to login form

## Testing
- `flake8` *(fails: inventory/models/fields.py:4:1 E302 expected 2 blank lines, found 1; inventory/models/orders.py:8:1 F401 '.fields.CoerceFloatField' imported but unused; inventory/models/orders.py:10:1 E302 expected 2 blank lines, found 1)*
- `flake8 core/views.py`
- `pytest` *(fails: fixture 'client' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68accf1584f88326a0e943087eb25518