### PR TITLE
Expand item edit modal fields

### DIFF
--- a/templates/inventory/_item_form_partial.html
+++ b/templates/inventory/_item_form_partial.html
@@ -1,4 +1,4 @@
-<div class="card" style="max-width: 860px;">
+<div class="card" style="max-width: 860px; max-height: 90vh; overflow-y: auto;">
   <div class="card-header flex items-center justify-between">
     <h3 class="text-lg font-semibold">Edit Item — {{ item.name }}</h3>
     <button type="button" class="btn-secondary btn-sm" data-modal-close>Close</button>
@@ -7,36 +7,93 @@
     <form method="post" data-modal-form action="{% url 'item_edit' item.item_id %}?partial=1">
       {% csrf_token %}
       <input type="hidden" name="partial" value="1"/>
-      <div class="grid" style="grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem;">
-        <div>
-          <label for="{{ form.name.id_for_label }}" class="form-label">Name</label>
-          {{ form.name }}
-          {% include "forms/feedback.html" %}
+      <div class="grid" style="grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 1rem;">
+        <!-- Essentials -->
+        <div class="section-panel" style="grid-column: span 12;" id="essentials-panel">
+          <h3 class="section-header">Essentials</h3>
+          <div class="grid" style="grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; align-items:start;">
+            <div class="space-y-1">
+              <label for="{{ form.name.id_for_label }}" class="form-label">Name</label>
+              {{ form.name }}
+              {% include "forms/feedback.html" %}
+            </div>
+            <div class="space-y-1">
+              <label for="{{ form.unit_id.id_for_label }}" class="form-label">Unit</label>
+              {{ form.unit_id }}
+              {% include "forms/feedback.html" %}
+            </div>
+            <div class="space-y-1">
+              <label for="{{ form.category_id.id_for_label }}" class="form-label">Category</label>
+              {{ form.category_id }}
+              {% include "forms/feedback.html" %}
+            </div>
+            <div class="space-y-1">
+              <label for="{{ form.current_stock.id_for_label }}" class="form-label">Current Stock</label>
+              {{ form.current_stock }}
+              {% include "forms/feedback.html" %}
+            </div>
+            <div class="space-y-1">
+              <label for="{{ form.reorder_point.id_for_label }}" class="form-label">Reorder Point</label>
+              {{ form.reorder_point }}
+              {% include "forms/feedback.html" %}
+            </div>
+            <div class="space-y-1">
+              <label for="{{ form.is_active.id_for_label }}" class="form-label">Status</label>
+              <div class="inline-flex items-center gap-2 text-gray-700" style="height:38px;align-items:center;">
+                {{ form.is_active }}
+                <span>Active</span>
+              </div>
+              {% include "forms/feedback.html" %}
+            </div>
+          </div>
         </div>
-        <div>
-          <label for="{{ form.category_id.id_for_label }}" class="form-label">Category</label>
-          {{ form.category_id }}
-          {% include "forms/feedback.html" %}
+
+        <!-- Advanced -->
+        <div class="section-panel" style="grid-column: span 12;" id="advanced-panel">
+          <h3 class="section-header">Advanced</h3>
+          <div class="grid" style="grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; align-items:start;">
+            <div class="space-y-1">
+              <label for="{{ form.preferred_supplier.id_for_label }}" class="form-label">Preferred Supplier</label>
+              {{ form.preferred_supplier }}
+              {% include "forms/feedback.html" %}
+            </div>
+            <div class="space-y-1">
+              <label for="{{ form.initial_purchase_price.id_for_label }}" class="form-label">Initial Purchase Price</label>
+              {{ form.initial_purchase_price }}
+              {% include "forms/feedback.html" %}
+            </div>
+            <div class="space-y-1">
+              <label for="{{ form.minimum_order_qty.id_for_label }}" class="form-label">Min Order Qty</label>
+              {{ form.minimum_order_qty }}
+              {% include "forms/feedback.html" %}
+            </div>
+            <div class="space-y-1">
+              <label for="{{ form.lead_time_days.id_for_label }}" class="form-label">Lead Time (days)</label>
+              {{ form.lead_time_days }}
+              {% include "forms/feedback.html" %}
+            </div>
+            <div class="col-span-3 space-y-1">
+              <label for="{{ form.departments.id_for_label }}" class="form-label">Departments</label>
+              <div class="dept-grid">
+                {{ form.departments }}
+              </div>
+              {% include "forms/feedback.html" %}
+            </div>
+            <div class="col-span-3 space-y-1">
+              <label for="{{ form.notes.id_for_label }}" class="form-label">Notes</label>
+              {{ form.notes }}
+              {% include "forms/feedback.html" %}
+            </div>
+          </div>
         </div>
-        <div>
-          <label for="{{ form.reorder_point.id_for_label }}" class="form-label">Reorder Point</label>
-          {{ form.reorder_point }}
-          {% include "forms/feedback.html" %}
+
+        <!-- Actions -->
+        <div style="grid-column: span 12;">
+          <div class="form-actions">
+            <button type="button" class="btn-secondary" data-modal-close>Cancel</button>
+            <button type="submit" class="btn-primary">Save</button>
+          </div>
         </div>
-        <div>
-          <label for="{{ form.is_active.id_for_label }}" class="form-label">Active</label>
-          {{ form.is_active }}
-          {% include "forms/feedback.html" %}
-        </div>
-        <div style="grid-column: span 2;">
-          <label for="{{ form.notes.id_for_label }}" class="form-label">Notes</label>
-          {{ form.notes }}
-          {% include "forms/feedback.html" %}
-        </div>
-      </div>
-      <div class="mt-3 flex items-center justify-end" style="gap:.5rem">
-        <button type="button" class="btn-secondary" data-modal-close>Cancel</button>
-        <button type="submit" class="btn-primary">Save</button>
       </div>
     </form>
   </div>

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -4,7 +4,7 @@ from django.template.loader import render_to_string
 from django.test import RequestFactory
 
 from inventory.forms.item_forms import ItemForm
-from inventory.models import Category, Unit
+from inventory.models import Category, Department, Item, Unit
 from tests.forms.test_item_forms import TestItemForm  # Use simplified test form
 
 
@@ -94,3 +94,31 @@ def test_item_form_uses_model_choice_fields():
     assert list(category_field.queryset) == list(
         Category.objects.all().order_by("category", "sub_category")
     )
+
+
+@pytest.mark.django_db
+def test_item_edit_modal_renders_all_fields():
+    unit = Unit.objects.create(purchase_unit="kg", base_unit="kg", conversion_factor=1)
+    category = Category.objects.create(category="Food", sub_category="Veg")
+    Department.objects.create(name="Kitchen")
+    item = Item.objects.create(name="T", unit=unit, category=category)
+    form = ItemForm(instance=item)
+    request = RequestFactory().get("/")
+    content = render_to_string(
+        "inventory/_item_form_partial.html", {"form": form, "item": item}, request=request
+    )
+    for field in [
+        "name",
+        "unit_id",
+        "category_id",
+        "departments",
+        "initial_purchase_price",
+        "preferred_supplier",
+        "minimum_order_qty",
+        "lead_time_days",
+        "reorder_point",
+        "current_stock",
+        "notes",
+        "is_active",
+    ]:
+        assert f'name="{field}"' in content


### PR DESCRIPTION
## Summary
- Expand item edit modal to include all ItemForm fields and match Add Item layout
- Add modal scrolling for long forms
- Test that edit modal renders every ItemForm field

## Testing
- `pre-commit run --files templates/inventory/_item_form_partial.html tests/test_item_form.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `pytest tests/test_item_form.py`


------
https://chatgpt.com/codex/tasks/task_e_68b485aaae0c8326aabea3f1e5925dbe