### PR TITLE
fix: remove htmx loader on dashboard

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -50,9 +50,11 @@
         </form>
       </div>
     </div>
-    <div class="card lg:col-span-2">
+      <div class="card lg:col-span-2">
       <div class="card-header"><h3 class="text-lg font-semibold">Stock Trend</h3></div>
       <div class="card-body"><div class="h-64"><canvas id="stock-trend-chart" class="w-full h-full"></canvas></div></div>
     </div>
   </div>
 {% endblock %}
+
+{% block table_container %}{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -39,3 +39,13 @@ def test_dashboard_kpis_endpoint(client, item_factory):
     assert b"Low-stock Items" in resp.content
     assert b"Suppliers" in resp.content
     assert b"Pending Indents" in resp.content
+
+
+@pytest.mark.django_db
+def test_dashboard_has_single_filter_form(client, django_user_model):
+    user = django_user_model.objects.create_user(username="u", password="pw")
+    client.force_login(user)
+    resp = client.get(reverse("dashboard"))
+    assert resp.status_code == 200
+    assert resp.content.count(b"dashboard-filters") == 1
+    assert b'hx-get=""' not in resp.content


### PR DESCRIPTION
## Summary
- suppress default HTMX table container on dashboard
- test dashboard renders single filter form without empty hx-get

## Testing
- `pytest tests/test_dashboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b314cbea2c8326a83f05adb675a842