### PR TITLE
Add client-side form validation and feedback

### DIFF
--- a/static/js/forms.js
+++ b/static/js/forms.js
@@ -1,0 +1,41 @@
+// Real-time form validation
+// Adds event listeners to inputs to show success/error feedback
+
+document.addEventListener('DOMContentLoaded', () => {
+  const forms = document.querySelectorAll('form');
+  forms.forEach(form => {
+    const inputs = form.querySelectorAll('input, select, textarea');
+    inputs.forEach(input => {
+      const container = input.closest('div');
+      if (!container) return;
+      const success = container.querySelector('[data-feedback="success"]');
+      const error = container.querySelector('[data-feedback="error"]');
+
+      const validate = () => {
+        if (input.checkValidity()) {
+          if (success) {
+            success.textContent = 'Looks good!';
+            success.classList.remove('hidden');
+          }
+          if (error) {
+            error.textContent = '';
+            error.classList.add('hidden');
+          }
+        } else {
+          if (success) {
+            success.textContent = '';
+            success.classList.add('hidden');
+          }
+          if (error) {
+            error.textContent = input.validationMessage;
+            error.classList.remove('hidden');
+          }
+        }
+      };
+
+      input.addEventListener('input', validate);
+      input.addEventListener('blur', validate);
+    });
+  });
+});
+

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -20,6 +20,7 @@
   <script src="{% static 'js/table-sort.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/tabs.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/modal.js' %}?v={{ STATIC_VERSION }}" defer></script>
+  <script src="{% static 'js/forms.js' %}?v={{ STATIC_VERSION }}" defer></script>
     {% block extra_css %}{% endblock %}
   </head>
   <body class="min-h-screen bg-gray-50">

--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -10,6 +10,7 @@
   {% else %}
     {{ field|add_class:"form-control" }}
   {% endif %}
+  {% include "forms/feedback.html" %}
   {% if field.help_text %}
     <p class="text-sm text-gray-500">{{ field.help_text }}</p>
   {% endif %}

--- a/templates/forms/feedback.html
+++ b/templates/forms/feedback.html
@@ -1,0 +1,2 @@
+<p class="text-sm text-green-600 mt-1 hidden" data-feedback="success"></p>
+<p class="text-sm text-red-600 mt-1 hidden" data-feedback="error"></p>

--- a/templates/inventory/_bulk_upload_partial.html
+++ b/templates/inventory/_bulk_upload_partial.html
@@ -8,8 +8,9 @@
       {% csrf_token %}
       <input type="hidden" name="partial" value="1"/>
       <div class="mb-3">
-        <label class="form-label">Select CSV File</label>
+        <label for="{{ form.file.id_for_label }}" class="form-label">Select CSV File</label>
         {{ form.file }}
+        {% include "forms/feedback.html" %}
       </div>
       <div class="flex items-center justify-end" style="gap:.5rem">
         <button type="button" class="btn-secondary" data-modal-close>Cancel</button>

--- a/templates/inventory/_item_create_partial.html
+++ b/templates/inventory/_item_create_partial.html
@@ -9,52 +9,65 @@
       <input type="hidden" name="partial" value="1"/>
       <div class="grid" style="grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem;">
         <div>
-          <label class="form-label">Name</label>
+          <label for="{{ form.name.id_for_label }}" class="form-label">Name</label>
           {{ form.name }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Unit</label>
+          <label for="{{ form.unit_id.id_for_label }}" class="form-label">Unit</label>
           {{ form.unit_id }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Category</label>
+          <label for="{{ form.category_id.id_for_label }}" class="form-label">Category</label>
           {{ form.category_id }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Current Stock</label>
+          <label for="{{ form.current_stock.id_for_label }}" class="form-label">Current Stock</label>
           {{ form.current_stock }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Reorder Point</label>
+          <label for="{{ form.reorder_point.id_for_label }}" class="form-label">Reorder Point</label>
           {{ form.reorder_point }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Initial Purchase Price</label>
+          <label for="{{ form.initial_purchase_price.id_for_label }}" class="form-label">Initial Purchase Price</label>
           {{ form.initial_purchase_price }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Min Order Qty</label>
+          <label for="{{ form.minimum_order_qty.id_for_label }}" class="form-label">Min Order Qty</label>
           {{ form.minimum_order_qty }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Lead Time (days)</label>
+          <label for="{{ form.lead_time_days.id_for_label }}" class="form-label">Lead Time (days)</label>
           {{ form.lead_time_days }}
+          {% include "forms/feedback.html" %}
         </div>
         <div style="grid-column: span 2;">
-          <label class="form-label">Departments</label>
+          <label for="{{ form.departments.id_for_label }}" class="form-label">Departments</label>
           <div class="p-2 border rounded">
             {{ form.departments }}
           </div>
+          {% include "forms/feedback.html" %}
         </div>
         <div style="grid-column: span 2;">
-          <label class="form-label">Notes</label>
+          <label for="{{ form.notes.id_for_label }}" class="form-label">Notes</label>
           {{ form.notes }}
+          {% include "forms/feedback.html" %}
         </div>
         <div style="grid-column: span 2; display:flex; justify-content:space-between; align-items:center; gap:.5rem;">
-          <label class="inline-flex items-center gap-2 text-gray-700">
-            {{ form.is_active }}
-            <span>Active</span>
-          </label>
+          <div>
+            <label for="{{ form.is_active.id_for_label }}" class="inline-flex items-center gap-2 text-gray-700">
+              {{ form.is_active }}
+              <span>Active</span>
+            </label>
+            {% include "forms/feedback.html" %}
+          </div>
           <div>
             <button type="button" class="btn-secondary" data-modal-close>Cancel</button>
             <button type="submit" class="btn-primary">Create</button>

--- a/templates/inventory/_item_form_partial.html
+++ b/templates/inventory/_item_form_partial.html
@@ -9,32 +9,39 @@
       <input type="hidden" name="partial" value="1"/>
       <div class="grid" style="grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem;">
         <div>
-          <label class="form-label">Name</label>
+          <label for="{{ form.name.id_for_label }}" class="form-label">Name</label>
           {{ form.name }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Item Code</label>
+          <label for="{{ form.item_code.id_for_label }}" class="form-label">Item Code</label>
           {{ form.item_code }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Category</label>
+          <label for="{{ form.category.id_for_label }}" class="form-label">Category</label>
           {{ form.category }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Sub Category</label>
+          <label for="{{ form.sub_category.id_for_label }}" class="form-label">Sub Category</label>
           {{ form.sub_category }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Reorder Point</label>
+          <label for="{{ form.reorder_point.id_for_label }}" class="form-label">Reorder Point</label>
           {{ form.reorder_point }}
+          {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label class="form-label">Active</label>
+          <label for="{{ form.is_active.id_for_label }}" class="form-label">Active</label>
           {{ form.is_active }}
+          {% include "forms/feedback.html" %}
         </div>
         <div style="grid-column: span 2;">
-          <label class="form-label">Notes</label>
+          <label for="{{ form.notes.id_for_label }}" class="form-label">Notes</label>
           {{ form.notes }}
+          {% include "forms/feedback.html" %}
         </div>
       </div>
       <div class="mt-3 flex items-center justify-end" style="gap:.5rem">

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -5,14 +5,16 @@
 {% block filters %}
   <form method="get" class="mb-4 grid gap-2 grid-cols-4 max-lg:grid-cols-4 max-md:grid-cols-2 max-sm:grid-cols-1 items-end">
     <div class="space-y-1">
-      <label class="block text-sm font-medium">Supplier</label>
+      <label for="id_supplier" class="block text-sm font-medium">Supplier</label>
       <input
+        id="id_supplier"
         type="text"
         name="supplier"
         list="grn-suppliers"
         class="form-control w-full"
         value="{{ current_supplier }}"
       />
+      {% include "forms/feedback.html" %}
       <datalist id="grn-suppliers">
         <option value="" label="All"></option>
         {% for s in suppliers %}
@@ -21,12 +23,14 @@
       </datalist>
     </div>
     <div class="space-y-1">
-      <label class="block text-sm font-medium">Start Date</label>
-      <input type="date" name="start_date" value="{{ start_date }}" class="form-control w-full" />
+      <label for="id_start_date" class="block text-sm font-medium">Start Date</label>
+      <input id="id_start_date" type="date" name="start_date" value="{{ start_date }}" class="form-control w-full" />
+      {% include "forms/feedback.html" %}
     </div>
     <div class="space-y-1">
-      <label class="block text-sm font-medium">End Date</label>
-      <input type="date" name="end_date" value="{{ end_date }}" class="form-control w-full" />
+      <label for="id_end_date" class="block text-sm font-medium">End Date</label>
+      <input id="id_end_date" type="date" name="end_date" value="{{ end_date }}" class="form-control w-full" />
+      {% include "forms/feedback.html" %}
     </div>
     <div class="space-y-1">
       <button type="submit" class="btn-primary w-full">Filter</button>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -46,31 +46,37 @@
             <h3 class="section-header">Essentials</h3>
             <div class="grid" style="grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; align-items:start;">
             <div class="space-y-1">
-              <label class="form-label">Name</label>
+              <label for="{{ form.name.id_for_label }}" class="form-label">Name</label>
               {{ form.name }}
+              {% include "forms/feedback.html" %}
             </div>
             <div class="space-y-1">
-              <label class="form-label">Unit</label>
+              <label for="{{ form.unit_id.id_for_label }}" class="form-label">Unit</label>
               {{ form.unit_id }}
+              {% include "forms/feedback.html" %}
             </div>
             <div class="space-y-1">
-              <label class="form-label">Category</label>
+              <label for="{{ form.category_id.id_for_label }}" class="form-label">Category</label>
               {{ form.category_id }}
+              {% include "forms/feedback.html" %}
             </div>
             <div class="space-y-1">
-              <label class="form-label">Current Stock</label>
+              <label for="{{ form.current_stock.id_for_label }}" class="form-label">Current Stock</label>
               {{ form.current_stock }}
+              {% include "forms/feedback.html" %}
             </div>
             <div class="space-y-1">
-              <label class="form-label">Reorder Point</label>
+              <label for="{{ form.reorder_point.id_for_label }}" class="form-label">Reorder Point</label>
               {{ form.reorder_point }}
+              {% include "forms/feedback.html" %}
             </div>
             <div class="space-y-1">
-              <label class="form-label">Status</label>
-              <label class="inline-flex items-center gap-2 text-gray-700" style="height:38px;align-items:center;">
+              <label for="{{ form.is_active.id_for_label }}" class="form-label">Status</label>
+              <div class="inline-flex items-center gap-2 text-gray-700" style="height:38px;align-items:center;">
                 {{ form.is_active }}
                 <span>Active</span>
-              </label>
+              </div>
+              {% include "forms/feedback.html" %}
             </div>
             </div>
           </div>
@@ -80,30 +86,36 @@
             <h3 class="section-header">Advanced</h3>
             <div class="grid" style="grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; align-items:start;">
               <div class="space-y-1">
-                <label class="form-label">Preferred Supplier</label>
+                <label for="{{ form.preferred_supplier.id_for_label }}" class="form-label">Preferred Supplier</label>
                 {{ form.preferred_supplier }}
+                {% include "forms/feedback.html" %}
               </div>
               <div class="space-y-1">
-                <label class="form-label">Initial Purchase Price</label>
+                <label for="{{ form.initial_purchase_price.id_for_label }}" class="form-label">Initial Purchase Price</label>
                 {{ form.initial_purchase_price }}
+                {% include "forms/feedback.html" %}
               </div>
               <div class="space-y-1">
-                <label class="form-label">Min Order Qty</label>
+                <label for="{{ form.minimum_order_qty.id_for_label }}" class="form-label">Min Order Qty</label>
                 {{ form.minimum_order_qty }}
+                {% include "forms/feedback.html" %}
               </div>
               <div class="space-y-1">
-                <label class="form-label">Lead Time (days)</label>
+                <label for="{{ form.lead_time_days.id_for_label }}" class="form-label">Lead Time (days)</label>
                 {{ form.lead_time_days }}
+                {% include "forms/feedback.html" %}
               </div>
               <div class="col-span-3 space-y-1">
-                <label class="form-label">Departments</label>
+                <label for="{{ form.departments.id_for_label }}" class="form-label">Departments</label>
                 <div class="dept-grid">
                   {{ form.departments }}
                 </div>
+                {% include "forms/feedback.html" %}
               </div>
               <div class="col-span-3 space-y-1">
-                <label class="form-label">Notes</label>
+                <label for="{{ form.notes.id_for_label }}" class="form-label">Notes</label>
                 {{ form.notes }}
+                {% include "forms/feedback.html" %}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add real-time validation script and load it globally
- introduce reusable form feedback partial and integrate with form field
- ensure form labels reference their inputs across item and GRN forms

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b214bb946083268065a933fd2f8692