### PR TITLE
Enable editing items via modal from table

### DIFF
--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -32,7 +32,9 @@
                                 <div class="flex items-center gap-3">
                                     <!-- Item Status Indicator -->
                                     <div class="w-3 h-3 rounded-full {{ item.is_active|yesno:'bg-green-400,bg-red-400' }} flex-shrink-0 shadow-sm"></div>
-                                    <a href="{% url 'item_detail' item.item_id %}" data-ignore-toggle>
+                                    <a href="{% url 'item_edit' item.item_id %}"
+                                       data-modal-url="{% url 'item_edit' item.item_id %}?partial=1"
+                                       data-ignore-toggle>
                                         <h3 id="item-title-{{ item.item_id }}" class="text-base font-semibold text-gray-900 line-clamp-2">{{ item.name }}</h3>
                                     </a>
                                 </div>

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -29,7 +29,10 @@ def test_item_link_in_grid_layout(client):
     item = _create_item()
     resp = client.get(reverse("items_table") + "?layout=grid")
     assert resp.status_code == 200
-    assert reverse("item_detail", args=[item.pk]) in resp.content.decode()
+    edit_url = reverse("item_edit", args=[item.pk])
+    html = resp.content.decode()
+    assert f'href="{edit_url}"' in html
+    assert f'data-modal-url="{edit_url}?partial=1"' in html
 
 
 def test_item_link_in_table_layout(client):


### PR DESCRIPTION
## Summary
- open item edit modal when clicking item name in grid view
- cover new modal trigger in items list tests

## Testing
- `pre-commit run --files templates/inventory/_items_table.html tests/test_items_list.py`
- `pytest tests/test_items_list.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4825ca8808326be6e566fa68bde8f