### PR TITLE
fix: ensure ALLOWED_HOSTS defaults use strings

### DIFF
--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -44,10 +44,7 @@ ALLOWED_HOSTS = env.list(
         "localhost",
         "testserver",
         "127.0.0.1",
-        (
-            "curly-space-sniffle-"
-            "pjxw7ww6r76frgp-8000.app.github.dev"
-        ),
+        "curly-space-sniffle-pjxw7ww6r76frgp-8000.app.github.dev",
     ],
 )
 


### PR DESCRIPTION
## Summary
- simplify ALLOWED_HOSTS default by replacing tuple entry with a single string

## Testing
- `flake8 inventory_app/settings.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b361c9cfcc8326abfed94a96685860