### PR TITLE
feat: add home navigation link and root logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MAJOR CLEANUP: Repository refactoring - removed duplicate templates, organized documentation into docs/ structure, cleaned backup files for maintainable codebase
 - PRE-PRODUCTION TESTING COMPLETE: Comprehensive testing completed - inline form functional, clean codebase, ready for production deployment
 - Shared `templates/components/kpi_card.html` for consistent card-based KPI display
+- Home link added to primary navigation
 
 ### Changed
 
@@ -53,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLEANUP: Remove '\_speed' naming convention - renamed item_detail_speed.html to item_detail.html and item_form_speed.html to item_form.html for consistent naming
 - Refactor: split item views into list, detail, and stock modules and converted helper views to class-based implementations
 - KPI sections in items and purchase orders now render via the shared card component
+- Top navigation logo now routes to the home page instead of the dashboard
 
 ## [2.1.0] - 2025-08-28
 

--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -1,4 +1,5 @@
 NAVIGATION_LINKS = [
+    {"title": "Home", "url_name": "root"},
     {"title": "Dashboard", "url_name": "dashboard"},
     {"title": "Inventory", "url_name": "items_list"},
     {"title": "Orders", "url_name": "purchase_orders_list"},

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -6,7 +6,7 @@
       <!-- Left side: Logo and main nav -->
       <div class="flex items-center">
         <!-- Logo -->
-        <a href="{% url 'dashboard' %}" aria-label="Home" class="flex-shrink-0 flex items-center">
+        <a href="{% url 'root' %}" aria-label="Home" class="flex-shrink-0 flex items-center">
           <div class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center">
             {% icon 'squares-2x2' 'h-5 w-5 text-white' variant='solid' size=20 %}
           </div>

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -12,6 +12,7 @@ def test_top_nav_template_contains_links(django_user_model):
     request.user = user
     html = render_to_string("components/top_nav.html", request=request)
     expected = [
+        "Home",
         "Dashboard",
         "Inventory",
         "Orders",
@@ -20,6 +21,7 @@ def test_top_nav_template_contains_links(django_user_model):
     ]
     for text in expected:
         assert text in html
+    assert f'href="{reverse("root")}"' in html
 
 
 @pytest.mark.django_db
@@ -51,6 +53,7 @@ def test_home_page_contains_nav_links(client, django_user_model):
     resp = client.get(reverse("root"))
     html = resp.content.decode()
     expected = [
+        "Home",
         "Dashboard",
         "Inventory",
         "Orders",


### PR DESCRIPTION
## Summary
- Link top navigation logo to root path
- Add Home link alongside Dashboard in primary navigation
- Test logo link to root and updated navigation links

## Testing
- `pytest tests/test_navigation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b31c0f2ff4832699f1a15a66dacc90