### PR TITLE
feat: announce active page in top navigation

### DIFF
--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -23,24 +23,29 @@
           {% url 'suppliers_list' as suppliers_url %}
           {% url 'history_reports' as reports_url %}
           
-          <a href="{{ dashboard_url }}" 
-             class="nav-item {% if request.resolver_match.url_name == 'dashboard' %}nav-item-active{% endif %}">
+          <a href="{{ dashboard_url }}"
+             class="nav-item {% if request.resolver_match.url_name == 'dashboard' %}nav-item-active{% endif %}"
+             {% if request.resolver_match.url_name == 'dashboard' %}aria-current="page"{% endif %}>
             Dashboard
           </a>
           <a href="{{ items_url }}"
-             class="nav-item {% if request.resolver_match.url_name == 'items_list' %}nav-item-active{% endif %}">
+             class="nav-item {% if request.resolver_match.url_name == 'items_list' %}nav-item-active{% endif %}"
+             {% if request.resolver_match.url_name == 'items_list' %}aria-current="page"{% endif %}>
             Inventory
           </a>
           <a href="{{ po_url }}"
-             class="nav-item {% if request.resolver_match.url_name == 'purchase_orders_list' %}nav-item-active{% endif %}">
+             class="nav-item {% if request.resolver_match.url_name == 'purchase_orders_list' %}nav-item-active{% endif %}"
+             {% if request.resolver_match.url_name == 'purchase_orders_list' %}aria-current="page"{% endif %}>
             Orders
           </a>
           <a href="{{ suppliers_url }}"
-             class="nav-item {% if request.resolver_match.url_name == 'suppliers_list' %}nav-item-active{% endif %}">
+             class="nav-item {% if request.resolver_match.url_name == 'suppliers_list' %}nav-item-active{% endif %}"
+             {% if request.resolver_match.url_name == 'suppliers_list' %}aria-current="page"{% endif %}>
             Suppliers
           </a>
           <a href="{{ reports_url }}"
-             class="nav-item {% if request.resolver_match.url_name == 'history_reports' %}nav-item-active{% endif %}">
+             class="nav-item {% if request.resolver_match.url_name == 'history_reports' %}nav-item-active{% endif %}"
+             {% if request.resolver_match.url_name == 'history_reports' %}aria-current="page"{% endif %}>
             Reports
           </a>
         </div>


### PR DESCRIPTION
## Summary
- announce active navigation link using `aria-current="page"`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2cc98b38483269f61b77f70fdab6c