### PR TITLE
Enable inline supplier creation and bulk CSV upload

### DIFF
--- a/inventory/views/suppliers.py
+++ b/inventory/views/suppliers.py
@@ -66,7 +66,51 @@ class SuppliersListView(TemplateView):
                 "container_id": container_id,
             }
         )
+        # Include forms for inline creation and bulk upload
+        if self.request.method == "POST":
+            ctx["form"] = SupplierForm(self.request.POST)
+            ctx["bulk_form"] = BulkUploadForm(self.request.POST, self.request.FILES)
+        else:
+            ctx["form"] = SupplierForm()
+            ctx["bulk_form"] = BulkUploadForm()
         return ctx
+
+    def post(self, request, *args, **kwargs):
+        """Handle inline supplier creation and CSV bulk upload."""
+        if request.POST.get("bulk_upload"):
+            bulk_form = BulkUploadForm(request.POST, request.FILES)
+            if bulk_form.is_valid():
+                inserted = 0
+                file = bulk_form.cleaned_data["file"]
+                data = io.StringIO(file.read().decode("utf-8"))
+                reader = csv.DictReader(data)
+                for row in reader:
+                    form_row = SupplierForm(row)
+                    if form_row.is_valid():
+                        ok, msg = supplier_service.add_supplier(form_row.cleaned_data)
+                        if ok:
+                            inserted += 1
+                        else:
+                            messages.error(request, msg)
+                    else:
+                        messages.error(request, str(form_row.errors))
+                messages.success(request, f"{inserted} supplier(s) uploaded successfully.")
+            else:
+                messages.error(request, "Please upload a valid CSV file.")
+            return redirect("suppliers_list")
+
+        form = SupplierForm(request.POST)
+        if form.is_valid():
+            ok, msg = supplier_service.add_supplier(form.cleaned_data)
+            if ok:
+                messages.success(request, f'Supplier "{form.cleaned_data.get("name")}" created successfully!')
+                return redirect("suppliers_list")
+            messages.error(request, msg)
+        else:
+            for field, errors in form.errors.items():
+                for error in errors:
+                    messages.error(request, f"{field}: {error}")
+        return self.get(request, *args, **kwargs)
 
 
 class SuppliersTableView(TemplateView):

--- a/templates/inventory/_bulk_upload_partial.html
+++ b/templates/inventory/_bulk_upload_partial.html
@@ -1,12 +1,17 @@
 <div class="card drawer-panel" style="max-width: 520px;">
   <div class="card-header flex items-center justify-between">
-    <h3 class="text-lg font-semibold">Bulk Upload Items</h3>
+    <h3 class="text-lg font-semibold">{{ title|default:"Bulk Upload Items" }}</h3>
     <button type="button" class="btn-secondary btn-sm" data-modal-close>Close</button>
   </div>
   <div class="card-body">
+    {% if upload_url %}
+    <form method="post" enctype="multipart/form-data" data-modal-form action="{{ upload_url }}">
+    {% else %}
     <form method="post" enctype="multipart/form-data" data-modal-form action="{% url 'upload_csv' %}?partial=1">
+    {% endif %}
       {% csrf_token %}
       <input type="hidden" name="partial" value="1"/>
+      {% if bulk_upload %}<input type="hidden" name="bulk_upload" value="1" />{% endif %}
       <div class="mb-3">
         <label for="{{ form.file.id_for_label }}" class="form-label">Select CSV File</label>
         {{ form.file }}
@@ -17,7 +22,6 @@
         <button type="submit" class="btn-primary">Upload</button>
       </div>
     </form>
-    <p class="text-sm text-gray-600 mt-3">CSV must include headers compatible with the item form fields.</p>
+    <p class="text-sm text-gray-600 mt-3">{{ help_text|default:"CSV must include headers compatible with the item form fields." }}</p>
   </div>
 </div>
-

--- a/templates/inventory/_supplier_bulk_upload_collapsible.html
+++ b/templates/inventory/_supplier_bulk_upload_collapsible.html
@@ -1,0 +1,6 @@
+{% extends "components/collapsible.html" %}
+{% block title %}Bulk Upload Suppliers{% endblock %}
+{% block content %}
+  {% url 'suppliers_list' as upload_url %}
+  {% include "inventory/_bulk_upload_partial.html" with form=bulk_form upload_url=upload_url title="Bulk Upload Suppliers" bulk_upload=1 help_text="CSV must include headers compatible with the supplier form fields." %}
+{% endblock %}

--- a/templates/inventory/_supplier_form_collapsible.html
+++ b/templates/inventory/_supplier_form_collapsible.html
@@ -1,0 +1,16 @@
+{% extends "components/collapsible.html" %}
+{% block title %}Add Supplier{% endblock %}
+{% block content %}
+  <form method="post" action="{% url 'suppliers_list' %}">
+    {% csrf_token %}
+    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+      {% for field in form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
+    </div>
+    <div class="form-actions mt-4">
+      <button type="reset" class="btn-secondary btn-sm">Clear</button>
+      <button type="submit" class="btn-primary btn-sm">Create</button>
+    </div>
+  </form>
+{% endblock %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -2,12 +2,7 @@
 {% block page_title %}Suppliers – Inventory App{% endblock %}
 {% block heading %}Suppliers ({{ total_suppliers }}){% endblock %}
 
-{% block primary_actions %}
-  {% url 'supplier_create' as supplier_create_url %}
-  {% include "components/button.html" with href=supplier_create_url variant='primary' label='New Supplier' %}
-  {% url 'suppliers_bulk_upload' as suppliers_bulk_upload_url %}
-  {% include "components/button.html" with href=suppliers_bulk_upload_url variant='secondary' label='Bulk Upload' %}
-{% endblock %}
+{% block primary_actions %}{% endblock %}
 
 {% block secondary_actions %}
   {% url 'suppliers_bulk_delete' as suppliers_bulk_delete_url %}
@@ -29,6 +24,11 @@
 {% block filters %}
   {% url hx_view_name as suppliers_view_url %}
   {% include "components/filter_bar.html" with search_placeholder="Search suppliers..." hx_get=suppliers_view_url hx_target='#'|add:container_id filters=filters export_url=export_url export_param_name="export" export_param_value="1" page_size=page_size sort=sort direction=direction %}
+{% endblock %}
+
+{% block extra_top %}
+  {% include "inventory/_supplier_form_collapsible.html" with form=form %}
+  {% include "inventory/_supplier_bulk_upload_collapsible.html" with bulk_form=bulk_form %}
 {% endblock %}
 
 {% block data_container %}


### PR DESCRIPTION
## Summary
- allow creating suppliers or bulk uploading CSVs directly from supplier list view
- introduce collapsible sections for supplier form and bulk upload form
- make reusable bulk upload partial with configurable title and action

## Testing
- `pytest` *(fails: ImportError: cannot import name 'baseconv' from 'django.utils')*


------
https://chatgpt.com/codex/tasks/task_e_68b2b304222c8326837ea430e73cd20b