### PR TITLE
Improve modal accessibility and focus handling

### DIFF
--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -1,13 +1,19 @@
 (function () {
   let lastFocused = null;
+  let trapHandler = null;
   function trapFocus(container) {
+    if (trapHandler) container.removeEventListener("keydown", trapHandler);
     const focusable = container.querySelectorAll(
       'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])',
     );
-    if (!focusable.length) return;
+    if (!focusable.length) {
+      container.focus();
+      trapHandler = null;
+      return;
+    }
     const first = focusable[0];
     const last = focusable[focusable.length - 1];
-    function handler(e) {
+    trapHandler = function (e) {
       if (e.key !== "Tab") return;
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault();
@@ -16,9 +22,19 @@
         e.preventDefault();
         first.focus();
       }
-    }
-    container.addEventListener("keydown", handler);
+    };
+    container.addEventListener("keydown", trapHandler);
     first.focus();
+  }
+  function setAria(root, content) {
+    const heading = content.querySelector("h1, h2, h3, h4, h5, h6");
+    if (heading) {
+      const id = heading.id || "modal-heading";
+      heading.id = id;
+      root.setAttribute("aria-labelledby", id);
+    } else {
+      root.removeAttribute("aria-labelledby");
+    }
   }
   function openModal(html) {
     const root = document.getElementById("modal-root");
@@ -26,8 +42,9 @@
     if (!root || !content) return;
     lastFocused = document.activeElement;
     content.innerHTML = html;
+    setAria(root, content);
     root.classList.remove("hidden");
-    trapFocus(content);
+    trapFocus(root);
   }
   function openDrawer(html, side = "right") {
     const root = document.getElementById("modal-root");
@@ -35,14 +52,16 @@
     if (!root || !content) return;
     lastFocused = document.activeElement;
     content.innerHTML = `<div class="drawer ${side}">${html}</div>`;
+    setAria(root, content);
     root.classList.remove("hidden");
-    trapFocus(content);
+    trapFocus(root);
   }
   function closeModal() {
     const root = document.getElementById("modal-root");
     const content = document.getElementById("modal-content");
     if (!root || !content) return;
     root.classList.add("hidden");
+    root.removeAttribute("aria-labelledby");
     content.innerHTML = "";
     if (lastFocused && typeof lastFocused.focus === "function") {
       lastFocused.focus();

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -54,8 +54,19 @@
       </main>
 
       <!-- Modal Root -->
-      <div id="modal-root" class="hidden fixed inset-0 z-50">
-        <div class="absolute inset-0 bg-modal-overlay" data-modal-close aria-label="Close modal"></div>
+      <div
+        id="modal-root"
+        class="hidden fixed inset-0 z-50"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-heading"
+        tabindex="-1"
+      >
+        <div
+          class="absolute inset-0 bg-modal-overlay"
+          data-modal-close
+          aria-label="Close modal"
+        ></div>
         <div class="absolute inset-0 flex items-center justify-center p-4">
           <div id="modal-content" class="max-w-3xl w-full"></div>
         </div>


### PR DESCRIPTION
## Summary
- add dialog role and aria attributes to modal container
- manage focus and heading labeling in modal JS

## Testing
- `pre-commit run --files templates/_base.html static/js/modal.js` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2a611f15c832683d98a7b9aff16bb