### PR TITLE
refactor: modernize items list layout

### DIFF
--- a/templates/components/create_manage_layout.html
+++ b/templates/components/create_manage_layout.html
@@ -1,34 +1,41 @@
-{% extends "components/list_layout.html" %}
+{% extends "_base.html" %}
 {% load static %}
 
 {% block title %}{% block page_title %}Manage{% endblock %}{% endblock %}
 
-{% block heading %}
-  {% block heading_icon %}{% endblock %}
-  {% block page_heading %}{% endblock %}
-{% endblock %}
-
-{% block actions %}
-  <div class="flex items-center gap-2">
-    {% block primary_actions %}{% endblock %}
-    {% block secondary_actions %}{% endblock %}
+{% block content %}
+  {% block breadcrumbs %}{% endblock %}
+  <div class="page-header">
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="page-title">{% block page_heading %}{% endblock %}</h1>
+        {% block page_subtitle %}{% endblock %}
+      </div>
+      <div class="flex items-center space-x-3">
+        {% block header_actions %}{% endblock %}
+      </div>
+    </div>
   </div>
-{% endblock %}
 
-{% block filter_bar %}
-  {% block filters %}{% endblock %}
-{% endblock %}
+  {% block filter_bar %}
+    {% block filters %}{% endblock %}
+  {% endblock %}
 
-{% block extra %}
   {% block description %}{% endblock %}
   {% block kpis %}{% endblock %}
   {% block extra_top %}{% endblock %}
-{% endblock %}
 
-{% block table_container %}
-  {% block data_container %}{% endblock %}
+  {% block table_container %}
+  <div id="{% block table_id %}{% endblock %}"
+       hx-get="{% block hx_get %}{% endblock %}"
+       hx-trigger="load"
+       hx-include="#filters"
+       hx-indicator="#htmx-spinner">
+    {% block data_container %}{% endblock %}
+  </div>
   {% block bulk_actions %}{% endblock %}
   {% block pagination %}{% endblock %}
+  {% endblock %}
 {% endblock %}
 
 {% block extra_js %}

--- a/templates/inventory/_add_item_section.html
+++ b/templates/inventory/_add_item_section.html
@@ -1,0 +1,96 @@
+{% extends "components/collapsible.html" %}
+{% block title %}Add Item{% endblock %}
+{% block content %}
+  <form method="post" action="{% url 'items_list' %}">
+    {% csrf_token %}
+    <input type="hidden" name="partial" value="0"/>
+
+    <div class="grid" style="grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 1rem;">
+      <!-- Essentials -->
+      <div class="section-panel" style="grid-column: span 12;" id="essentials-panel">
+        <h3 class="section-header">Essentials</h3>
+        <div class="grid" style="grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; align-items:start;">
+          <div class="space-y-1">
+            <label for="{{ form.name.id_for_label }}" class="form-label">Name</label>
+            {{ form.name }}
+            {% include "forms/feedback.html" %}
+          </div>
+          <div class="space-y-1">
+            <label for="{{ form.unit_id.id_for_label }}" class="form-label">Unit</label>
+            {{ form.unit_id }}
+            {% include "forms/feedback.html" %}
+          </div>
+          <div class="space-y-1">
+            <label for="{{ form.category_id.id_for_label }}" class="form-label">Category</label>
+            {{ form.category_id }}
+            {% include "forms/feedback.html" %}
+          </div>
+          <div class="space-y-1">
+            <label for="{{ form.current_stock.id_for_label }}" class="form-label">Current Stock</label>
+            {{ form.current_stock }}
+            {% include "forms/feedback.html" %}
+          </div>
+          <div class="space-y-1">
+            <label for="{{ form.reorder_point.id_for_label }}" class="form-label">Reorder Point</label>
+            {{ form.reorder_point }}
+            {% include "forms/feedback.html" %}
+          </div>
+          <div class="space-y-1">
+            <label for="{{ form.is_active.id_for_label }}" class="form-label">Status</label>
+            <div class="inline-flex items-center gap-2 text-gray-700" style="height:38px;align-items:center;">
+              {{ form.is_active }}
+              <span>Active</span>
+            </div>
+            {% include "forms/feedback.html" %}
+          </div>
+        </div>
+      </div>
+
+      <!-- Advanced -->
+      <div class="section-panel" style="grid-column: span 12;" id="advanced-panel">
+        <h3 class="section-header">Advanced</h3>
+        <div class="grid" style="grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; align-items:start;">
+          <div class="space-y-1">
+            <label for="{{ form.preferred_supplier.id_for_label }}" class="form-label">Preferred Supplier</label>
+            {{ form.preferred_supplier }}
+            {% include "forms/feedback.html" %}
+          </div>
+          <div class="space-y-1">
+            <label for="{{ form.initial_purchase_price.id_for_label }}" class="form-label">Initial Purchase Price</label>
+            {{ form.initial_purchase_price }}
+            {% include "forms/feedback.html" %}
+          </div>
+          <div class="space-y-1">
+            <label for="{{ form.minimum_order_qty.id_for_label }}" class="form-label">Min Order Qty</label>
+            {{ form.minimum_order_qty }}
+            {% include "forms/feedback.html" %}
+          </div>
+          <div class="space-y-1">
+            <label for="{{ form.lead_time_days.id_for_label }}" class="form-label">Lead Time (days)</label>
+            {{ form.lead_time_days }}
+            {% include "forms/feedback.html" %}
+          </div>
+          <div class="col-span-3 space-y-1">
+            <label for="{{ form.departments.id_for_label }}" class="form-label">Departments</label>
+            <div class="dept-grid">
+              {{ form.departments }}
+            </div>
+            {% include "forms/feedback.html" %}
+          </div>
+          <div class="col-span-3 space-y-1">
+            <label for="{{ form.notes.id_for_label }}" class="form-label">Notes</label>
+            {{ form.notes }}
+            {% include "forms/feedback.html" %}
+          </div>
+        </div>
+      </div>
+      <!-- Actions below Advanced -->
+      <div style="grid-column: span 12;">
+        <div class="form-actions">
+          <button type="reset" class="btn-secondary btn-sm">Clear</button>
+          <button type="submit" class="btn-primary btn-sm">Create</button>
+        </div>
+      </div>
+    </div>
+  </form>
+{% endblock %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -6,14 +6,9 @@
 {% endblock %}
 
 {% block page_title %}Item Master Management{% endblock %}
-
-{% block heading_icon %}<span class="text-2xl" aria-hidden="true">📦</span>{% endblock %}
 {% block page_heading %}Item Master Management{% endblock %}
-{% block description %}<p class="text-gray-600 mt-2">Manage your inventory items: add new items, edit existing ones, and view stock levels.</p>{% endblock %}
 
-{% block primary_actions %}{% endblock %}
-
-{% block secondary_actions %}
+{% block header_actions %}
   <div id="dept-options" class="hidden">
     <select id="dept-select-template">
       {% for d in departments_for_form %}
@@ -33,120 +28,20 @@
   </div>
 {% endblock %}
 
+{% block description %}
+<div class="card mb-6">
+  <div class="card-header">
+    <h2 class="text-lg font-semibold">About</h2>
+  </div>
+  <div class="card-body">
+    <p class="text-gray-600">Manage your inventory items: add new items, edit existing ones, and view stock levels.</p>
+  </div>
+</div>
+{% endblock %}
+
 {% block extra_top %}
-  <!-- Add Item collapsible -->
-  <details class="border rounded mb-4 bg-white">
-    <summary class="cursor-pointer px-4 py-2 bg-gray-100">
-      <h2 class="text-base font-semibold text-gray-900">Add Item</h2>
-    </summary>
-    <div class="p-4">
-      <form method="post" action="{% url 'items_list' %}">
-        {% csrf_token %}
-        <input type="hidden" name="partial" value="0"/>
-
-        <div class="grid" style="grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 1rem;">
-          <!-- Essentials -->
-          <div class="section-panel" style="grid-column: span 12;" id="essentials-panel">
-            <h3 class="section-header">Essentials</h3>
-            <div class="grid" style="grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; align-items:start;">
-            <div class="space-y-1">
-              <label for="{{ form.name.id_for_label }}" class="form-label">Name</label>
-              {{ form.name }}
-              {% include "forms/feedback.html" %}
-            </div>
-            <div class="space-y-1">
-              <label for="{{ form.unit_id.id_for_label }}" class="form-label">Unit</label>
-              {{ form.unit_id }}
-              {% include "forms/feedback.html" %}
-            </div>
-            <div class="space-y-1">
-              <label for="{{ form.category_id.id_for_label }}" class="form-label">Category</label>
-              {{ form.category_id }}
-              {% include "forms/feedback.html" %}
-            </div>
-            <div class="space-y-1">
-              <label for="{{ form.current_stock.id_for_label }}" class="form-label">Current Stock</label>
-              {{ form.current_stock }}
-              {% include "forms/feedback.html" %}
-            </div>
-            <div class="space-y-1">
-              <label for="{{ form.reorder_point.id_for_label }}" class="form-label">Reorder Point</label>
-              {{ form.reorder_point }}
-              {% include "forms/feedback.html" %}
-            </div>
-            <div class="space-y-1">
-              <label for="{{ form.is_active.id_for_label }}" class="form-label">Status</label>
-              <div class="inline-flex items-center gap-2 text-gray-700" style="height:38px;align-items:center;">
-                {{ form.is_active }}
-                <span>Active</span>
-              </div>
-              {% include "forms/feedback.html" %}
-            </div>
-            </div>
-          </div>
-
-          <!-- Advanced -->
-          <div class="section-panel" style="grid-column: span 12;" id="advanced-panel">
-            <h3 class="section-header">Advanced</h3>
-            <div class="grid" style="grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; align-items:start;">
-              <div class="space-y-1">
-                <label for="{{ form.preferred_supplier.id_for_label }}" class="form-label">Preferred Supplier</label>
-                {{ form.preferred_supplier }}
-                {% include "forms/feedback.html" %}
-              </div>
-              <div class="space-y-1">
-                <label for="{{ form.initial_purchase_price.id_for_label }}" class="form-label">Initial Purchase Price</label>
-                {{ form.initial_purchase_price }}
-                {% include "forms/feedback.html" %}
-              </div>
-              <div class="space-y-1">
-                <label for="{{ form.minimum_order_qty.id_for_label }}" class="form-label">Min Order Qty</label>
-                {{ form.minimum_order_qty }}
-                {% include "forms/feedback.html" %}
-              </div>
-              <div class="space-y-1">
-                <label for="{{ form.lead_time_days.id_for_label }}" class="form-label">Lead Time (days)</label>
-                {{ form.lead_time_days }}
-                {% include "forms/feedback.html" %}
-              </div>
-              <div class="col-span-3 space-y-1">
-                <label for="{{ form.departments.id_for_label }}" class="form-label">Departments</label>
-                <div class="dept-grid">
-                  {{ form.departments }}
-                </div>
-                {% include "forms/feedback.html" %}
-              </div>
-              <div class="col-span-3 space-y-1">
-                <label for="{{ form.notes.id_for_label }}" class="form-label">Notes</label>
-                {{ form.notes }}
-                {% include "forms/feedback.html" %}
-              </div>
-            </div>
-          </div>
-          <!-- Actions below Advanced -->
-          <div style="grid-column: span 12;">
-            <div class="form-actions">
-              <button type="reset" class="btn-secondary btn-sm">Clear</button>
-              <button type="submit" class="btn-primary btn-sm">Create</button>
-            </div>
-          </div>
-        </div>
-      </form>
-    </div>
-  </details>
-
-  <!-- Bulk Upload collapsible -->
-  <details class="border rounded mb-6 bg-white">
-    <summary class="cursor-pointer px-5 py-3 bg-gray-100">
-      <h2 class="text-base font-semibold text-gray-900">Bulk Upload</h2>
-    </summary>
-    <div class="p-5">
-      {% include "inventory/_bulk_upload_partial.html" with form=bulk_form only %}
-      <div class="mt-3">
-        <a href="{% static 'sample_stock_upload.csv' %}" download class="btn-outline">Download sample CSV</a>
-      </div>
-    </div>
-  </details>
+  {% include "inventory/_add_item_section.html" with form=form %}
+  {% include "inventory/_bulk_upload_section.html" with bulk_form=bulk_form bulk_success_count=bulk_success_count bulk_errors=bulk_errors %}
 {% endblock %}
 
 {% block filters %}
@@ -177,13 +72,20 @@
 {% endblock %}
 
 {% block kpis %}
-<div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-  {% include "components/kpi_card.html" with icon='cube' color='blue' label='Items' value=page_obj.paginator.count|default:"0" %}
-  {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low Stock' value=stats.low_stock_count|default:"0" %}
-  {% include "components/kpi_card.html" with icon='clock' color='yellow' label='Pending' value=stats.pending_orders|default:"0" %}
-  {% with total_value_formatted=stats.total_value|floatformat:0|default:"0" %}
-    {% include "components/kpi_card.html" with icon='banknotes' color='green' label='Stock Value' value="$"|add:total_value_formatted %}
-  {% endwith %}
+<div class="card mb-6">
+  <div class="card-header">
+    <h2 class="text-lg font-semibold">Key Metrics</h2>
+  </div>
+  <div class="card-body">
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
+      {% include "components/kpi_card.html" with icon='cube' color='blue' label='Items' value=page_obj.paginator.count|default:"0" %}
+      {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low Stock' value=stats.low_stock_count|default:"0" %}
+      {% include "components/kpi_card.html" with icon='clock' color='yellow' label='Pending' value=stats.pending_orders|default:"0" %}
+      {% with total_value_formatted=stats.total_value|floatformat:0|default:"0" %}
+        {% include "components/kpi_card.html" with icon='banknotes' color='green' label='Stock Value' value="$"|add:total_value_formatted %}
+      {% endwith %}
+    </div>
+  </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- integrate shared page-header into create_manage_layout
- convert items list details to collapsible partials
- wrap description and KPIs in cards

## Testing
- `pytest`
- `pre-commit run --files templates/inventory/items_list.html templates/components/create_manage_layout.html templates/inventory/_add_item_section.html` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*

------
https://chatgpt.com/codex/tasks/task_e_68b4a78940d88326893bf20dab829244