### PR TITLE
Refactor exception handling in inventory services

### DIFF
--- a/inventory/services/category_filters.py
+++ b/inventory/services/category_filters.py
@@ -21,11 +21,7 @@ def resolve_category_filters(request) -> Dict[str, Any]:
     department = (request.GET.get("department") or "").strip()
 
     # First try Supabase-provided categories (used by tests via monkeypatch)
-    categories_map = {}
-    try:
-        categories_map = get_supabase_categories() or {}
-    except Exception:  # pragma: no cover - defensive
-        logger.debug("Supabase categories unavailable; falling back to DB")
+    categories_map = get_supabase_categories() or {}
 
     if categories_map:
         categories = [c["name"] for c in categories_map.get(None, [])]

--- a/inventory/services/form_service.py
+++ b/inventory/services/form_service.py
@@ -4,7 +4,7 @@ import logging
 from functools import lru_cache
 from typing import Dict, List, Optional, Tuple
 
-from django.db import connection
+from django.db import DatabaseError, connection
 from django.db.utils import OperationalError
 
 from ..models import Department, Supplier
@@ -85,17 +85,7 @@ class FormService:
 @lru_cache(maxsize=None)
 def get_units_map() -> Dict[str, List[str]]:
     """Get units mapping for JavaScript consumption."""
-    try:
-        return get_units()
-    except Exception as e:
-        logger.warning(f"Could not load units map: {e}")
-        return {
-            'kg': ['kg', 'g', 'lb'],
-            'ltr': ['ltr', 'ml', 'gallon'],
-            'pc': ['pc', 'each', 'dozen'],
-            'box': ['box', 'case', 'carton'],
-            'pack': ['pack', 'bundle', 'set'],
-        }
+    return get_units()
 
 
 @lru_cache(maxsize=None)
@@ -124,7 +114,7 @@ def get_categories_map() -> Dict[str, List[Dict[str, str]]]:
             category: [{'name': subcat[1]} for subcat in subcategories]
             for category, subcategories in grouped.items()
         }
-    except Exception as e:
+    except DatabaseError as e:
         logger.warning(f"Could not load categories map: {e}")
         # Fallback for development/testing
         return {
@@ -167,7 +157,7 @@ def get_subcategory_choices(category: Optional[str] = None) -> List[Tuple[str, s
                 list(set(cat['sub_category'] for cat in all_categories))
             )
             return [(subcat, subcat) for subcat in unique_subcategories]
-    except Exception as e:
+    except DatabaseError as e:
         logger.warning(f"Could not load subcategories: {e}")
         return []
 
@@ -179,7 +169,7 @@ def get_department_choices() -> List[Tuple[int, str]]:
             'department_id', 'name'
         )
         return [(dept[0], dept[1]) for dept in departments if dept[1]]
-    except Exception as e:
+    except DatabaseError as e:
         logger.warning(f"Could not load departments: {e}")
         return []
 
@@ -191,7 +181,7 @@ def get_supplier_choices() -> List[Tuple[int, str]]:
             'supplier_id', 'name'
         )
         return [(supplier[0], supplier[1]) for supplier in suppliers]
-    except Exception as e:
+    except DatabaseError as e:
         logger.warning(f"Could not load suppliers: {e}")
         return []
 
@@ -201,13 +191,9 @@ def get_purchase_unit_choices(base_unit: Optional[str] = None) -> List[Tuple[str
     if not base_unit:
         return []
 
-    try:
-        units_map = get_units_map()
-        purchase_units = units_map.get(base_unit, [base_unit])
-        return [(unit, unit) for unit in purchase_units]
-    except Exception as e:
-        logger.warning(f"Could not load purchase units for {base_unit}: {e}")
-        return [(base_unit, base_unit)] if base_unit else []
+    units_map = get_units_map()
+    purchase_units = units_map.get(base_unit, [base_unit])
+    return [(unit, unit) for unit in purchase_units]
 
 
 # Clear cache functions

--- a/inventory/services/goods_receiving_service.py
+++ b/inventory/services/goods_receiving_service.py
@@ -2,7 +2,7 @@ import logging
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple
 
-from django.db import transaction
+from django.db import DatabaseError, transaction
 from django.db.models import Max, Sum
 
 from inventory.constants import TransactionType
@@ -134,6 +134,6 @@ def create_grn(
         PurchaseOrderItem.DoesNotExist,
     ) as exc:
         return False, f"Invalid reference: {exc}", None
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.error("Error creating GRN: %s", exc)
+    except DatabaseError as exc:  # pragma: no cover - defensive
+        logger.exception("Error creating GRN: %s", exc)
         return False, "Database error creating GRN.", None

--- a/inventory/services/item_service.py
+++ b/inventory/services/item_service.py
@@ -9,12 +9,11 @@ mutating operations.
 from __future__ import annotations
 
 import logging
-import traceback
 from decimal import Decimal, InvalidOperation
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple
 
-from django.db import IntegrityError, transaction
+from django.db import DatabaseError, IntegrityError, transaction
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
 
@@ -159,11 +158,9 @@ def add_new_item(details: Dict[str, Any]) -> Tuple[bool, str]:
             False,
             f"Item name '{params['name']}' already exists. Choose a unique name.",
         )
-    except Exception as e:  # pragma: no cover - defensive logging
-        logger.error(
-            "ERROR [item_service.add_new_item]: Database error adding item: %s\n%s",
-            e,
-            traceback.format_exc(),
+    except DatabaseError as e:
+        logger.exception(
+            "ERROR [item_service.add_new_item]: Database error adding item"
         )
         return False, "A database error occurred while adding the item."
 
@@ -230,11 +227,9 @@ def add_items_bulk(items: List[Dict[str, Any]]) -> Tuple[int, List[str]]:
         return len(objs), []
     except IntegrityError as e:
         return 0, [str(e)]
-    except Exception as e:  # pragma: no cover - defensive logging
-        logger.error(
-            "ERROR [item_service.add_items_bulk]: Database error adding items: %s\n%s",
-            e,
-            traceback.format_exc(),
+    except DatabaseError:
+        logger.exception(
+            "ERROR [item_service.add_items_bulk]: Database error adding items"
         )
         return 0, ["A database error occurred while adding items."]
 
@@ -252,14 +247,9 @@ def remove_items_bulk(item_ids: List[int]) -> Tuple[int, List[str]]:
             get_all_items_with_stock.clear()
             get_distinct_departments_from_items.clear()
         return affected, []
-    except Exception as e:  # pragma: no cover - defensive logging
-        logger.error(
-            (
-                "ERROR [item_service.remove_items_bulk]: "
-                "Database error removing items: %s\n%s"
-            ),
-            e,
-            traceback.format_exc(),
+    except DatabaseError:
+        logger.exception(
+            "ERROR [item_service.remove_items_bulk]: Database error removing items"
         )
         return 0, ["A database error occurred while removing items."]
 
@@ -308,12 +298,10 @@ def update_item(item_id: int, updates: Dict[str, Any]) -> Tuple[bool, str]:
             False,
             f"Update failed: Potential duplicate name '{updates.get('name')}'.",
         )
-    except Exception as exc:  # pragma: no cover - defensive logging
-        logger.error(
-            "ERROR [item_service.update_item]: Database error updating item %s: %s\n%s",
+    except DatabaseError:
+        logger.exception(
+            "ERROR [item_service.update_item]: Database error updating item %s",
             item_id,
-            exc,
-            traceback.format_exc(),
         )
         return False, "A database error occurred while updating the item."
 

--- a/inventory/services/ml.py
+++ b/inventory/services/ml.py
@@ -91,14 +91,14 @@ def train_models(periods: int = 7) -> Dict[int, List[float]]:
 def train_models_task(periods: int, cache_key: str, ttl: int) -> bool:
     """Train models and store results in cache.
 
-    Returns ``True`` on success and ``False`` if an exception is raised.
+    Returns ``True`` on success and re-raises any encountered exception.
     """
     try:
         cache.set(cache_key, train_models(periods), ttl)
         return True
-    except Exception:  # pragma: no cover - defensive catch-all
-        logger.exception("Failed to train forecasting models")
-        return False
+    except Exception as exc:  # pragma: no cover - defensive catch-all
+        logger.exception("Failed to train forecasting models: %s", exc)
+        raise
 
 
 def queue_train_models(

--- a/inventory/services/purchase_order_service.py
+++ b/inventory/services/purchase_order_service.py
@@ -2,7 +2,7 @@ import logging
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Tuple
 
-from django.db import IntegrityError, transaction
+from django.db import DatabaseError, IntegrityError, transaction
 from django.db.models import Max, Sum
 
 from inventory.models import Item, PurchaseOrder, PurchaseOrderItem, Supplier
@@ -48,9 +48,9 @@ def create_po(
     except IntegrityError as exc:
         logger.error("Integrity error creating PO: %s", exc)
         return False, f"Database error: {exc}", None
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.error("Error creating PO: %s", exc)
-        return False, f"Database error: {exc}", None
+    except DatabaseError as exc:
+        logger.exception("Error creating PO: %s", exc)
+        raise
 
 
 def get_po_by_id(po_id: int) -> Optional[Dict[str, Any]]:

--- a/inventory/services/recipe_service.py
+++ b/inventory/services/recipe_service.py
@@ -5,7 +5,7 @@ import logging
 from decimal import Decimal
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
-from django.db import IntegrityError, transaction
+from django.db import DatabaseError, IntegrityError, transaction
 
 from inventory.constants import PLACEHOLDER_SELECT_COMPONENT, TransactionType
 
@@ -283,8 +283,8 @@ def delete_recipe(recipe_id: int) -> Tuple[bool, str]:
             RecipeComponent.objects.filter(parent_recipe=recipe).delete()
             recipe.delete()
         return True, "Recipe deleted."
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.error("DB error deleting recipe: %s", exc)
+    except DatabaseError as exc:  # pragma: no cover - defensive
+        logger.exception("DB error deleting recipe: %s", exc)
         return False, "A database error occurred."
 
 
@@ -393,6 +393,6 @@ def record_sale(
     except (Item.DoesNotExist, ValueError) as ve:
         logger.error("Error recording sale: %s", ve)
         return False, str(ve)
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.error("DB error recording sale: %s", exc)
+    except DatabaseError as exc:  # pragma: no cover - defensive
+        logger.exception("DB error recording sale: %s", exc)
         return False, "A database error occurred during sale recording."

--- a/inventory/services/stock_service.py
+++ b/inventory/services/stock_service.py
@@ -3,7 +3,7 @@ import time
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
-from django.db import OperationalError, transaction
+from django.db import DatabaseError, OperationalError, transaction
 from django.db.models import F
 
 from inventory.constants import TransactionType
@@ -52,8 +52,8 @@ def record_stock_transaction(
             logger.error("Error recording stock transaction: %s", exc)
             time.sleep(0.1 * attempt)
             continue
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Error recording stock transaction: %s", exc)
+        except DatabaseError as exc:  # pragma: no cover - defensive
+            logger.exception("Error recording stock transaction: %s", exc)
             return False
     return False
 
@@ -86,8 +86,8 @@ def record_stock_transactions_bulk(transactions: List[Dict[str, Any]]) -> bool:
                     notes=tx.get("notes"),
                 )
         return True
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.error("Bulk stock transaction failed: %s", exc)
+    except DatabaseError as exc:  # pragma: no cover - defensive
+        logger.exception("Bulk stock transaction failed: %s", exc)
         return False
 
 
@@ -109,8 +109,8 @@ def remove_stock_transactions_bulk(transaction_ids: List[int]) -> bool:
                 item.save(update_fields=["current_stock"])
             StockTransaction.objects.filter(transaction_id__in=transaction_ids).delete()
         return True
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.error("Error removing stock transactions: %s", exc)
+    except DatabaseError as exc:  # pragma: no cover - defensive
+        logger.exception("Error removing stock transactions: %s", exc)
         return False
 
 

--- a/inventory/services/supabase_cache.py
+++ b/inventory/services/supabase_cache.py
@@ -53,10 +53,8 @@ def get_cached(fetch_func: Callable[[], T], ttl: int) -> Callable[[bool], T]:
 
             try:
                 state.value = fetch_func()
-            except Exception:
-                if state.value is not None:
-                    logger.exception("Failed to refresh cached value")
-                    return state.value
+            except Exception as exc:
+                logger.exception("Failed to refresh cached value: %s", exc)
                 raise
             state.time = now
             return state.value

--- a/inventory/services/supplier_service.py
+++ b/inventory/services/supplier_service.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
-from django.db import IntegrityError, transaction
+from django.db import DatabaseError, IntegrityError, transaction
 
 from inventory.models import Supplier
 
@@ -32,8 +32,8 @@ def add_supplier(details: Dict[str, Any]) -> Tuple[bool, str]:
             False,
             f"Supplier name '{name}' already exists. Please use a unique name.",
         )
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.error("Error adding supplier: %s", exc)
+    except DatabaseError as exc:
+        logger.exception("Error adding supplier: %s", exc)
         return False, "A database error occurred while adding the supplier."
 
 
@@ -100,8 +100,8 @@ def update_supplier(supplier_id: int, updates: Dict[str, Any]) -> Tuple[bool, st
             False,
             f"Update failed: Potential duplicate name '{updates.get('name')}'.",
         )
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.error("Error updating supplier %s: %s", supplier_id, exc)
+    except DatabaseError as exc:
+        logger.exception("Error updating supplier %s: %s", supplier_id, exc)
         return False, "A database error occurred while updating the supplier."
 
 

--- a/tests/test_form_service.py
+++ b/tests/test_form_service.py
@@ -1,5 +1,9 @@
 from unittest.mock import patch
 
+import pytest
+from django.db import DatabaseError
+
+from inventory.services import form_service
 from inventory.services.form_service import get_purchase_unit_choices
 
 
@@ -17,3 +21,20 @@ def test_get_purchase_unit_choices_defaults_to_base_unit():
 
 def test_get_purchase_unit_choices_no_base_unit_returns_empty():
     assert get_purchase_unit_choices() == []
+
+
+def test_get_department_choices_database_error(monkeypatch):
+    def boom(*args, **kwargs):
+        raise DatabaseError("boom")
+
+    monkeypatch.setattr(form_service.Department.objects, "filter", boom)
+    assert form_service.get_department_choices() == []
+
+
+def test_get_department_choices_unexpected_exception(monkeypatch):
+    def boom(*args, **kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(form_service.Department.objects, "filter", boom)
+    with pytest.raises(ValueError):
+        form_service.get_department_choices()

--- a/tests/test_goods_receiving_service_django.py
+++ b/tests/test_goods_receiving_service_django.py
@@ -2,6 +2,8 @@ from datetime import date
 
 import pytest
 
+from django.db import DatabaseError
+
 from inventory.models import PurchaseOrder, PurchaseOrderItem, Supplier
 from inventory.services import goods_receiving_service, purchase_order_service
 
@@ -41,3 +43,58 @@ def test_create_grn_updates_stock_and_po(item_factory):
     assert po_item.received_total == 5
     po = PurchaseOrder.objects.get(pk=po_id)
     assert po.status == "PARTIAL"
+
+
+@pytest.mark.django_db
+def test_create_grn_database_error(monkeypatch, item_factory):
+    supplier = Supplier.objects.create(name="Vendor")
+    item = item_factory(name="Widget", current_stock=0)
+    grn_data = {
+        "supplier_id": supplier.pk,
+        "received_date": date.today(),
+        "received_by_user_id": "tester",
+    }
+    items_data = [
+        {
+            "item_id": item.item_id,
+            "po_item_id": 1,
+            "quantity_ordered_on_po": 1,
+            "quantity_received": 1,
+            "unit_price_at_receipt": 1,
+        }
+    ]
+
+    def boom(*args, **kwargs):
+        raise DatabaseError("boom")
+
+    monkeypatch.setattr(goods_receiving_service, "_create_grn_header", boom)
+    ok, msg, _ = goods_receiving_service.create_grn(grn_data, items_data)
+    assert not ok
+    assert "database" in msg.lower()
+
+
+@pytest.mark.django_db
+def test_create_grn_unexpected_exception(monkeypatch, item_factory):
+    supplier = Supplier.objects.create(name="Vendor")
+    item = item_factory(name="Widget", current_stock=0)
+    grn_data = {
+        "supplier_id": supplier.pk,
+        "received_date": date.today(),
+        "received_by_user_id": "tester",
+    }
+    items_data = [
+        {
+            "item_id": item.item_id,
+            "po_item_id": 1,
+            "quantity_ordered_on_po": 1,
+            "quantity_received": 1,
+            "unit_price_at_receipt": 1,
+        }
+    ]
+
+    def boom(*args, **kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(goods_receiving_service, "_create_grn_header", boom)
+    with pytest.raises(ValueError):
+        goods_receiving_service.create_grn(grn_data, items_data)

--- a/tests/test_item_service.py
+++ b/tests/test_item_service.py
@@ -11,6 +11,7 @@ from inventory.models import (
     RecipeComponent,
     StockTransaction,
 )
+from django.db import DatabaseError
 from inventory.services import item_service
 
 pytestmark = pytest.mark.django_db
@@ -154,6 +155,27 @@ def test_add_new_item_requires_unit_id():
     success, message = item_service.add_new_item(details)
     assert not success
     assert "unit_id" in message
+
+
+def test_add_new_item_database_error(monkeypatch):
+    def boom(*args, **kwargs):
+        raise DatabaseError("boom")
+
+    monkeypatch.setattr(Item.objects, "create", boom)
+    details = {"name": "Widget", "unit_id": 55}
+    success, message = item_service.add_new_item(details)
+    assert not success
+    assert "database" in message.lower()
+
+
+def test_add_new_item_unexpected_exception_propagates(monkeypatch):
+    def boom(*args, **kwargs):
+        raise ValueError("bad")
+
+    monkeypatch.setattr(Item.objects, "create", boom)
+    details = {"name": "Widget", "unit_id": 55}
+    with pytest.raises(ValueError):
+        item_service.add_new_item(details)
 
 
 def test_remove_items_bulk_marks_inactive():

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -6,6 +6,8 @@ from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
 
+import pytest
+
 from inventory.models import Item, StockTransaction
 from inventory.services import ml
 
@@ -121,7 +123,7 @@ def test_queue_train_models_logs_exception(db, monkeypatch, caplog):
     monkeypatch.setattr(ml, "train_models", bad_train)
     cache_key = "test_ml_train_models_error"
     cache.delete(cache_key)
-    with caplog.at_level("ERROR"):
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError):
         ml.queue_train_models(periods=1, cache_key=cache_key, ttl=300, sync=True)
     assert cache.get(cache_key) is None
     assert "Failed to train forecasting models" in caplog.text

--- a/tests/test_purchase_order_service_django.py
+++ b/tests/test_purchase_order_service_django.py
@@ -2,6 +2,8 @@ from datetime import date
 
 import pytest
 
+from django.db import DatabaseError
+
 from inventory.models import (
     GoodsReceivedNote,
     GRNItem,
@@ -24,6 +26,23 @@ def test_create_po_and_get_po(item_factory):
     po = purchase_order_service.get_po_by_id(po_id)
     assert po["supplier_id"] == supplier.pk
     assert po["items"][0]["item_id"] == item.item_id
+
+
+@pytest.mark.django_db
+def test_create_po_database_error_propagates(monkeypatch, item_factory):
+    supplier = Supplier.objects.create(name="Vendor")
+    item = item_factory(name="Widget")
+
+    def boom(*args, **kwargs):
+        raise DatabaseError("boom")
+
+    monkeypatch.setattr(PurchaseOrder.objects, "create", boom)
+
+    with pytest.raises(DatabaseError):
+        purchase_order_service.create_po(
+            {"supplier_id": supplier.pk, "order_date": date.today()},
+            [{"item_id": item.item_id, "quantity_ordered": 5, "unit_price": 2.0}],
+        )
 
 
 @pytest.mark.django_db

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -2,6 +2,8 @@
 
 import pytest
 from django.db import OperationalError, connection
+from decimal import Decimal
+from django.db import DatabaseError
 
 from inventory.models import Item, Recipe, RecipeComponent, SaleTransaction
 from inventory.services.recipe_service import create_recipe, record_sale, update_recipe
@@ -166,6 +168,38 @@ def test_record_sale_reduces_nested_stock():
     item = Item.objects.get(pk=item_id)
     expected = round(20 - (2 * 1 / (1 - 0.2) / (1 - 0.1)), 2)
     assert float(item.current_stock) == expected
+
+
+def test_record_sale_database_error(monkeypatch):
+    def boom(*args, **kwargs):
+        raise DatabaseError("boom")
+
+    monkeypatch.setattr(Recipe.objects, "get", boom)
+    ok, msg = record_sale(1, Decimal("1"), "u")
+    assert not ok
+    assert "database" in msg.lower()
+
+
+def test_record_sale_unexpected_exception_propagates(monkeypatch, item_factory):
+    item = item_factory(name="Itm")
+    recipe = Recipe.objects.create(name="R", is_active=True, default_yield_unit="KG")
+    RecipeComponent.objects.create(
+        parent_recipe=recipe,
+        component_kind="ITEM",
+        component_id=item.item_id,
+        quantity=1,
+        unit="KG",
+    )
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        "inventory.services.recipe_service.StockTransaction.objects.create", boom
+    )
+
+    with pytest.raises(RuntimeError):
+        record_sale(recipe.recipe_id, Decimal("1"), "u")
 
 
 @pytest.mark.django_db

--- a/tests/test_stock_service.py
+++ b/tests/test_stock_service.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 import pytest
 from django.db.utils import OperationalError
 
+from django.db import DatabaseError
+
 from inventory.models import (
     IndentItem,
     Item,
@@ -129,6 +131,31 @@ def test_remove_stock_transactions_bulk_rollback_on_error(item_factory):
     item.refresh_from_db()
     assert item.current_stock == current_stock
     assert StockTransaction.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_record_stock_transaction_database_error(monkeypatch, item_factory):
+    def boom(*args, **kwargs):
+        raise DatabaseError("boom")
+
+    monkeypatch.setattr(Item.objects, "filter", boom)
+    item = item_factory(name="Err", current_stock=0)
+    assert not stock_service.record_stock_transaction(
+        item.item_id, 1, TransactionType.RECEIVING.value, "u"
+    )
+
+
+@pytest.mark.django_db
+def test_record_stock_transaction_unexpected_exception(monkeypatch, item_factory):
+    def boom(*args, **kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(Item.objects, "filter", boom)
+    item = item_factory(name="Err", current_stock=0)
+    with pytest.raises(ValueError):
+        stock_service.record_stock_transaction(
+            item.item_id, 1, TransactionType.RECEIVING.value, "u"
+        )
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/test_supabase_cache.py
+++ b/tests/test_supabase_cache.py
@@ -1,0 +1,12 @@
+import pytest
+
+from inventory.services.supabase_cache import get_cached
+
+
+def test_get_cached_raises_on_error():
+    def fetch():
+        raise ValueError("boom")
+
+    cached = get_cached(fetch, ttl=1)
+    with pytest.raises(ValueError):
+        cached()

--- a/tests/test_supplier_service_django.py
+++ b/tests/test_supplier_service_django.py
@@ -2,6 +2,8 @@ import pytest
 from django.urls import reverse
 
 from inventory.models import Supplier
+from django.db import DatabaseError
+
 from inventory.services import supplier_service
 
 
@@ -68,6 +70,27 @@ def test_get_all_suppliers_returns_list_of_dicts():
     all_suppliers = supplier_service.get_all_suppliers(include_inactive=True)
     names_all = {row["name"] for row in all_suppliers}
     assert {"Vendor D", "Vendor E"}.issubset(names_all)
+
+
+@pytest.mark.django_db
+def test_add_supplier_database_error(monkeypatch):
+    def boom(*args, **kwargs):
+        raise DatabaseError("boom")
+
+    monkeypatch.setattr(Supplier.objects, "create", boom)
+    success, msg = supplier_service.add_supplier({"name": "Vendor"})
+    assert not success
+    assert "database" in msg.lower()
+
+
+@pytest.mark.django_db
+def test_add_supplier_unexpected_exception_propagates(monkeypatch):
+    def boom(*args, **kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(Supplier.objects, "create", boom)
+    with pytest.raises(ValueError):
+        supplier_service.add_supplier({"name": "Vendor"})
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- narrow overly broad exception handlers in service layer and re-raise unexpected errors
- add tests covering database errors and propagation paths
- ensure cached wrapper and training task propagate failures

## Testing
- `pytest -o addopts=""` *(fails: TypeError in unrelated view tests)*
- `pytest tests/test_supabase_cache.py tests/test_item_service.py::test_add_new_item_database_error tests/test_form_service.py::test_get_department_choices_database_error tests/test_supplier_service_django.py::test_add_supplier_database_error tests/test_stock_service.py::test_record_stock_transaction_database_error tests/test_purchase_order_service_django.py::test_create_po_database_error_propagates tests/test_recipe_service.py::test_record_sale_database_error tests/test_goods_receiving_service_django.py::test_create_grn_database_error -o addopts=""`

------
https://chatgpt.com/codex/tasks/task_e_68b2fdeb6bf48326803e3e7ee7b214f7