### PR TITLE
refactor: centralize environment templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,11 @@
 .env.render*
 *env.txt
 *ENV*.txt
+env/*.local
 
 # Python virtual environment
 venv/
 .venv/
-env/
 
 # Python cache files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ python manage.py collectstatic --noinput
 
 ## Configuration
 
-Configuration is controlled via environment variables. Copy `.env.example` to `.env` and set values for your database and other settings:
+Configuration is controlled via environment variables. Template files live in the `env/` directory. Copy `env/dev.example` to `.env` for local development and set values for your database and other settings:
 
 ```bash
-cp .env.example .env
+cp env/dev.example .env
 # edit .env with your configuration
 ```
 
-You can also set these values directly in the environment instead of using a `.env` file.
+You can also set these values directly in the environment instead of using a `.env` file. For staging and production deployments, copy the appropriate template (e.g., `env/staging.example` or `env/production.example`) to a matching `env/*.local` file which is excluded from version control.
 
 Set `DJANGO_DEBUG` to `True` to enable Django's debug mode (defaults to `False`).
 
@@ -118,7 +118,7 @@ Docker Compose. It sets up three services:
 ### Setup
 
 1. Ensure Docker and Docker Compose are installed.
-2. Copy `.env.example` to `.env` and provide values, including a
+2. Copy `env/dev.example` to `.env` and provide values, including a
    `DATABASE_URL` that points to the `db` service and credentials for the
    Postgres container:
 
@@ -201,4 +201,3 @@ The application exposes the following REST endpoints under `/api/`:
 ## Deployment
 
 Settings are determined by the `DJANGO_ENV` environment variable. For production deployments (e.g., on Render) set `DJANGO_ENV=production`. The `DJANGO_SETTINGS_MODULE` variable is no longer required.
-

--- a/deploy-production.sh
+++ b/deploy-production.sh
@@ -8,7 +8,7 @@ echo "🚀 Starting Production Deployment..."
 echo "====================================="
 
 # Configuration
-PRODUCTION_ENV_FILE=".env.production"
+PRODUCTION_ENV_FILE="env/production.local"
 DOCKER_COMPOSE_FILE="docker-compose.production.yml"
 BACKUP_DIR="backups/production/$(date +%Y%m%d-%H%M%S)"
 LOG_FILE="/var/log/inventory-deployment.log"
@@ -50,27 +50,27 @@ highlight() {
 # Pre-deployment checks
 pre_deployment_checks() {
     log "Running pre-deployment checks..."
-    
+
     # Check if running as root
     if [[ $EUID -eq 0 ]]; then
         warning "Running as root. Consider using a non-root user for security."
     fi
-    
+
     # Check if Docker is running
     if ! docker info > /dev/null 2>&1; then
         error "Docker is not running. Please start Docker and try again."
     fi
-    
+
     # Check if docker-compose is available
     if ! command -v docker-compose &> /dev/null; then
         error "docker-compose is not installed. Please install it and try again."
     fi
-    
+
     # Check if production environment file exists
     if [[ ! -f "$PRODUCTION_ENV_FILE" ]]; then
-        error "Production environment file not found. Please create $PRODUCTION_ENV_FILE from template."
+        error "Production environment file not found. Please create $PRODUCTION_ENV_FILE from env/production.example."
     fi
-    
+
     # Check critical environment variables
     source "$PRODUCTION_ENV_FILE"
     critical_vars=("DJANGO_SECRET_KEY" "DATABASE_URL" "DJANGO_ALLOWED_HOSTS")
@@ -79,7 +79,7 @@ pre_deployment_checks() {
             error "Critical environment variable $var is not set in $PRODUCTION_ENV_FILE"
         fi
     done
-    
+
     # Check SSL certificates
     if [[ ! -f "ssl/cert.pem" ]] || [[ ! -f "ssl/key.pem" ]]; then
         warning "SSL certificates not found. HTTPS will not work."
@@ -90,54 +90,54 @@ pre_deployment_checks() {
             error "SSL certificates required for production deployment."
         fi
     fi
-    
+
     # Check disk space
     available_space=$(df / | awk 'NR==2 {print $4}')
     if [[ $available_space -lt 5000000 ]]; then  # Less than 5GB
         warning "Low disk space available: $(($available_space/1000))MB"
     fi
-    
+
     success "Pre-deployment checks completed"
 }
 
 # Security validation
 security_validation() {
     log "Running security validation..."
-    
+
     # Check if DEBUG is disabled
     if grep -q "DEBUG=True" "$PRODUCTION_ENV_FILE"; then
         error "DEBUG=True found in production environment. This is a security risk."
     fi
-    
+
     # Check secret key strength
     secret_key=$(grep "DJANGO_SECRET_KEY=" "$PRODUCTION_ENV_FILE" | cut -d'=' -f2)
     if [[ ${#secret_key} -lt 50 ]]; then
         warning "Django secret key appears to be short. Consider using a longer, more secure key."
     fi
-    
+
     # Check allowed hosts
     allowed_hosts=$(grep "DJANGO_ALLOWED_HOSTS=" "$PRODUCTION_ENV_FILE" | cut -d'=' -f2)
     if [[ "$allowed_hosts" == *"localhost"* ]] || [[ "$allowed_hosts" == *"127.0.0.1"* ]]; then
         warning "localhost/127.0.0.1 found in ALLOWED_HOSTS. Remove for production."
     fi
-    
+
     success "Security validation completed"
 }
 
 # Run comprehensive tests
 run_production_tests() {
     log "Running production readiness tests..."
-    
+
     # Set production test environment
     export DJANGO_SETTINGS_MODULE=inventory_app.settings_production
-    
+
     # Run Django system checks
     if python manage.py check --settings=inventory_app.settings_production --deploy; then
         success "Django production checks passed"
     else
         error "Django production checks failed. Fix issues before deployment."
     fi
-    
+
     # Run tests with production settings
     log "Running test suite with production settings..."
     if python manage.py test --settings=inventory_app.settings_production --verbosity=1; then
@@ -145,77 +145,77 @@ run_production_tests() {
     else
         error "Tests failed with production settings. Deployment aborted."
     fi
-    
+
     success "Production tests completed"
 }
 
 # Create comprehensive backup
 create_backup() {
     log "Creating production backup..."
-    
+
     mkdir -p "$BACKUP_DIR"
-    
+
     # Backup existing database if running
     if docker-compose -f "$DOCKER_COMPOSE_FILE" ps db | grep -q "Up"; then
         log "Backing up production database..."
         docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T db pg_dump -U inventory_user inventory_production > "$BACKUP_DIR/database.sql"
         success "Database backup created"
     fi
-    
+
     # Backup static files
     if [[ -d "staticfiles" ]]; then
         log "Backing up static files..."
         tar -czf "$BACKUP_DIR/staticfiles.tar.gz" staticfiles/
         success "Static files backup created"
     fi
-    
+
     # Backup media files
     if [[ -d "media" ]]; then
         log "Backing up media files..."
         tar -czf "$BACKUP_DIR/media.tar.gz" media/
         success "Media files backup created"
     fi
-    
+
     # Backup configuration
     log "Backing up configuration files..."
     cp "$PRODUCTION_ENV_FILE" "$BACKUP_DIR/"
     cp nginx/production.conf "$BACKUP_DIR/"
     cp "$DOCKER_COMPOSE_FILE" "$BACKUP_DIR/"
-    
+
     success "Comprehensive backup created in $BACKUP_DIR"
 }
 
 # Deploy to production
 deploy() {
     log "Deploying to production environment..."
-    
+
     # Pull latest images
     log "Pulling latest base images..."
     docker-compose -f "$DOCKER_COMPOSE_FILE" pull db redis nginx monitoring
-    
+
     # Build production application image
     log "Building production application image..."
     docker-compose -f "$DOCKER_COMPOSE_FILE" build web
-    
+
     # Stop existing containers gracefully
     log "Stopping existing containers..."
     docker-compose -f "$DOCKER_COMPOSE_FILE" down --remove-orphans
-    
+
     # Start production services
     log "Starting production services..."
     docker-compose -f "$DOCKER_COMPOSE_FILE" up -d
-    
+
     success "Production services started"
 }
 
 # Health checks and validation
 health_checks() {
     log "Performing comprehensive health checks..."
-    
+
     # Wait for services to start
     log "Waiting for services to initialize..."
     sleep 60
-    
+
     # Check service status
     services=("web" "db" "redis" "nginx")
     for service in "${services[@]}"; do
@@ -225,7 +225,7 @@ health_checks() {
             error "$service container failed to start"
         fi
     done
-    
+
     # Check database connectivity
     log "Checking database connectivity..."
     if docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T web python manage.py shell -c "
@@ -238,7 +238,7 @@ print('Database connection: OK')
     else
         error "Database connection failed"
     fi
-    
+
     # Check Redis connectivity
     log "Checking Redis connectivity..."
     if docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T redis redis-cli ping | grep -q "PONG"; then
@@ -246,12 +246,12 @@ print('Database connection: OK')
     else
         warning "Redis connection failed"
     fi
-    
+
     # Check HTTPS endpoint
     log "Checking HTTPS endpoint..."
     max_attempts=20
     attempt=1
-    
+
     while [[ $attempt -le $max_attempts ]]; do
         if curl -k -f -s https://localhost/healthz > /dev/null; then
             success "HTTPS endpoint responding"
@@ -262,11 +262,11 @@ print('Database connection: OK')
             ((attempt++))
         fi
     done
-    
+
     if [[ $attempt -gt $max_attempts ]]; then
         error "HTTPS endpoint not responding after $max_attempts attempts"
     fi
-    
+
     # Run production validation script
     log "Running production validation script..."
     if docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T web python staging_validation.py; then
@@ -279,7 +279,7 @@ print('Database connection: OK')
 # Performance testing
 performance_tests() {
     log "Running performance tests..."
-    
+
     # Basic load test if Apache Bench is available
     if command -v ab &> /dev/null; then
         log "Running basic load test..."
@@ -293,7 +293,7 @@ performance_tests() {
 # Setup monitoring
 setup_monitoring() {
     log "Setting up monitoring and alerting..."
-    
+
     # Check if monitoring container is running
     if docker-compose -f "$DOCKER_COMPOSE_FILE" ps monitoring | grep -q "Up"; then
         success "Monitoring service is running"
@@ -301,7 +301,7 @@ setup_monitoring() {
     else
         warning "Monitoring service not running"
     fi
-    
+
     # Setup log rotation
     if command -v logrotate &> /dev/null; then
         log "Setting up log rotation..."
@@ -325,17 +325,17 @@ EOF
 # Cleanup old resources
 cleanup() {
     log "Cleaning up old resources..."
-    
+
     # Remove unused Docker images
     docker image prune -f
-    
+
     # Remove old backup files (keep last 10)
     if [[ -d "backups/production" ]]; then
         cd backups/production
         ls -t | tail -n +11 | xargs -r rm -rf
         cd ../..
     fi
-    
+
     success "Cleanup completed"
 }
 
@@ -378,10 +378,10 @@ rollback() {
     error_msg="$1"
     warning "Production deployment failed: $error_msg"
     log "Starting emergency rollback procedure..."
-    
+
     # Stop current deployment
     docker-compose -f "$DOCKER_COMPOSE_FILE" down
-    
+
     # Restore from backup if available
     if [[ -d "$BACKUP_DIR" && -f "$BACKUP_DIR/database.sql" ]]; then
         log "Restoring database from backup..."
@@ -389,7 +389,7 @@ rollback() {
         sleep 30
         docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T db psql -U inventory_user -d inventory_production < "$BACKUP_DIR/database.sql"
     fi
-    
+
     error "Emergency rollback completed. Please investigate issues and retry deployment."
 }
 
@@ -397,7 +397,7 @@ rollback() {
 main() {
     # Trap errors and rollback
     trap 'rollback "Unexpected error occurred"' ERR
-    
+
     highlight "🚀 PRODUCTION DEPLOYMENT STARTING"
     echo "This will deploy the application to PRODUCTION environment."
     echo "Ensure you have:"
@@ -407,12 +407,12 @@ main() {
     echo ""
     echo "Continue with production deployment? (y/N)"
     read -r confirm_deployment
-    
+
     if [[ ! "$confirm_deployment" =~ ^[Yy]$ ]]; then
         echo "Deployment cancelled by user."
         exit 0
     fi
-    
+
     pre_deployment_checks
     security_validation
     run_production_tests
@@ -423,7 +423,7 @@ main() {
     setup_monitoring
     cleanup
     show_deployment_info
-    
+
     # Remove error trap on successful completion
     trap - ERR
 }

--- a/deploy-staging.sh
+++ b/deploy-staging.sh
@@ -8,7 +8,7 @@ echo "🚀 Starting Staging Deployment..."
 echo "=================================="
 
 # Configuration
-STAGING_ENV_FILE=".env.staging"
+STAGING_ENV_FILE="env/staging.local"
 DOCKER_COMPOSE_FILE="docker-compose.staging.yml"
 BACKUP_DIR="backups/$(date +%Y%m%d-%H%M%S)"
 
@@ -40,22 +40,22 @@ error() {
 # Check prerequisites
 check_prerequisites() {
     log "Checking prerequisites..."
-    
+
     # Check if Docker is running
     if ! docker info > /dev/null 2>&1; then
         error "Docker is not running. Please start Docker and try again."
     fi
-    
+
     # Check if docker-compose is available
     if ! command -v docker-compose &> /dev/null; then
         error "docker-compose is not installed. Please install it and try again."
     fi
-    
+
     # Check if staging environment file exists
     if [[ ! -f "$STAGING_ENV_FILE" ]]; then
         warning "Staging environment file not found. Creating from template..."
-        if [[ -f ".env.staging.example" ]]; then
-            cp .env.staging.example "$STAGING_ENV_FILE"
+        if [[ -f "env/staging.example" ]]; then
+            cp env/staging.example "$STAGING_ENV_FILE"
             warning "Please edit $STAGING_ENV_FILE with your staging configuration."
             echo "Press Enter when ready to continue..."
             read
@@ -63,17 +63,17 @@ check_prerequisites() {
             error "No staging environment template found."
         fi
     fi
-    
+
     success "Prerequisites check passed"
 }
 
 # Run tests
 run_tests() {
     log "Running tests before deployment..."
-    
+
     # Set test environment
     export DJANGO_SETTINGS_MODULE=inventory_app.settings
-    
+
     # Run tests
     if python manage.py test --verbosity=2; then
         success "All tests passed"
@@ -85,64 +85,64 @@ run_tests() {
 # Create backup
 create_backup() {
     log "Creating backup..."
-    
+
     mkdir -p "$BACKUP_DIR"
-    
+
     # Backup database if it exists
     if docker-compose -f "$DOCKER_COMPOSE_FILE" ps db | grep -q "Up"; then
         log "Backing up database..."
         docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T db pg_dump -U staging_user staging_inventory > "$BACKUP_DIR/database.sql"
         success "Database backup created"
     fi
-    
+
     # Backup static files if they exist
     if [[ -d "staticfiles" ]]; then
         log "Backing up static files..."
         tar -czf "$BACKUP_DIR/staticfiles.tar.gz" staticfiles/
         success "Static files backup created"
     fi
-    
+
     success "Backup created in $BACKUP_DIR"
 }
 
 # Build and deploy
 deploy() {
     log "Building and deploying application..."
-    
+
     # Pull latest images
     log "Pulling latest base images..."
     docker-compose -f "$DOCKER_COMPOSE_FILE" pull db redis nginx
-    
+
     # Build application image
     log "Building application image..."
     docker-compose -f "$DOCKER_COMPOSE_FILE" build web
-    
+
     # Stop existing containers
     log "Stopping existing containers..."
     docker-compose -f "$DOCKER_COMPOSE_FILE" down
-    
+
     # Start services
     log "Starting services..."
     docker-compose -f "$DOCKER_COMPOSE_FILE" up -d
-    
+
     success "Services started"
 }
 
 # Health checks
 health_checks() {
     log "Performing health checks..."
-    
+
     # Wait for services to start
     log "Waiting for services to initialize..."
     sleep 30
-    
+
     # Check if web container is running
     if docker-compose -f "$DOCKER_COMPOSE_FILE" ps web | grep -q "Up"; then
         success "Web container is running"
     else
         error "Web container failed to start"
     fi
-    
+
     # Check database connectivity
     log "Checking database connectivity..."
     if docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T web python manage.py shell -c "
@@ -155,12 +155,12 @@ print('Database connection: OK')
     else
         error "Database connection failed"
     fi
-    
+
     # Check health endpoint
     log "Checking health endpoint..."
     max_attempts=10
     attempt=1
-    
+
     while [[ $attempt -le $max_attempts ]]; do
         if curl -f -s http://localhost/healthz > /dev/null; then
             success "Health endpoint responding"
@@ -171,7 +171,7 @@ print('Database connection: OK')
             ((attempt++))
         fi
     done
-    
+
     if [[ $attempt -gt $max_attempts ]]; then
         error "Health endpoint not responding after $max_attempts attempts"
     fi
@@ -180,7 +180,7 @@ print('Database connection: OK')
 # Validation tests
 validation_tests() {
     log "Running validation tests..."
-    
+
     # Run critical tests in staging environment
     log "Running critical path tests..."
     docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T web python manage.py test \
@@ -188,24 +188,24 @@ validation_tests() {
         tests.test_recipe_service \
         tests.test_dashboard_service \
         --settings=inventory_app.settings_staging
-    
+
     success "Validation tests passed"
 }
 
 # Cleanup old resources
 cleanup() {
     log "Cleaning up old resources..."
-    
+
     # Remove unused Docker images
     docker image prune -f
-    
+
     # Remove old backup files (keep last 5)
     if [[ -d "backups" ]]; then
         cd backups
         ls -t | tail -n +6 | xargs -r rm -rf
         cd ..
     fi
-    
+
     success "Cleanup completed"
 }
 
@@ -243,10 +243,10 @@ rollback() {
     error_msg="$1"
     warning "Deployment failed: $error_msg"
     log "Starting rollback procedure..."
-    
+
     # Stop current deployment
     docker-compose -f "$DOCKER_COMPOSE_FILE" down
-    
+
     # Restore from backup if available
     if [[ -d "$BACKUP_DIR" && -f "$BACKUP_DIR/database.sql" ]]; then
         log "Restoring database from backup..."
@@ -254,7 +254,7 @@ rollback() {
         sleep 10
         docker-compose -f "$DOCKER_COMPOSE_FILE" exec -T db psql -U staging_user -d staging_inventory < "$BACKUP_DIR/database.sql"
     fi
-    
+
     error "Rollback completed. Please check the issues and try again."
 }
 
@@ -262,7 +262,7 @@ rollback() {
 main() {
     # Trap errors and rollback
     trap 'rollback "Unexpected error occurred"' ERR
-    
+
     check_prerequisites
     run_tests
     create_backup
@@ -271,7 +271,7 @@ main() {
     validation_tests
     cleanup
     show_info
-    
+
     # Remove error trap on successful completion
     trap - ERR
 }

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   web:
-    build: 
+    build:
       context: .
       dockerfile: Dockerfile.production
     command: >
@@ -25,7 +25,7 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=inventory_app.settings_production
     env_file:
-      - .env.production
+      - env/production.local
     depends_on:
       - db
       - redis
@@ -76,8 +76,8 @@ services:
   redis:
     image: redis:7-alpine
     command: >
-      redis-server 
-      --appendonly yes 
+      redis-server
+      --appendonly yes
       --requirepass ${REDIS_PASSWORD}
       --maxmemory 256mb
       --maxmemory-policy allkeys-lru

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=inventory_app.settings_staging
     env_file:
-      - .env.staging
+      - env/staging.local
     depends_on:
       - db
       - redis
@@ -41,7 +41,7 @@ services:
     volumes:
       - staging_postgres_data:/var/lib/postgresql/data
     env_file:
-      - .env.staging
+      - env/staging.local
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}

--- a/docs/deployment/PRODUCTION_READINESS_CHECKLIST.md
+++ b/docs/deployment/PRODUCTION_READINESS_CHECKLIST.md
@@ -158,7 +158,7 @@ ssl/key.pem     # Your private key
 
 ```bash
 # Copy template and configure
-cp .env.production.example .env.production
+cp env/production.example env/production.local
 
 # Required configurations:
 - DATABASE_URL=postgresql://<DB_USER>:<DB_PASSWORD>@<DB_HOST>:5432/<DB_NAME>

--- a/docs/deployment/RENDER_SECURITY_GUIDE.md
+++ b/docs/deployment/RENDER_SECURITY_GUIDE.md
@@ -10,8 +10,8 @@
 
 ### **Step 1: Use the Template**
 
-1. Copy `.env.render.template`
-2. Create a local `.env.render` file (already in `.gitignore`)
+1. Copy `env/production.example`
+2. Create a local `env/production.local` file (already in `.gitignore`)
 3. Replace all placeholder values with your real credentials
 
 ### **Step 2: Add to Render Dashboard Only**
@@ -74,7 +74,7 @@ SUPABASE_KEY=<SUPABASE_SERVICE_ROLE_KEY>
 ### **✅ DO:**
 
 - Add environment variables directly in Render dashboard
-- Use `.env.render.template` as a reference
+- Use `env/production.example` as a reference
 - Generate new secret keys for production
 - Keep credentials in secure password managers
 - Use different credentials for staging/production

--- a/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
+++ b/docs/deployment/STAGING_DEPLOYMENT_GUIDE.md
@@ -6,7 +6,7 @@
 
 ### 1. Staging Environment Variables
 
-Create a `.env.staging` file with:
+Copy `env/staging.example` to `env/staging.local` and update values:
 
 ```bash
 # Django Configuration
@@ -201,7 +201,7 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=inventory_app.settings_staging
     env_file:
-      - .env.staging
+      - env/staging.local
     depends_on:
       - db
       - redis
@@ -209,7 +209,7 @@ services:
   db:
     image: postgres:15
     env_file:
-      - .env.staging
+      - env/staging.local
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}

--- a/docs/deployment/STAGING_VALIDATION_REPORT.md
+++ b/docs/deployment/STAGING_VALIDATION_REPORT.md
@@ -2,9 +2,9 @@
 
 ## ✅ **STAGING DEPLOYMENT SUCCESSFUL!**
 
-**Date:** August 27, 2025  
-**Environment:** Staging  
-**Application URL:** https://curly-space-sniffle-pjxw7ww6r76frgp-8001.app.github.dev  
+**Date:** August 27, 2025
+**Environment:** Staging
+**Application URL:** https://curly-space-sniffle-pjxw7ww6r76frgp-8001.app.github.dev
 **Status:** 🟢 **LIVE AND OPERATIONAL**
 
 ---
@@ -13,7 +13,7 @@
 
 ### ✅ Infrastructure Setup
 - [x] Staging settings configuration (`inventory_app/settings_staging.py`)
-- [x] Environment variables setup (`.env.staging`)  
+- [x] Environment variables setup (`env/staging.local`)
 - [x] Docker configuration files created
 - [x] Nginx configuration for staging
 - [x] Health check endpoint `/healthz`

--- a/env/dev.example
+++ b/env/dev.example
@@ -1,4 +1,4 @@
-# NOTE: Do not commit live secrets. Replace placeholders with real values in your local environment.
+# NOTE: Do not commit live secrets. Copy to .env for local development and replace placeholders with real values.
 DJANGO_SECRET_KEY=<DEV_SECRET_KEY>
 DATABASE_URL=<DEV_DATABASE_URL>
 # For local runs, you can set DATABASE_URL=sqlite:///db.sqlite3

--- a/env/production.example
+++ b/env/production.example
@@ -1,5 +1,5 @@
 # Production Environment Configuration
-# NOTE: Do not commit live secrets. Replace placeholders before production deployment.
+# NOTE: Do not commit live secrets. Copy to env/production.local and replace placeholders before production deployment.
 
 # Django Core Configuration
 DJANGO_SECRET_KEY=<PRODUCTION_SECRET_KEY>

--- a/env/staging.example
+++ b/env/staging.example
@@ -1,5 +1,5 @@
 # Staging Environment Configuration
-# NOTE: Do not commit live secrets. Copy to .env.staging and replace placeholders with real values.
+# NOTE: Do not commit live secrets. Copy to env/staging.local and replace placeholders with real values.
 
 # Django Configuration
 DJANGO_SECRET_KEY=<STAGING_SECRET_KEY>

--- a/env/test.example
+++ b/env/test.example
@@ -1,5 +1,5 @@
-# .env.test - isolated test configuration
-# NOTE: Do not commit live secrets. Replace placeholders before use.
+# Test Environment Configuration
+# NOTE: Do not commit live secrets. Copy to env/test.local for customization and replace placeholders before use.
 
 DJANGO_SECRET_KEY=<TEST_SECRET_KEY>
 DJANGO_DEBUG=False

--- a/inventory_app/settings/base.py
+++ b/inventory_app/settings/base.py
@@ -20,7 +20,7 @@ from ..logging import configure_logging
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 env = environ.Env()
-# Only read .env if it exists; tests load .env.test via pytest.ini
+# Only read .env if it exists; tests load env/test.example via pytest.ini
 env_file = BASE_DIR / ".env"
 if env_file.exists():
     environ.Env.read_env(env_file)

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,4 @@ DJANGO_SETTINGS_MODULE = inventory_app.settings.test
 python_files = tests/test_*.py
 addopts = --reuse-db --maxfail=3 --disable-warnings
 env_files =
-    .env.test
+    env/test.example


### PR DESCRIPTION
## Summary
- move `.env.*.example` files into new `env/` directory as `dev.example`, `staging.example`, `production.example`, and `test.example`
- ignore real secrets via `env/*.local`
- update scripts, docker compose files, and docs to use new template locations

## Testing
- `pre-commit run end-of-file-fixer --files env/dev.example env/staging.example env/production.example env/test.example .gitignore README.md docs/deployment/PRODUCTION_READINESS_CHECKLIST.md docs/deployment/STAGING_DEPLOYMENT_GUIDE.md docs/deployment/RENDER_SECURITY_GUIDE.md docs/deployment/STAGING_VALIDATION_REPORT.md deploy-staging.sh deploy-production.sh docker-compose.staging.yml docker-compose.production.yml pytest.ini inventory_app/settings/base.py`
- `pre-commit run trailing-whitespace --files env/dev.example env/staging.example env/production.example env/test.example .gitignore README.md docs/deployment/PRODUCTION_READINESS_CHECKLIST.md docs/deployment/STAGING_DEPLOYMENT_GUIDE.md docs/deployment/RENDER_SECURITY_GUIDE.md docs/deployment/STAGING_VALIDATION_REPORT.md deploy-staging.sh deploy-production.sh docker-compose.staging.yml docker-compose.production.yml pytest.ini inventory_app/settings/base.py`
- `pre-commit run check-yaml --files docker-compose.staging.yml docker-compose.production.yml`
- `pre-commit run check-merge-conflict --files env/dev.example env/staging.example env/production.example env/test.example .gitignore README.md docs/deployment/PRODUCTION_READINESS_CHECKLIST.md docs/deployment/STAGING_DEPLOYMENT_GUIDE.md docs/deployment/RENDER_SECURITY_GUIDE.md docs/deployment/STAGING_VALIDATION_REPORT.md deploy-staging.sh deploy-production.sh docker-compose.staging.yml docker-compose.production.yml pytest.ini inventory_app/settings/base.py`
- `pre-commit run detect-private-key --files env/dev.example env/staging.example env/production.example env/test.example .gitignore README.md docs/deployment/PRODUCTION_READINESS_CHECKLIST.md docs/deployment/STAGING_DEPLOYMENT_GUIDE.md docs/deployment/RENDER_SECURITY_GUIDE.md docs/deployment/STAGING_VALIDATION_REPORT.md deploy-staging.sh deploy-production.sh docker-compose.staging.yml docker-compose.production.yml pytest.ini inventory_app/settings/base.py`
- `flake8 inventory_app/settings/base.py`
- `pytest`

> Note: `pre-commit run --files env/dev.example env/staging.example env/production.example env/test.example .gitignore README.md docs/deployment/PRODUCTION_READINESS_CHECKLIST.md docs/deployment/STAGING_DEPLOYMENT_GUIDE.md docs/deployment/RENDER_SECURITY_GUIDE.md docs/deployment/STAGING_VALIDATION_REPORT.md deploy-staging.sh deploy-production.sh docker-compose.staging.yml docker-compose.production.yml pytest.ini inventory_app/settings/base.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*

------
https://chatgpt.com/codex/tasks/task_e_68b40df0302083269045a064961e1346