### PR TITLE
Add reusable breadcrumb component for detail views

### DIFF
--- a/templates/components/breadcrumb.html
+++ b/templates/components/breadcrumb.html
@@ -1,0 +1,8 @@
+{% comment %}Reusable breadcrumb component. Expects list_url, list_title, current_title, optional class{% endcomment %}
+<div class="{{ class|default:'flex items-center gap-1 text-sm text-gray-500 mb-4' }}">
+  <a href="{{ list_url }}" class="text-primary hover:underline">{{ list_title }}</a>
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <polyline points="9,18 15,12 9,6"></polyline>
+  </svg>
+  <span>{{ current_title }}</span>
+</div>

--- a/templates/components/detail_layout.html
+++ b/templates/components/detail_layout.html
@@ -1,6 +1,7 @@
 {% extends "_base.html" %}
 {% block title %}Detail – Inventory App{% endblock %}
 {% block content %}
+  {% block breadcrumbs %}{% endblock %}
   <h1 class="text-h1 font-semibold mb-4">{% block heading %}{% endblock %}</h1>
   <div class="mb-4 flex justify-end gap-2">{% block actions %}{% endblock %}</div>
   {% block detail_table %}{% endblock %}

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -266,13 +266,8 @@
     <!-- Header with Navigation -->
     <div class="speed-header">
         <div>
-            <div class="speed-breadcrumb">
-                <a href="{% url 'items_list' %}">Items</a>
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <polyline points="9,18 15,12 9,6"></polyline>
-                </svg>
-                <span>{{ item.name }}</span>
-            </div>
+            {% url 'items_list' as list_url %}
+            {% include "components/breadcrumb.html" with class="speed-breadcrumb" list_url=list_url list_title="Items" current_title=item.name %}
             <h1 class="speed-title">{{ item.name }}</h1>
             {% if item.brand %}
                 <div style="color: var(--speed-text-muted); font-size: 0.875rem;">{{ item.brand }}</div>

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -1,5 +1,11 @@
 {% extends "components/detail_layout.html" %}
 {% block title %}Purchase Order Detail – Inventory App{% endblock %}
+{% block breadcrumbs %}
+  {% url 'purchase_orders_list' as list_url %}
+  {% with current_title="Purchase Order "|add:po.pk %}
+    {% include "components/breadcrumb.html" with list_url=list_url list_title="Purchase Orders" current_title=current_title %}
+  {% endwith %}
+{% endblock %}
 {% block heading %}Purchase Order {{ po.pk }}{% endblock %}
 {% block actions %}
   <a href="{% url 'purchase_order_edit' po.pk %}" class="btn-primary">Edit</a>

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -1,0 +1,17 @@
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from inventory.models import PurchaseOrder
+
+
+@pytest.mark.django_db
+def test_purchase_order_detail_has_breadcrumbs(client, supplier_factory):
+    supplier = supplier_factory()
+    po = PurchaseOrder.objects.create(
+        supplier=supplier,
+        order_date=timezone.now().date(),
+    )
+    response = client.get(reverse("purchase_order_detail", args=[po.pk]))
+    html = response.content.decode()
+    assert f'href="{reverse("purchase_orders_list")}"' in html
+    assert f"Purchase Order {po.pk}" in html


### PR DESCRIPTION
## Summary
- add generic breadcrumb partial
- insert breadcrumb block into detail layout and apply to purchase order detail
- use breadcrumb component in item detail page
- test breadcrumb rendering on purchase order detail view

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2ea96d1f88326b9689285f932d43d