### PR TITLE
feat: add detail section cards for item view

### DIFF
--- a/templates/components/detail_section.html
+++ b/templates/components/detail_section.html
@@ -1,0 +1,10 @@
+<div class="card mb-6">
+  {% if title %}
+  <div class="card-header">
+    <h2 class="text-lg font-semibold">{{ title }}</h2>
+  </div>
+  {% endif %}
+  <div class="card-body">
+    {% include content_template %}
+  </div>
+</div>

--- a/templates/inventory/_stock_movements.html
+++ b/templates/inventory/_stock_movements.html
@@ -1,0 +1,7 @@
+<ul class="space-y-2">
+  {% for tx in stock_movements %}
+  <li>
+    {{ tx.transaction_date }} – {{ tx.transaction_type }} {{ tx.quantity_change }}
+  </li>
+  {% endfor %}
+</ul>

--- a/templates/inventory/_supplier_history.html
+++ b/templates/inventory/_supplier_history.html
@@ -1,0 +1,5 @@
+<ul class="space-y-2">
+  {% for supplier in suppliers %}
+  <li>{{ supplier.name }}</li>
+  {% endfor %}
+</ul>

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -18,35 +18,14 @@
 {% endblock %}
 
 {% block detail_table %}
-  <table class="w-full text-sm">
-    <tbody>
-      {% for label, value in rows %}
-      <tr class="border-b last:border-b-0">
-        <th class="text-left py-2 pr-4 font-medium">{{ label }}</th>
-        <td class="py-2">{{ value }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  {% include "components/detail_section.html" with title="Details" content_template="components/detail_table.html" %}
 {% endblock %}
 
 {% block extra_tables %}
   {% if suppliers %}
-  <h2 class="text-lg font-semibold mt-8 mb-4">Supplier History</h2>
-  <ul class="space-y-2">
-    {% for supplier in suppliers %}
-    <li>{{ supplier.name }}</li>
-    {% endfor %}
-  </ul>
+    {% include "components/detail_section.html" with title="Supplier History" content_template="inventory/_supplier_history.html" %}
   {% endif %}
   {% if stock_movements %}
-  <h2 class="text-lg font-semibold mt-8 mb-4">Stock Movements</h2>
-  <ul class="space-y-2">
-    {% for tx in stock_movements %}
-    <li>
-      {{ tx.transaction_date }} – {{ tx.transaction_type }} {{ tx.quantity_change }}
-    </li>
-    {% endfor %}
-  </ul>
+    {% include "components/detail_section.html" with title="Stock Movements" content_template="inventory/_stock_movements.html" %}
   {% endif %}
 {% endblock %}

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -79,3 +79,5 @@ def test_item_detail_includes_supplier_and_movements(client):
     assert supplier.name in content
     assert tx.transaction_type in content
     assert str(tx.quantity_change) in content
+    assert '<h2 class="text-lg font-semibold">Supplier History</h2>' in content
+    assert '<h2 class="text-lg font-semibold">Stock Movements</h2>' in content


### PR DESCRIPTION
## Summary
- add reusable `detail_section` card partial
- wrap item details, supplier history, and stock movements in cards
- test heading hierarchy for item detail view

## Testing
- `pre-commit run --files templates/inventory/item_detail.html templates/components/detail_section.html templates/inventory/_stock_movements.html templates/inventory/_supplier_history.html tests/test_items_list.py`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b2828e448326b60e5217ef45cc04