### PR TITLE
Automate task tracking via GitHub issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLEANUP: Remove undefined item_duplicate URL references from templates - fixed template errors causing view failures
 
 ### Added
+- feat: add task issue migration utility
+- docs: archive task history in favor of changelog
 
 - `.github/copilot-instructions.md` - Comprehensive AI agent guidance document
 - Changelog maintenance utility script (tools/changelog.py)

--- a/TASK_HISTORY.md
+++ b/TASK_HISTORY.md
@@ -1,20 +1,22 @@
-# Task History
+# Task History (Archived)
 
-This log records assistant-tracked work on this repository. For multi-step work, I’ll also keep an in-CLI plan so progress is visible during a session.
+This file is kept for historical reference. Current changes are tracked automatically in `CHANGELOG.md` using `tools/changelog.py`.
 
-## 2025-08-29
+## Previous Entries
+
+### 2025-08-29
 - Initialized task history and enabled planning.
 - Added `TASK_HISTORY.md` for persistent logs.
 - Please confirm preferred detail level (all changes vs major milestones).
 
-## 2025-08-28
+### 2025-08-28
 - Milestone: Phase 1 UI hardening and cleanup
 - Highlights: removed tracked `staticfiles/`; pinned Prettier v3.2.5 in hooks; replaced inline `onclick` with `data-*` + delegated events in items table/cards; refined row toggle to ignore link clicks.
 - Recent features included: Add Item drawer and Bulk Upload via in-page modal; in-page partial editor for items; table inline editing with select-all and bulk actions; column visibility toggles; cache-busting via `STATIC_VERSION`; exposed `extra_css`/`extra_js` blocks for form styling.
 
 ---
 
-Template for future entries:
+Template for future entries (if manual notes are needed):
 
 ## YYYY-MM-DD
 - Summary: <what changed>

--- a/docs/guides/TASKS.md
+++ b/docs/guides/TASKS.md
@@ -1,5 +1,7 @@
 # Combined Task List
 
+> **Note:** Tasks are synchronized to GitHub issues using `tools/issue_migrator.py`. Update this file and rerun the script to generate labeled issues and track them via milestones or project boards.
+
 This document consolidates the remediation tasks identified for resolving the Internal Server Error and improving project robustness.
 
 ## 1. Align requirements with service dependencies

--- a/tests/test_issue_migrator.py
+++ b/tests/test_issue_migrator.py
@@ -1,0 +1,11 @@
+from tools.issue_migrator import parse_tasks, TASKS_PATH
+
+
+def test_parse_tasks_titles():
+    tasks = parse_tasks(TASKS_PATH)
+    titles = [t["title"] for t in tasks]
+    assert "Align requirements with service dependencies" in titles
+    assert "Provide safe defaults for critical environment variables" in titles
+    assert "Generalize database engine creation" in titles
+    assert "Home Page" in titles
+    assert "Dashboard" in titles

--- a/tools/issue_migrator.py
+++ b/tools/issue_migrator.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Create GitHub issues from docs/guides/TASKS.md entries.
+
+This utility parses the task list and opens labeled issues on GitHub.
+A personal access token is required unless running in --dry-run mode.
+
+Example:
+    python tools/issue_migrator.py --repo owner/repo --token $GITHUB_TOKEN \
+        --milestone "Backlog" --dry-run
+"""
+import argparse
+import os
+import re
+from pathlib import Path
+from typing import Dict, List
+
+import json
+from urllib import request as urlrequest
+
+TASKS_PATH = Path(__file__).parent.parent / "docs/guides/TASKS.md"
+
+
+def parse_tasks(file_path: Path) -> List[Dict[str, str]]:
+    """Parse TASKS.md into a list of issue dictionaries."""
+    lines = file_path.read_text().splitlines()
+    tasks: List[Dict[str, str]] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        heading = re.match(r"##\s+\d+\.\s+(.*)", line)
+        if heading:
+            title = heading.group(1).strip()
+            if title == "Feature and UI Enhancements":
+                i += 1
+                while i < len(lines) and not lines[i].startswith("## "):
+                    sub = lines[i].strip()
+                    if sub.startswith("- **"):
+                        sub_title = re.match(r"- \*\*(.+?)\*\*", sub).group(1)
+                        i += 1
+                        sub_body: List[str] = []
+                        while i < len(lines) and (lines[i].startswith("  -") or not lines[i].strip()):
+                            content = lines[i].strip()
+                            if content:
+                                sub_body.append(content[2:])
+                            i += 1
+                        tasks.append({"title": sub_title, "body": "\n".join(sub_body).strip()})
+                    else:
+                        i += 1
+            else:
+                i += 1
+                body: List[str] = []
+                while i < len(lines) and not lines[i].startswith("## "):
+                    if lines[i].strip():
+                        body.append(lines[i].strip())
+                    i += 1
+                tasks.append({"title": title, "body": "\n".join(body).strip()})
+        else:
+            i += 1
+    return tasks
+
+
+def create_issue(repo: str, token: str, title: str, body: str,
+                 labels: List[str], milestone: int | None, dry_run: bool) -> None:
+    """Create a GitHub issue via REST API."""
+    if dry_run:
+        print(f"[DRY-RUN] {title}\n{body}\n")
+        return
+    url = f"https://api.github.com/repos/{repo}/issues"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    payload: Dict[str, object] = {"title": title, "body": body, "labels": labels}
+    if milestone is not None:
+        payload["milestone"] = milestone
+    data = json.dumps(payload).encode("utf-8")
+    req = urlrequest.Request(url, data=data, headers=headers, method="POST")
+    with urlrequest.urlopen(req, timeout=10) as resp:
+        issue = json.load(resp)
+    print(f"Created issue #{issue['number']}: {title}")
+
+
+def get_milestone_number(repo: str, token: str, milestone: str) -> int | None:
+    """Retrieve milestone number by name."""
+    url = f"https://api.github.com/repos/{repo}/milestones"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    req = urlrequest.Request(url, headers=headers)
+    with urlrequest.urlopen(req, timeout=10) as resp:
+        milestones = json.load(resp)
+    for ms in milestones:
+        if ms["title"] == milestone:
+            return ms["number"]
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create GitHub issues from TASKS.md")
+    parser.add_argument("--repo", required=True, help="GitHub repo in 'owner/repo' format")
+    parser.add_argument("--token", default=os.getenv("GITHUB_TOKEN"),
+                        help="GitHub personal access token")
+    parser.add_argument("--label", action="append", default=["task"],
+                        help="Label to apply to created issues")
+    parser.add_argument("--milestone", help="Milestone name to assign to issues")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print issues without creating them")
+    args = parser.parse_args()
+
+    if not args.token and not args.dry_run:
+        parser.error("GitHub token required unless using --dry-run")
+
+    milestone_number = None
+    if args.milestone and not args.dry_run:
+        milestone_number = get_milestone_number(args.repo, args.token, args.milestone)
+        if milestone_number is None:
+            parser.error(f"Milestone '{args.milestone}' not found")
+
+    for task in parse_tasks(TASKS_PATH):
+        create_issue(
+            repo=args.repo,
+            token=args.token,
+            title=task["title"],
+            body=task["body"],
+            labels=args.label,
+            milestone=milestone_number,
+            dry_run=args.dry_run,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add issue_migrator utility to push tasks into labeled GitHub issues and optional milestones
- archive task history in favor of auto-generated changelog
- document issue-based workflow in TASKS guide

## Testing
- `flake8`
- `pytest`
- `python tools/issue_migrator.py --repo placeholder/repo --dry-run | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b35d7af1048326970bc1bac7de0eeb