### PR TITLE
feat: unify item list layouts

### DIFF
--- a/inventory/views/items.py
+++ b/inventory/views/items.py
@@ -244,10 +244,10 @@ class ItemsTableView(TemplateView):
     """Render the paginated table of items.
 
     Accepts the same GET filters as ItemsListView plus a page number.
-    Template: inventory/_items_table.html.
+    Template: components/items_table.html.
     """
 
-    template_name = "inventory/_items_table.html"
+    template_name = "components/items_table.html"
 
     def _get_queryset(self):
         qs, params = _filter_and_sort_items(self.request)
@@ -259,14 +259,9 @@ class ItemsTableView(TemplateView):
         qs = self._get_queryset()
         page_obj, per_page = list_utils.paginate(self.request, qs)
         ctx.update(self._filter_params)
-        ctx.update({"page_obj": page_obj, "page_size": per_page})
+        layout = (self.request.GET.get("layout") or "table").lower()
+        ctx.update({"page_obj": page_obj, "page_size": per_page, "layout": layout})
         return ctx
-
-    def get_template_names(self):
-        layout = (self.request.GET.get("layout") or "").lower()
-        if layout == "table":
-            return ["inventory/_items_table_grid.html"]
-        return [self.template_name]
 
 
 class ItemsExportView(View):

--- a/templates/components/items_table.html
+++ b/templates/components/items_table.html
@@ -1,0 +1,6 @@
+{% comment %}Unified items list component supporting grid and table layouts{% endcomment %}
+{% if layout == 'table' %}
+  {% include "inventory/_items_table_grid.html" %}
+{% else %}
+  {% include "inventory/_items_table.html" %}
+{% endif %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -179,7 +179,7 @@
 <div id="items-container" class="card">
   <div class="table-scroll">
     <div class="overflow-x-auto" id="items-list">
-      {% include "inventory/_items_table_grid.html" %}
+      {% include "components/items_table.html" with layout=request.GET.layout|default:'table' %}
     </div>
   </div>
   <div id="items-loading" class="hidden p-4">


### PR DESCRIPTION
## Summary
- add layout-switching items table component that toggles between grid and table markup
- use the unified component in the items list view and template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1b787636c8326a5bc07a2b66f35dd