### PR TITLE
feat: add supplier and unit filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Layout toggle buttons on the items list to switch between table and grid views.
+- Supplier and unit dropdown filters on the items list for more precise results.
 
 ### Removed
 

--- a/inventory/services/category_filters.py
+++ b/inventory/services/category_filters.py
@@ -9,12 +9,14 @@ logger = logging.getLogger(__name__)
 
 
 def resolve_category_filters(request) -> Dict[str, Any]:
-    """Return selected category values and available options."""
-    from ..models import Department
+    """Return selected filter values and available options."""
+    from ..models import Department, Supplier, Unit
 
     category = (request.GET.get("category") or "").strip()
     subcategory = (request.GET.get("subcategory") or "").strip()
     department = (request.GET.get("department") or "").strip()
+    base_unit = (request.GET.get("base_unit") or "").strip()
+    supplier = (request.GET.get("supplier") or "").strip()
 
     try:
         categories_map = CategoriesService.get_category_choices_grouped()
@@ -30,15 +32,29 @@ def resolve_category_filters(request) -> Dict[str, Any]:
         Department.objects.all().values_list("name", flat=True).order_by("name")
     )
 
+    base_units = list(
+        Unit.objects.order_by("base_unit")
+        .values_list("base_unit", flat=True)
+        .distinct()
+    )
+
+    suppliers = list(
+        Supplier.objects.filter(is_active=True)
+        .order_by("name")
+        .values_list("supplier_id", "name")
+    )
+
     return {
         "category": category,
         "subcategory": subcategory,
-        "base_unit": "",
+        "base_unit": base_unit,
+        "supplier": supplier,
         "department": department,
         "categories": categories,
         "subcategories": subcategories,
-        "base_units": [],
+        "base_units": base_units,
         "units": [],
+        "suppliers": suppliers,
         "departments": [(d, d) for d in departments],
     }
 
@@ -54,6 +70,14 @@ def build_filters(request) -> List[Dict[str, Any]]:
     subcategory_options = [{"value": "", "label": "All Subcategories"}]
     for c in resolved["subcategories"]:
         subcategory_options.append({"value": c, "label": c})
+
+    base_unit_options = [{"value": "", "label": "All Units"}]
+    for u in resolved["base_units"]:
+        base_unit_options.append({"value": u, "label": u})
+
+    supplier_options = [{"value": "", "label": "All Suppliers"}]
+    for sid, name in resolved.get("suppliers", []):
+        supplier_options.append({"value": str(sid), "label": name})
 
     department_options = [{"value": "", "label": "All Departments"}]
     department_options.extend(
@@ -77,7 +101,13 @@ def build_filters(request) -> List[Dict[str, Any]]:
             "name": "base_unit",
             "label": "Unit",
             "value": resolved["base_unit"],
-            "options": [],
+            "options": base_unit_options,
+        },
+        {
+            "name": "supplier",
+            "label": "Supplier",
+            "value": resolved["supplier"],
+            "options": supplier_options,
         },
         {
             "name": "department",

--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -39,6 +39,8 @@ def _filter_and_sort_items(request, qs=None):
         "category": "category__category",
         "subcategory": "category__sub_category",
         "department": "departments__name",
+        "supplier": "preferred_supplier_id",
+        "base_unit": "unit__base_unit",
     }
     allowed_sorts = {
         "item_id",

--- a/tests/test_items_filters.py
+++ b/tests/test_items_filters.py
@@ -1,0 +1,54 @@
+import pytest
+from django.test import RequestFactory
+
+from inventory.models import Item, Supplier, Unit
+from inventory.views.items.list import _filter_and_sort_items
+from inventory.services import category_filters
+
+
+@pytest.mark.django_db
+def test_filter_by_supplier_and_unit():
+    rf = RequestFactory()
+    supplier1 = Supplier.objects.create(name="Acme")
+    supplier2 = Supplier.objects.create(name="Beta")
+    unit_kg = Unit.objects.create(purchase_unit="kg", base_unit="kg", conversion_factor=1)
+    unit_l = Unit.objects.create(purchase_unit="l", base_unit="l", conversion_factor=1)
+    item1 = Item.objects.create(
+        name="Sugar",
+        unit=unit_kg,
+        preferred_supplier=supplier1,
+        reorder_point=1,
+        notes="n",
+        is_active=True,
+    )
+    item2 = Item.objects.create(
+        name="Milk",
+        unit=unit_l,
+        preferred_supplier=supplier2,
+        reorder_point=1,
+        notes="n",
+        is_active=True,
+    )
+
+    request = rf.get("/items/", {"base_unit": "kg"})
+    qs, params = _filter_and_sort_items(request)
+    assert list(qs) == [item1]
+    assert params["base_unit"] == "kg"
+
+    request = rf.get("/items/", {"supplier": str(supplier2.pk)})
+    qs, params = _filter_and_sort_items(request)
+    assert list(qs) == [item2]
+    assert params["supplier"] == str(supplier2.pk)
+
+
+@pytest.mark.django_db
+def test_category_filters_include_supplier_and_units():
+    rf = RequestFactory()
+    Supplier.objects.create(name="Acme")
+    Unit.objects.create(purchase_unit="kg", base_unit="kg", conversion_factor=1)
+    request = rf.get("/items/")
+    filters = category_filters.build_filters(request)
+    base_filter = next(f for f in filters if f["name"] == "base_unit")
+    assert any(opt["value"] == "kg" for opt in base_filter["options"])
+    supplier_filter = next(f for f in filters if f["name"] == "supplier")
+    assert any(opt["label"] == "Acme" for opt in supplier_filter["options"])


### PR DESCRIPTION
## Summary
- add supplier and unit filter options to category filter helpers
- support `supplier` and `base_unit` query parameters for item list filtering
- cover new filter paths with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b563f42ac083268d12d3b7836b5ce4