### PR TITLE
centralize design tokens

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,29 @@
+# Design System
+
+This project uses a small design system shared between code and design tools.
+
+## Tokens
+
+Core design tokens are centralized in [`static/css/_variables.scss`](../static/css/_variables.scss). These CSS variables define the
+application's colors, typography scale, and spacing values.
+
+Use them in stylesheets or inline styles via the `var()` function:
+
+```css
+.button {
+  background-color: var(--color-primary);
+  padding: var(--space-2) var(--space-4);
+}
+```
+
+Changing a token in `_variables.scss` updates the value across the codebase.
+
+## Figma Component Library
+
+A reusable Figma component library mirrors these code components. When updating a component or token:
+
+1. Update `_variables.scss` and relevant code.
+2. Reflect the change in the shared Figma library so designs stay in sync.
+3. Use the Figma components when designing new screens to ensure parity with code.
+
+The Figma library can be found in the team's shared workspace.

--- a/static/css/_variables.scss
+++ b/static/css/_variables.scss
@@ -30,5 +30,3 @@
   --font-size-h2: 1.3rem;
   --font-size-badge: 0.8rem;
 }
-
-

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -1,5 +1,5 @@
 @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap");
-@import "./tokens.css";
+@import "../css/_variables.scss";
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
## Summary
- centralize design tokens in `static/css/_variables.scss` and update imports
- add design system usage guidelines referencing Figma component library

## Testing
- `npm run build-css`
- `pre-commit run --files docs/design-system.md static/css/_variables.scss static/src/app.css` *(fails: RuntimeError: failed to find interpreter for python3.13)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d03422a08326a7707cd170ed75d0