### PR TITLE
Enable recipe creation on list view

### DIFF
--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -53,7 +53,21 @@ class RecipesListView(TemplateView):
         grid_html = render_to_string(
             self.grid_template, {"recipes": recipes}, request=request
         )
-        ctx = {"recipes_grid": grid_html, "q": q}
+        ctx = {"recipes_grid": grid_html, "q": q, "form": RecipeForm()}
+        return render(request, self.template_name, ctx)
+
+    def post(self, request, *args, **kwargs):
+        form = RecipeForm(request.POST)
+        if form.is_valid():
+            recipe = form.save()
+            messages.success(request, "Recipe created")
+            return redirect("recipe_detail", pk=recipe.pk)
+
+        recipes, q = self._get_recipes()
+        grid_html = render_to_string(
+            self.grid_template, {"recipes": recipes}, request=request
+        )
+        ctx = {"recipes_grid": grid_html, "q": q, "form": form}
         return render(request, self.template_name, ctx)
 
 

--- a/templates/inventory/recipes/_form_fields.html
+++ b/templates/inventory/recipes/_form_fields.html
@@ -1,0 +1,9 @@
+<div class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
+  {% for field in form %}
+    {% if field.name == 'description' or field.name == 'plating_notes' %}
+      {% include "components/form_field.html" with field=field container_class="col-span-2" %}
+    {% else %}
+      {% include "components/form_field.html" with field=field %}
+    {% endif %}
+  {% endfor %}
+</div>

--- a/templates/inventory/recipes/_recipe_create_section.html
+++ b/templates/inventory/recipes/_recipe_create_section.html
@@ -1,0 +1,12 @@
+{% extends "components/collapsible.html" %}
+{% block title %}Add Recipe{% endblock %}
+{% block open %}{% if form.errors %}open{% endif %}{% endblock %}
+{% block content %}
+  <form method="post">
+    {% csrf_token %}
+    {% include "inventory/recipes/_form_fields.html" with form=form %}
+    <div class="flex gap-2">
+      <button type="submit" class="btn-primary">Save</button>
+    </div>
+  </form>
+{% endblock %}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -3,15 +3,7 @@
 {% block heading %}{% if recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}{% endblock %}
 {% block form_attrs %}id="recipe-form"{% endblock %}
 {% block fields %}
-  <div class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
-    {% for field in form %}
-      {% if field.name == 'description' or field.name == 'plating_notes' %}
-        {% include "components/form_field.html" with field=field container_class="col-span-2" %}
-      {% else %}
-        {% include "components/form_field.html" with field=field %}
-      {% endif %}
-    {% endfor %}
-  </div>
+  {% include "inventory/recipes/_form_fields.html" with form=form %}
   {{ formset.management_form }}
   {% if formset.non_form_errors %}
   <ul class="text-red-600 list-disc pl-5">

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -11,6 +11,10 @@
   {% include "components/filter_bar.html" with search_placeholder="Search recipes..." hx_get=recipes_list_url hx_target="#recipes_grid" q=q %}
 {% endblock %}
 
+{% block extra_top %}
+  {% include "inventory/recipes/_recipe_create_section.html" %}
+{% endblock %}
+
 {% block data_container %}
   <div id="recipes_grid"
        hx-get="{% url 'recipes_list' %}"


### PR DESCRIPTION
## Summary
- support creating recipes directly from the list view via a collapsible form
- share recipe form fields across list and detail templates

## Testing
- `ruff check inventory/views/recipes.py templates/inventory/recipes/detail.html templates/inventory/recipes/list.html`
- `pre-commit run --files inventory/views/recipes.py templates/inventory/recipes/detail.html templates/inventory/recipes/list.html templates/inventory/recipes/_form_fields.html templates/inventory/recipes/_recipe_create_section.html` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `apt-get install -y python3.13` *(fails: Unable to locate package python3.13)*
- `pytest tests/test_recipe_service.py::test_nested_recipes_and_cycle_prevention -q` *(fails: ImportError: cannot import name 'baseconv' from 'django.utils')*

------
https://chatgpt.com/codex/tasks/task_e_68b2b30fd3288326aefb191df7cd42a7