### PR TITLE
Add item detail links and archiving with supplier history

### DIFF
--- a/inventory/views/items/detail.py
+++ b/inventory/views/items/detail.py
@@ -13,7 +13,7 @@ from django.views import View
 from django.views.decorators.csrf import csrf_protect
 
 from ...forms.item_forms import ItemForm
-from ...models import Item, StockTransaction
+from ...models import Item, Supplier, StockTransaction
 from ...services import item_service, stock_service
 from .constants import EXCLUDED_FIELDS
 from .list import ItemsTableView
@@ -187,14 +187,22 @@ class ItemDetailView(View):
             ("Notes", details.get("notes", "None")),
             ("Active", "Yes" if details["is_active"] else "No"),
         ]
-        recent_activity = StockTransaction.objects.filter(item_id=pk).order_by(
+        stock_movements = StockTransaction.objects.filter(item_id=pk).order_by(
             "-transaction_date"
-        )[:5]
+        )
+        recent_activity = stock_movements[:5]
+        suppliers = (
+            Supplier.objects.filter(
+                purchaseorder__purchaseorderitem__item_id=pk
+            ).distinct()
+        )
         stock_history = stock_service.get_stock_history(pk)
         ctx = {
             "item": details,
             "rows": rows,
+            "stock_movements": stock_movements,
             "recent_activity": recent_activity,
+            "suppliers": suppliers,
             "stock_history": json.dumps(stock_history),
             "list_url": reverse("items_list"),
             "list_title": "Items",

--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -307,6 +307,32 @@
       });
   }
 
+  function archiveItem(row) {
+    const itemId = row?.dataset.itemId;
+    if (!itemId) return;
+    const csrf = getCsrfToken();
+    fetch(`/items/${itemId}/toggle/`, {
+      method: "POST",
+      headers: {
+        ...(csrf ? { "X-CSRFToken": csrf } : {}),
+        "X-Requested-With": "fetch",
+      },
+      body: new URLSearchParams({ page: "1" }),
+    })
+      .then((r) => {
+        if (r.ok) {
+          window.location.reload();
+        } else if (window.notifications && window.notifications.showToast) {
+          window.notifications.showToast("Unable to update item.", "error");
+        }
+      })
+      .catch(() => {
+        if (window.notifications && window.notifications.showToast) {
+          window.notifications.showToast("Unable to update item.", "error");
+        }
+      });
+  }
+
   // Event delegation
   document.addEventListener("click", function (e) {
     const target = e.target.closest("[data-action]");
@@ -352,6 +378,10 @@
       case "delete":
         e.preventDefault();
         deleteItem(row);
+        break;
+      case "archive":
+        e.preventDefault();
+        archiveItem(row);
         break;
       case "open-edit":
         e.preventDefault();

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -32,7 +32,9 @@
                                 <div class="flex items-center gap-3">
                                     <!-- Item Status Indicator -->
                                     <div class="w-3 h-3 rounded-full {{ item.is_active|yesno:'bg-green-400,bg-red-400' }} flex-shrink-0 shadow-sm"></div>
-                                    <h3 id="item-title-{{ item.item_id }}" class="text-base font-semibold text-gray-900 line-clamp-2">{{ item.name }}</h3>
+                                    <a href="{% url 'item_detail' item.item_id %}" data-ignore-toggle>
+                                        <h3 id="item-title-{{ item.item_id }}" class="text-base font-semibold text-gray-900 line-clamp-2">{{ item.name }}</h3>
+                                    </a>
                                 </div>
                                         <div class="flex items-center flex-wrap gap-3 text-xs text-gray-600 mt-1">
                                     {% if item.category %}
@@ -130,6 +132,10 @@
                            class="p-2 text-gray-400 hover:text-green-600 hover:bg-green-50 rounded-lg transition-all duration-200" title="View Details">
                             {% icon 'eye' 'w-5 h-5' %}
                         </a>
+                        <button type="button" data-action="archive"
+                                class="p-2 text-gray-400 hover:text-yellow-600 hover:bg-yellow-50 rounded-lg transition-all duration-200" title="{% if item.is_active %}Archive{% else %}Activate{% endif %}">
+                            {% icon 'archive-box' 'w-5 h-5' %}
+                        </button>
                         <button type="button" data-action="delete"
                                 class="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all duration-200" title="Delete">
                             {% icon 'trash' 'w-5 h-5' %}
@@ -179,6 +185,13 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
                             </svg>
                         </a>
+                        <button type="button" data-action="archive"
+                                class="text-gray-400 hover:text-yellow-600 transition-colors"
+                                title="{% if item.is_active %}Archive{% else %}Activate{% endif %}">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h18v4H3zM3 7l1 14h16l1-14"/>
+                            </svg>
+                        </button>
                         <button type="button"
                                 class="text-gray-400 hover:text-red-600 transition-colors"
                                 title="Delete"

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -8,6 +8,10 @@
 
 {% block actions %}
   <a href="{% url 'item_edit' item.item_id %}" class="btn-secondary">Edit</a>
+  <a href="{% url 'item_toggle_active' item.item_id %}" class="btn-secondary">
+    {% if item.is_active %}Archive{% else %}Activate{% endif %}
+  </a>
+  <a href="{% url 'item_delete' item.item_id %}" class="btn-danger">Delete</a>
 {% endblock %}
 
 {% block detail_table %}
@@ -24,10 +28,18 @@
 {% endblock %}
 
 {% block extra_tables %}
-  {% if recent_activity %}
-  <h2 class="text-lg font-semibold mt-8 mb-4">Recent Activity</h2>
+  {% if suppliers %}
+  <h2 class="text-lg font-semibold mt-8 mb-4">Supplier History</h2>
   <ul class="space-y-2">
-    {% for tx in recent_activity %}
+    {% for supplier in suppliers %}
+    <li>{{ supplier.name }}</li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+  {% if stock_movements %}
+  <h2 class="text-lg font-semibold mt-8 mb-4">Stock Movements</h2>
+  <ul class="space-y-2">
+    {% for tx in stock_movements %}
     <li>
       {{ tx.transaction_date }} – {{ tx.transaction_type }} {{ tx.quantity_change }}
     </li>

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -1,0 +1,67 @@
+from datetime import date
+from decimal import Decimal
+
+from django.urls import reverse
+
+from inventory.models import (
+    Item,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    StockTransaction,
+    Supplier,
+)
+
+
+def _create_item(**kwargs):
+    defaults = {
+        "name": "Widget",
+        "unit_id": 55,
+        "reorder_point": 1,
+        "notes": "n",
+        "is_active": True,
+        "category_id": 1,
+    }
+    defaults.update(kwargs)
+    return Item.objects.create(**defaults)
+
+
+def test_items_table_links_to_detail(client):
+    item = _create_item()
+    resp = client.get(reverse("items_table") + "?layout=grid")
+    assert resp.status_code == 200
+    assert reverse("item_detail", args=[item.pk]) in resp.content.decode()
+
+
+def test_archive_action_toggles_item(client):
+    item = _create_item()
+    resp = client.get(reverse("items_table") + "?layout=grid")
+    assert "data-action=\"archive\"" in resp.content.decode()
+
+    url = reverse("item_toggle_active", args=[item.pk])
+    client.post(url, {"page": "1"})
+    item.refresh_from_db()
+    assert item.is_active is False
+
+    client.post(url, {"page": "1"})
+    item.refresh_from_db()
+    assert item.is_active is True
+
+
+def test_item_detail_includes_supplier_and_movements(client):
+    item = _create_item()
+    supplier = Supplier.objects.create(name="Acme Corp")
+    po = PurchaseOrder.objects.create(supplier=supplier, order_date=date.today())
+    PurchaseOrderItem.objects.create(
+        purchase_order=po,
+        item=item,
+        quantity_ordered=1,
+        unit_price=Decimal("1.00"),
+    )
+    tx = StockTransaction.objects.create(
+        item=item, quantity_change=Decimal("5"), transaction_type="IN"
+    )
+    resp = client.get(reverse("item_detail", args=[item.pk]))
+    content = resp.content.decode()
+    assert supplier.name in content
+    assert tx.transaction_type in content
+    assert str(tx.quantity_change) in content


### PR DESCRIPTION
## Summary
- Link item names in list view to detailed item pages
- Show supplier history and stock movements on item detail view
- Add archive toggle alongside existing actions and cover with tests

## Testing
- `pytest tests/test_items_list.py`

------
https://chatgpt.com/codex/tasks/task_e_68b45780da8c8326b3cbb9c18928b55d