### PR TITLE
Add accessibility scan report

### DIFF
--- a/docs/accessibility-report.md
+++ b/docs/accessibility-report.md
@@ -1,0 +1,18 @@
+# Accessibility Report
+
+## Scan Attempts
+- `@axe-core/cli` on `http://127.0.0.1:8000/` – failed: **cannot find Chrome binary**
+- `pa11y` on `http://127.0.0.1:8000/` – failed: **Failed to launch the browser process**
+
+Automated accessibility scans could not run because a headless Chrome/Chromium instance is unavailable in the current environment.
+
+## Manual Review of Login View (`/`)
+- The `<html>` tag includes `lang="en"`.
+- Heading hierarchy contains a single `<h1>` element.
+- Notification container uses `aria-live="polite"` and `aria-label`.
+
+## Recommendations
+- Install a headless browser to enable automated Axe or Pa11y scans across all views.
+- Verify and adjust color contrast to meet WCAG AA.
+- Confirm logical focus order with keyboard navigation.
+- Review ARIA attributes to ensure they provide meaningful context without redundancy.


### PR DESCRIPTION
## Summary
- document attempts to run automated accessibility scans
- note manual review of login view and recommendations

## Testing
- `npx --yes @axe-core/cli http://127.0.0.1:8000/` *(fails: cannot find Chrome binary)*
- `npx --yes pa11y http://127.0.0.1:8000/` *(fails: Failed to launch the browser process)*
- `pytest` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b21622ad248326bfb21083147718a5