### PR TITLE
Use ORM for unit and category services

### DIFF
--- a/inventory/services/categories_service.py
+++ b/inventory/services/categories_service.py
@@ -23,8 +23,9 @@ import logging
 from functools import lru_cache
 from typing import Dict, List, Optional, Tuple
 
-from django.db import connection
 from django.db.utils import OperationalError
+
+from inventory.models.category import Category
 
 logger = logging.getLogger(__name__)
 
@@ -45,23 +46,15 @@ class CategoriesService:
             }
         """
         try:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    (
-                        "SELECT category, sub_category FROM category "
-                        "WHERE category_id = %s"
-                    ),
-                    [category_id],
-                )
-                row = cursor.fetchone()
-                if row:
-                    return {
-                        'category_id': category_id,
-                        'category': row[0],
-                        'sub_category': row[1]
-                    }
-        except OperationalError as e:
-            logger.warning(f"Could not access category table: {e}")
+            category = Category.objects.get(category_id=category_id)
+            return {
+                'category_id': category.category_id,
+                'category': category.category,
+                'sub_category': category.sub_category,
+            }
+        except (Category.DoesNotExist, OperationalError) as e:
+            if isinstance(e, OperationalError):
+                logger.warning(f"Could not access category table: {e}")
 
         # Fallback for test environment - based on actual database values
         fallback_categories = {
@@ -106,23 +99,15 @@ class CategoriesService:
     def get_all_categories() -> List[Dict]:
         """Get all available categories for dropdown population."""
         try:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    """
-                    SELECT category_id, category, sub_category
-                    FROM category
-                    ORDER BY category, sub_category
-                    """
-                )
-                rows = cursor.fetchall()
-                return [
-                    {
-                        'category_id': row[0],
-                        'category': row[1],
-                        'sub_category': row[2]
-                    }
-                    for row in rows
-                ]
+            categories = Category.objects.all().order_by('category', 'sub_category')
+            return [
+                {
+                    'category_id': cat.category_id,
+                    'category': cat.category,
+                    'sub_category': cat.sub_category,
+                }
+                for cat in categories
+            ]
         except OperationalError as e:
             logger.warning(f"Could not load categories: {e}")
             return [
@@ -193,16 +178,13 @@ class CategoriesService:
     def find_category_id(category: str, sub_category: str) -> Optional[int]:
         """Find category_id for a given category/sub_category combination."""
         try:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    (
-                        "SELECT category_id FROM category WHERE category = %s "
-                        "AND sub_category = %s"
-                    ),
-                    [category, sub_category],
+            return (
+                Category.objects.filter(
+                    category=category, sub_category=sub_category
                 )
-                row = cursor.fetchone()
-                return row[0] if row else None
+                .values_list('category_id', flat=True)
+                .first()
+            )
         except OperationalError:
             # Fallback for test environment
             fallback_mappings = {
@@ -221,16 +203,12 @@ class CategoriesService:
         Use when sub_category doesn't matter.
         """
         try:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    (
-                        "SELECT category_id FROM category WHERE category = %s "
-                        "ORDER BY sub_category LIMIT 1"
-                    ),
-                    [category],
-                )
-                row = cursor.fetchone()
-                return row[0] if row else None
+            return (
+                Category.objects.filter(category=category)
+                .order_by('sub_category')
+                .values_list('category_id', flat=True)
+                .first()
+            )
         except OperationalError:
             # Fallback for test environment
             fallback_categories = {

--- a/inventory/services/units_service.py
+++ b/inventory/services/units_service.py
@@ -24,8 +24,9 @@ import logging
 from functools import lru_cache
 from typing import Dict, List, Tuple
 
-from django.db import connection
 from django.db.utils import OperationalError
+
+from inventory.models.unit import Unit
 
 logger = logging.getLogger(__name__)
 
@@ -66,24 +67,16 @@ class UnitsService:
             }
         """
         try:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    (
-                        "SELECT base_unit, purchase_unit, conversion_factor "
-                        "FROM units WHERE unit_id = %s"
-                    ),
-                    [unit_id],
-                )
-                row = cursor.fetchone()
-                if row:
-                    return {
-                        'unit_id': unit_id,
-                        'base_unit': row[0],
-                        'purchase_unit': row[1],
-                        'conversion_factor': float(row[2])
-                    }
-        except OperationalError as e:
-            logger.warning(f"Could not access units table: {e}")
+            unit = Unit.objects.get(unit_id=unit_id)
+            return {
+                'unit_id': unit.unit_id,
+                'base_unit': unit.base_unit,
+                'purchase_unit': unit.purchase_unit,
+                'conversion_factor': float(unit.conversion_factor),
+            }
+        except (Unit.DoesNotExist, OperationalError) as e:
+            if isinstance(e, OperationalError):
+                logger.warning(f"Could not access units table: {e}")
 
         # Fallback for test environment - based on actual database values
         fallback_units = {
@@ -171,24 +164,16 @@ class UnitsService:
     def get_all_units() -> List[Dict]:
         """Get all available units for dropdown population."""
         try:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    (
-                        "SELECT unit_id, base_unit, purchase_unit, conversion_factor "
-                        "FROM units "
-                        "ORDER BY base_unit, purchase_unit"
-                    )
-                )
-                rows = cursor.fetchall()
-                return [
-                    {
-                        'unit_id': row[0],
-                        'base_unit': row[1],
-                        'purchase_unit': row[2],
-                        'conversion_factor': float(row[3])
-                    }
-                    for row in rows
-                ]
+            units = Unit.objects.all().order_by('base_unit', 'purchase_unit')
+            return [
+                {
+                    'unit_id': unit.unit_id,
+                    'base_unit': unit.base_unit,
+                    'purchase_unit': unit.purchase_unit,
+                    'conversion_factor': float(unit.conversion_factor),
+                }
+                for unit in units
+            ]
         except OperationalError as e:
             logger.warning(f"Could not load units: {e}")
             return [

--- a/tests/test_units_categories_services.py
+++ b/tests/test_units_categories_services.py
@@ -1,0 +1,60 @@
+import types
+
+import pytest
+
+from inventory.models.category import Category
+from inventory.models.unit import Unit
+from inventory.services.categories_service import CategoriesService
+from inventory.services.units_service import UnitsService
+
+
+@pytest.mark.django_db
+def test_get_unit_info_uses_orm(monkeypatch):
+    """UnitsService should query the Unit model via the ORM."""
+
+    UnitsService.get_unit_info.cache_clear()
+    dummy_unit = types.SimpleNamespace(
+        unit_id=1, base_unit="GM", purchase_unit="2 KG", conversion_factor=2000
+    )
+    called = {}
+
+    def mock_get(unit_id):
+        called["unit_id"] = unit_id
+        return dummy_unit
+
+    monkeypatch.setattr(Unit.objects, "get", mock_get)
+    info = UnitsService.get_unit_info(1)
+
+    assert called["unit_id"] == 1
+    assert info == {
+        "unit_id": 1,
+        "base_unit": "GM",
+        "purchase_unit": "2 KG",
+        "conversion_factor": 2000.0,
+    }
+
+
+@pytest.mark.django_db
+def test_get_category_info_uses_orm(monkeypatch):
+    """CategoriesService should query the Category model via the ORM."""
+
+    CategoriesService.get_category_info.cache_clear()
+    dummy_category = types.SimpleNamespace(
+        category_id=1, category="Grocery", sub_category="Juices And Purees"
+    )
+    called = {}
+
+    def mock_get(category_id):
+        called["category_id"] = category_id
+        return dummy_category
+
+    monkeypatch.setattr(Category.objects, "get", mock_get)
+    info = CategoriesService.get_category_info(1)
+
+    assert called["category_id"] == 1
+    assert info == {
+        "category_id": 1,
+        "category": "Grocery",
+        "sub_category": "Juices And Purees",
+    }
+


### PR DESCRIPTION
## Summary
- Replace raw SQL queries with Django ORM in unit and category services
- Add tests to ensure services call ORM for lookups

## Testing
- `pre-commit run --files inventory/services/units_service.py inventory/services/categories_service.py tests/test_units_categories_services.py` *(failed: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b446583ce08326b1708de83f0907f5