### PR TITLE
feat(nav): link logo to dashboard

### DIFF
--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -5,14 +5,14 @@
       <!-- Left side: Logo and main nav -->
       <div class="flex items-center">
         <!-- Logo -->
-        <div class="flex-shrink-0 flex items-center">
+        <a href="{% url 'dashboard' %}" aria-label="Home" class="flex-shrink-0 flex items-center">
           <div class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center">
             <svg class="h-5 w-5 text-white" fill="currentColor" viewBox="0 0 20 20">
               <path d="M5 3a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2V5a2 2 0 00-2-2H5zM5 11a2 2 0 00-2 2v2a2 2 0 002 2h2a2 2 0 002-2v-2a2 2 0 00-2-2H5zM11 5a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V5zM11 13a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>
             </svg>
           </div>
           <span class="ml-3 text-xl font-semibold text-gray-900">Inventory Pro</span>
-        </div>
+        </a>
         
         <!-- Main Navigation -->
         {% if user.is_authenticated %}


### PR DESCRIPTION
## Summary
- wrap navigation logo in a home link pointing to dashboard
- add aria-label for accessible home link

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2c71b47a88326b1f74294ba76e449