### PR TITLE
Narrow exception handling for test item form

### DIFF
--- a/inventory/forms/test_item_forms.py
+++ b/inventory/forms/test_item_forms.py
@@ -1,6 +1,7 @@
 """Simplified ItemForm for testing with the units table architecture."""
 
 from django import forms
+from django.db.utils import OperationalError
 
 from ..models import Item
 
@@ -70,7 +71,7 @@ class TestItemForm(forms.ModelForm):
                                 "units table."
                             )
                         )
-            except Exception:
+            except OperationalError:
                 # In test environment, allow known test unit IDs
                 if unit_id not in [19, 55]:  # Known good test unit IDs
                     raise forms.ValidationError(


### PR DESCRIPTION
## Summary
- Replace generic `Exception` catch with `OperationalError` in test `TestItemForm` cleanup
- Import `OperationalError` from `django.db.utils`

## Testing
- `pytest tests/test_item_form.py`

------
https://chatgpt.com/codex/tasks/task_e_68b2af5589748326a8de24ece40e5077