### PR TITLE
Add modal edit link in items table

### DIFF
--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -213,6 +213,15 @@
             {% icon 'pencil-square' 'w-4 h-4' %}
           </button>
           <a
+            href="{% url 'item_edit' item.item_id %}"
+            data-modal-url="{% url 'item_edit' item.item_id %}?partial=1"
+            class="btn-square btn-sm text-gray-400 hover:text-blue-600"
+            title="Edit"
+            aria-label="Edit {{ item.name }}"
+          >
+            {% icon 'pencil' 'w-4 h-4' %}
+          </a>
+          <a
             href="{% url 'item_detail' item.item_id %}"
             data-action="view"
             data-href="{% url 'item_detail' item.item_id %}?partial=1"


### PR DESCRIPTION
## Summary
- add explicit modal-based edit link beside quick edit in items table

## Testing
- `pre-commit run --files templates/inventory/_items_table.html` *(fails: RuntimeError: failed to find interpreter for python3.13)*
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5715515688326ba4254da9a3ce0cf