### PR TITLE
refactor: centralize ui components

### DIFF
--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -1,0 +1,39 @@
+# Component Guide
+
+A quick reference for common UI components used throughout the application.
+
+## Buttons
+
+`templates/components/button.html`
+
+```django
+{% include "components/button.html" with label="Save" type="submit" variant="primary" %}
+```
+
+Variants: `primary`, `secondary`, `danger`, `icon`, etc. Pass `href` for link-style buttons and `extra_classes` for additional styling.
+
+## Modal
+
+`templates/components/modal.html`
+
+```django
+{% include "components/modal.html" with id="sample-modal" open_id="open-btn" content_template="path/to/content.html" %}
+```
+
+The `content_template` is rendered inside the modal. Opening and closing behavior is wired automatically based on the IDs provided.
+
+## Tables
+
+`templates/components/basic_table.html`
+
+```django
+{% extends "components/basic_table.html" %}
+{% block headers %}
+  <th>Column A</th>
+{% endblock %}
+{% block rows %}
+  <tr><td>Row 1</td></tr>
+{% endblock %}
+```
+
+Extend this component to build simple tabular layouts.

--- a/templates/components/basic_table.html
+++ b/templates/components/basic_table.html
@@ -1,0 +1,11 @@
+{% comment %}Basic table component with block areas for headers and rows{% endcomment %}
+<table class="table w-full">
+  <thead>
+    <tr>
+      {% block headers %}{% endblock %}
+    </tr>
+  </thead>
+  <tbody>
+    {% block rows %}{% endblock %}
+  </tbody>
+</table>

--- a/templates/components/button.html
+++ b/templates/components/button.html
@@ -1,0 +1,10 @@
+{% comment %}
+Generic button component. Use `href` for links or rely on `type` for button elements.
+Supported variants: primary, secondary, danger, icon, etc.
+Optional `extra_classes` to append additional Tailwind classes.
+{% endcomment %}
+{% if href %}
+<a href="{{ href }}" id="{{ id }}" class="btn-{{ variant|default:'primary' }} {{ extra_classes }}">{{ label }}</a>
+{% else %}
+<button id="{{ id }}" name="{{ name }}" type="{{ type|default:'button' }}" class="btn-{{ variant|default:'primary' }} {{ extra_classes }}">{{ label }}</button>
+{% endif %}

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -1,0 +1,25 @@
+{% comment %}
+Generic modal component. Include with:
+{% include "components/modal.html" with id="my-modal" open_id="open-btn" content_template="path/to/template.html" %}
+The `content_template` is rendered inside the modal container.
+{% endcomment %}
+<div id="{{ id }}" class="fixed inset-0 hidden items-center justify-center bg-black/50 z-50">
+  <div class="bg-white p-6 rounded shadow-lg w-full max-w-md relative">
+    <button type="button" class="absolute top-2 right-2 text-bodyText hover:text-primary" data-close>
+      <span class="sr-only">Close</span>&times;
+    </button>
+    {% include content_template %}
+  </div>
+</div>
+<script>
+  (function () {
+    const modal = document.getElementById('{{ id }}');
+    const openBtn = document.getElementById('{{ open_id }}');
+    const closeBtn = modal.querySelector('[data-close]');
+    function open() { modal.classList.remove('hidden'); }
+    function close() { modal.classList.add('hidden'); }
+    openBtn && openBtn.addEventListener('click', open);
+    closeBtn && closeBtn.addEventListener('click', close);
+    modal.addEventListener('click', function (e) { if (e.target === modal) { close(); } });
+  })();
+</script>

--- a/templates/inventory/_ml_dashboard_table.html
+++ b/templates/inventory/_ml_dashboard_table.html
@@ -1,0 +1,17 @@
+{% extends "components/basic_table.html" %}
+{% block headers %}
+  <th class="p-2 text-left">Item</th>
+  <th class="p-2 text-left">ABC</th>
+  <th class="p-2 text-left">Forecast (next day)</th>
+{% endblock %}
+{% block rows %}
+  {% for row in results %}
+  <tr>
+    <td class="p-2">{{ row.item.name }}</td>
+    <td class="p-2">{{ row.classification }}</td>
+    <td class="p-2">{{ row.forecast|floatformat:2 }}</td>
+  </tr>
+  {% empty %}
+  <tr><td colspan="3" class="p-2">No data available.</td></tr>
+  {% endfor %}
+{% endblock %}

--- a/templates/inventory/_receive_form.html
+++ b/templates/inventory/_receive_form.html
@@ -16,6 +16,6 @@
     {% endif %}
   {% endfor %}
   <div class="col-span-2">
-    <button type="submit" name="submit_receive" class="btn-primary">Record</button>
+    {% include "components/button.html" with type="submit" name="submit_receive" variant="primary" label="Record" %}
   </div>
 </form>

--- a/templates/inventory/_record_movement_form.html
+++ b/templates/inventory/_record_movement_form.html
@@ -1,0 +1,7 @@
+<form method="post" class="grid gap-4">
+  {% csrf_token %}
+  {% for field in quick_form %}
+    {% include "components/form_field.html" with field=field %}
+  {% endfor %}
+  {% include "components/button.html" with type='submit' variant='primary' label='Save' extra_classes='w-full' %}
+</form>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -57,7 +57,8 @@
   <tr>
     <td colspan="7" class="px-4 py-2 text-center">
       0 suppliers yet.
-      <a href="{% url 'supplier_create' %}" class="btn-primary ml-2">New Supplier</a>
+      {% url 'supplier_create' as supplier_create_url %}
+      {% include "components/button.html" with href=supplier_create_url variant='primary' label='New Supplier' extra_classes='ml-2' %}
     </td>
   </tr>
   {% endfor %}

--- a/templates/inventory/ml_dashboard.html
+++ b/templates/inventory/ml_dashboard.html
@@ -4,24 +4,5 @@
 {% block heading %}ML Dashboard{% endblock %}
 
 {% block data_container %}
-<table class="table w-full">
-  <thead>
-    <tr>
-      <th class="p-2 text-left">Item</th>
-      <th class="p-2 text-left">ABC</th>
-      <th class="p-2 text-left">Forecast (next day)</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for row in results %}
-    <tr>
-      <td class="p-2">{{ row.item.name }}</td>
-      <td class="p-2">{{ row.classification }}</td>
-      <td class="p-2">{{ row.forecast|floatformat:2 }}</td>
-    </tr>
-    {% empty %}
-    <tr><td colspan="3" class="p-2">No data available.</td></tr>
-    {% endfor %}
-  </tbody>
-</table>
+  {% include "inventory/_ml_dashboard_table.html" %}
 {% endblock %}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -6,31 +6,6 @@
   {% include "inventory/_manual_entry_section.html" %}
   {% include "inventory/_bulk_upload_section.html" %}
   {% include "inventory/_recent_transactions_section.html" %}
-  <button id="record-movement-btn" class="btn-primary rounded-full fixed bottom-6 right-6 z-40 px-4 py-2">Record Movement</button>
-  <div id="record-modal" class="fixed inset-0 hidden items-center justify-center bg-black/50 z-50">
-    <div class="bg-white p-6 rounded shadow-lg w-full max-w-md relative">
-      <button type="button" class="absolute top-2 right-2 text-bodyText hover:text-primary" data-close>
-        <span class="sr-only">Close</span>&times;
-      </button>
-      <form method="post" class="grid gap-4">
-        {% csrf_token %}
-        {% for field in quick_form %}
-          {% include "components/form_field.html" with field=field %}
-        {% endfor %}
-        <button type="submit" name="submit_quick" class="btn-primary w-full">Save</button>
-      </form>
-    </div>
-  </div>
-  <script>
-    (function () {
-      const modal = document.getElementById('record-modal');
-      const openBtn = document.getElementById('record-movement-btn');
-      const closeBtn = modal.querySelector('[data-close]');
-      function open() { modal.classList.remove('hidden'); }
-      function close() { modal.classList.add('hidden'); }
-      openBtn && openBtn.addEventListener('click', open);
-      closeBtn && closeBtn.addEventListener('click', close);
-      modal.addEventListener('click', function (e) { if (e.target === modal) { close(); } });
-    })();
-  </script>
+  {% include "components/button.html" with id="record-movement-btn" label="Record Movement" variant="primary" type="button" extra_classes="rounded-full fixed bottom-6 right-6 z-40 px-4 py-2" %}
+  {% include "components/modal.html" with id="record-modal" open_id="record-movement-btn" content_template="inventory/_record_movement_form.html" %}
 {% endblock %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -3,17 +3,26 @@
 {% block heading %}Suppliers ({{ total_suppliers }}){% endblock %}
 
 {% block primary_actions %}
-  <a href="{% url 'supplier_create' %}" class="btn-primary">New Supplier</a>
-  <a href="{% url 'suppliers_bulk_upload' %}" class="btn-secondary">Bulk Upload</a>
+  {% url 'supplier_create' as supplier_create_url %}
+  {% include "components/button.html" with href=supplier_create_url variant='primary' label='New Supplier' %}
+  {% url 'suppliers_bulk_upload' as suppliers_bulk_upload_url %}
+  {% include "components/button.html" with href=suppliers_bulk_upload_url variant='secondary' label='Bulk Upload' %}
 {% endblock %}
 
 {% block secondary_actions %}
-  <a href="{% url 'suppliers_bulk_delete' %}" class="btn-danger">Bulk Delete</a>
-  <a href="{% url 'suppliers_table' %}?export=1" class="btn-secondary">Export CSV</a>
+  {% url 'suppliers_bulk_delete' as suppliers_bulk_delete_url %}
+  {% include "components/button.html" with href=suppliers_bulk_delete_url variant='danger' label='Bulk Delete' %}
+  {% url 'suppliers_table' as suppliers_table_url %}
+  {% with export_url=suppliers_table_url|add:'?export=1' %}
+    {% include "components/button.html" with href=export_url variant='secondary' label='Export CSV' %}
+  {% endwith %}
+  {% url 'suppliers_list' as suppliers_list_url %}
   {% if view == 'cards' %}
-    <a href="{% url 'suppliers_list' %}" class="btn-secondary">Table View</a>
+    {% include "components/button.html" with href=suppliers_list_url variant='secondary' label='Table View' %}
   {% else %}
-    <a href="{% url 'suppliers_list' %}?view=cards" class="btn-secondary">Card View</a>
+    {% with card_view_url=suppliers_list_url|add:'?view=cards' %}
+      {% include "components/button.html" with href=card_view_url variant='secondary' label='Card View' %}
+    {% endwith %}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- extract generic button, modal, and table components
- refactor inventory pages to consume shared components
- document available components in new guide

## Testing
- `pre-commit run --files templates/inventory/_receive_form.html templates/inventory/_suppliers_table.html templates/inventory/ml_dashboard.html templates/inventory/stock_movements.html templates/inventory/suppliers_list.html docs/component-guide.md templates/components/basic_table.html templates/components/button.html templates/components/modal.html templates/inventory/_ml_dashboard_table.html templates/inventory/_record_movement_form.html` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `pytest` *(fails: unrecognized arguments: --reuse-db)*

------
https://chatgpt.com/codex/tasks/task_e_68b214b4d9288326963b5e8c9752792a