### PR TITLE
Refactor collapsible component into card layout

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -143,6 +143,17 @@
     padding: 1rem;
   }
 
+  /* Collapsible Card */
+  .card > details > summary {
+    list-style: none;
+  }
+  .card > details > summary::-webkit-details-marker {
+    display: none;
+  }
+  .card > details:not([open]) > .card-header {
+    border-bottom: 0;
+  }
+
   /* Button System */
   .btn-primary {
     display: inline-flex;

--- a/templates/components/collapsible.html
+++ b/templates/components/collapsible.html
@@ -1,8 +1,10 @@
-<details class="border rounded mb-4" {% block open %}{% endblock %}>
-  <summary class="cursor-pointer px-4 py-2 bg-gray-100">
-    <h2 class="text-h2 font-semibold">{% block title %}{% endblock %}</h2>
-  </summary>
-  <div class="p-4">
-    {% block content %}{% endblock %}
-  </div>
-</details>
+<div class="card mb-4">
+  <details {% block open %}{% endblock %}>
+    <summary class="card-header cursor-pointer">
+      <h2 class="text-h2 font-semibold">{% block title %}{% endblock %}</h2>
+    </summary>
+    <div class="card-body">
+      {% block content %}{% endblock %}
+    </div>
+  </details>
+</div>


### PR DESCRIPTION
## Summary
- Wrap collapsible sections in a `.card` with dedicated header and body containers
- Hide native details marker and adjust border behavior for collapsed cards

## Testing
- `flake8` *(fails: E301, W391 in unrelated files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5617a71c88326bcb67db87d46e87f