### PR TITLE
chore: redact secrets and add security notices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-DJANGO_SECRET_KEY=
-DATABASE_URL=
+# NOTE: Do not commit live secrets. Replace placeholders with real values in your local environment.
+DJANGO_SECRET_KEY=<DEV_SECRET_KEY>
+DATABASE_URL=<DEV_DATABASE_URL>
 # For local runs, you can set DATABASE_URL=sqlite:///db.sqlite3
 # Set to True to enable Django's debug mode (default: False)
 DJANGO_DEBUG=True

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,14 +1,14 @@
 # Production Environment Configuration
-# CRITICAL: Configure these values before production deployment
+# NOTE: Do not commit live secrets. Replace placeholders before production deployment.
 
 # Django Core Configuration
-DJANGO_SECRET_KEY=your-production-secret-key-CHANGE-THIS-NOW
+DJANGO_SECRET_KEY=<PRODUCTION_SECRET_KEY>
 DJANGO_DEBUG=False
 DJANGO_ALLOWED_HOSTS=inventory.yourdomain.com,www.yourdomain.com
 DJANGO_SETTINGS_MODULE=inventory_app.settings_production
 
 # Database Configuration (REQUIRED)
-DATABASE_URL=postgresql://prod_user:secure_password@prod-db-host:5432/inventory_production
+DATABASE_URL=postgresql://<PROD_DB_USER>:<PROD_DB_PASSWORD>@<PROD_DB_HOST>:5432/<PROD_DB_NAME>
 
 # Cache Configuration (RECOMMENDED)
 REDIS_URL=redis://redis-prod-host:6379/0
@@ -17,7 +17,7 @@ REDIS_URL=redis://redis-prod-host:6379/0
 EMAIL_HOST=smtp.yourdomain.com
 EMAIL_PORT=587
 EMAIL_HOST_USER=noreply@yourdomain.com
-EMAIL_HOST_PASSWORD=your-email-password
+EMAIL_HOST_PASSWORD=<EMAIL_HOST_PASSWORD>
 DEFAULT_FROM_EMAIL=noreply@yourdomain.com
 
 # Security Configuration
@@ -25,7 +25,7 @@ ADMIN_URL=secure-admin-path/
 APP_VERSION=1.0.0
 
 # Monitoring & Error Reporting (RECOMMENDED)
-SENTRY_DSN=https://your-sentry-dsn@sentry.io/project-id
+SENTRY_DSN=<SENTRY_DSN>
 
 # Backup Configuration (RECOMMENDED)
 BACKUP_LOCATION=/var/backups/inventory/

--- a/.env.staging
+++ b/.env.staging
@@ -1,14 +1,14 @@
 # Staging Environment Configuration
-# This is the actual staging environment file
+# NOTE: Do not commit live secrets. Replace placeholders before deployment.
 
 # Django Configuration
-DJANGO_SECRET_KEY=staging-secret-key-7$9#mK2@pLq8&xR5*nW3vB6!zT1yU4
+DJANGO_SECRET_KEY=<STAGING_SECRET_KEY>
 DJANGO_DEBUG=False
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0
 DJANGO_SETTINGS_MODULE=inventory_app.settings_staging
 
 # Database Configuration
-DATABASE_URL=postgresql://staging_user:staging_password@db:5432/staging_inventory
+DATABASE_URL=postgresql://<STAGING_DB_USER>:<STAGING_DB_PASSWORD>@<STAGING_DB_HOST>:5432/<STAGING_DB_NAME>
 
 # Cache Configuration
 REDIS_URL=redis://redis:6379/0
@@ -17,9 +17,9 @@ REDIS_URL=redis://redis:6379/0
 EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
 
 # PostgreSQL Database Variables (for docker-compose)
-POSTGRES_DB=staging_inventory
-POSTGRES_USER=staging_user
-POSTGRES_PASSWORD=staging_password
+POSTGRES_DB=<STAGING_DB_NAME>
+POSTGRES_USER=<STAGING_DB_USER>
+POSTGRES_PASSWORD=<STAGING_DB_PASSWORD>
 
 # Logging Level
 LOG_LEVEL=INFO

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,15 +1,15 @@
 # Staging Environment Configuration
-# Copy this file to .env.staging and update values for your staging environment
+# NOTE: Do not commit live secrets. Copy to .env.staging and replace placeholders with real values.
 
 # Django Configuration
-DJANGO_SECRET_KEY=your-staging-secret-key-change-this-value
+DJANGO_SECRET_KEY=<STAGING_SECRET_KEY>
 DJANGO_DEBUG=False
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,your-staging-domain.com
 DJANGO_SETTINGS_MODULE=inventory_app.settings_staging
 
 # Database Configuration
 # For PostgreSQL (recommended for staging)
-DATABASE_URL=postgresql://staging_user:staging_password@db:5432/staging_inventory
+DATABASE_URL=postgresql://<STAGING_DB_USER>:<STAGING_DB_PASSWORD>@<STAGING_DB_HOST>:5432/<STAGING_DB_NAME>
 
 # For SQLite (simple setup)
 # DATABASE_URL=sqlite:///staging.db
@@ -21,9 +21,9 @@ REDIS_URL=redis://redis:6379/0
 EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
 
 # PostgreSQL Database Variables (for docker-compose)
-POSTGRES_DB=staging_inventory
-POSTGRES_USER=staging_user
-POSTGRES_PASSWORD=staging_password
+POSTGRES_DB=<STAGING_DB_NAME>
+POSTGRES_USER=<STAGING_DB_USER>
+POSTGRES_PASSWORD=<STAGING_DB_PASSWORD>
 
 # Optional: Monitoring and Error Reporting
 # SENTRY_DSN=your-sentry-dsn-for-staging
@@ -38,7 +38,7 @@ CSRF_COOKIE_SECURE=False
 
 # Application Settings
 ADMIN_URL=admin/
-DEFAULT_FROM_EMAIL=noreply@staging.yourdomain.com
+DEFAULT_FROM_EMAIL=noreply@example.com
 
 # Performance Settings
 DATA_UPLOAD_MAX_MEMORY_SIZE=2621440

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,7 @@
 # .env.test - isolated test configuration
+# NOTE: Do not commit live secrets. Replace placeholders before use.
 
-DJANGO_SECRET_KEY=test-secret-key
+DJANGO_SECRET_KEY=<TEST_SECRET_KEY>
 DJANGO_DEBUG=False
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,testserver
 
@@ -9,4 +10,4 @@ DATABASE_URL=sqlite:///:memory:
 
 # Dummy Supabase values (not used in tests)
 SUPABASE_URL=http://localhost
-SUPABASE_KEY=dummy-key
+SUPABASE_KEY=<TEST_SUPABASE_KEY>

--- a/ENV_FILES_ANALYSIS.md
+++ b/ENV_FILES_ANALYSIS.md
@@ -1,4 +1,5 @@
 # 🔍 Environment Files Analysis - Purpose & Redundancy
+> **Note:** Placeholder credentials only. Do not commit live secrets to version control.
 
 ## 📋 **Current .env Files Overview**
 
@@ -48,8 +49,8 @@ Your repository has **8 different .env files**, which seems excessive at first g
 ### **Live Credentials in Repository:**
 ```bash
 # From .env.render and .env.render.minimal:
-DATABASE_URL=postgresql://postgres.xuzylmblpkncyztcjrhh:B0t3co1027.@aws-0-ap-south-1.pooler.supabase.com:5432/postgres
-DJANGO_SECRET_KEY=849b052a49e2110ca225ae04ffaf57ec9f71f5cdefb5b7150127b342e1d076e9
+DATABASE_URL=postgresql://<DB_USER>:<DB_PASSWORD>@<DB_HOST>:5432/<DB_NAME>
+DJANGO_SECRET_KEY=<DJANGO_SECRET_KEY>
 ```
 
 **❌ CRITICAL PROBLEM**: Your production database credentials and secret key are exposed in version control!

--- a/docs/deployment/RENDER_ENV_SETUP_GUIDE.md
+++ b/docs/deployment/RENDER_ENV_SETUP_GUIDE.md
@@ -1,4 +1,5 @@
 # 📋 HOW TO ADD ENVIRONMENT VARIABLES TO RENDER
+> **Note:** Replace placeholders with real values in Render's dashboard. Never commit live secrets to version control.
 
 ## 🎯 **STEP-BY-STEP RENDER CONFIGURATION**
 
@@ -27,7 +28,7 @@ Value: False
 #### **🔗 DATABASE**
 ```
 Key: DATABASE_URL
-Value: postgresql://postgres.xuzylmblpkncyztcjrhh:B0t3co1027.@aws-0-ap-south-1.pooler.supabase.com:5432/postgres
+Value: postgresql://<DB_USER>:<DB_PASSWORD>@<DB_HOST>:5432/<DB_NAME>
 ```
 
 #### **🏠 HOSTS & SECURITY**
@@ -36,7 +37,7 @@ Key: DJANGO_ALLOWED_HOSTS
 Value: .onrender.com,localhost,127.0.0.1
 
 Key: DJANGO_SECRET_KEY
-Value: 849b052a49e2110ca225ae04ffaf57ec9f71f5cdefb5b7150127b342e1d076e9
+Value: <DJANGO_SECRET_KEY>
 ```
 
 #### **🔐 SSL/HTTPS CONFIGURATION**
@@ -78,10 +79,10 @@ Value: True
 #### **📊 SUPABASE INTEGRATION**
 ```
 Key: SUPABASE_URL
-Value: https://xuzylmblpkncyztcjrhh.supabase.co
+Value: <SUPABASE_URL>
 
 Key: SUPABASE_KEY
-Value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inh1enlsbWJscGtuY3l6dGNqcmhoIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0NDc5NDkxNSwiZXhwIjoyMDYwMzcwOTE1fQ.qOeTKh3s_Rota_ZhCM1H7CLJIPIHstb3oZszl4LSnEA
+Value: <SUPABASE_SERVICE_ROLE_KEY>
 ```
 
 ### **Step 4: Remove Conflicting Variables**
@@ -122,9 +123,9 @@ For faster setup, here's a format you can copy section by section:
 ```bash
 DJANGO_SETTINGS_MODULE=inventory_app.settings_production
 DEBUG=False
-DATABASE_URL=postgresql://postgres.xuzylmblpkncyztcjrhh:B0t3co1027.@aws-0-ap-south-1.pooler.supabase.com:5432/postgres
+DATABASE_URL=postgresql://<DB_USER>:<DB_PASSWORD>@<DB_HOST>:5432/<DB_NAME>
 DJANGO_ALLOWED_HOSTS=.onrender.com,localhost,127.0.0.1
-DJANGO_SECRET_KEY=849b052a49e2110ca225ae04ffaf57ec9f71f5cdefb5b7150127b342e1d076e9
+DJANGO_SECRET_KEY=<DJANGO_SECRET_KEY>
 DJANGO_SECURE_SSL_REDIRECT=True
 DJANGO_SECURE_HSTS_SECONDS=31536000
 DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS=True
@@ -134,8 +135,8 @@ DJANGO_SECURE_BROWSER_XSS_FILTER=True
 DJANGO_SECURE_REFERRER_POLICY=strict-origin-when-cross-origin
 DJANGO_SESSION_COOKIE_SECURE=True
 DJANGO_CSRF_COOKIE_SECURE=True
-SUPABASE_URL=https://xuzylmblpkncyztcjrhh.supabase.co
-SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inh1enlsbWJscGtuY3l6dGNqcmhoIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0NDc5NDkxNSwiZXhwIjoyMDYwMzcwOTE1fQ.qOeTKh3s_Rota_ZhCM1H7CLJIPIHstb3oZszl4LSnEA
+SUPABASE_URL=<SUPABASE_URL>
+SUPABASE_KEY=<SUPABASE_SERVICE_ROLE_KEY>
 ```
 
 **✅ Ready for production deployment!**

--- a/docs/development/analysis/ENV_FILES_ANALYSIS.md
+++ b/docs/development/analysis/ENV_FILES_ANALYSIS.md
@@ -1,4 +1,5 @@
 # 🔍 Environment Files Analysis - Purpose & Redundancy
+> **Note:** Placeholder credentials only. Do not commit live secrets to version control.
 
 ## 📋 **Current .env Files Overview**
 
@@ -48,8 +49,8 @@ Your repository has **8 different .env files**, which seems excessive at first g
 ### **Live Credentials in Repository:**
 ```bash
 # From .env.render and .env.render.minimal:
-DATABASE_URL=postgresql://postgres.xuzylmblpkncyztcjrhh:B0t3co1027.@aws-0-ap-south-1.pooler.supabase.com:5432/postgres
-DJANGO_SECRET_KEY=849b052a49e2110ca225ae04ffaf57ec9f71f5cdefb5b7150127b342e1d076e9
+DATABASE_URL=postgresql://<DB_USER>:<DB_PASSWORD>@<DB_HOST>:5432/<DB_NAME>
+DJANGO_SECRET_KEY=<DJANGO_SECRET_KEY>
 ```
 
 **❌ CRITICAL PROBLEM**: Your production database credentials and secret key are exposed in version control!


### PR DESCRIPTION
## Summary
- replace committed credentials with placeholders in env files and docs
- add warnings against committing live secrets

## Testing
- `pre-commit run --files .env.staging .env.test .env.example .env.production.example .env.staging.example ENV_FILES_ANALYSIS.md docs/development/analysis/ENV_FILES_ANALYSIS.md docs/deployment/RENDER_ENV_SETUP_GUIDE.md` *(fails: CalledProcessError: ... python3.13 interpreter not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b359d86fcc83268c75746975d0e8eb