### PR TITLE
feat: add stock status column to item tables

### DIFF
--- a/docs/design_decisions.md
+++ b/docs/design_decisions.md
@@ -1,0 +1,7 @@
+# Design Decisions
+
+## Stock Status Column
+
+- Introduces a `stock_status` column in the items table to align with the grid view.
+- Uses design-system badges (`badge-error`, `badge-success`, `badge-gray`) to display **Low Stock**, **In Stock**, or **No Data** based on `current_stock` and `reorder_point`.
+- Column visibility is toggleable like other columns via the column menu and remembered in local storage.

--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -40,6 +40,17 @@
     if (detailsView) detailsView.classList.add("hidden");
   }
 
+  function renderStockStatus(stock, rop) {
+    const s = parseFloat(stock);
+    const r = parseFloat(rop);
+    if (!isNaN(s) && !isNaN(r)) {
+      if (s <= r)
+        return '<span class="badge badge-error">Low Stock</span>';
+      return '<span class="badge badge-success">In Stock</span>';
+    }
+    return '<span class="badge badge-gray">No Data</span>';
+  }
+
   // New: in-row inline editing (no extra row)
   function beginRowEdit(row) {
     if (!row || row.dataset.editing === "1") return;
@@ -186,6 +197,14 @@
           const stockCell = row.querySelector('td[data-col="stock"]');
           if (stockCell && currentStock !== "")
             stockCell.textContent = currentStock;
+          const stockStatusCell = row.querySelector(
+            'td[data-col="stock_status"]',
+          );
+          if (stockStatusCell)
+            stockStatusCell.innerHTML = renderStockStatus(
+              currentStock,
+              rop,
+            );
           const statusCell = row.querySelector('td[data-col="status"]');
           if (statusCell) {
             statusCell.innerHTML = active

--- a/static/js/items-table.test.js
+++ b/static/js/items-table.test.js
@@ -123,3 +123,30 @@ describe("column visibility menu", () => {
     expect(document.activeElement).toBe(btn);
   });
 });
+
+describe("stock_status column toggle", () => {
+  beforeEach(() => {
+    localStorage.setItem("items_table_hidden", '["stock_status"]');
+    document.body.innerHTML = `
+      <div>
+        <label><input type="checkbox" data-col-toggle value="stock_status" checked></label>
+        <table><tr><td data-col="stock_status">val</td></tr></table>
+      </div>`;
+    jest.isolateModules(() => {
+      require("./items-table.js");
+    });
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+  });
+
+  test("toggles visibility of stock_status column", () => {
+    const cb = document.querySelector(
+      '[data-col-toggle][value="stock_status"]',
+    );
+    const cell = document.querySelector('[data-col="stock_status"]');
+    expect(cb.checked).toBe(false);
+    expect(cell.classList.contains("hidden")).toBe(true);
+    cb.checked = true;
+    cb.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(cell.classList.contains("hidden")).toBe(false);
+  });
+});

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -74,6 +74,22 @@
           <input
             type="checkbox"
             data-col-toggle
+            value="stock_status"
+            checked
+            class="form-checkbox"
+          />
+          <span>Stock Status</span>
+        </label>
+      </li>
+      <li role="none">
+        <label
+          class="flex items-center gap-2"
+          role="menuitemcheckbox"
+          tabindex="-1"
+        >
+          <input
+            type="checkbox"
+            data-col-toggle
             value="rop"
             checked
             class="form-checkbox"
@@ -135,6 +151,9 @@
       <th scope="col" class="sticky top-0 z-10 bg-white" data-col="stock">
         Stock
       </th>
+      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="stock_status">
+        Stock Status
+      </th>
       <th scope="col" class="sticky top-0 z-10 bg-white" data-col="rop">ROP</th>
       <th scope="col" class="sticky top-0 z-10 bg-white" data-col="departments">
         Departments
@@ -184,6 +203,17 @@
         {% if item.current_stock is not None %} {{ item.current_stock }} {% else
         %}
         <span class="text-gray-400">—</span>
+        {% endif %}
+      </td>
+      <td data-col="stock_status">
+        {% if item.current_stock and item.reorder_point %}
+          {% if item.current_stock <= item.reorder_point %}
+            <span class="badge badge-error">Low Stock</span>
+          {% else %}
+            <span class="badge badge-success">In Stock</span>
+          {% endif %}
+        {% else %}
+          <span class="badge badge-gray">No Data</span>
         {% endif %}
       </td>
       <td data-col="rop">{{ item.reorder_point|default:"—" }}</td>
@@ -254,7 +284,7 @@
     </tr>
     {% empty %}
     <tr>
-      <td colspan="9" class="text-center text-gray-500">No items found.</td>
+      <td colspan="10" class="text-center text-gray-500">No items found.</td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- show stock status badges in items table using design-system classes
- refresh stock status after inline edits and support column toggling
- document the stock status column design

## Testing
- `pytest`
- `npx jest static/js/items-table.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b572059aec8326afabb93961550aac