### PR TITLE
refactor: unify list templates

### DIFF
--- a/templates/inventory/explore.html
+++ b/templates/inventory/explore.html
@@ -1,6 +1,9 @@
-{% extends "_base.html" %}
-{% block content %}
-<h1>Explore Items</h1>
+{% extends "components/create_manage_page.html" %}
+
+{% block page_title %}Explore Items – Inventory App{% endblock %}
+{% block heading %}Explore Items{% endblock %}
+
+{% block filters %}
 <form method="get">
   <input type="text" name="q" value="{{ q }}" placeholder="Search" />
   <select name="active">
@@ -11,6 +14,9 @@
   <button type="submit">Filter</button>
 </form>
 <a href="{{ export_url }}?{{ querystring }}">Export CSV</a>
+{% endblock %}
+
+{% block data_container %}
 <ul>
 {% for item in page_obj.object_list %}
   <li>{{ item.name }}</li>
@@ -18,6 +24,9 @@
   <li>No results</li>
 {% endfor %}
 </ul>
+{% endblock %}
+
+{% block pagination %}
 <div class="pagination">
   {% if page_obj.has_previous %}
     <a href="?{{ querystring }}&page={{ page_obj.previous_page_number }}">Prev</a>

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -1,7 +1,8 @@
-{% extends "components/list_layout.html" %}
-{% block title %}Goods Received Notes – Inventory App{% endblock %}
+{% extends "components/create_manage_page.html" %}
+{% block page_title %}Goods Received Notes – Inventory App{% endblock %}
 {% block heading %}Goods Received Notes{% endblock %}
-{% block filter_bar %}
+
+{% block filters %}
   <form method="get" class="mb-4 grid gap-2 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
       <label class="block text-sm font-medium">Supplier</label>
@@ -32,7 +33,8 @@
     </div>
   </form>
 {% endblock %}
-{% block table_container %}
+
+{% block data_container %}
   <ol class="relative border-l border-border">
     {% for grn in grns %}
       <li class="mb-10 ml-6">

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -1,7 +1,8 @@
-{% extends "components/list_layout.html" %}
-{% block title %}History Reports – Inventory App{% endblock %}
+{% extends "components/create_manage_page.html" %}
+{% block page_title %}History Reports – Inventory App{% endblock %}
 {% block heading %}History Reports{% endblock %}
-{% block filter_bar %}
+
+{% block filters %}
   {% url 'history_reports' as history_url %}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
@@ -59,7 +60,14 @@
     });
   </script>
 {% endblock %}
-{% block table_id %}history_table{% endblock %}
-{% block hx_get %}{% url 'history_reports' %}{% endblock %}
-{% block table_content %}{% include "inventory/_history_tabs.html" %}{% endblock %}
+
+{% block data_container %}
+  <div id="history_table"
+       hx-get="{% url 'history_reports' %}"
+       hx-trigger="load"
+       hx-include="#filters"
+       hx-indicator="#htmx-spinner">
+    {% include "inventory/_history_tabs.html" %}
+  </div>
+{% endblock %}
 

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -1,18 +1,25 @@
-{% extends "components/list_layout.html" %}
-{% block title %}Indents – Inventory App{% endblock %}
+{% extends "components/create_manage_page.html" %}
+{% block page_title %}Indents – Inventory App{% endblock %}
 {% block heading %}Indents ({{ total_indents }}){% endblock %}
-{% block actions %}
+
+{% block primary_actions %}
   <a href="{% url 'indent_create' %}" class="btn-primary">New Indent</a>
 {% endblock %}
-{% block filter_bar %}
+
+{% block filters %}
   {% url 'indents_table' as indents_table_url %}
   {% include "components/filter_bar.html" with search_placeholder="Search indents..." hx_get=indents_table_url hx_target="#indents_table" filters=filters search_delay="500ms" %}
 {% endblock %}
-{% block table_id %}indents_table{% endblock %}
-{% block hx_get %}{% url 'indents_table' %}{% endblock %}
-{% block table_content %}
-  {% if total_indents == 0 %}
-    {% url 'indent_create' as indent_create_url %}
-    {% include "components/empty_state.html" with title="No Indents" message="Create your first indent to get started." cta_label="New Indent" cta_url=indent_create_url %}
-  {% endif %}
+
+{% block data_container %}
+  <div id="indents_table"
+       hx-get="{% url 'indents_table' %}"
+       hx-trigger="load"
+       hx-include="#filters"
+       hx-indicator="#htmx-spinner">
+    {% if total_indents == 0 %}
+      {% url 'indent_create' as indent_create_url %}
+      {% include "components/empty_state.html" with title="No Indents" message="Create your first indent to get started." cta_label="New Indent" cta_url=indent_create_url %}
+    {% endif %}
+  </div>
 {% endblock %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -131,16 +131,18 @@
       </div>
     </div>
   </details>
+{% endblock %}
 
+{% block filters %}
   <!-- Title should come before filters -->
   <h2 class="text-lg font-semibold text-gray-900 mb-2">Inventory Items</h2>
 
   <!-- Place filters directly above the table -->
   <div class="card mb-4">
     <div class="card-body">
-  <div class="text-sm text-gray-600 mb-2">Filter and explore</div>
+      <div class="text-sm text-gray-600 mb-2">Filter and explore</div>
       {% url 'items_table' as items_table_url %}
-  {% include "components/filter_bar.html" with q=request.GET.q filters=filters hx_get=items_table_url hx_target='#items-list' hx_indicator='#items-loading' search_placeholder='e.g., Tomato, Rice' export_url=export_url layout=request.GET.layout|default:'table' %}
+      {% include "components/filter_bar.html" with q=request.GET.q filters=filters hx_get=items_table_url hx_target='#items-list' hx_indicator='#items-loading' search_placeholder='e.g., Tomato, Rice' export_url=export_url layout=request.GET.layout|default:'table' %}
     </div>
   </div>
 
@@ -172,8 +174,6 @@
   </div>
 </div>
 {% endblock %}
-
-{% block filters %}{% endblock %}
 
 {% block data_container %}
 <div id="items-container" class="card">

--- a/templates/inventory/ml_dashboard.html
+++ b/templates/inventory/ml_dashboard.html
@@ -1,7 +1,9 @@
-{% extends "_base.html" %}
+{% extends "components/create_manage_page.html" %}
 
-{% block content %}
-<h1 class="text-h1 mb-4">ML Dashboard</h1>
+{% block page_title %}ML Dashboard – Inventory App{% endblock %}
+{% block heading %}ML Dashboard{% endblock %}
+
+{% block data_container %}
 <table class="table w-full">
   <thead>
     <tr>

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -1,34 +1,30 @@
-{% extends "_base.html" %}
+{% extends "components/create_manage_page.html" %}
 {% load static %}
 
-{% block title %}Purchase Orders - Inventory Pro{% endblock %}
+{% block page_title %}Purchase Orders - Inventory Pro{% endblock %}
 
-{% block content %}
-<!-- Page Header -->
-<div class="page-header">
-  <div class="flex items-center justify-between">
-    <div>
-      <h1 class="page-title">Purchase Orders</h1>
-      <p class="page-subtitle">Manage your purchase orders and supplier relationships</p>
-    </div>
-    <div class="flex items-center space-x-3">
-      <a href="{% url 'purchase_order_create' %}" class="btn-primary">
-        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
-        </svg>
-        New Purchase Order
-      </a>
-      <a href="{% url 'grn_list' %}" class="btn-secondary">
-        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
-        </svg>
-        GRNs
-      </a>
-    </div>
-  </div>
-</div>
+{% block heading %}Purchase Orders{% endblock %}
+{% block description %}<p class="page-subtitle">Manage your purchase orders and supplier relationships</p>{% endblock %}
 
-<!-- Stats Cards -->
+{% block primary_actions %}
+  <a href="{% url 'purchase_order_create' %}" class="btn-primary">
+    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
+    </svg>
+    New Purchase Order
+  </a>
+{% endblock %}
+
+{% block secondary_actions %}
+  <a href="{% url 'grn_list' %}" class="btn-secondary">
+    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+    </svg>
+    GRNs
+  </a>
+{% endblock %}
+
+{% block kpis %}
 <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
   <div class="card">
     <div class="card-compact">
@@ -102,8 +98,9 @@
     </div>
   </div>
 </div>
+{% endblock %}
 
-<!-- Search and Filters -->
+{% block filters %}
 <div class="card mb-6">
   <div class="card-body">
     <form method="get" class="grid grid-cols-1 lg:grid-cols-5 gap-4">
@@ -149,8 +146,9 @@
     </form>
   </div>
 </div>
+{% endblock %}
 
-<!-- Purchase Orders Table -->
+{% block data_container %}
 <div class="card">
   <div class="card-header">
     <div class="flex items-center justify-between">
@@ -165,13 +163,14 @@
       </div>
     </div>
   </div>
-  
+
   <div class="overflow-x-auto">
     {% include "inventory/purchase_orders/_table.html" %}
   </div>
 </div>
+{% endblock %}
 
-<!-- Pagination -->
+{% block pagination %}
 {% if page_obj.has_other_pages %}
 <div class="mt-6 flex items-center justify-between">
   <div class="text-sm text-gray-700">
@@ -179,26 +178,26 @@
   </div>
   <div class="flex items-center space-x-2">
     {% if page_obj.has_previous %}
-      <a href="?page={{ page_obj.previous_page_number }}{% if current_status %}&status={{ current_status }}{% endif %}{% if current_supplier %}&supplier={{ current_supplier }}{% endif %}{% if start_date %}&start_date={{ start_date }}{% endif %}{% if end_date %}&end_date={{ end_date }}{% endif %}" 
-         class="btn-secondary btn-sm">
+      <a href="?page={{ page_obj.previous_page_number }}{% if current_status %}&status={{ current_status }}{% endif %}{% if current_supplier %}&supplier={{ current_supplier }}{% endif %}{% if start_date %}&start_date={{ start_date }}{% endif %}{% if end_date %}&end_date={{ end_date }}{% endif %}" class="btn-secondary btn-sm">
         Previous
       </a>
     {% endif %}
-    
+
     <span class="text-sm text-gray-700">
       Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
     </span>
-    
+
     {% if page_obj.has_next %}
-      <a href="?page={{ page_obj.next_page_number }}{% if current_status %}&status={{ current_status }}{% endif %}{% if current_supplier %}&supplier={{ current_supplier }}{% endif %}{% if start_date %}&start_date={{ start_date }}{% endif %}{% if end_date %}&end_date={{ end_date }}{% endif %}" 
-         class="btn-secondary btn-sm">
+      <a href="?page={{ page_obj.next_page_number }}{% if current_status %}&status={{ current_status }}{% endif %}{% if current_supplier %}&supplier={{ current_supplier }}{% endif %}{% if start_date %}&start_date={{ start_date }}{% endif %}{% if end_date %}&end_date={{ end_date }}{% endif %}" class="btn-secondary btn-sm">
         Next
       </a>
     {% endif %}
   </div>
 </div>
 {% endif %}
+{% endblock %}
 
+{% block page_scripts %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Bulk actions functionality
@@ -210,5 +209,5 @@ document.addEventListener('DOMContentLoaded', function() {
     };
 });
 </script>
-
 {% endblock %}
+

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -1,13 +1,22 @@
-{% extends "components/list_layout.html" %}
-{% block title %}Recipes – Inventory App{% endblock %}
+{% extends "components/create_manage_page.html" %}
+{% block page_title %}Recipes – Inventory App{% endblock %}
 {% block heading %}Recipes{% endblock %}
-{% block actions %}
+
+{% block primary_actions %}
   <a class="btn-primary" href="{% url 'recipe_create' %}">New Recipe</a>
 {% endblock %}
-{% block filter_bar %}
+
+{% block filters %}
   {% url 'recipes_list' as recipes_list_url %}
   {% include "components/filter_bar.html" with search_placeholder="Search recipes..." hx_get=recipes_list_url hx_target="#recipes_grid" q=q %}
 {% endblock %}
-{% block table_id %}recipes_grid{% endblock %}
-{% block hx_get %}{% url 'recipes_list' %}{% endblock %}
-{% block table_content %}{{ recipes_grid|safe }}{% endblock %}
+
+{% block data_container %}
+  <div id="recipes_grid"
+       hx-get="{% url 'recipes_list' %}"
+       hx-trigger="load"
+       hx-include="#filters"
+       hx-indicator="#htmx-spinner">
+    {{ recipes_grid|safe }}
+  </div>
+{% endblock %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -1,9 +1,13 @@
-{% extends "components/list_layout.html" %}
-{% block title %}Suppliers – Inventory App{% endblock %}
+{% extends "components/create_manage_page.html" %}
+{% block page_title %}Suppliers – Inventory App{% endblock %}
 {% block heading %}Suppliers ({{ total_suppliers }}){% endblock %}
-{% block actions %}
+
+{% block primary_actions %}
   <a href="{% url 'supplier_create' %}" class="btn-primary">New Supplier</a>
   <a href="{% url 'suppliers_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
+{% endblock %}
+
+{% block secondary_actions %}
   <a href="{% url 'suppliers_bulk_delete' %}" class="btn-danger">Bulk Delete</a>
   <a href="{% url 'suppliers_table' %}?export=1" class="btn-secondary">Export CSV</a>
   {% if view == 'cards' %}
@@ -12,15 +16,21 @@
     <a href="{% url 'suppliers_list' %}?view=cards" class="btn-secondary">Card View</a>
   {% endif %}
 {% endblock %}
-{% block filter_bar %}
+
+{% block filters %}
   {% url hx_view_name as suppliers_view_url %}
   {% include "components/filter_bar.html" with search_placeholder="Search suppliers..." hx_get=suppliers_view_url hx_target='#'|add:container_id filters=filters export_url=export_url export_param_name="export" export_param_value="1" page_size=page_size sort=sort direction=direction %}
 {% endblock %}
-{% block table_id %}{{ container_id }}{% endblock %}
-{% block hx_get %}{% url hx_view_name %}{% endblock %}
-{% block table_content %}
-  {% if total_suppliers == 0 %}
-    {% url 'supplier_create' as supplier_create_url %}
-    {% include "components/empty_state.html" with title="No Suppliers" message="Start by adding your first supplier." cta_label="New Supplier" cta_url=supplier_create_url img='img/no_suppliers.svg' %}
-  {% endif %}
+
+{% block data_container %}
+  <div id="{{ container_id }}"
+       hx-get="{% url hx_view_name %}"
+       hx-trigger="load"
+       hx-include="#filters"
+       hx-indicator="#htmx-spinner">
+    {% if total_suppliers == 0 %}
+      {% url 'supplier_create' as supplier_create_url %}
+      {% include "components/empty_state.html" with title="No Suppliers" message="Start by adding your first supplier." cta_label="New Supplier" cta_url=supplier_create_url img='img/no_suppliers.svg' %}
+    {% endif %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- refactor inventory list templates to use create_manage_page layout
- ensure actions, filters, and KPI blocks share consistent structure
- move item list filters into dedicated block and add purchase orders list layout

## Testing
- `pre-commit run --files templates/inventory/explore.html templates/inventory/grns/list.html templates/inventory/history_reports.html templates/inventory/indents_list.html templates/inventory/items_list.html templates/inventory/ml_dashboard.html templates/inventory/purchase_orders/list.html templates/inventory/recipes/list.html templates/inventory/suppliers_list.html` *(fails: CalledProcessError: ... python_spec='python3.13')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1b76cc77c8326a4ba670e9c2c0d6f