### PR TITLE
Add accessible label to top navigation search

### DIFF
--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -52,16 +52,17 @@
         {% if user.is_authenticated %}
         <!-- Search (global) -->
         <div class="hidden lg:block">
-          <div class="relative">
-            <input type="text" 
-                   placeholder="Search items, orders..." 
+          <form action="#" role="search" class="relative">
+            <label for="global-search" class="sr-only">Search items and orders</label>
+            <input id="global-search" type="text"
+                   placeholder="Search items, orders..."
                    class="w-64 pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent">
             <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
               <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 014 0z"/>
               </svg>
             </div>
-          </div>
+          </form>
         </div>
 
         <!-- Notifications -->


### PR DESCRIPTION
## Summary
- wrap top navigation search input in a form and add hidden label for screen readers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2a4e40e2c8326b0de6d9034a939b4