### PR TITLE
Link KPI cards to filtered lists

### DIFF
--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -88,12 +88,14 @@
     <h2 class="text-lg font-semibold">Key Metrics</h2>
   </div>
   <div class="card-body">
+    {% url 'items_list' as items_list_url %}
+    {% url 'purchase_orders_list' as po_list_url %}
     <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
-      {% include "components/kpi_card.html" with icon='cube' color='blue' label='Items' value=page_obj.paginator.count|default:"0" %}
-      {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low Stock' value=stats.low_stock_count|default:"0" %}
-      {% include "components/kpi_card.html" with icon='clock' color='yellow' label='Pending' value=stats.pending_orders|default:"0" %}
+      {% include "components/kpi_card.html" with icon='cube' color='blue' label='Items' value=page_obj.paginator.count|default:"0" href=items_list_url %}
+      {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low Stock' value=stats.low_stock_count|default:"0" href=items_list_url|add:'?stock_status=low' %}
+      {% include "components/kpi_card.html" with icon='clock' color='yellow' label='Pending' value=stats.pending_orders|default:"0" href=po_list_url|add:'?status=ORDERED' %}
       {% with total_value_formatted=stats.total_value|floatformat:0|default:"0" %}
-        {% include "components/kpi_card.html" with icon='banknotes' color='green' label='Stock Value' value="$"|add:total_value_formatted %}
+        {% include "components/kpi_card.html" with icon='banknotes' color='green' label='Stock Value' value="$"|add:total_value_formatted href=items_list_url %}
       {% endwith %}
     </div>
   </div>

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -11,6 +11,8 @@ from inventory.models import (
     Supplier,
 )
 
+import pytest
+
 
 def _create_item(**kwargs):
     defaults = {
@@ -81,3 +83,16 @@ def test_item_detail_includes_supplier_and_movements(client):
     assert str(tx.quantity_change) in content
     assert '<h2 class="text-lg font-semibold">Supplier History</h2>' in content
     assert '<h2 class="text-lg font-semibold">Stock Movements</h2>' in content
+
+
+@pytest.mark.django_db
+def test_items_list_kpi_card_links(client):
+    _create_item()
+    url = reverse("items_list")
+    resp = client.get(url)
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    po_url = reverse("purchase_orders_list")
+    assert html.count(f'href="{url}"') >= 2
+    assert f'href="{url}?stock_status=low"' in html
+    assert f'href="{po_url}?status=ORDERED"' in html


### PR DESCRIPTION
## Summary
- Add hyperlinks to KPI cards in inventory items list linking to relevant views and filters
- Test KPI card links in items list page

## Testing
- `pytest tests/test_items_list.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b55f26ed68832687f2e5ad037d5cf7