### PR TITLE
feat: add layout toggle for items list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Layout toggle buttons on the items list to switch between table and grid views.
+
 ### Removed
 
 - Legacy speed templates no longer referenced by views:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Inventory-App is a Django application for managing restaurant inventory with a P
 - Indent and purchase order tracking
 - Dashboard showing key metrics such as low-stock items
 - Bulk upload items and stock transactions from CSV files
+- Toggle between table and grid views for inventory items
 
 ## Style Guide
 

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -1,5 +1,5 @@
 {% extends "components/create_manage_layout.html" %}
-{% load static %}
+{% load static icon_tags %}
 
 {% block breadcrumbs %}
   {% include "components/breadcrumb.html" with list_url=list_url list_title=list_title current_title=current_title %}
@@ -156,7 +156,17 @@
   <!-- Place filters directly above the table -->
   <div class="card mb-4">
     <div class="card-body">
-      <div class="text-sm text-gray-600 mb-2">Filter and explore</div>
+      <div class="flex items-center justify-between mb-2">
+        <div class="text-sm text-gray-600">Filter and explore</div>
+        <div class="flex items-center gap-2" role="toolbar" aria-label="Layout options">
+          <button type="button" class="btn-icon" data-layout-btn data-value="table" aria-label="Table view"{% if request.GET.layout|default:'table' == 'table' %} aria-pressed="true"{% else %} aria-pressed="false"{% endif %}>
+            {% icon 'list-bullet' 'w-4 h-4' %}
+          </button>
+          <button type="button" class="btn-icon" data-layout-btn data-value="grid" aria-label="Grid view"{% if request.GET.layout == 'grid' %} aria-pressed="true"{% else %} aria-pressed="false"{% endif %}>
+            {% icon 'squares-2x2' 'w-4 h-4' %}
+          </button>
+        </div>
+      </div>
       {% url 'items_table' as items_table_url %}
       {% include "components/filter_bar.html" with q=request.GET.q filters=filters hx_get=items_table_url hx_target='#items-list' hx_indicator='#items-loading' search_placeholder='e.g., Tomato, Rice' export_url=export_url layout=request.GET.layout|default:'table' %}
     </div>
@@ -237,7 +247,8 @@ document.addEventListener('DOMContentLoaded', function() {
       container.setAttribute('data-density', value);
     });
   });
-  document.querySelectorAll('[data-layout-btn]').forEach(btn => {
+  const layoutBtns = document.querySelectorAll('[data-layout-btn]');
+  layoutBtns.forEach(btn => {
     btn.addEventListener('click', () => {
       const value = btn.getAttribute('data-value');
       const url = new URL(window.location.href);
@@ -254,6 +265,10 @@ document.addEventListener('DOMContentLoaded', function() {
       window.location.replace(url.toString());
     }
   }
+  const currentLayout = new URL(window.location.href).searchParams.get('layout') || 'table';
+  layoutBtns.forEach(btn => {
+    btn.setAttribute('aria-pressed', btn.getAttribute('data-value') === currentLayout ? 'true' : 'false');
+  });
   // Announce updates
   const live = document.getElementById('items-aria-live');
   function announce(text){ if(live){ live.textContent = text; } }

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -182,6 +182,29 @@ def test_items_export_view_returns_csv(client):
     assert "Widget" in content
 
 
+def test_items_list_view_renders_layout_buttons(client):
+    url = reverse("items_list")
+    resp = client.get(url)
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    assert "data-layout-btn" in content
+    assert 'data-value="table"' in content
+    assert 'data-value="grid"' in content
+
+
+def test_items_list_layout_query_switches_partials(client):
+    _create_item()
+    resp = client.get(reverse("items_list") + "?layout=grid")
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert '<div class="grid grid-cols-1' in html
+
+    resp = client.get(reverse("items_list") + "?layout=table")
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert '<table class="table w-full' in html
+
+
 def test_toggle_item_post(client):
     item = _create_item()
     url = reverse("item_toggle_active", args=[item.pk])


### PR DESCRIPTION
## Summary
- add table/grid layout toggle buttons to inventory item list
- persist selection in query params and local storage
- document layout toggle and cover with tests

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b47367b4a0832684ef2f05488ff5d2