### PR TITLE
Add accessible captions and header scopes to tables

### DIFF
--- a/templates/components/detail_table.html
+++ b/templates/components/detail_table.html
@@ -2,7 +2,7 @@
   <tbody>
     {% for label, value in rows %}
     <tr>
-      <th class="text-left pr-4">{{ label }}</th>
+      <th scope="row" class="text-left pr-4">{{ label }}</th>
       <td>{{ value }}</td>
     </tr>
     {% endfor %}

--- a/templates/components/responsive_table.html
+++ b/templates/components/responsive_table.html
@@ -4,6 +4,7 @@ Responsive table component with sticky headers and row hover states.
 <div class="max-md:overflow-x-auto">
   {% block actions %}{% endblock %}
   <table class="table w-full table-auto text-sm"{% if table_id %} id="{{ table_id }}"{% endif %}>
+    {% block caption %}{% endblock %}
     <thead class="sticky top-0 bg-primary text-white">
       <tr>
         {% block headers %}{% endblock %}

--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -1,50 +1,52 @@
 {% extends "components/responsive_table.html" %}
 
+{% block caption %}<caption>Transaction History</caption>{% endblock %}
+
 {% block headers %}
-<th class="px-4 py-2 text-right">
+<th scope="col" class="px-4 py-2 text-right">
   <a hx-get="{% url 'history_reports' %}?sort=id&direction={% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='id';document.querySelector('#filters input[name=direction]').value='{% if sort == 'id' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     ID{% if sort == 'id' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
   </a>
 </th>
-<th class="px-4 py-2">
+<th scope="col" class="px-4 py-2">
   <a hx-get="{% url 'history_reports' %}?sort=item&direction={% if sort == 'item' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='item';document.querySelector('#filters input[name=direction]').value='{% if sort == 'item' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     Item{% if sort == 'item' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
   </a>
 </th>
-<th class="px-4 py-2">
+<th scope="col" class="px-4 py-2">
   <a hx-get="{% url 'history_reports' %}?sort=type&direction={% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='type';document.querySelector('#filters input[name=direction]').value='{% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     Type{% if sort == 'type' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
   </a>
 </th>
-<th class="px-4 py-2 text-right">
+<th scope="col" class="px-4 py-2 text-right">
   <a hx-get="{% url 'history_reports' %}?sort=qty&direction={% if sort == 'qty' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='qty';document.querySelector('#filters input[name=direction]').value='{% if sort == 'qty' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     Qty{% if sort == 'qty' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
   </a>
 </th>
-<th class="px-4 py-2 text-right">
+  <th scope="col" class="px-4 py-2 text-right">
   <a hx-get="{% url 'history_reports' %}?sort=user&direction={% if sort == 'user' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='user';document.querySelector('#filters input[name=direction]').value='{% if sort == 'user' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     User{% if sort == 'user' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
   </a>
 </th>
-<th class="px-4 py-2">
+  <th scope="col" class="px-4 py-2">
   <a hx-get="{% url 'history_reports' %}?sort=date&direction={% if sort == 'date' and direction == 'asc' %}desc{% else %}asc{% endif %}"
      hx-target="#history_table" hx-include="#filters" hx-indicator="#htmx-spinner"
      hx-on:click="document.querySelector('#filters input[name=sort]').value='date';document.querySelector('#filters input[name=direction]').value='{% if sort == 'date' and direction == 'asc' %}desc{% else %}asc{% endif %}'">
     Date{% if sort == 'date' %}{% if direction == 'asc' %} ▲{% else %} ▼{% endif %}{% endif %}
   </a>
 </th>
-<th class="px-4 py-2">Notes</th>
-{% endblock %}
+  <th scope="col" class="px-4 py-2">Notes</th>
+  {% endblock %}
 
 {% block rows %}
   {% for row in page_obj %}
@@ -75,4 +77,3 @@
     {% include "components/pagination.html" with page_obj=page_obj base_url=history_url extra_query="" hx_target="#history_table" hx_include="#filters" hx_indicator="#htmx-spinner" %}
   </div>
 {% endblock %}
-

--- a/templates/inventory/_indent_items_form_table.html
+++ b/templates/inventory/_indent_items_form_table.html
@@ -1,10 +1,12 @@
 {% extends "components/responsive_table.html" %}
 
+{% block caption %}<caption>Indent Items</caption>{% endblock %}
+
 {% block headers %}
-  <th>Item</th>
-  <th>Qty</th>
-  <th>Notes</th>
-  <th></th>
+  <th scope="col">Item</th>
+  <th scope="col">Qty</th>
+  <th scope="col">Notes</th>
+  <th scope="col"></th>
 {% endblock %}
 
 {% block rows %}
@@ -17,4 +19,3 @@
   </tr>
   {% endfor %}
 {% endblock %}
-

--- a/templates/inventory/_indent_items_table.html
+++ b/templates/inventory/_indent_items_table.html
@@ -1,8 +1,10 @@
 {% extends "components/responsive_table.html" %}
 
+{% block caption %}<caption>Indent Items</caption>{% endblock %}
+
 {% block headers %}
-  <th class="px-4 py-2">Item</th>
-  <th class="px-4 py-2">Qty</th>
+  <th scope="col" class="px-4 py-2">Item</th>
+  <th scope="col" class="px-4 py-2">Qty</th>
 {% endblock %}
 
 {% block rows %}

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -1,13 +1,15 @@
 {% extends "components/responsive_table.html" %}
 {% load form_tags %}
 
+{% block caption %}<caption>Indents</caption>{% endblock %}
+
 {% block headers %}
-  <th class="px-4 py-2 text-right">ID</th>
-  <th class="px-4 py-2 text-right">MRN</th>
-  <th class="px-4 py-2">Requested By</th>
-  <th class="px-4 py-2">Department</th>
-  <th class="px-4 py-2">Status</th>
-  <th class="px-4 py-2">Actions</th>
+  <th scope="col" class="px-4 py-2 text-right">ID</th>
+  <th scope="col" class="px-4 py-2 text-right">MRN</th>
+  <th scope="col" class="px-4 py-2">Requested By</th>
+  <th scope="col" class="px-4 py-2">Department</th>
+  <th scope="col" class="px-4 py-2">Status</th>
+  <th scope="col" class="px-4 py-2">Actions</th>
 {% endblock %}
 
 {% block rows %}
@@ -46,4 +48,3 @@
   </div>
   {% endwith %}
 {% endblock %}
-

--- a/templates/inventory/_items_table_grid.html
+++ b/templates/inventory/_items_table_grid.html
@@ -10,15 +10,15 @@
 <table class="table w-full bg-white border border-gray-200 rounded-lg table-sticky" id="grid-table">
   <thead class="table-header">
     <tr>
-      <th class="sticky top-0 z-10 bg-white" style="width:32px"><input type="checkbox" data-select-all aria-label="Select all"></th>
-      <th class="sticky top-0 z-10 bg-white" data-col="name">Name</th>
-      <th class="sticky top-0 z-10 bg-white" data-col="category">Category</th>
-      <th class="sticky top-0 z-10 bg-white" data-col="unit">Unit</th>
-      <th class="sticky top-0 z-10 bg-white" data-col="stock">Stock</th>
-      <th class="sticky top-0 z-10 bg-white" data-col="rop">ROP</th>
-      <th class="sticky top-0 z-10 bg-white" data-col="departments">Departments</th>
-      <th class="sticky top-0 z-10 bg-white" data-col="status">Status</th>
-      <th class="sticky top-0 z-10 bg-white" style="width:120px">Actions</th>
+      <th scope="col" class="sticky top-0 z-10 bg-white" style="width:32px"><input type="checkbox" data-select-all aria-label="Select all"></th>
+      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="name">Name</th>
+      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="category">Category</th>
+      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="unit">Unit</th>
+      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="stock">Stock</th>
+      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="rop">ROP</th>
+      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="departments">Departments</th>
+      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="status">Status</th>
+      <th scope="col" class="sticky top-0 z-10 bg-white" style="width:120px">Actions</th>
     </tr>
   </thead>
   <tbody class="table-body">

--- a/templates/inventory/_ml_dashboard_table.html
+++ b/templates/inventory/_ml_dashboard_table.html
@@ -1,8 +1,8 @@
 {% extends "components/basic_table.html" %}
 {% block headers %}
-  <th class="p-2 text-left">Item</th>
-  <th class="p-2 text-left">ABC</th>
-  <th class="p-2 text-left">Forecast (next day)</th>
+  <th scope="col" class="p-2 text-left">Item</th>
+  <th scope="col" class="p-2 text-left">ABC</th>
+  <th scope="col" class="p-2 text-left">Forecast (next day)</th>
 {% endblock %}
 {% block rows %}
   {% for row in results %}

--- a/templates/inventory/_recent_transactions_table.html
+++ b/templates/inventory/_recent_transactions_table.html
@@ -1,13 +1,15 @@
 {% extends "components/responsive_table.html" %}
 
+{% block caption %}<caption>Recent Transactions</caption>{% endblock %}
+
 {% block headers %}
-  <th>ID</th>
-  <th>Item</th>
-  <th>Type</th>
-  <th>Qty</th>
-  <th>User</th>
-  <th>Date</th>
-  <th>Notes</th>
+  <th scope="col">ID</th>
+  <th scope="col">Item</th>
+  <th scope="col">Type</th>
+  <th scope="col">Qty</th>
+  <th scope="col">User</th>
+  <th scope="col">Date</th>
+  <th scope="col">Notes</th>
 {% endblock %}
 
 {% block rows %}
@@ -39,4 +41,3 @@
     {% include "components/pagination.html" with page_obj=page_obj base_url="" extra_query=query_string %}
   </div>
 {% endblock %}
-

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -1,13 +1,15 @@
 {% extends "components/responsive_table.html" %}
 
+{% block caption %}<caption>Suppliers</caption>{% endblock %}
+
 {% block headers %}
-  <th class="px-4 py-2 text-right">ID</th>
-  <th class="px-4 py-2">Name</th>
-  <th class="px-4 py-2">Contact</th>
-  <th class="px-4 py-2">Email</th>
-  <th class="px-4 py-2 text-right">Phone</th>
-  <th class="px-4 py-2">Active</th>
-  <th class="px-4 py-2">Actions</th>
+  <th scope="col" class="px-4 py-2 text-right">ID</th>
+  <th scope="col" class="px-4 py-2">Name</th>
+  <th scope="col" class="px-4 py-2">Contact</th>
+  <th scope="col" class="px-4 py-2">Email</th>
+  <th scope="col" class="px-4 py-2 text-right">Phone</th>
+  <th scope="col" class="px-4 py-2">Active</th>
+  <th scope="col" class="px-4 py-2">Actions</th>
 {% endblock %}
 
 {% block rows %}
@@ -72,4 +74,3 @@
   </div>
   {% endwith %}
 {% endblock %}
-

--- a/templates/inventory/grns/_items_table.html
+++ b/templates/inventory/grns/_items_table.html
@@ -1,9 +1,11 @@
 {% extends "components/responsive_table.html" %}
 
+{% block caption %}<caption>GRN Items</caption>{% endblock %}
+
 {% block headers %}
-  <th class="px-4 py-2">Item</th>
-  <th class="px-4 py-2">Ordered</th>
-  <th class="px-4 py-2">Received</th>
+  <th scope="col" class="px-4 py-2">Item</th>
+  <th scope="col" class="px-4 py-2">Ordered</th>
+  <th scope="col" class="px-4 py-2">Received</th>
 {% endblock %}
 
 {% block rows %}

--- a/templates/inventory/purchase_orders/_items_table.html
+++ b/templates/inventory/purchase_orders/_items_table.html
@@ -1,9 +1,11 @@
 {% extends "components/responsive_table.html" %}
 
+{% block caption %}<caption>Purchase Order Items</caption>{% endblock %}
+
 {% block headers %}
-  <th class="px-4 py-2">Item</th>
-  <th class="px-4 py-2">Ordered</th>
-  <th class="px-4 py-2">Received</th>
+  <th scope="col" class="px-4 py-2">Item</th>
+  <th scope="col" class="px-4 py-2">Ordered</th>
+  <th scope="col" class="px-4 py-2">Received</th>
 {% endblock %}
 
 {% block rows %}

--- a/templates/inventory/purchase_orders/_receive_table.html
+++ b/templates/inventory/purchase_orders/_receive_table.html
@@ -1,10 +1,12 @@
 {% extends "components/responsive_table.html" %}
 
+{% block caption %}<caption>Receive Items</caption>{% endblock %}
+
 {% block headers %}
-  <th>Item</th>
-  <th>Ordered</th>
-  <th>Received</th>
-  <th>Receive Now</th>
+  <th scope="col">Item</th>
+  <th scope="col">Ordered</th>
+  <th scope="col">Received</th>
+  <th scope="col">Receive Now</th>
 {% endblock %}
 
 {% block rows %}
@@ -17,4 +19,3 @@
   </tr>
   {% endfor %}
 {% endblock %}
-

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -1,12 +1,14 @@
 {% extends "components/responsive_table.html" %}
 
+{% block caption %}<caption>Purchase Orders</caption>{% endblock %}
+
 {% block headers %}
-<th class="px-4 py-2 text-right">PO #</th>
-<th class="px-4 py-2">Supplier</th>
-<th class="px-4 py-2">Order Date</th>
-<th class="px-4 py-2">Status</th>
-<th class="px-4 py-2">Progress</th>
-<th class="px-4 py-2 text-right">Actions</th>
+<th scope="col" class="px-4 py-2 text-right">PO #</th>
+<th scope="col" class="px-4 py-2">Supplier</th>
+<th scope="col" class="px-4 py-2">Order Date</th>
+<th scope="col" class="px-4 py-2">Status</th>
+<th scope="col" class="px-4 py-2">Progress</th>
+<th scope="col" class="px-4 py-2 text-right">Actions</th>
 {% endblock %}
 
 {% block rows %}

--- a/templates/inventory/recipes/_components_form_table.html
+++ b/templates/inventory/recipes/_components_form_table.html
@@ -1,12 +1,14 @@
 {% extends "components/responsive_table.html" %}
 
+{% block caption %}<caption>Recipe Components</caption>{% endblock %}
+
 {% block headers %}
-  <th>Kind</th>
-  <th>ID</th>
-  <th>Qty</th>
-  <th>Unit</th>
-  <th>Loss %</th>
-  <th></th>
+  <th scope="col">Kind</th>
+  <th scope="col">ID</th>
+  <th scope="col">Qty</th>
+  <th scope="col">Unit</th>
+  <th scope="col">Loss %</th>
+  <th scope="col"></th>
 {% endblock %}
 
 {% block rows %}
@@ -23,4 +25,3 @@
   </tr>
   {% endfor %}
 {% endblock %}
-


### PR DESCRIPTION
## Summary
- add optional caption block to responsive tables
- supply table captions and header scopes in inventory templates
- ensure row headers use `scope="row"`

## Testing
- `pre-commit run --files templates/components/responsive_table.html templates/inventory/_indents_table.html templates/inventory/_recent_transactions_table.html templates/inventory/_indent_items_table.html templates/inventory/grns/_items_table.html templates/inventory/purchase_orders/_items_table.html templates/inventory/purchase_orders/_receive_table.html templates/inventory/purchase_orders/_table.html templates/inventory/_history_table.html templates/inventory/recipes/_components_form_table.html templates/inventory/_suppliers_table.html templates/inventory/_indent_items_form_table.html templates/inventory/_items_table_grid.html templates/inventory/_ml_dashboard_table.html templates/components/detail_table.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2a749b1c08326837830fee9729333