### PR TITLE
Enable async item deletion with fetch and add tests

### DIFF
--- a/inventory/views/items/detail.py
+++ b/inventory/views/items/detail.py
@@ -197,7 +197,10 @@ class ItemDetailView(View):
             ("Departments", details.get("department_names", "None")),
             ("Current Stock", details["current_stock"]),
             ("Reorder Point", details["reorder_point"]),
-            ("Initial Purchase Price", details.get("initial_purchase_price", "Not set")),
+            (
+                "Initial Purchase Price",
+                details.get("initial_purchase_price", "Not set"),
+            ),
             ("Minimum Order Qty", details.get("minimum_order_qty", "Not set")),
             ("Lead Time (Days)", details.get("lead_time_days", "Not set")),
             ("Notes", details.get("notes", "None")),
@@ -239,8 +242,11 @@ class ItemDeleteView(View):
 
     def post(self, request, pk: int):
         item = self.get_object(pk)
+        is_fetch = request.headers.get("x-requested-with") == "fetch"
         if StockTransaction.objects.filter(item=item).exists():
             ok, _ = item_service.deactivate_item(item.pk)
+            if is_fetch:
+                return JsonResponse({"ok": ok})
             if ok:
                 messages.success(request, "Item deactivated")
             else:  # pragma: no cover - defensive
@@ -250,15 +256,21 @@ class ItemDeleteView(View):
             item.delete()
             item_service.get_all_items_with_stock.clear()
             item_service.get_distinct_departments_from_items.clear()
+            if is_fetch:
+                return JsonResponse({"ok": True})
             messages.success(request, "Item deleted")
         except IntegrityError:
             ok, _ = item_service.deactivate_item(item.pk)
+            if is_fetch:
+                return JsonResponse({"ok": ok})
             if ok:
                 messages.success(request, "Item deactivated")
             else:  # pragma: no cover - defensive
                 messages.error(request, "Unable to delete item")
         except DatabaseError:  # pragma: no cover - defensive
             logger.exception("Error deleting item %s", pk)
+            if is_fetch:
+                return JsonResponse({"ok": False}, status=400)
             messages.error(request, "Unable to delete item")
         return redirect("items_list")
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "Django Inventory Management Application",
   "scripts": {
     "build-css": "tailwindcss -i ./static/src/app.css -o ./static/css/app.css --minify",
-    "dev-css": "tailwindcss -i ./static/src/app.css -o ./static/css/app.css --watch"
+    "dev-css": "tailwindcss -i ./static/src/app.css -o ./static/css/app.css --watch",
+    "test": "jest"
   },
   "devDependencies": {
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "tailwindcss": "^3.4.0"
   },
   "dependencies": {

--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -10,7 +10,7 @@
     const itemId = row?.dataset.itemId;
     if (!itemId) return;
     const details = document.getElementById(`details-${itemId}`);
-    const toggleBtn = row.querySelector('button.main-row');
+    const toggleBtn = row.querySelector("button.main-row");
     if (!details || !toggleBtn) return;
 
     const expanded = toggleBtn.getAttribute("aria-expanded") === "true";
@@ -278,10 +278,33 @@
       )
     )
       return;
-    // TODO: AJAX delete; for now, toast only
-    if (window.notifications && window.notifications.showToast) {
-      window.notifications.showToast("Item deleted successfully!", "success");
-    }
+    const csrf = getCsrfToken();
+    fetch(`/items/${itemId}/delete/`, {
+      method: "POST",
+      headers: {
+        ...(csrf ? { "X-CSRFToken": csrf } : {}),
+        "X-Requested-With": "fetch",
+      },
+    })
+      .then((r) => r.json().catch(() => ({})))
+      .then((data) => {
+        if (data && data.ok) {
+          row.remove();
+          if (window.notifications && window.notifications.showToast) {
+            window.notifications.showToast(
+              "Item deleted successfully!",
+              "success",
+            );
+          }
+        } else if (window.notifications && window.notifications.showToast) {
+          window.notifications.showToast("Unable to delete item.", "error");
+        }
+      })
+      .catch(() => {
+        if (window.notifications && window.notifications.showToast) {
+          window.notifications.showToast("Unable to delete item.", "error");
+        }
+      });
   }
 
   // Event delegation

--- a/static/js/items-table.test.js
+++ b/static/js/items-table.test.js
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+
+// Integration test for delete action in items-table.js
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("items-table delete", () => {
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<table><tr class="item-row" data-item-id="1"><td><button data-action="delete">Del</button></td></tr></table>';
+    document.cookie = "csrftoken=abc";
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ ok: true }),
+      }),
+    );
+    global.confirm = jest.fn(() => true);
+    window.notifications = { showToast: jest.fn() };
+    // Require script after mocks and DOM setup
+    jest.isolateModules(() => {
+      require("./items-table.js");
+    });
+  });
+
+  test("calls delete endpoint and removes row", async () => {
+    const btn = document.querySelector('[data-action="delete"]');
+    btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await flushPromises();
+    expect(fetch).toHaveBeenCalledWith(
+      "/items/1/delete/",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "X-CSRFToken": "abc", "X-Requested-With": "fetch" },
+      }),
+    );
+    expect(document.querySelector(".item-row")).toBeNull();
+    expect(window.notifications.showToast).toHaveBeenCalledWith(
+      "Item deleted successfully!",
+      "success",
+    );
+  });
+});

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -83,6 +83,26 @@ def test_item_delete_view_deactivates_with_transactions(client):
     assert item.is_active is False
 
 
+def test_item_delete_view_fetch_returns_json(client):
+    item = _create_item()
+    url = reverse("item_delete", args=[item.pk])
+    resp = client.post(url, HTTP_X_REQUESTED_WITH="fetch")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert Item.objects.count() == 0
+
+
+def test_item_delete_view_fetch_deactivates(client):
+    item = _create_item()
+    StockTransaction.objects.create(item=item, quantity_change=2)
+    url = reverse("item_delete", args=[item.pk])
+    resp = client.post(url, HTTP_X_REQUESTED_WITH="fetch")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    item.refresh_from_db()
+    assert item.is_active is False
+
+
 def test_item_edit_view_updates_and_clears_cache(client, monkeypatch):
 
     item_service.get_all_items_with_stock.clear()


### PR DESCRIPTION
## Summary
- use fetch in items table to delete items and remove rows on success
- support JSON responses in item delete view
- test deletion endpoint and front-end behavior

## Testing
- `npx prettier --write static/js/items-table.js static/js/items-table.test.js package.json`
- `npm test`
- `pytest tests/test_item_views.py::test_item_delete_view_fetch_returns_json tests/test_item_views.py::test_item_delete_view_fetch_deactivates`


------
https://chatgpt.com/codex/tasks/task_e_68b32c1451248326b238686f6940ed7b