### PR TITLE
feat: enforce unit foreign key and default unit selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MAJOR CLEANUP: Repository refactoring - removed duplicate templates, organized documentation into docs/ structure, cleaned backup files for maintainable codebase
 - PRE-PRODUCTION TESTING COMPLETE: Comprehensive testing completed - inline form functional, clean codebase, ready for production deployment
 - `Unit` model with ORM-powered `UnitsService` and `FormService` replacing raw SQL queries
+- Enforced `Unit` foreign key on items with default unit preselection
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Inventory-App is a Django application for managing restaurant inventory with a P
 - Dashboard showing key metrics such as low-stock items
 - Bulk upload items and stock transactions from CSV files
 - Unit model for standardized base and purchase unit conversions
+- Default unit flag to preselect common measurement in item forms
 
 ## Style Guide
 

--- a/docs/guides/UNITS_ARCHITECTURE.md
+++ b/docs/guides/UNITS_ARCHITECTURE.md
@@ -11,7 +11,8 @@ CREATE TABLE units (
     unit_id INTEGER PRIMARY KEY,      -- Unique identifier used across application
     base_unit TEXT NOT NULL,          -- Standard unit for recipes (GM, ML, PC)
     purchase_unit TEXT NOT NULL,      -- Unit for procurement (2 KG, 50 GM PKT, PC)
-    conversion_factor NUMERIC NOT NULL -- Factor to convert purchase → base
+    conversion_factor NUMERIC NOT NULL, -- Factor to convert purchase → base
+    is_default BOOLEAN DEFAULT FALSE   -- Marks default unit selection in forms
 );
 ```
 
@@ -52,10 +53,19 @@ unit_id | base_unit | purchase_unit | conversion_factor
 
 ## Implementation in Code
 
+### Unit Model
+```python
+class Unit(models.Model):
+    base_unit = models.CharField(max_length=10)
+    purchase_unit = models.CharField(max_length=50)
+    conversion_factor = models.FloatField()
+    is_default = models.BooleanField(default=False)
+```
+
 ### Item Model
 ```python
 class Item(models.Model):
-    unit_id = models.IntegerField()  # References units.unit_id
+    unit = models.ForeignKey('Unit', on_delete=models.PROTECT)
     # DON'T store base_unit/purchase_unit separately - derive from units table
 ```
 

--- a/inventory/forms/item_forms.py
+++ b/inventory/forms/item_forms.py
@@ -1,12 +1,12 @@
 from django import forms
 
-from ..models import Department, Item, Supplier
+from ..models import Department, Item, Supplier, Unit
 from ..services.categories_service import CategoriesService
 from ..services.form_service import (
     get_categories_map,
     get_category_choices,
 )
-from ..services.units_service import UnitsService, BASE_UNIT_TO_UNIT_ID
+from ..services.units_service import BASE_UNIT_TO_UNIT_ID
 from .base import INPUT_CLASS, StyledFormMixin
 
 
@@ -43,11 +43,21 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
         widget=forms.Select(attrs={"class": INPUT_CLASS}),
     )
 
+    # Unit selection
+    unit = forms.ModelChoiceField(
+        queryset=Unit.objects.all(),
+        empty_label=None,
+        widget=forms.Select(attrs={"class": INPUT_CLASS, "data-field": "unit"}),
+        help_text=(
+            "Select the unit for this item (handles both kitchen and procurement units)"
+        ),
+    )
+
     class Meta:
         model = Item
         fields = [
             "name",
-            "unit_id",
+            "unit",
             "category_id",
             "departments",
             "initial_purchase_price",
@@ -81,9 +91,6 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
             ),
             "lead_time_days": forms.NumberInput(
                 attrs={"class": INPUT_CLASS, "min": "0", "placeholder": "7"}
-            ),
-            "unit_id": forms.Select(
-                attrs={"class": INPUT_CLASS, "data-field": "unit_id"}
             ),
             "reorder_point": forms.NumberInput(
                 attrs={
@@ -123,25 +130,15 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
         )
         self.fields["category_id"].choices = category_choices
 
-        # Use unit_id field instead of separate base_unit/purchase_unit fields
-        unit_choices = [("", "Select Unit")] + UnitsService.get_unit_choices_for_forms()
-        self.fields["unit_id"] = forms.ChoiceField(
-            choices=unit_choices,
-            required=True,
-            widget=forms.Select(attrs={"class": INPUT_CLASS, "data-field": "unit_id"}),
-            help_text=(
-                "Select the unit for this item (handles both kitchen and "
-                "procurement units)"
-            ),
-        )
-
         # Make name field required
         if "name" in self.fields:
             self.fields["name"].required = True
 
-        # Set default unit_id for compatibility
-        if not self.instance.pk and "unit_id" in self.fields:
-            self.fields["unit_id"].initial = 55  # Default PC unit
+        # Set default unit
+        if not self.instance.pk:
+            default_unit = Unit.objects.filter(is_default=True).first()
+            if default_unit:
+                self.fields["unit"].initial = default_unit
 
         # Add data for JavaScript dropdowns (for categories)
         self.category_options = [choice[0] for choice in get_category_choices()]
@@ -174,10 +171,10 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
                 "Category is required when subcategory is specified"
             )
 
-        # Set unit_id based on base_unit for compatibility
-        if base_unit and not cleaned_data.get("unit_id"):
-            # Map base units to unit_ids (you may need to adjust these mappings)
-            cleaned_data["unit_id"] = BASE_UNIT_TO_UNIT_ID.get(base_unit, 55)
+        # Set unit based on base_unit for compatibility
+        if base_unit and not cleaned_data.get("unit"):
+            unit_id = BASE_UNIT_TO_UNIT_ID.get(base_unit, 55)
+            cleaned_data["unit"] = Unit.objects.filter(pk=unit_id).first()
 
         return cleaned_data
 
@@ -185,7 +182,7 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
         """Save the item with enhanced business logic."""
         instance = super().save(commit=False)
 
-        # Update unit_id based on base_unit if needed
+        # Update unit based on base_unit if needed
         if self.cleaned_data.get("base_unit") and not instance.unit_id:
             instance.unit_id = BASE_UNIT_TO_UNIT_ID.get(
                 self.cleaned_data["base_unit"], 55
@@ -197,3 +194,11 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
             self.save_m2m()
 
         return instance
+
+    def clean_unit(self):
+        unit = self.cleaned_data.get("unit")
+        if not unit or not Unit.objects.filter(pk=unit.pk).exists():
+            raise forms.ValidationError(
+                "Selected unit does not exist in units table."
+            )
+        return unit

--- a/inventory/migrations/0010_unit_default_and_item_unit_fk.py
+++ b/inventory/migrations/0010_unit_default_and_item_unit_fk.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0009_unit"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="unit",
+            name="is_default",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RenameField(
+            model_name="item",
+            old_name="unit_id",
+            new_name="unit",
+        ),
+        migrations.AlterField(
+            model_name="item",
+            name="unit",
+            field=models.ForeignKey(
+                on_delete=models.PROTECT,
+                related_name="items",
+                db_column="unit_id",
+                to="inventory.unit",
+            ),
+        ),
+    ]
+

--- a/inventory/models/items.py
+++ b/inventory/models/items.py
@@ -1,9 +1,11 @@
 from decimal import Decimal
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from .fields import CoerceFloatField
+from .units import Unit
 
 
 class Item(models.Model):
@@ -11,7 +13,12 @@ class Item(models.Model):
 
     item_id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255, unique=True, blank=False, null=False)
-    unit_id = models.IntegerField(blank=False, null=False)
+    unit = models.ForeignKey(
+        Unit,
+        models.PROTECT,
+        db_column="unit_id",
+        related_name="items",
+    )
     category_id = models.BigIntegerField(
         blank=True, null=True, db_column="category_id_ref"
     )
@@ -93,6 +100,14 @@ class Item(models.Model):
     class Meta:
         managed = True
         db_table = "items"
+
+    def clean(self):
+        if self.unit_id and not Unit.objects.filter(pk=self.unit_id).exists():
+            raise ValidationError({"unit": "Selected unit does not exist in units table."})
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)
 
 
 class StockTransaction(models.Model):

--- a/inventory/models/units.py
+++ b/inventory/models/units.py
@@ -8,6 +8,7 @@ class Unit(models.Model):
     base_unit = models.CharField(max_length=10)
     purchase_unit = models.CharField(max_length=50)
     conversion_factor = models.FloatField()
+    is_default = models.BooleanField(default=False)
 
     class Meta:
         managed = True

--- a/inventory/services/dashboard_service.py
+++ b/inventory/services/dashboard_service.py
@@ -25,7 +25,6 @@ def get_low_stock_items():
     }
     whens = [When(unit_id=k, then=Value(v)) for k, v in units_map.items()]
     qs = qs.annotate(
-        unit=F("unit_id"),
         uom=Case(
             *whens,
             default=Value(""),

--- a/inventory/templatetags/icon_tags.py
+++ b/inventory/templatetags/icon_tags.py
@@ -19,12 +19,13 @@ def icon(name, css_class="w-5 h-5", variant="outline", size=24, aria_label=None)
         size: Icon size directory (20 or 24).
         aria_label: Optional aria-label for accessibility.
     """
+    variant = str(variant).strip()
     base_dir = Path(settings.BASE_DIR) / "node_modules" / "heroicons" / str(size) / variant
     svg_path = base_dir / f"{name}.svg"
     if not svg_path.exists():
         svg_path = base_dir / "question-mark-circle.svg"
-        if not svg_path.exists():
-            return ""
+    if not svg_path.exists():
+        return mark_safe("<svg></svg>")
     svg = svg_path.read_text()
     attrs = f'class="{css_class}" role="img"'
     if aria_label:

--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -96,7 +96,7 @@
       if (tplU) {
         const selU = tplU.cloneNode(true);
         selU.id = "";
-        selU.name = "unit_id";
+        selU.name = "unit";
         selU.classList.add("form-select");
         Array.from(selU.options).forEach((o) => {
           if (o.value == uid) o.selected = true;
@@ -128,7 +128,7 @@
     const rop = row.querySelector('input[name="reorder_point"]')?.value || "";
     const categoryId =
       row.querySelector('select[name="category_id"]')?.value || "";
-    const unitId = row.querySelector('select[name="unit_id"]')?.value || "";
+    const unitId = row.querySelector('select[name="unit"]')?.value || "";
     const currentStock =
       row.querySelector('input[name="current_stock"]')?.value || "";
     const active =
@@ -138,7 +138,7 @@
     fd.append("name", name);
     if (rop !== "") fd.append("reorder_point", rop);
     if (categoryId !== "") fd.append("category_id", categoryId);
-    if (unitId !== "") fd.append("unit_id", unitId);
+    if (unitId !== "") fd.append("unit", unitId);
     if (currentStock !== "") fd.append("current_stock", currentStock);
     if (active) fd.append("is_active", "on"); // presence -> True for Django
 

--- a/templates/inventory/_item_create_partial.html
+++ b/templates/inventory/_item_create_partial.html
@@ -14,8 +14,8 @@
           {% include "forms/feedback.html" %}
         </div>
         <div>
-          <label for="{{ form.unit_id.id_for_label }}" class="form-label">Unit</label>
-          {{ form.unit_id }}
+          <label for="{{ form.unit.id_for_label }}" class="form-label">Unit</label>
+          {{ form.unit }}
           {% include "forms/feedback.html" %}
         </div>
         <div>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -51,8 +51,8 @@
               {% include "forms/feedback.html" %}
             </div>
             <div class="space-y-1">
-              <label for="{{ form.unit_id.id_for_label }}" class="form-label">Unit</label>
-              {{ form.unit_id }}
+              <label for="{{ form.unit.id_for_label }}" class="form-label">Unit</label>
+              {{ form.unit }}
               {% include "forms/feedback.html" %}
             </div>
             <div class="space-y-1">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ if PROJECT_ROOT not in sys.path:
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inventory_app.settings.test")
 django.setup()
 
-from inventory.models import Item, StockTransaction, Supplier  # noqa: E402
+from inventory.models import Item, StockTransaction, Supplier, Unit  # noqa: E402
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -39,6 +39,28 @@ def create_test_schema(django_db_setup, django_db_blocker):
                         cursor.execute(stmt)
 
 
+@pytest.fixture(autouse=True)
+def ensure_default_units(db):
+    Unit.objects.get_or_create(
+        unit_id=55,
+        defaults={
+            "base_unit": "PC",
+            "purchase_unit": "PC",
+            "conversion_factor": 1.0,
+            "is_default": True,
+        },
+    )
+    Unit.objects.get_or_create(
+        unit_id=19,
+        defaults={
+            "base_unit": "KG",
+            "purchase_unit": "KG",
+            "conversion_factor": 1.0,
+            "is_default": False,
+        },
+    )
+
+
 # ---------- FACTORIES ----------
 
 @pytest.fixture
@@ -50,13 +72,26 @@ def item_factory(db):
     def create_item(**kwargs):
         defaults = {
             "name": "Item",
-            "unit_id": 19,  # Use unit_id=19 which maps to "KG" for consistent test expectations
             "category_id": 1,
             "reorder_point": 0,
             "current_stock": 0,
             "is_active": True,
         }
         defaults.update(kwargs)
+
+        unit = defaults.pop("unit", None)
+        unit_id = defaults.pop("unit_id", 19)
+        unit_obj, _ = Unit.objects.get_or_create(
+            unit_id=unit_id,
+            defaults={
+                "base_unit": "GM",
+                "purchase_unit": "KG",
+                "conversion_factor": 1.0,
+                "is_default": True if unit_id == 19 else False,
+            },
+        )
+        defaults["unit"] = unit or unit_obj
+
         return Item.objects.create(**defaults)
     return create_item
 

--- a/tests/forms/test_item_forms.py
+++ b/tests/forms/test_item_forms.py
@@ -2,20 +2,25 @@
 
 from django import forms
 
-from inventory.models import Item
-from inventory.services.units_service import UnitsService
+from inventory.models import Item, Unit
 
 INPUT_CLASS = "form-input"
 
 
 class TestItemForm(forms.ModelForm):
-    """Simplified item form for testing that only uses unit_id reference."""
+    """Simplified item form for testing that only uses unit reference."""
+
+    unit = forms.ModelChoiceField(
+        queryset=Unit.objects.all(),
+        empty_label=None,
+        widget=forms.Select(attrs={'class': INPUT_CLASS}),
+    )
 
     class Meta:
         model = Item
         fields = [
             "name",
-            "unit_id",
+            "unit",
             "reorder_point",
             "current_stock",
             "notes",
@@ -25,10 +30,6 @@ class TestItemForm(forms.ModelForm):
             'name': forms.TextInput(attrs={
                 'class': INPUT_CLASS,
                 'placeholder': 'Enter item name'
-            }),
-            'unit_id': forms.NumberInput(attrs={
-                'class': INPUT_CLASS,
-                'placeholder': 'Unit ID'
             }),
             'reorder_point': forms.NumberInput(attrs={
                 'class': INPUT_CLASS,
@@ -53,11 +54,16 @@ class TestItemForm(forms.ModelForm):
             "name": {"required": "Item name is required."},
         }
 
-    def clean_unit_id(self):
-        """Validate that the unit_id exists in the units table."""
-        unit_id = self.cleaned_data.get('unit_id')
-        if unit_id and not UnitsService.validate_unit_id(unit_id):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        default_unit = Unit.objects.filter(is_default=True).first()
+        if default_unit:
+            self.fields['unit'].initial = default_unit
+
+    def clean_unit(self):
+        unit = self.cleaned_data.get('unit')
+        if not unit or not Unit.objects.filter(pk=unit.pk).exists():
             raise forms.ValidationError(
-                f"Unit ID {unit_id} does not exist in units table."
+                "Selected unit does not exist in units table."
             )
-        return unit_id
+        return unit

--- a/tests/test_explore_view.py
+++ b/tests/test_explore_view.py
@@ -3,16 +3,24 @@ import csv
 import pytest
 from django.urls import reverse
 
-from inventory.models import Item
+from inventory.models import Item, Unit
 
 pytestmark = pytest.mark.django_db
 
 
 def _create_item(name="Widget", active=True):
+    unit, _ = Unit.objects.get_or_create(
+        unit_id=55,
+        defaults={
+            "base_unit": "PC",
+            "purchase_unit": "PC",
+            "conversion_factor": 1.0,
+            "is_default": True,
+        },
+    )
     return Item.objects.create(
         name=name,
-        unit_id=55,
-
+        unit=unit,
         reorder_point=1,
         notes="n",
         is_active=active,

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -3,56 +3,71 @@ from django import forms
 from django.template.loader import render_to_string
 from django.test import RequestFactory
 
+from inventory.models import Unit
 from tests.forms.test_item_forms import TestItemForm  # Use simplified test form
 
 
+@pytest.fixture
+def units(db):
+    Unit.objects.filter(is_default=True).update(is_default=False)
+    default = Unit.objects.create(
+        base_unit="kg", purchase_unit="KG", conversion_factor=1.0, is_default=True
+    )
+    other = Unit.objects.create(
+        base_unit="g", purchase_unit="G", conversion_factor=1.0
+    )
+    return default, other
+
+
 @pytest.mark.django_db
-def test_item_form_preserves_metadata(monkeypatch):
+def test_item_form_preserves_metadata(units):
     form = TestItemForm()
     name_field = form.fields["name"]
-    unit_field = form.fields["unit_id"]
+    unit_field = form.fields["unit"]
     assert name_field.label == "Name"
     assert name_field.required is True
     assert isinstance(name_field.widget, forms.TextInput)
-    assert isinstance(unit_field, forms.IntegerField)
+    assert isinstance(unit_field, forms.ModelChoiceField)
 
 
 @pytest.mark.django_db
-def test_item_form_validation():
-    # Test valid form data with unit_id=19 (maps to "KG")
-    form = TestItemForm(data={
-        "name": "Test Item",
-        "unit_id": 19,  # Use unit_id=19 which exists and maps to "KG"
-        "reorder_point": 10,
-        "current_stock": 0,
-        "notes": "Test notes",
-        "is_active": True,
-    })
+def test_item_form_validation(units):
+    default_unit, _ = units
+    form = TestItemForm(
+        data={
+            "name": "Test Item",
+            "unit": default_unit.pk,
+            "reorder_point": 10,
+            "current_stock": 0,
+            "notes": "Test notes",
+            "is_active": True,
+        }
+    )
     assert form.is_valid(), f"Form errors: {form.errors}"
 
     # Test invalid form data (missing required name)
-    form = TestItemForm(data={
-        "unit_id": 19,
-        "reorder_point": 10,
-    })
+    form = TestItemForm(data={"unit": default_unit.pk, "reorder_point": 10})
     assert not form.is_valid()
     assert "name" in form.errors
 
 
 @pytest.mark.django_db
-def test_item_form_save():
-    form = TestItemForm(data={
-        "name": "Test Item",
-        "unit_id": 19,  # Use unit_id=19 which exists and maps to "KG"
-        "reorder_point": 10,
-        "current_stock": 5,
-        "notes": "Test notes",
-        "is_active": True,
-    })
+def test_item_form_save(units):
+    default_unit, _ = units
+    form = TestItemForm(
+        data={
+            "name": "Test Item",
+            "unit": default_unit.pk,
+            "reorder_point": 10,
+            "current_stock": 5,
+            "notes": "Test notes",
+            "is_active": True,
+        }
+    )
     assert form.is_valid(), f"Form errors: {form.errors}"
     item = form.save()
     assert item.name == "Test Item"
-    assert item.unit_id == 19
+    assert item.unit == default_unit
     assert item.reorder_point == 10
     assert item.current_stock == 5
     assert item.notes == "Test notes"
@@ -60,7 +75,7 @@ def test_item_form_save():
 
 
 @pytest.mark.django_db
-def test_item_form_render():
+def test_item_form_render(units):
     form = TestItemForm()
     request = RequestFactory().get("/")
     content = render_to_string(
@@ -70,4 +85,20 @@ def test_item_form_render():
     )
     # Check that the form renders without errors
     assert "name" in content.lower()
-    assert "unit_id" in content.lower() or "unit" in content.lower()
+    assert "unit" in content.lower()
+
+
+@pytest.mark.django_db
+def test_item_form_rejects_invalid_unit(units):
+    form = TestItemForm(
+        data={"name": "Bad", "unit": 999, "reorder_point": 1}
+    )
+    assert not form.is_valid()
+    assert "unit" in form.errors
+
+
+@pytest.mark.django_db
+def test_default_unit_preselected(units):
+    default_unit, _ = units
+    form = TestItemForm()
+    assert form.fields["unit"].initial == default_unit

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -10,6 +10,7 @@ from inventory.models import (
     Recipe,
     RecipeComponent,
     StockTransaction,
+    Unit,
 )
 from inventory.services import item_service
 
@@ -32,6 +33,15 @@ def clear_tables(db):
             pass
     item_service.get_all_items_with_stock.clear()
     item_service.get_distinct_departments_from_items.clear()
+    Unit.objects.get_or_create(
+        unit_id=55,
+        defaults={
+            "base_unit": "PC",
+            "purchase_unit": "PC",
+            "conversion_factor": 1.0,
+            "is_default": True,
+        },
+    )
 
 
 def test_add_new_item_inserts_row():

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -1,7 +1,7 @@
 import pytest
 from django.urls import reverse
 
-from inventory.models import Item, StockTransaction
+from inventory.models import Item, StockTransaction, Unit
 from inventory.services import item_service
 
 pytestmark = pytest.mark.django_db
@@ -10,13 +10,23 @@ pytestmark = pytest.mark.django_db
 def _create_item(**kwargs):
     defaults = {
         "name": "Widget",
-        "unit_id": 55,
         "reorder_point": 1,
         "notes": "n",
         "is_active": True,
         "category_id": 1,
     }
     defaults.update(kwargs)
+    unit = Unit.objects.get_or_create(
+        unit_id=55,
+        defaults={
+            "base_unit": "PC",
+            "purchase_unit": "PC",
+            "conversion_factor": 1.0,
+            "is_default": True,
+        },
+    )[0]
+    defaults.setdefault("unit", unit)
+    defaults.pop("unit_id", None)
     return Item.objects.create(**defaults)
 
 
@@ -31,11 +41,19 @@ def test_item_detail_view(client):
 
 
 def test_item_create_view_htmx_success(client, monkeypatch):
-
+    Unit.objects.get_or_create(
+        unit_id=55,
+        defaults={
+            "base_unit": "PC",
+            "purchase_unit": "PC",
+            "conversion_factor": 1.0,
+            "is_default": True,
+        },
+    )
     url = reverse("item_create")
     data = {
         "name": "Widget",
-        "unit_id": "55",
+        "unit": "55",
         "reorder_point": "1",
         "current_stock": "0",
         "notes": "n",
@@ -102,7 +120,7 @@ def test_item_edit_view_updates_and_clears_cache(client, monkeypatch):
 
     data = {
         "name": "Gadget",
-        "unit_id": "55",
+        "unit": "55",
         "reorder_point": "5",
         "current_stock": "0",
         "notes": "updated",

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -6,12 +6,21 @@ from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
 
-from inventory.models import Item, StockTransaction
+from inventory.models import Item, StockTransaction, Unit
 from inventory.services import ml
 
 
 def create_item(name: str) -> Item:
-    return Item.objects.create(name=name, unit_id=19)
+    unit, _ = Unit.objects.get_or_create(
+        unit_id=19,
+        defaults={
+            "base_unit": "KG",
+            "purchase_unit": "KG",
+            "conversion_factor": 1.0,
+            "is_default": True,
+        },
+    )
+    return Item.objects.create(name=name, unit=unit)
 
 
 def test_forecast_returns_expected_values(db):
@@ -104,7 +113,6 @@ def test_ml_dashboard_uses_cache(client):
         client.get(reverse("ml_dashboard"))
         assert mock_queue.call_count == 2
         assert mock_abc.call_count == 2
-
 
 
 def test_queue_train_models_updates_cache(db):

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -3,7 +3,7 @@
 import pytest
 from django.db import OperationalError, connection
 
-from inventory.models import Item, Recipe, RecipeComponent, SaleTransaction
+from inventory.models import Item, Recipe, RecipeComponent, SaleTransaction, Unit
 from inventory.services.recipe_service import create_recipe, record_sale, update_recipe
 
 pytestmark = pytest.mark.django_db
@@ -35,9 +35,18 @@ def create_tables(django_db_blocker):
 
 
 def _create_item(name="Flour", unit_id=19, stock=20):
+    unit, _ = Unit.objects.get_or_create(
+        unit_id=unit_id,
+        defaults={
+            "base_unit": "KG",
+            "purchase_unit": "KG",
+            "conversion_factor": 1.0,
+            "is_default": True,
+        },
+    )
     item = Item.objects.create(
         name=name,
-        unit_id=unit_id,
+        unit=unit,
         category_id=1,
         reorder_point=0,
         current_stock=stock,


### PR DESCRIPTION
## Summary
- enforce Item to reference Unit via foreign key with validation
- add default unit flag and preselect in item forms
- harden unit-aware forms, views, and tests

## Testing
- `flake8 inventory/models/units.py inventory/models/items.py inventory/forms/item_forms.py tests/forms/test_item_forms.py tests/test_item_form.py tests/conftest.py inventory/services/dashboard_service.py inventory/templatetags/icon_tags.py tests/test_explore_view.py tests/test_item_service.py tests/test_item_views.py tests/test_ml.py tests/test_recipe_service.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2f5a4e5a8832695ec558a1d146edc