### PR TITLE
feat: keep inventory filters visible with sticky layout

### DIFF
--- a/templates/components/filter_bar.html
+++ b/templates/components/filter_bar.html
@@ -1,47 +1,49 @@
 <form id="filters" class="filters-inline mb-4" method="get">
-  <div class="flex flex-col">
-    <label for="filter-q" class="text-sm font-medium">{{ search_label|default:'Search' }}</label>
-    <input
-      id="filter-q"
-      type="text"
-      name="q"
-      placeholder="{{ search_placeholder }}"
-      class="form-control w-full"
-      value="{{ q }}"
-      hx-get="{{ hx_get }}"
-      hx-target="{{ hx_target }}"
-      hx-trigger="keyup changed delay:{{ search_delay|default:'300ms' }}"
-      hx-include="#filters"
-      {% if hx_indicator %}hx-indicator="{{ hx_indicator }}"{% endif %}
-    />
-  </div>
-  {% for f in filters %}
+  <div class="flex flex-wrap items-end gap-4">
     <div class="flex flex-col">
-      <label for="{{ f.id|default:f.name }}" class="text-sm font-medium">{{ f.label|default:f.name|capfirst }}</label>
-      <select
-        name="{{ f.name }}"
+      <label for="filter-q" class="text-sm font-medium">{{ search_label|default:'Search' }}</label>
+      <input
+        id="filter-q"
+        type="text"
+        name="q"
+        placeholder="{{ search_placeholder }}"
         class="form-control w-full"
+        value="{{ q }}"
         hx-get="{{ hx_get }}"
         hx-target="{{ hx_target }}"
-        hx-trigger="change"
+        hx-trigger="keyup changed delay:{{ search_delay|default:'300ms' }}"
         hx-include="#filters"
         {% if hx_indicator %}hx-indicator="{{ hx_indicator }}"{% endif %}
-        id="{{ f.id|default:f.name }}"
-      >
-        {% for opt in f.options %}
-          <option value="{{ opt.value }}"{% if opt.value == f.value %} selected{% endif %}>
-            {{ opt.label|default:opt.value }}
-          </option>
-        {% endfor %}
-      </select>
+      />
     </div>
-  {% endfor %}
-  {% if export_url %}
-    <div class="flex flex-col">
-      <span class="text-sm font-medium">&nbsp;</span>
-      <button type="submit" {% if export_param_name and export_param_value %}name="{{ export_param_name }}" value="{{ export_param_value }}"{% endif %} formaction="{{ export_url }}" formmethod="get" class="btn-secondary w-full">{{ export_label|default:'Export' }}</button>
-    </div>
-  {% endif %}
+    {% for f in filters %}
+      <div class="flex flex-col">
+        <label for="{{ f.id|default:f.name }}" class="text-sm font-medium">{{ f.label|default:f.name|capfirst }}</label>
+        <select
+          name="{{ f.name }}"
+          class="form-control w-full"
+          hx-get="{{ hx_get }}"
+          hx-target="{{ hx_target }}"
+          hx-trigger="change"
+          hx-include="#filters"
+          {% if hx_indicator %}hx-indicator="{{ hx_indicator }}"{% endif %}
+          id="{{ f.id|default:f.name }}"
+        >
+          {% for opt in f.options %}
+            <option value="{{ opt.value }}"{% if opt.value == f.value %} selected{% endif %}>
+              {{ opt.label|default:opt.value }}
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+    {% endfor %}
+    {% if export_url %}
+      <div class="flex flex-col">
+        <span class="text-sm font-medium">&nbsp;</span>
+        <button type="submit" {% if export_param_name and export_param_value %}name="{{ export_param_name }}" value="{{ export_param_value }}"{% endif %} formaction="{{ export_url }}" formmethod="get" class="btn-secondary w-full">{{ export_label|default:'Export' }}</button>
+      </div>
+    {% endif %}
+  </div>
   {% if layout %}<input type="hidden" name="layout" value="{{ layout }}">{% endif %}
   {% if page_size %}<input type="hidden" name="page_size" value="{{ page_size|default:25 }}">{% endif %}
   {% if sort %}<input type="hidden" name="sort" value="{{ sort|default:'name' }}">{% endif %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -55,32 +55,7 @@
   {% include "inventory/_bulk_upload_section.html" with bulk_form=bulk_form bulk_success_count=bulk_success_count bulk_errors=bulk_errors %}
 {% endblock %}
 
-{% block filters %}
-  <!-- Title should come before filters -->
-  <h2 class="text-lg font-semibold text-gray-900 mb-2">Inventory Items</h2>
-
-  <!-- Place filters directly above the table -->
-  <div class="card mb-4">
-    <div class="card-body">
-      <div class="flex items-center justify-between mb-2">
-        <div class="text-sm text-gray-600">Filter and explore</div>
-        <div class="flex items-center gap-2" role="toolbar" aria-label="Layout options">
-          <button type="button" class="btn-square" data-layout-btn data-value="table" aria-label="Table view"{% if request.GET.layout|default:'table' == 'table' %} aria-pressed="true"{% else %} aria-pressed="false"{% endif %}>
-            {% icon 'list-bullet' 'w-4 h-4' %}
-          </button>
-          <button type="button" class="btn-square" data-layout-btn data-value="grid" aria-label="Grid view"{% if request.GET.layout == 'grid' %} aria-pressed="true"{% else %} aria-pressed="false"{% endif %}>
-            {% icon 'squares-2x2' 'w-4 h-4' %}
-          </button>
-        </div>
-      </div>
-      {% url 'items_table' as items_table_url %}
-      {% include "components/filter_bar.html" with q=request.GET.q filters=filters hx_get=items_table_url hx_target='#items-list' hx_indicator='#items-loading' search_placeholder='e.g., Tomato, Rice' export_url=export_url layout=request.GET.layout|default:'table' %}
-    </div>
-  </div>
-
-  <!-- Screen-reader live region for list updates -->
-  <div id="items-aria-live" class="sr-only" aria-live="polite"></div>
-{% endblock %}
+{# Filter block moved directly above the table within data_container #}
 
 {% block kpis %}
 <div class="card mb-6">
@@ -103,8 +78,24 @@
 {% endblock %}
 
 {% block data_container %}
+<h2 class="text-lg font-semibold text-gray-900 mb-2">Inventory Items</h2>
 <div class="card">
   <div class="table-scroll">
+    <div class="sticky top-0 z-10 bg-white p-4">
+      <div class="flex items-center justify-between mb-2">
+        <div class="text-sm text-gray-600">Filter and explore</div>
+        <div class="flex items-center gap-2" role="toolbar" aria-label="Layout options">
+          <button type="button" class="btn-square" data-layout-btn data-value="table" aria-label="Table view"{% if request.GET.layout|default:'table' == 'table' %} aria-pressed="true"{% else %} aria-pressed="false"{% endif %}>
+            {% icon 'list-bullet' 'w-4 h-4' %}
+          </button>
+          <button type="button" class="btn-square" data-layout-btn data-value="grid" aria-label="Grid view"{% if request.GET.layout == 'grid' %} aria-pressed="true"{% else %} aria-pressed="false"{% endif %}>
+            {% icon 'squares-2x2' 'w-4 h-4' %}
+          </button>
+        </div>
+      </div>
+      {% url 'items_table' as items_table_url %}
+      {% include "components/filter_bar.html" with q=request.GET.q filters=filters hx_get=items_table_url hx_target='#items-list' hx_indicator='#items-loading' search_placeholder='e.g., Tomato, Rice' export_url=export_url layout=request.GET.layout|default:'table' %}
+    </div>
     <div class="overflow-x-auto" id="items-list">
       {% include "components/items_table.html" with layout=request.GET.layout|default:'table' %}
     </div>
@@ -115,6 +106,7 @@
     <div class="skeleton-row"></div>
   </div>
 </div>
+<div id="items-aria-live" class="sr-only" aria-live="polite"></div>
 {% endblock %}
 
 {% block pagination %}


### PR DESCRIPTION
## Summary
- arrange filter bar inputs side by side with flex wrap
- keep filters visible while scrolling items

## Testing
- `pre-commit run --files templates/components/filter_bar.html templates/inventory/items_list.html` *(fails: RuntimeError: failed to find interpreter for python3.13)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b579c806a48326913da268a1ae12d4