### PR TITLE
Use DJANGO_ENV for Render deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor: split item views into list, detail, and stock modules and converted helper views to class-based implementations
 - KPI sections in items and purchase orders now render via the shared card component
 - Top navigation logo now routes to the home page instead of the dashboard
+- Render deployment now relies on `DJANGO_ENV=production` instead of `DJANGO_SETTINGS_MODULE`
 
 ## [2.1.0] - 2025-08-28
 

--- a/README.md
+++ b/README.md
@@ -198,3 +198,7 @@ The application exposes the following REST endpoints under `/api/`:
 - `/api/goods-received-notes/` – log received goods.
 - `/api/grn-items/` – items contained in a goods received note.
 
+## Deployment
+
+Settings are determined by the `DJANGO_ENV` environment variable. For production deployments (e.g., on Render) set `DJANGO_ENV=production`. The `DJANGO_SETTINGS_MODULE` variable is no longer required.
+

--- a/docs/deployment/FINAL_DEPLOYMENT_STATUS.md
+++ b/docs/deployment/FINAL_DEPLOYMENT_STATUS.md
@@ -136,7 +136,7 @@ DATABASE_URL=postgresql://<DB_USER>:<DB_PASSWORD>@<DB_HOST>:<DB_PORT>/<DB_NAME>?
 DJANGO_SECRET_KEY=<DJANGO_SECRET_KEY>
 DJANGO_DEBUG=False
 DJANGO_ALLOWED_HOSTS=<RENDER_DOMAIN>
-DJANGO_SETTINGS_MODULE=inventory_app.settings_production
+DJANGO_ENV=production
 ```
 
 ### **2. Build Process** (Automated via render.yaml)

--- a/docs/deployment/LOGIN_ISSUE_RESOLUTION.md
+++ b/docs/deployment/LOGIN_ISSUE_RESOLUTION.md
@@ -169,7 +169,7 @@ python manage.py createsuperuser
 ### **Option 3: Check Environment Variables**
 Verify these are set in Render dashboard:
 - `DJANGO_SUPERUSER_PASSWORD=YourSecurePassword123!`
-- `DJANGO_SETTINGS_MODULE=inventory_app.settings_production`
+- `DJANGO_ENV=production`
 
 ---
 

--- a/docs/deployment/RENDER_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/RENDER_DEPLOYMENT_GUIDE.md
@@ -11,7 +11,7 @@ In your Render service dashboard, add these environment variables:
 #### **Required Variables:**
 
 ```bash
-DJANGO_SETTINGS_MODULE=inventory_app.settings_production
+DJANGO_ENV=production
 DEBUG=False
 DJANGO_ALLOWED_HOSTS=<RENDER_DOMAIN>
 DJANGO_SECRET_KEY=<DJANGO_SECRET_KEY>

--- a/docs/deployment/RENDER_ENV_SETUP_GUIDE.md
+++ b/docs/deployment/RENDER_ENV_SETUP_GUIDE.md
@@ -18,8 +18,8 @@ Copy and paste each variable exactly as shown:
 
 #### **🔧 CORE CONFIGURATION**
 ```
-Key: DJANGO_SETTINGS_MODULE
-Value: inventory_app.settings_production
+Key: DJANGO_ENV
+Value: production
 
 Key: DEBUG
 Value: False
@@ -121,7 +121,7 @@ If you have these variables, **DELETE** them:
 For faster setup, here's a format you can copy section by section:
 
 ```bash
-DJANGO_SETTINGS_MODULE=inventory_app.settings_production
+DJANGO_ENV=production
 DEBUG=False
 DATABASE_URL=postgresql://<DB_USER>:<DB_PASSWORD>@<DB_HOST>:5432/<DB_NAME>
 DJANGO_ALLOWED_HOSTS=.onrender.com,localhost,127.0.0.1

--- a/docs/deployment/RENDER_SECURITY_GUIDE.md
+++ b/docs/deployment/RENDER_SECURITY_GUIDE.md
@@ -21,7 +21,7 @@
 #### **🔧 CORE SETTINGS**
 
 ```
-DJANGO_SETTINGS_MODULE=inventory_app.settings_production
+DJANGO_ENV=production
 DEBUG=False
 ```
 

--- a/render.yaml
+++ b/render.yaml
@@ -30,8 +30,8 @@ services:
       --error-logfile - 
       inventory_app.wsgi:application
     envVars:
-      - key: DJANGO_SETTINGS_MODULE
-        value: inventory_app.settings_production
+      - key: DJANGO_ENV
+        value: production
       - key: DEBUG
         value: False
       - key: DJANGO_SECURE_SSL_REDIRECT


### PR DESCRIPTION
## Summary
- remove legacy `DJANGO_SETTINGS_MODULE` from Render config
- document `DJANGO_ENV=production` for deployments
- note environment change in changelog

## Testing
- `DJANGO_ENV=production DJANGO_SECRET_KEY=test python manage.py collectstatic --noinput`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b40793f42c8326bb7c19ed309f33b5