### PR TITLE
Add unmanaged Category and Unit models migration

### DIFF
--- a/inventory/migrations/0009_a_category_unit_models.py
+++ b/inventory/migrations/0009_a_category_unit_models.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("inventory", "0008_remove_stocktransaction_related_po_id_and_more"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Category",
+            fields=[
+                ("category_id", models.AutoField(primary_key=True, serialize=False)),
+                ("category", models.TextField()),
+                ("sub_category", models.TextField()),
+            ],
+            options={
+                "db_table": "category",
+                "managed": False,
+            },
+        ),
+        migrations.CreateModel(
+            name="Unit",
+            fields=[
+                ("purchase_unit", models.TextField()),
+                ("base_unit", models.TextField()),
+                (
+                    "conversion_factor",
+                    models.DecimalField(decimal_places=6, max_digits=18),
+                ),
+                ("unit_id", models.AutoField(primary_key=True, serialize=False)),
+            ],
+            options={
+                "db_table": "units",
+                "managed": False,
+            },
+        ),
+    ]

--- a/inventory/migrations/0009_category_unit_fk.py
+++ b/inventory/migrations/0009_category_unit_fk.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("inventory", "0008_remove_stocktransaction_related_po_id_and_more"),
+        ("inventory", "0009_a_category_unit_models"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary
- define unmanaged Category and Unit models in a new migration
- link existing FK migration to rely on the new models

## Testing
- `pre-commit run --files inventory/migrations/0009_a_category_unit_models.py inventory/migrations/0009_category_unit_fk.py`
- `python manage.py makemigrations`
- `python manage.py migrate` *(fails: near "EXTENSION": syntax error)*
- `python manage.py sqlmigrate inventory 0009_category_unit_fk`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b43347eef88326a9e8d3c953f1bc4e