### PR TITLE
Enforce DJANGO_SECRET_KEY configuration in production

### DIFF
--- a/docs/deployment/RENDER_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/RENDER_DEPLOYMENT_GUIDE.md
@@ -14,12 +14,12 @@ In your Render service dashboard, add these environment variables:
 DJANGO_SETTINGS_MODULE=inventory_app.settings_production
 DEBUG=False
 DJANGO_ALLOWED_HOSTS=<RENDER_DOMAIN>
+DJANGO_SECRET_KEY=<DJANGO_SECRET_KEY>
 ```
 
 #### **Security Variables:**
 
 ```bash
-DJANGO_SECRET_KEY=<DJANGO_SECRET_KEY>
 DJANGO_SECURE_SSL_REDIRECT=True
 DJANGO_SECURE_HSTS_SECONDS=31536000
 DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS=True

--- a/inventory_app/settings.py
+++ b/inventory_app/settings.py
@@ -14,6 +14,8 @@ import os
 from pathlib import Path
 
 import environ
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management.utils import get_random_secret_key
 
 from .logging import configure_logging
 
@@ -31,12 +33,16 @@ configure_logging()
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = env("DJANGO_SECRET_KEY", default="dev-secret-key")
-
 # SECURITY WARNING: don't run with debug turned on in production!
-# Enabled temporarily for debugging
-DEBUG = env.bool("DJANGO_DEBUG", default=False)
+DEBUG = env.bool("DJANGO_DEBUG", default=False)  # Controlled via environment
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = env("DJANGO_SECRET_KEY", default=None)
+if not SECRET_KEY:
+    if DEBUG:
+        SECRET_KEY = get_random_secret_key()
+    else:
+        raise ImproperlyConfigured("DJANGO_SECRET_KEY must be set in production")
 
 ALLOWED_HOSTS = env.list(
     "DJANGO_ALLOWED_HOSTS",


### PR DESCRIPTION
## Summary
- Require `DJANGO_SECRET_KEY` environment variable and raise error if missing when `DEBUG` is false
- Clarify `DJANGO_DEBUG` behavior in settings
- Document `DJANGO_SECRET_KEY` as a required variable for deployment

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b36465c9308326b9d914d64e62a53b