### PR TITLE
Aggregate forecasting queries and async caching

### DIFF
--- a/inventory/services/ml.py
+++ b/inventory/services/ml.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List
+from threading import Thread
+from typing import Dict, List, Optional
 
+from django.core.cache import cache
 from django.db.models import Sum
 from django.db.models.functions import Abs, TruncDate
 from statsmodels.tsa.holtwinters import SimpleExpSmoothing
@@ -12,42 +14,94 @@ from ..models import Item, StockTransaction
 logger = logging.getLogger(__name__)
 
 
-def forecast_item_demand(item: Item, periods: int = 7) -> List[float]:
+def forecast_item_demand(
+    item: Optional[Item] = None,
+    *,
+    periods: int = 7,
+    series: Optional[List[float]] = None,
+) -> List[float]:
     """Forecast future demand for an item using exponential smoothing.
 
+    Either ``item`` or ``series`` must be provided. When ``series`` is supplied
+    the database is not queried, allowing callers to batch-load time series data
+    and avoid per-item queries.
+
     Args:
-        item: Item to forecast.
+        item: Item to forecast. Required if ``series`` is not provided.
         periods: Number of future periods (days) to predict.
+        series: Precomputed historical demand values.
 
     Returns:
         List of forecasted quantities for each future period. If fewer than two
         historical data points are available, returns zeros.
     """
-    qs = (
-        StockTransaction.objects.filter(item=item)
-        .annotate(day=TruncDate("transaction_date"))
-        .values("day")
-        .annotate(total=Sum("quantity_change"))
-        .order_by("day")
-    )
-    series = [float(row["total"]) for row in qs]
+    if series is None:
+        if item is None:
+            raise ValueError("Either item or series must be provided")
+        qs = (
+            StockTransaction.objects.filter(item=item)
+            .annotate(day=TruncDate("transaction_date"))
+            .values("day")
+            .annotate(total=Sum("quantity_change"))
+            .order_by("day")
+        )
+        series = [float(row["total"]) for row in qs]
+
     if len(series) < 2:
         return [0.0 for _ in range(periods)]
     try:
         model = SimpleExpSmoothing(series).fit()
         forecast = model.forecast(periods)
     except ValueError:
-        logger.exception("Failed to forecast demand for item %s", item.pk)
+        logger.exception(
+            "Failed to forecast demand for item %s", getattr(item, "pk", "<series>")
+        )
         return [0.0 for _ in range(periods)]
     return [float(v) for v in forecast]
 
 
 def train_models(periods: int = 7) -> Dict[int, List[float]]:
-    """Train forecasting models for all items and return forecasts."""
+    """Train forecasting models for all items and return forecasts.
+
+    To avoid per-item database queries the required stock data for all items is
+    fetched in a single aggregated query and the precomputed series are passed to
+    :func:`forecast_item_demand`.
+    """
+    data = (
+        StockTransaction.objects.annotate(day=TruncDate("transaction_date"))
+        .values("item_id", "day")
+        .annotate(total=Sum("quantity_change"))
+        .order_by("item_id", "day")
+    )
+
+    series_by_item: Dict[int, List[float]] = {}
+    for row in data:
+        series_by_item.setdefault(row["item_id"], []).append(float(row["total"]))
+
     forecasts: Dict[int, List[float]] = {}
-    for item in Item.objects.all():
-        forecasts[item.pk] = forecast_item_demand(item, periods=periods)
+    for item_id in Item.objects.values_list("id", flat=True):
+        series = series_by_item.get(item_id, [])
+        forecasts[item_id] = forecast_item_demand(
+            periods=periods, series=series if series else [0.0]
+        )
+
     return forecasts
+
+
+def queue_train_models(
+    periods: int = 7, *, cache_key: str = "ml_train_models", ttl: int = 300
+) -> None:
+    """Queue training in a background thread and store results in cache.
+
+    This lightweight approach avoids blocking the requesting thread. In a real
+    deployment, a proper background worker such as Celery or a scheduled job
+    should perform this work instead.
+    """
+
+    def _task() -> None:
+        cache.set(cache_key, train_models(periods), ttl)
+
+    Thread(target=_task, daemon=True).start()
 
 
 def abc_classification() -> Dict[int, str]:

--- a/inventory/views/ml.py
+++ b/inventory/views/ml.py
@@ -17,8 +17,11 @@ def ml_dashboard(request):
 
     forecasts = cache.get("ml_train_models")
     if forecasts is None:
-        forecasts = ml.train_models(periods=1)
-        cache.set("ml_train_models", forecasts, ttl)
+        # Training can be expensive. Trigger it in the background and use any
+        # cached results available. The background task populates the cache when
+        # finished so subsequent requests receive data without blocking.
+        ml.queue_train_models(periods=1, ttl=ttl)
+        forecasts = {}
 
     classifications = cache.get("ml_abc_classification")
     if classifications is None:

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -64,6 +64,7 @@ def test_abc_classification(db):
 def test_ml_dashboard_uses_cache(client):
     # Ensure user is logged in explicitly
     from django.contrib.auth import get_user_model
+
     User = get_user_model()
     user, _ = User.objects.get_or_create(username="admin")
     if not user.has_usable_password():
@@ -74,26 +75,30 @@ def test_ml_dashboard_uses_cache(client):
     # Clear all caches explicitly
     cache.clear()
     from django.core.cache import caches
+
     for cache_name in caches:
         caches[cache_name].clear()
 
     with (
-        patch("inventory.services.ml.train_models", return_value={}) as mock_train,
+        patch("inventory.services.ml.queue_train_models") as mock_queue,
         patch("inventory.services.ml.abc_classification", return_value={}) as mock_abc,
     ):
+        # When queue_train_models is called we synchronously populate the cache to
+        # emulate the background worker completing its task.
+        mock_queue.side_effect = lambda periods=1, ttl=300: cache.set(
+            "ml_train_models", {}, ttl
+        )
+
         response = client.get(reverse("ml_dashboard"))
-        print(f"Response status: {response.status_code}")
-        print(f"Mock train called: {mock_train.called}")
-        print(f"Mock abc called: {mock_abc.called}")
         assert response.status_code == 200
-        assert mock_train.call_count == 1
+        assert mock_queue.call_count == 1
         assert mock_abc.call_count == 1
 
         client.get(reverse("ml_dashboard"))
-        assert mock_train.call_count == 1
+        assert mock_queue.call_count == 1
         assert mock_abc.call_count == 1
 
         cache.clear()
         client.get(reverse("ml_dashboard"))
-        assert mock_train.call_count == 2
+        assert mock_queue.call_count == 2
         assert mock_abc.call_count == 2


### PR DESCRIPTION
## Summary
- batch-load stock transactions for all items in one query
- pass precomputed series into forecasting to avoid per-item hits
- cache training in background thread and update ml dashboard to trigger async training

## Testing
- `pytest`
- `pre-commit run --files inventory/services/ml.py inventory/views/ml.py tests/test_ml.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*

------
https://chatgpt.com/codex/tasks/task_e_68b2a389e0f08326a19ecaae3004dfe7