### PR TITLE
Prefetch departments to speed item queries

### DIFF
--- a/inventory/models/items.py
+++ b/inventory/models/items.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.db import models
+from django.utils.functional import cached_property
 
 from .fields import CoerceFloatField
 
@@ -85,10 +86,15 @@ class Item(models.Model):
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return self.name or f"Item {self.pk}"
 
-    @property
+    @cached_property
     def department_names(self):
-        """Return a comma-separated string of department names."""
-        return ", ".join(self.departments.values_list('name', flat=True))
+        """Return a comma-separated string of department names.
+
+        Cached per instance to avoid recomputing the joined list when accessed
+        multiple times. Prefetching ``departments`` ensures this does not hit
+        the database repeatedly.
+        """
+        return ", ".join(dept.name for dept in self.departments.all())
 
     class Meta:
         managed = True

--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -40,7 +40,10 @@ class ItemSerializer(serializers.ModelSerializer):
 
     def get_departments(self, obj):
         """Return department IDs and names."""
-        return list(obj.departments.values('department_id', 'name'))
+        return [
+            {"department_id": dept.department_id, "name": dept.name}
+            for dept in obj.departments.all()
+        ]
 
     def get_department_names(self, obj):
         """Return comma-separated department names."""

--- a/inventory/services/item_service.py
+++ b/inventory/services/item_service.py
@@ -350,45 +350,39 @@ def reactivate_item(item_id: int) -> Tuple[bool, str]:
 def get_item_details(item_id: int) -> Optional[Dict[str, Any]]:
     """Return the details for a single item."""
 
-    row = (
+    item = (
         Item.objects.filter(pk=item_id)
+        .prefetch_related("departments")
         .annotate(
             _stock=Coalesce(Sum("stocktransaction__quantity_change"), Decimal("0"))
         )
-        .values(
-            "item_id",
-            "name",
-            "unit_id",
-            "category_id",
-            "category",
-            "sub_category",
-            "base_unit",
-            "purchase_unit",
-            "initial_purchase_price",
-            "minimum_order_qty",
-            "lead_time_days",
-            "reorder_point",
-            "current_stock",
-            "notes",
-            "is_active",
-            "_stock",
-        )
         .first()
     )
-    if row:
-        row["unit"] = get_unit_display_name(row["unit_id"])
-        row["current_stock"] = row.pop("_stock")
+    if not item:
+        return None
 
-        # Add department information
-        try:
-            item = Item.objects.get(pk=item_id)
-            row["departments"] = list(item.departments.values_list('name', flat=True))
-            row["department_names"] = (
-                ", ".join(row["departments"]) if row["departments"] else "None"
-            )
-        except Item.DoesNotExist:
-            row["departments"] = []
-            row["department_names"] = "None"
+    row = {
+        "item_id": item.item_id,
+        "name": item.name,
+        "unit_id": item.unit_id,
+        "category_id": item.category_id,
+        "category": item.category,
+        "sub_category": item.sub_category,
+        "base_unit": item.base_unit,
+        "purchase_unit": item.purchase_unit,
+        "initial_purchase_price": item.initial_purchase_price,
+        "minimum_order_qty": item.minimum_order_qty,
+        "lead_time_days": item.lead_time_days,
+        "reorder_point": item.reorder_point,
+        "current_stock": item._stock,
+        "notes": item.notes,
+        "is_active": item.is_active,
+    }
 
-        return row
-    return None
+    row["unit"] = get_unit_display_name(item.unit_id)
+
+    departments = [dept.name for dept in item.departments.all()]
+    row["departments"] = departments
+    row["department_names"] = ", ".join(departments) if departments else "None"
+
+    return row

--- a/inventory/views/api.py
+++ b/inventory/views/api.py
@@ -47,7 +47,7 @@ class ItemViewSet(viewsets.ModelViewSet):
         name: optional substring to filter item names.
     """
 
-    queryset = Item.objects.all()
+    queryset = Item.objects.all().prefetch_related("departments")
     serializer_class = ItemSerializer
     permission_classes = [permissions.IsAuthenticated]
     pagination_class = DefaultPagination

--- a/tests/test_department_prefetch.py
+++ b/tests/test_department_prefetch.py
@@ -1,0 +1,32 @@
+import pytest
+
+from inventory.models import Department
+from inventory.services import item_service
+
+
+@pytest.mark.django_db
+def test_item_viewset_prefetch_departments(client, item_factory, django_assert_num_queries):
+    dept = Department.objects.create(name="Kitchen")
+    item1 = item_factory(name="Item1")
+    item2 = item_factory(name="Item2")
+    item1.departments.add(dept)
+    item2.departments.add(dept)
+
+    with django_assert_num_queries(4):
+        response = client.get("/api/items/")
+    assert response.status_code == 200
+    data = response.json()
+    assert {r["department_names"] for r in data["results"]} == {"Kitchen"}
+
+
+@pytest.mark.django_db
+def test_get_item_details_prefetch(item_factory, django_assert_num_queries, monkeypatch):
+    item = item_factory(name="Item1")
+    dept = Department.objects.create(name="Kitchen")
+    item.departments.add(dept)
+
+    monkeypatch.setattr(item_service, "get_unit_display_name", lambda unit_id: "KG")
+
+    with django_assert_num_queries(2):
+        details = item_service.get_item_details(item.item_id)
+    assert details["department_names"] == "Kitchen"


### PR DESCRIPTION
## Summary
- prefetch Item.departments in API and service layer
- cache and reuse department names on Item model
- add performance tests ensuring department prefetching uses minimal queries

## Testing
- `ruff check inventory/models/items.py inventory/serializers.py inventory/services/item_service.py inventory/views/api.py tests/test_department_prefetch.py`
- `export $(grep -v '^#' .env.test | xargs) && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3fdb5a3348326807fc90ec827ff7b