### PR TITLE
Move TestItemForm to tests suite

### DIFF
--- a/tests/forms/test_item_forms.py
+++ b/tests/forms/test_item_forms.py
@@ -2,7 +2,7 @@
 
 from django import forms
 
-from ..models import Item
+from inventory.models import Item
 
 INPUT_CLASS = "form-input"
 

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -3,7 +3,7 @@ from django import forms
 from django.template.loader import render_to_string
 from django.test import RequestFactory
 
-from inventory.forms.test_item_forms import TestItemForm  # Use simplified test form
+from tests.forms.test_item_forms import TestItemForm  # Use simplified test form
 
 
 @pytest.mark.django_db
@@ -12,10 +12,9 @@ def test_item_form_preserves_metadata(monkeypatch):
     name_field = form.fields["name"]
     unit_field = form.fields["unit_id"]
     assert name_field.label == "Name"
-    assert name_field.required == True
+    assert name_field.required is True
     assert isinstance(name_field.widget, forms.TextInput)
     assert isinstance(unit_field, forms.IntegerField)
-
 
 
 @pytest.mark.django_db
@@ -57,7 +56,7 @@ def test_item_form_save():
     assert item.reorder_point == 10
     assert item.current_stock == 5
     assert item.notes == "Test notes"
-    assert item.is_active == True
+    assert item.is_active is True
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- remove test-only TestItemForm from production inventory/forms
- add TestItemForm under tests/forms and reference Item via inventory package
- update item form tests to import from new location

## Testing
- `flake8 tests/forms/test_item_forms.py tests/test_item_form.py`
- `pytest tests/test_item_form.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2bf68c1e4832699d3d09df72c486f