### PR TITLE
Refactor high price purchase KPI to single annotated query

### DIFF
--- a/inventory/services/kpis.py
+++ b/inventory/services/kpis.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from decimal import Decimal
 from typing import List, Tuple
 
-from django.db.models import Avg, Count, F, Max, Q, Sum
+from django.db.models import Avg, Count, F, Max, Q, Sum, OuterRef, Subquery
 from django.db.models.functions import TruncDate
 from django.utils import timezone
 
@@ -67,18 +67,23 @@ def high_price_purchases(threshold: Decimal) -> List[GRNItem]:
     """
 
     cutoff = timezone.now() - timedelta(days=30)
-    flagged: List[GRNItem] = []
-    for grn_item in GRNItem.objects.filter(
-        grn__received_date__gte=cutoff
-    ).select_related("po_item__item"):
-        avg_price = (
-            GRNItem.objects.filter(po_item__item=grn_item.po_item.item)
-            .exclude(pk=grn_item.pk)
-            .aggregate(avg=Avg("unit_price_at_receipt"))["avg"]
+    avg_price = (
+        GRNItem.objects.filter(po_item__item_id=OuterRef("po_item__item_id"))
+        .exclude(pk=OuterRef("pk"))
+        .values("po_item__item_id")
+        .annotate(avg=Avg("unit_price_at_receipt"))
+        .values("avg")[:1]
+    )
+    qs = (
+        GRNItem.objects.filter(grn__received_date__gte=cutoff)
+        .select_related("po_item__item")
+        .annotate(avg_price=Subquery(avg_price))
+        .filter(
+            avg_price__isnull=False,
+            unit_price_at_receipt__gt=F("avg_price") * (1 + threshold),
         )
-        if avg_price and grn_item.unit_price_at_receipt > avg_price * (1 + threshold):
-            flagged.append(grn_item)
-    return flagged
+    )
+    return list(qs)
 
 
 def pending_po_status_counts() -> dict:

--- a/tests/test_kpis_service.py
+++ b/tests/test_kpis_service.py
@@ -51,7 +51,7 @@ def test_kpi_calculations(item_factory):
 
 
 @pytest.mark.django_db
-def test_high_price_purchase_detection(item_factory):
+def test_high_price_purchase_detection(item_factory, django_assert_num_queries):
     item = item_factory(name="X")
     supplier = Supplier.objects.create(name="Supp")
     po = PurchaseOrder.objects.create(
@@ -60,11 +60,11 @@ def test_high_price_purchase_detection(item_factory):
     poi = PurchaseOrderItem.objects.create(
         purchase_order=po, item=item, quantity_ordered=1, unit_price=Decimal("100")
     )
-    grn = GoodsReceivedNote.objects.create(
+    grn1 = GoodsReceivedNote.objects.create(
         purchase_order=po, supplier=supplier, received_date=timezone.now().date()
     )
     GRNItem.objects.create(
-        grn=grn,
+        grn=grn1,
         po_item=poi,
         quantity_ordered_on_po=1,
         quantity_received=1,
@@ -80,9 +80,20 @@ def test_high_price_purchase_detection(item_factory):
         quantity_received=1,
         unit_price_at_receipt=Decimal("150"),
     )
+    grn3 = GoodsReceivedNote.objects.create(
+        purchase_order=po, supplier=supplier, received_date=timezone.now().date()
+    )
+    GRNItem.objects.create(
+        grn=grn3,
+        po_item=poi,
+        quantity_ordered_on_po=1,
+        quantity_received=1,
+        unit_price_at_receipt=Decimal("110"),
+    )
 
-    flagged = kpis.high_price_purchases(Decimal("0.2"))
-    assert list(flagged) == [high]
+    with django_assert_num_queries(1):
+        flagged = kpis.high_price_purchases(Decimal("0.2"))
+    assert flagged == [high]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- optimize `high_price_purchases` to annotate historical averages via `Subquery` and filter flagged GRN items in one query
- extend KPI service test to cover multiple GRN items and assert only one DB query

## Testing
- `pytest tests/test_kpis_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b219514644832690981eb485db1d27