### PR TITLE
Add metric and date range filters to dashboard

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -1,4 +1,5 @@
 {% extends "components/list_layout.html" %}
+{% load static %}
 
 {% block breadcrumbs %}
   {% include "components/breadcrumb.html" with list_url=list_url list_title=list_title current_title=current_title %}
@@ -39,12 +40,19 @@
             </select>
           </div>
           <div>
-            <label for="start" class="form-label">Start Date</label>
-            <input type="date" id="start" name="start" class="form-input" />
+            <label for="metric" class="form-label">Metric</label>
+            <select id="metric" name="metric" class="form-select">
+              <option value="quantity">Quantity</option>
+              <option value="value">Value</option>
+            </select>
           </div>
           <div>
-            <label for="end" class="form-label">End Date</label>
-            <input type="date" id="end" name="end" class="form-input" />
+            <label for="range" class="form-label">Date Range</label>
+            <select id="range" name="range" class="form-select">
+              <option value="7">Last 7 Days</option>
+              <option value="30" selected>Last 30 Days</option>
+              <option value="90">Last 90 Days</option>
+            </select>
           </div>
           <button type="button" id="apply-filters" class="btn-primary w-full">Apply Filters</button>
         </form>
@@ -52,9 +60,18 @@
     </div>
       <div class="card lg:col-span-2">
       <div class="card-header"><h3 class="text-lg font-semibold">Stock Trend</h3></div>
-      <div class="card-body"><div class="h-64"><canvas id="stock-trend-chart" class="w-full h-full"></canvas></div></div>
+      <div class="card-body">
+        <div id="stock-trend-placeholder" class="h-64 flex items-center justify-center text-gray-500 hidden">
+          No data available for the selected filters.
+        </div>
+        <div class="h-64"><canvas id="stock-trend-chart" class="w-full h-full"></canvas></div>
+      </div>
     </div>
   </div>
 {% endblock %}
 
 {% block table_container %}{% endblock %}
+
+{% block extra_js %}
+  <script src="{% static 'core/dashboard.js' %}?v={{ STATIC_VERSION }}" defer></script>
+{% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -1,17 +1,18 @@
 import json
 import logging
+from datetime import timedelta
 from decimal import Decimal
 
 from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.forms import AuthenticationForm
 from django.core.cache import cache
-from django.db.models import Sum
-from django.db.models.functions import TruncDate
+from django.db.models import DecimalField, ExpressionWrapper, F, Sum
+from django.db.models.functions import TruncDate, Coalesce
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from django.utils.dateparse import parse_date
+from django.utils import timezone
 
 from inventory.models import Item, PurchaseOrder, StockTransaction, Supplier
 from inventory.services import counts, dashboard_service, kpis
@@ -95,8 +96,19 @@ def dashboard_kpis(request):
     return render(request, "core/_kpi_cards.html", data)
 
 
-def _stock_trend_data(item_id=None, supplier_id=None, start=None, end=None):
-    """Return stock transaction totals grouped by day."""
+def _stock_trend_data(
+    item_id=None, supplier_id=None, start=None, end=None, metric="quantity"
+):
+    """Return stock transaction totals grouped by day.
+
+    Args:
+        item_id: Optional item identifier to filter by item.
+        supplier_id: Optional supplier identifier to filter by supplier.
+        start: Start date for filtering (inclusive).
+        end: End date for filtering (inclusive).
+        metric: "quantity" to aggregate quantities or "value" for monetary value.
+    """
+
     qs = StockTransaction.objects.all()
     if item_id:
         qs = qs.filter(item_id=item_id)
@@ -110,11 +122,21 @@ def _stock_trend_data(item_id=None, supplier_id=None, start=None, end=None):
     if end:
         qs = qs.filter(transaction_date__date__lte=end)
 
+    annotation = {"total": Sum("quantity_change")}
+    if metric == "value":
+        annotation["total"] = Sum(
+            ExpressionWrapper(
+                F("quantity_change") * Coalesce(F("item__last_purchase_price"), 0),
+                output_field=DecimalField(max_digits=12, decimal_places=2),
+            )
+        )
+        qs = qs.select_related("item")
+
     data = (
         qs.annotate(day=TruncDate("transaction_date"))
         .values("day")
         .order_by("day")
-        .annotate(total=Sum("quantity_change"))
+        .annotate(**annotation)
     )
     labels = [d["day"].strftime("%Y-%m-%d") for d in data]
     values = [float(d["total"]) for d in data]
@@ -125,10 +147,12 @@ def interactive_dashboard(request):
     """Render dashboard with filter controls for asynchronous charts."""
     item_id = request.GET.get("item")
     supplier_id = request.GET.get("supplier")
-    start = parse_date(request.GET.get("start")) if request.GET.get("start") else None
-    end = parse_date(request.GET.get("end")) if request.GET.get("end") else None
+    metric = request.GET.get("metric", "quantity")
+    days = int(request.GET.get("range", 30))
+    end = timezone.now().date()
+    start = end - timedelta(days=days - 1)
 
-    labels, values = _stock_trend_data(item_id, supplier_id, start, end)
+    labels, values = _stock_trend_data(item_id, supplier_id, start, end, metric)
     context = {
         "low_stock": dashboard_service.get_low_stock_items(),
         "trend_labels": json.dumps(labels),
@@ -146,8 +170,10 @@ def ajax_dashboard_data(request):
     """Return JSON data for dashboard charts based on filters."""
     item_id = request.GET.get("item")
     supplier_id = request.GET.get("supplier")
-    start = parse_date(request.GET.get("start")) if request.GET.get("start") else None
-    end = parse_date(request.GET.get("end")) if request.GET.get("end") else None
+    metric = request.GET.get("metric", "quantity")
+    days = int(request.GET.get("range", 30))
+    end = timezone.now().date()
+    start = end - timedelta(days=days - 1)
 
-    labels, values = _stock_trend_data(item_id, supplier_id, start, end)
+    labels, values = _stock_trend_data(item_id, supplier_id, start, end, metric)
     return JsonResponse({"labels": labels, "values": values})

--- a/static/core/dashboard.js
+++ b/static/core/dashboard.js
@@ -1,0 +1,53 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const ctx = document.getElementById('stock-trend-chart').getContext('2d');
+  const placeholder = document.getElementById('stock-trend-placeholder');
+  let chart;
+
+  async function fetchData() {
+    const form = document.getElementById('dashboard-filters');
+    const params = new URLSearchParams(new FormData(form));
+    const response = await fetch(`/dashboard/data/?${params.toString()}`);
+    const data = await response.json();
+
+    if (!data.values.length) {
+      if (chart) {
+        chart.destroy();
+        chart = null;
+      }
+      placeholder.classList.remove('hidden');
+      return;
+    }
+
+    placeholder.classList.add('hidden');
+    const metric = params.get('metric') === 'value' ? 'Stock Value' : 'Stock Quantity';
+    const dataset = {
+      labels: data.labels,
+      datasets: [
+        {
+          label: metric,
+          data: data.values,
+          borderColor: '#3b82f6',
+          fill: false,
+          tension: 0.1,
+        },
+      ],
+    };
+
+    if (!chart) {
+      chart = new Chart(ctx, {
+        type: 'line',
+        data: dataset,
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+        },
+      });
+    } else {
+      chart.data = dataset;
+      chart.update();
+    }
+  }
+
+  document.getElementById('apply-filters').addEventListener('click', fetchData);
+  fetchData();
+});

--- a/tests/test_interactive_dashboard.py
+++ b/tests/test_interactive_dashboard.py
@@ -30,7 +30,7 @@ def test_ajax_dashboard_data_filters(client, item_factory):
     day = timezone.now().date().isoformat()
     url = (
         reverse("ajax-dashboard-data")
-        + f"?item={item.pk}&supplier={supplier.pk}&start={day}&end={day}"
+        + f"?item={item.pk}&supplier={supplier.pk}&range=1&metric=quantity"
     )
     resp = client.get(url)
     assert resp.status_code == 200

--- a/tests/test_stock_trend_data.py
+++ b/tests/test_stock_trend_data.py
@@ -1,0 +1,34 @@
+import pytest
+from decimal import Decimal
+from django.utils import timezone
+
+from core.views import _stock_trend_data
+from inventory.models import StockTransaction
+
+
+@pytest.mark.django_db
+def test_stock_trend_data_metric_switch(item_factory):
+    item = item_factory(name="Metric", last_purchase_price=Decimal("2.50"))
+    StockTransaction.objects.create(
+        item_id=item.pk,
+        quantity_change=4,
+        transaction_type="RECEIVING",
+        transaction_date=timezone.now(),
+    )
+    today = timezone.now().date()
+    labels_q, values_q = _stock_trend_data(item_id=item.pk, start=today, end=today)
+    labels_v, values_v = _stock_trend_data(
+        item_id=item.pk, start=today, end=today, metric="value"
+    )
+    assert values_q == [4.0]
+    assert values_v == [10.0]
+    assert labels_q == labels_v == [today.strftime("%Y-%m-%d")]
+
+
+@pytest.mark.django_db
+def test_stock_trend_data_no_data(item_factory):
+    item = item_factory(name="Empty")
+    today = timezone.now().date()
+    labels, values = _stock_trend_data(item_id=item.pk, start=today, end=today)
+    assert labels == []
+    assert values == []


### PR DESCRIPTION
## Summary
- Load dashboard chart data via JS and render with Chart.js
- Add metric and date-range filters with empty-state placeholder
- Support quantity/value aggregation and no-data scenarios in views and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b451ea13488326b652fae46219fd91