### PR TITLE
Use button for items table row toggle

### DIFF
--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -10,7 +10,7 @@
     const itemId = row?.dataset.itemId;
     if (!itemId) return;
     const details = document.getElementById(`details-${itemId}`);
-    const toggleBtn = row.querySelector('[data-action="toggle-details"]');
+    const toggleBtn = row.querySelector('button.main-row');
     if (!details || !toggleBtn) return;
 
     const expanded = toggleBtn.getAttribute("aria-expanded") === "true";

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -3,15 +3,13 @@
     {% for item in page_obj.object_list %}
     <div class="item-row bg-white rounded-xl shadow-sm hover:shadow-md transition-all duration-200 border border-gray-200 hover:border-gray-300 overflow-hidden h-full" data-item-id="{{ item.item_id }}">
         <!-- Main Row -->
-    <div class="main-row px-5 py-5 hover:bg-gradient-to-r hover:from-gray-50 hover:to-white transition-all duration-200 cursor-pointer" data-action="toggle-details" role="button" tabindex="0" aria-label="Toggle details">
+    <button type="button" class="main-row w-full text-left px-5 py-5 hover:bg-gradient-to-r hover:from-gray-50 hover:to-white transition-all duration-200 cursor-pointer" data-action="toggle-details" aria-label="Toggle details" aria-expanded="false" aria-controls="details-{{ item.item_id }}">
             <div class="flex items-center justify-between">
                 <!-- Left side - Item info -->
                 <div class="flex items-center space-x-4 flex-1">
                     <!-- Expand/Collapse Icon -->
                     <button class="expand-icon text-gray-400 hover:text-blue-600 transition-all duration-200 p-1 rounded-lg hover:bg-blue-50"
                             type="button"
-                            aria-expanded="false"
-                            aria-controls="details-{{ item.item_id }}"
                             data-action="toggle-details">
                         <svg class="w-4 h-4 transform transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
@@ -145,7 +143,7 @@
                     </div>
                 </div>
             </div>
-        </div>
+        </button>
 
                     <!-- Department -->
                     <div class="text-right min-w-0">


### PR DESCRIPTION
## Summary
- replace clickable item row div with full-width button carrying aria attributes
- update toggle JavaScript to reference the new button

## Testing
- `pre-commit run --files templates/inventory/_items_table.html static/js/items-table.js` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2aa42c4e483269d5c007295bae90b