### PR TITLE
Sanitize error logging

### DIFF
--- a/core/error_logging_middleware.py
+++ b/core/error_logging_middleware.py
@@ -3,10 +3,24 @@ import traceback
 
 logger = logging.getLogger(__name__)
 
+
+def _sanitize_post_data(post_data):
+    """Return a copy of POST data with sensitive values redacted."""
+    sanitized = {}
+    for key, value in post_data.items():
+        key_lower = key.lower()
+        if any(s in key_lower for s in ("password", "token", "secret")):
+            sanitized[key] = "[REDACTED]"
+        else:
+            sanitized[key] = value
+    return sanitized
+
+
 class DetailedErrorLoggingMiddleware:
     """
     Middleware to log detailed error information for debugging
     """
+
     def __init__(self, get_response):
         self.get_response = get_response
 
@@ -18,20 +32,22 @@ class DetailedErrorLoggingMiddleware:
         """
         Log detailed exception information
         """
-        logger.error('🚨 DETAILED ERROR REPORT 🚨')
-        logger.error(f'Exception Type: {type(exception).__name__}')
-        logger.error(f'Exception Message: {str(exception)}')
-        logger.error(f'Request Path: {request.path}')
-        logger.error(f'Request Method: {request.method}')
-        logger.error(f'Request User: {getattr(request, "user", "Anonymous")}')
-        logger.error(f'Request META: {dict(request.META)}')
+        logger.error("🚨 DETAILED ERROR REPORT 🚨")
+        logger.error(f"Exception Type: {type(exception).__name__}")
+        logger.error(f"Exception Message: {str(exception)}")
+        sanitized_meta = {
+            "path": request.path,
+            "method": request.method,
+            "user": str(getattr(request, "user", "Anonymous")),
+        }
+        logger.error(f"Request Info: {sanitized_meta}")
 
-        if request.method == 'POST':
-            logger.error(f'POST Data: {dict(request.POST)}')
+        if request.method == "POST":
+            logger.error(f"POST Data: {_sanitize_post_data(request.POST)}")
 
-        logger.error('🔍 FULL TRACEBACK:')
+        logger.error("🔍 FULL TRACEBACK:")
         logger.error(traceback.format_exc())
-        logger.error('🚨 END ERROR REPORT 🚨')
+        logger.error("🚨 END ERROR REPORT 🚨")
 
         # Don't return a response - let Django handle it normally
         return None

--- a/tests/test_error_logging_middleware.py
+++ b/tests/test_error_logging_middleware.py
@@ -1,0 +1,40 @@
+import logging
+
+from django.test import RequestFactory
+
+from core.error_logging_middleware import DetailedErrorLoggingMiddleware
+
+
+class DummyUser:
+    def __str__(self):
+        return "dummyuser"
+
+
+def test_middleware_redacts_sensitive_info(caplog):
+    middleware = DetailedErrorLoggingMiddleware(lambda req: None)
+    rf = RequestFactory()
+    request = rf.post(
+        "/test/",
+        {
+            "username": "alice",
+            "password": "topsecret",
+            "csrfmiddlewaretoken": "token123",
+        },
+        HTTP_AUTHORIZATION="Bearer abc123",
+        HTTP_COOKIE="sessionid=xyz",
+    )
+    request.user = DummyUser()
+
+    with caplog.at_level(logging.ERROR):
+        middleware.process_exception(request, ValueError("boom"))
+
+    log_output = " ".join(record.getMessage() for record in caplog.records)
+
+    assert "topsecret" not in log_output
+    assert "abc123" not in log_output
+    assert "sessionid=xyz" not in log_output
+    assert "[REDACTED]" in log_output
+    assert "Request Info" in log_output
+    assert "/test/" in log_output
+    assert "POST" in log_output
+    assert "dummyuser" in log_output


### PR DESCRIPTION
## Summary
- sanitize POST data and log only whitelisted metadata in DetailedErrorLoggingMiddleware
- add test ensuring sensitive request data is not logged

## Testing
- `pre-commit run --files core/error_logging_middleware.py tests/test_error_logging_middleware.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `pytest tests/test_error_logging_middleware.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2a7c015f48326a211b1867d975864