### PR TITLE
Queue ML training with Django-Q and test cache updates

### DIFF
--- a/inventory/services/ml.py
+++ b/inventory/services/ml.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import logging
-from threading import Thread
 from typing import Dict, List, Optional
 
 from django.core.cache import cache
 from django.db.models import Sum
 from django.db.models.functions import Abs, TruncDate
+from django_q.tasks import async_task
 from statsmodels.tsa.holtwinters import SimpleExpSmoothing
 
 from ..models import Item, StockTransaction
@@ -79,7 +79,7 @@ def train_models(periods: int = 7) -> Dict[int, List[float]]:
         series_by_item.setdefault(row["item_id"], []).append(float(row["total"]))
 
     forecasts: Dict[int, List[float]] = {}
-    for item_id in Item.objects.values_list("id", flat=True):
+    for item_id in Item.objects.values_list("pk", flat=True):
         series = series_by_item.get(item_id, [])
         forecasts[item_id] = forecast_item_demand(
             periods=periods, series=series if series else [0.0]
@@ -88,20 +88,39 @@ def train_models(periods: int = 7) -> Dict[int, List[float]]:
     return forecasts
 
 
-def queue_train_models(
-    periods: int = 7, *, cache_key: str = "ml_train_models", ttl: int = 300
-) -> None:
-    """Queue training in a background thread and store results in cache.
+def train_models_task(periods: int, cache_key: str, ttl: int) -> bool:
+    """Train models and store results in cache.
 
-    This lightweight approach avoids blocking the requesting thread. In a real
-    deployment, a proper background worker such as Celery or a scheduled job
-    should perform this work instead.
+    Returns ``True`` on success and ``False`` if an exception is raised.
+    """
+    try:
+        cache.set(cache_key, train_models(periods), ttl)
+        return True
+    except Exception:  # pragma: no cover - defensive catch-all
+        logger.exception("Failed to train forecasting models")
+        return False
+
+
+def queue_train_models(
+    periods: int = 7,
+    *,
+    cache_key: str = "ml_train_models",
+    ttl: int = 300,
+    sync: bool = False,
+) -> str:
+    """Queue training task and store results in cache when complete.
+
+    Args:
+        periods: Number of future periods (days) to predict.
+        cache_key: Cache key to store forecasts.
+        ttl: Cache time-to-live in seconds.
+        sync: If ``True`` the task runs synchronously (used in tests).
+
+    Returns:
+        The ID of the queued task.
     """
 
-    def _task() -> None:
-        cache.set(cache_key, train_models(periods), ttl)
-
-    Thread(target=_task, daemon=True).start()
+    return async_task(train_models_task, periods, cache_key, ttl, sync=sync)
 
 
 def abc_classification() -> Dict[int, str]:

--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "core",
     "inventory",
+    "django_q",
 ]
 
 MIDDLEWARE = [
@@ -188,6 +189,15 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 25,
+}
+
+Q_CLUSTER = {
+    'name': 'inventory',
+    'workers': 1,
+    'timeout': 60,
+    'queue_limit': 50,
+    'bulk': 10,
+    'orm': 'default',
 }
 
 # Login URL

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ gevent==24.11.1
 sentry-sdk[django]==2.19.0
 django-redis==5.4.0
 redis==5.0.8
+django-q2==1.8.0

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -85,8 +85,10 @@ def test_ml_dashboard_uses_cache(client):
     ):
         # When queue_train_models is called we synchronously populate the cache to
         # emulate the background worker completing its task.
-        mock_queue.side_effect = lambda periods=1, ttl=300: cache.set(
-            "ml_train_models", {}, ttl
+        mock_queue.side_effect = (
+            lambda periods=1, cache_key="ml_train_models", ttl=300: cache.set(
+                cache_key, {}, ttl
+            )
         )
 
         response = client.get(reverse("ml_dashboard"))
@@ -102,3 +104,24 @@ def test_ml_dashboard_uses_cache(client):
         client.get(reverse("ml_dashboard"))
         assert mock_queue.call_count == 2
         assert mock_abc.call_count == 2
+
+
+
+def test_queue_train_models_updates_cache(db):
+    cache_key = "test_ml_train_models"
+    cache.delete(cache_key)
+    ml.queue_train_models(periods=1, cache_key=cache_key, ttl=300, sync=True)
+    assert cache.get(cache_key) is not None
+
+
+def test_queue_train_models_logs_exception(db, monkeypatch, caplog):
+    def bad_train(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ml, "train_models", bad_train)
+    cache_key = "test_ml_train_models_error"
+    cache.delete(cache_key)
+    with caplog.at_level("ERROR"):
+        ml.queue_train_models(periods=1, cache_key=cache_key, ttl=300, sync=True)
+    assert cache.get(cache_key) is None
+    assert "Failed to train forecasting models" in caplog.text


### PR DESCRIPTION
## Summary
- replace background thread with Django-Q task for ML model training
- log training failures and allow synchronous execution for tests
- add integration tests verifying cache updates and error handling

## Testing
- `pre-commit run --files inventory/services/ml.py inventory_app/settings.py requirements.txt tests/test_ml.py` *(fails: missing Python 3.13 interpreter)*
- `pytest tests/test_ml.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2abd5d78c83268d3a926b83a050bf