### PR TITLE
Add quick indent form

### DIFF
--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -66,9 +66,23 @@ class IndentsListView(TemplateView):
                 "q": q,
                 "total_indents": total_indents,
                 "filters": filters,
+                "quick_form": IndentForm(),
             }
         )
         return ctx
+
+    def post(self, request, *args, **kwargs):
+        """Handle quick indent submission without line items."""
+
+        form = IndentForm(request.POST)
+        if form.is_valid():
+            indent = form.save()
+            messages.success(request, "Indent submitted")
+            return redirect("indent_detail", pk=indent.pk)
+
+        ctx = self.get_context_data(**kwargs)
+        ctx["quick_form"] = form
+        return render(request, self.template_name, ctx)
 
 
 class IndentsTableView(TemplateView):

--- a/templates/inventory/_quick_indent_form.html
+++ b/templates/inventory/_quick_indent_form.html
@@ -1,0 +1,15 @@
+{% extends "components/collapsible.html" %}
+{% block title %}Quick Indent{% endblock %}
+{% block content %}
+  <form method="post">
+    {% csrf_token %}
+    <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+      {% for field in quick_form %}
+        {% include "components/form_field.html" with field=field %}
+      {% endfor %}
+    </div>
+    <div class="mt-4">
+      <button type="submit" class="btn-primary">Submit</button>
+    </div>
+  </form>
+{% endblock %}

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -11,6 +11,10 @@
   {% include "components/filter_bar.html" with search_placeholder="Search indents..." hx_get=indents_table_url hx_target="#indents_table" filters=filters search_delay="500ms" %}
 {% endblock %}
 
+{% block extra_top %}
+  {% include "inventory/_quick_indent_form.html" %}
+{% endblock %}
+
 {% block data_container %}
   <div id="indents_table"
        hx-get="{% url 'indents_table' %}"


### PR DESCRIPTION
## Summary
- add quick IndentForm submission on indents list
- expose quick indent form in collapsible section on list page

## Testing
- `pre-commit run --files inventory/views/indents.py templates/inventory/indents_list.html templates/inventory/_quick_indent_form.html` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2b30cae608326a100b012902d23da