### PR TITLE
refactor: use kpi_card component on dashboard

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,33 +1,6 @@
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
-    <div class="flex items-center gap-4">
-      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.5c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v4.5h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/></svg>
-      <h2 class="text-lg font-medium">Items</h2>
-    </div>
-    <span class="text-4xl font-bold">{{ items }}</span>
-  </div>
-
-  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
-    <div class="flex items-center gap-4">
-      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9.303 3.376c.866 1.5-.217 3.374-1.948 3.374H4.645c-1.73 0-2.813-1.874-1.948-3.374L10.052 3.378c.866-1.5 3.032-1.5 3.898 0l7.303 12.748ZM12 15.75h.007v.008H12v-.008Z"/></svg>
-      <h2 class="text-lg font-medium">Low-stock Items</h2>
-    </div>
-    <span class="text-4xl font-bold">{{ low_stock }}</span>
-  </div>
-
-  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
-    <div class="flex items-center gap-4">
-      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M3 7.5l7.5-4.5 7.5 4.5M21 7.5v9l-7.5 4.5m0-9l7.5-4.5M12 12v9m0 0L3 16.5v-9"/></svg>
-      <h2 class="text-lg font-medium">Suppliers</h2>
-    </div>
-    <span class="text-4xl font-bold">{{ suppliers }}</span>
-  </div>
-
-  <div class="p-6 rounded-xl flex items-center justify-between text-white bg-gradient-to-r from-primary to-secondary">
-    <div class="flex items-center gap-4">
-      <svg aria-hidden="true" class="w-10 h-10 opacity-75" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a2 2 0 011.414.586l5.414 5.414A2 2 0 0120 9.414V19a2 2 0 01-2 2z"/></svg>
-      <h2 class="text-lg font-medium">Pending Indents</h2>
-    </div>
-    <span class="text-4xl font-bold">{{ pending_indents }}</span>
-  </div>
+  {% include "components/kpi_card.html" with icon='cube' color='blue' label='Items' value=items %}
+  {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low-stock Items' value=low_stock %}
+  {% include "components/kpi_card.html" with icon='truck' color='green' label='Suppliers' value=suppliers %}
+  {% include "components/kpi_card.html" with icon='clipboard-document-list' color='yellow' label='Pending Indents' value=pending_indents %}
 </div>


### PR DESCRIPTION
## Summary
- replace gradient KPI markup with reusable `kpi_card` includes for items, low stock, suppliers, and pending indents

## Testing
- `pytest`
- `npm run build-css`


------
https://chatgpt.com/codex/tasks/task_e_68b30db9f4188326bcf7491211327141