### PR TITLE
feat(api): add pagination and filtering

### DIFF
--- a/inventory/views/api.py
+++ b/inventory/views/api.py
@@ -1,4 +1,6 @@
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import permissions, viewsets
+from rest_framework.pagination import PageNumberPagination
 
 from ..models import (
     GoodsReceivedNote,
@@ -30,6 +32,14 @@ from ..serializers import (
 )
 
 
+class DefaultPagination(PageNumberPagination):
+    """Standard pagination settings for API viewsets."""
+
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+
 class ItemViewSet(viewsets.ModelViewSet):
     """API endpoint for CRUD operations on items.
 
@@ -40,13 +50,9 @@ class ItemViewSet(viewsets.ModelViewSet):
     queryset = Item.objects.all()
     serializer_class = ItemSerializer
     permission_classes = [permissions.IsAuthenticated]
-
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        name = self.request.query_params.get("name")
-        if name:
-            queryset = queryset.filter(name__icontains=name)
-        return queryset
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {"name": ["exact", "icontains"]}
 
 
 class SupplierViewSet(viewsets.ModelViewSet):
@@ -55,6 +61,9 @@ class SupplierViewSet(viewsets.ModelViewSet):
     queryset = Supplier.objects.all()
     serializer_class = SupplierSerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = "__all__"
 
 
 class StockTransactionViewSet(viewsets.ModelViewSet):
@@ -63,6 +72,9 @@ class StockTransactionViewSet(viewsets.ModelViewSet):
     queryset = StockTransaction.objects.all().select_related("item")
     serializer_class = StockTransactionSerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = "__all__"
 
 
 class IndentViewSet(viewsets.ModelViewSet):
@@ -76,16 +88,9 @@ class IndentViewSet(viewsets.ModelViewSet):
     queryset = Indent.objects.all()
     serializer_class = IndentSerializer
     permission_classes = [permissions.IsAuthenticated]
-
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        mrn = self.request.query_params.get("mrn")
-        status = self.request.query_params.get("status")
-        if mrn:
-            queryset = queryset.filter(mrn__icontains=mrn)
-        if status:
-            queryset = queryset.filter(status=status)
-        return queryset
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {"mrn": ["icontains"], "status": ["exact"]}
 
 
 class IndentItemViewSet(viewsets.ModelViewSet):
@@ -94,6 +99,9 @@ class IndentItemViewSet(viewsets.ModelViewSet):
     queryset = IndentItem.objects.all().select_related("indent", "item")
     serializer_class = IndentItemSerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = "__all__"
 
 
 class PurchaseOrderViewSet(viewsets.ModelViewSet):
@@ -102,6 +110,9 @@ class PurchaseOrderViewSet(viewsets.ModelViewSet):
     queryset = PurchaseOrder.objects.all().select_related("supplier")
     serializer_class = PurchaseOrderSerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = "__all__"
 
 
 class PurchaseOrderItemViewSet(viewsets.ModelViewSet):
@@ -110,6 +121,9 @@ class PurchaseOrderItemViewSet(viewsets.ModelViewSet):
     queryset = PurchaseOrderItem.objects.all().select_related("purchase_order", "item")
     serializer_class = PurchaseOrderItemSerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = "__all__"
 
 
 class GoodsReceivedNoteViewSet(viewsets.ModelViewSet):
@@ -120,6 +134,9 @@ class GoodsReceivedNoteViewSet(viewsets.ModelViewSet):
     )
     serializer_class = GoodsReceivedNoteSerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = "__all__"
 
 
 class GRNItemViewSet(viewsets.ModelViewSet):
@@ -128,6 +145,9 @@ class GRNItemViewSet(viewsets.ModelViewSet):
     queryset = GRNItem.objects.all().select_related("grn", "po_item")
     serializer_class = GRNItemSerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = "__all__"
 
 
 class RecipeViewSet(viewsets.ModelViewSet):
@@ -136,6 +156,9 @@ class RecipeViewSet(viewsets.ModelViewSet):
     queryset = Recipe.objects.all()
     serializer_class = RecipeSerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = "__all__"
 
 
 class RecipeComponentViewSet(viewsets.ModelViewSet):
@@ -144,6 +167,9 @@ class RecipeComponentViewSet(viewsets.ModelViewSet):
     queryset = RecipeComponent.objects.all().select_related("parent_recipe")
     serializer_class = RecipeComponentSerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = "__all__"
 
 
 class SaleTransactionViewSet(viewsets.ModelViewSet):
@@ -152,3 +178,6 @@ class SaleTransactionViewSet(viewsets.ModelViewSet):
     queryset = SaleTransaction.objects.all().select_related("recipe")
     serializer_class = SaleTransactionSerializer
     permission_classes = [permissions.IsAuthenticated]
+    pagination_class = DefaultPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = "__all__"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Django==5.2.5
 djangorestframework==3.16.1
+django-filter==24.2
 django-environ==0.12.0
 dj-database-url==2.1.0
 whitenoise==6.9.0

--- a/tests/test_api_pagination_filtering.py
+++ b/tests/test_api_pagination_filtering.py
@@ -1,0 +1,18 @@
+def test_item_pagination(client, item_factory):
+    for i in range(11):
+        item_factory(name=f"Item {i}")
+    response = client.get("/api/items/?page=2&page_size=5")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 11
+    assert len(data["results"]) == 5
+
+
+def test_item_filtering(client, item_factory):
+    item_factory(name="Sugar")
+    item_factory(name="Salt")
+    response = client.get("/api/items/?name__icontains=sug")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["count"] == 1
+    assert data["results"][0]["name"] == "Sugar"


### PR DESCRIPTION
## Summary
- add PageNumberPagination and DjangoFilterBackend to inventory API viewsets
- expose filterset fields and consistent pagination across all viewsets
- test API pagination and filtering logic

## Testing
- `ruff check inventory/views/api.py tests/test_api_pagination_filtering.py`
- `DJANGO_SECRET_KEY=test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b366f567688326bb289ffb26df9007