### PR TITLE
refactor: allow item title link in table

### DIFF
--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -10,20 +10,20 @@
     const itemId = row?.dataset.itemId;
     if (!itemId) return;
     const details = document.getElementById(`details-${itemId}`);
-    const toggleBtn = row.querySelector("button.main-row");
-    if (!details || !toggleBtn) return;
+    const toggleEl = row.querySelector(".main-row");
+    if (!details || !toggleEl) return;
 
-    const expanded = toggleBtn.getAttribute("aria-expanded") === "true";
+    const expanded = toggleEl.getAttribute("aria-expanded") === "true";
     if (expanded) {
       details.classList.add("hidden");
-      toggleBtn.setAttribute("aria-expanded", "false");
+      toggleEl.setAttribute("aria-expanded", "false");
       // reset chevron rotation
-      const svg = toggleBtn.querySelector("svg");
+      const svg = toggleEl.querySelector("svg");
       if (svg) svg.style.transform = "rotate(0deg)";
     } else {
       details.classList.remove("hidden");
-      toggleBtn.setAttribute("aria-expanded", "true");
-      const svg = toggleBtn.querySelector("svg");
+      toggleEl.setAttribute("aria-expanded", "true");
+      const svg = toggleEl.querySelector("svg");
       if (svg) svg.style.transform = "rotate(90deg)";
     }
   }

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -4,7 +4,7 @@
     {% for item in page_obj.object_list %}
     <div class="item-row bg-white rounded-xl shadow-sm hover:shadow-md transition-all duration-200 border border-gray-200 hover:border-gray-300 overflow-hidden h-full" data-item-id="{{ item.item_id }}">
         <!-- Main Row -->
-    <button type="button" class="main-row w-full text-left px-5 py-5 hover:bg-gradient-to-r hover:from-gray-50 hover:to-white transition-all duration-200 cursor-pointer" data-action="toggle-details" aria-label="Toggle details" aria-expanded="false" aria-controls="details-{{ item.item_id }}">
+    <div class="main-row w-full text-left px-5 py-5 hover:bg-gradient-to-r hover:from-gray-50 hover:to-white transition-all duration-200 cursor-pointer" data-action="toggle-details" aria-label="Toggle details" aria-expanded="false" aria-controls="details-{{ item.item_id }}" role="button" tabindex="0">
             <div class="flex items-center justify-between">
                 <!-- Left side - Item info -->
                 <div class="flex items-center space-x-4 flex-1">
@@ -143,7 +143,7 @@
                     </div>
                 </div>
             </div>
-        </button>
+        </div>
 
                     <!-- Department -->
                     <div class="text-right min-w-0">


### PR DESCRIPTION
## Summary
- make item title links directly clickable by replacing button wrapper with div
- update toggle logic to target new div wrapper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4602d0254832681bac478ed5a59dc