### PR TITLE
test: sync test schema with item models

### DIFF
--- a/tests/test_schema.sql
+++ b/tests/test_schema.sql
@@ -4,9 +4,17 @@ PRAGMA foreign_keys = ON;
 CREATE TABLE IF NOT EXISTS items (
   item_id INTEGER PRIMARY KEY AUTOINCREMENT,
   name TEXT NOT NULL,
+  unit_id INTEGER NOT NULL,
+  category_id_ref INTEGER,              -- ✅ was category_id; must be category_id_ref
   base_unit TEXT,
   purchase_unit TEXT,
-  category_id_ref INTEGER,              -- ✅ was category_id; must be category_id_ref
+  category TEXT,
+  sub_category TEXT,
+  initial_purchase_price NUMERIC,
+  last_purchase_price NUMERIC,
+  preferred_supplier_id INTEGER,
+  minimum_order_qty NUMERIC,
+  lead_time_days INTEGER,
   permitted_departments TEXT,           -- ✅ add this column (store JSON/string; tests only need presence)
   reorder_point NUMERIC DEFAULT 0,
   current_stock NUMERIC DEFAULT 0,
@@ -30,13 +38,13 @@ CREATE TABLE IF NOT EXISTS suppliers (
 -- Stock transactions: columns used by KPIs + tests
 CREATE TABLE IF NOT EXISTS stock_transactions (
   transaction_id INTEGER PRIMARY KEY AUTOINCREMENT,
-  item_id INTEGER NOT NULL,
-  quantity_change NUMERIC NOT NULL,
-  transaction_type TEXT NOT NULL,
+  item_id INTEGER,
+  quantity_change NUMERIC,
+  transaction_type TEXT,
   user_id TEXT,
   user_id_int INTEGER,
-  related_doc_type TEXT,
-  related_doc_id INTEGER,
+  related_indent_id INTEGER,
+  related_po_id INTEGER,
   notes TEXT,
   transaction_date TEXT NOT NULL,
   FOREIGN KEY (item_id) REFERENCES items(item_id)


### PR DESCRIPTION
## Summary
- expand test schema tables to match `Item` and `StockTransaction` models

## Testing
- `pre-commit run --files tests/test_schema.sql`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b32f4f22988326a6cbad15bd7833b5