### PR TITLE
Add header controls to inventory items list

### DIFF
--- a/templates/inventory/_add_item_section.html
+++ b/templates/inventory/_add_item_section.html
@@ -1,4 +1,5 @@
 {% extends "components/collapsible.html" %}
+{% block open %}id="add-item-section"{% endblock %}
 {% block title %}Add Item{% endblock %}
 {% block content %}
   <form method="post" action="{% url 'items_list' %}">

--- a/templates/inventory/_bulk_upload_section.html
+++ b/templates/inventory/_bulk_upload_section.html
@@ -1,5 +1,6 @@
 {% extends "components/collapsible.html" %}
 {% load static %}
+{% block open %}id="bulk-upload-section"{% endblock %}
 {% block title %}Bulk Upload{% endblock %}
 {% block content %}
   <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary">Download sample CSV</a></p>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -10,8 +10,16 @@
 
 {% block page_title %}Item Master Management{% endblock %}
 {% block page_heading %}Item Master Management{% endblock %}
+{% block page_subtitle %}
+  <div class="flex items-center gap-2 text-sm text-gray-600 mt-1">
+    {% icon 'cube' 'w-4 h-4' %}
+    <span>Manage your inventory items</span>
+  </div>
+{% endblock %}
 
 {% block header_actions %}
+  <button type="button" id="add-item-toggle" aria-controls="add-item-section" aria-expanded="false" class="btn-primary btn-sm">Add Item</button>
+  <button type="button" id="bulk-upload-toggle" aria-controls="bulk-upload-section" aria-expanded="false" class="btn-secondary btn-sm">Bulk Upload</button>
   <div id="dept-options" class="hidden">
     <select id="dept-select-template">
       {% for d in departments_for_form %}
@@ -218,6 +226,21 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     }
   }
+  function setupToggle(btnId, sectionId) {
+    const btn = document.getElementById(btnId);
+    const section = document.getElementById(sectionId);
+    if (btn && section) {
+      btn.addEventListener('click', () => {
+        section.open = !section.open;
+        btn.setAttribute('aria-expanded', section.open ? 'true' : 'false');
+        if (section.open) {
+          section.scrollIntoView({ behavior: 'smooth' });
+        }
+      });
+    }
+  }
+  setupToggle('add-item-toggle', 'add-item-section');
+  setupToggle('bulk-upload-toggle', 'bulk-upload-section');
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show cube icon and subtitle on items list page
- add Add Item and Bulk Upload buttons that toggle collapsible forms
- tag collapsible sections with IDs for external toggling

## Testing
- `pre-commit run --files templates/inventory/items_list.html templates/inventory/_add_item_section.html templates/inventory/_bulk_upload_section.html` (fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b554b22d4c832690faacd8f5a544b1