### PR TITLE
feat: add dashboard KPI links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PRE-PRODUCTION TESTING COMPLETE: Comprehensive testing completed - inline form functional, clean codebase, ready for production deployment
 - Shared `templates/components/kpi_card.html` for consistent card-based KPI display
 - Home link added to primary navigation
+- Dashboard KPI cards now link to items, low-stock items, suppliers, and pending indents
 
 ### Changed
 

--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,6 +1,9 @@
+{% url 'items_list' as items_list_url %}
+{% url 'suppliers_list' as suppliers_list_url %}
+{% url 'indents_list' as indents_list_url %}
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-  {% include "components/kpi_card.html" with icon='cube' color='blue' label='Items' value=items %}
-  {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low-stock Items' value=low_stock %}
-  {% include "components/kpi_card.html" with icon='truck' color='green' label='Suppliers' value=suppliers %}
-  {% include "components/kpi_card.html" with icon='clipboard-document-list' color='yellow' label='Pending Indents' value=pending_indents %}
+  {% include "components/kpi_card.html" with icon='cube' color='blue' label='Items' value=items href=items_list_url %}
+  {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low-stock Items' value=low_stock href=items_list_url|add:'?stock_status=low' %}
+  {% include "components/kpi_card.html" with icon='truck' color='green' label='Suppliers' value=suppliers href=suppliers_list_url %}
+  {% include "components/kpi_card.html" with icon='clipboard-document-list' color='yellow' label='Pending Indents' value=pending_indents href=indents_list_url|add:'?status=PENDING' %}
 </div>

--- a/templates/components/kpi_card.html
+++ b/templates/components/kpi_card.html
@@ -1,5 +1,9 @@
 {% load icon_tags %}
+{% if href %}
+<a href="{{ href }}" class="card block">
+{% else %}
 <div class="card">
+{% endif %}
   <div class="card-compact">
     <div class="flex items-center">
       <div class="flex-shrink-0">
@@ -15,4 +19,8 @@
       </div>
     </div>
   </div>
+{% if href %}
+</a>
+{% else %}
 </div>
+{% endif %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -40,6 +40,12 @@ def test_dashboard_kpis_endpoint(client, item_factory):
     assert b"Suppliers" in resp.content
     assert b"Pending Indents" in resp.content
 
+    html = resp.content.decode()
+    assert f'href="{reverse("items_list")}"' in html
+    assert f'href="{reverse("items_list")}?stock_status=low"' in html
+    assert f'href="{reverse("suppliers_list")}"' in html
+    assert f'href="{reverse("indents_list")}?status=PENDING"' in html
+
 
 @pytest.mark.django_db
 def test_dashboard_has_single_filter_form(client, django_user_model):


### PR DESCRIPTION
## Summary
- make KPI cards on dashboard clickable by passing hrefs
- allow kpi_card component to render as <a> when href provided
- test dashboard KPI links

## Testing
- `pytest tests/test_dashboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4501b905c8326ac98c0eab93afe4d