### PR TITLE
Fix missing env definition in production settings

### DIFF
--- a/inventory_app/settings_production.py
+++ b/inventory_app/settings_production.py
@@ -9,8 +9,15 @@ import logging
 import os
 
 import dj_database_url
+import environ
 
-from .settings import *
+from .settings import *  # noqa: F401,F403
+
+# Ensure `env` is available even when imported settings omit it
+try:  # pragma: no cover - defensive fallback
+    env  # type: ignore[name-defined]
+except NameError:  # pragma: no cover
+    env = environ.Env()
 
 # Override middleware for production (optimized for performance)
 MIDDLEWARE = [


### PR DESCRIPTION
## Summary
- ensure production settings initialize `env` if base settings omit it

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b20cc9a5748326bfc230c0f6254d1d