### PR TITLE
Link item names to detail and respect ignore toggle

### DIFF
--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -335,16 +335,12 @@
 
   // Event delegation
   document.addEventListener("click", function (e) {
+    if (e.target.closest("[data-ignore-toggle]")) {
+      return;
+    }
     const target = e.target.closest("[data-action]");
     if (!target) return;
     const action = target.getAttribute("data-action");
-    // Prevent toggle-details if clicking a link with data-ignore-toggle
-    if (
-      action === "toggle-details" &&
-      e.target.closest("[data-ignore-toggle]")
-    ) {
-      return;
-    }
     const row = findRow(target);
     if (!row) return;
 

--- a/templates/inventory/_items_table_grid.html
+++ b/templates/inventory/_items_table_grid.html
@@ -29,7 +29,9 @@
         <input type="checkbox" name="selected_items" value="{{ item.item_id }}" aria-label="Select {{ item.name }}" data-action="select-item">
       </td>
       <td data-col="name">
-        <div class="font-medium text-gray-900">{{ item.name }}</div>
+        <div class="font-medium text-gray-900">
+          <a href="{% url 'item_detail' item.item_id %}" data-ignore-toggle>{{ item.name }}</a>
+        </div>
         <div class="text-xs text-gray-500">{% if item.item_code %}SKU: {{ item.item_code }}{% endif %}</div>
       </td>
       <td data-col="category">

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -25,9 +25,16 @@ def _create_item(**kwargs):
     return Item.objects.create(**defaults)
 
 
-def test_items_table_links_to_detail(client):
+def test_item_link_in_grid_layout(client):
     item = _create_item()
     resp = client.get(reverse("items_table") + "?layout=grid")
+    assert resp.status_code == 200
+    assert reverse("item_detail", args=[item.pk]) in resp.content.decode()
+
+
+def test_item_link_in_table_layout(client):
+    item = _create_item()
+    resp = client.get(reverse("items_table") + "?layout=table")
     assert resp.status_code == 200
     assert reverse("item_detail", args=[item.pk]) in resp.content.decode()
 


### PR DESCRIPTION
## Summary
- link item names to their detail page and mark with `data-ignore-toggle`
- ensure items table JS skips actions when clicking `[data-ignore-toggle]`
- test both grid and table layouts for item name links

## Testing
- `pytest`
- `npm test`
- `pre-commit run --files static/js/items-table.js templates/inventory/_items_table_grid.html tests/test_items_list.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*

------
https://chatgpt.com/codex/tasks/task_e_68b469ae5730832697e673ad6cf420dd