### PR TITLE
Improve accessibility of inventory templates

### DIFF
--- a/templates/components/filter_bar.html
+++ b/templates/components/filter_bar.html
@@ -6,6 +6,7 @@
         id="filter-q"
         type="text"
         name="q"
+        autocomplete="off"
         placeholder="{{ search_placeholder }}"
         class="form-control w-full"
         value="{{ q }}"
@@ -28,6 +29,7 @@
           hx-include="#filters"
           {% if hx_indicator %}hx-indicator="{{ hx_indicator }}"{% endif %}
           id="{{ f.id|default:f.name }}"
+          autocomplete="off"
         >
           {% for opt in f.options %}
             <option value="{{ opt.value }}"{% if opt.value == f.value %} selected{% endif %}>

--- a/templates/inventory/explore.html
+++ b/templates/inventory/explore.html
@@ -6,14 +6,22 @@
 {% block page_heading %}Explore Items{% endblock %}
 
 {% block filters %}
-<form method="get">
-  <input type="text" name="q" value="{{ q }}" placeholder="Search" />
-  <select name="active">
-    <option value="" {% if not active %}selected{% endif %}>All</option>
-    <option value="1" {% if active == '1' %}selected{% endif %}>Active</option>
-    <option value="0" {% if active == '0' %}selected{% endif %}>Inactive</option>
-  </select>
-  <button type="submit">Filter</button>
+<form method="get" class="flex flex-col gap-2 sm:flex-row sm:items-end">
+  <div class="flex flex-col">
+    <label for="q" class="text-sm font-medium">Search</label>
+    <input id="q" type="text" name="q" value="{{ q }}" placeholder="Search" autocomplete="off" />
+  </div>
+  <div class="flex flex-col">
+    <label for="active" class="text-sm font-medium">Status</label>
+    <select id="active" name="active" autocomplete="off">
+      <option value="" {% if not active %}selected{% endif %}>All</option>
+      <option value="1" {% if active == '1' %}selected{% endif %}>Active</option>
+      <option value="0" {% if active == '0' %}selected{% endif %}>Inactive</option>
+    </select>
+  </div>
+  <div>
+    <button type="submit">Filter</button>
+  </div>
 </form>
 <a href="{{ export_url }}?{{ querystring }}">Export CSV</a>
 {% endblock %}

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -10,12 +10,15 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
   <div class="flex flex-col gap-2 mb-4">
+    <label for="date-range" class="text-sm font-medium">Date Range</label>
     <input
       id="date-range"
+      name="date_range"
       type="text"
       class="form-control w-full md:w-64"
       placeholder="Select Date Range"
       value="{% if start_date and end_date %}{{ start_date }} to {{ end_date }}{% endif %}"
+      autocomplete="off"
     />
     <div class="flex flex-col md:flex-row md:items-end gap-2">
       <div class="flex-1">

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -41,8 +41,8 @@
   <div class="card-body">
     <form method="get" class="grid grid-cols-1 lg:grid-cols-5 gap-4">
       <div>
-        <label class="form-label">Status</label>
-        <select name="status" class="form-select predictive">
+        <label for="status" class="form-label">Status</label>
+        <select id="status" name="status" class="form-select predictive" autocomplete="off">
           <option value="">All Statuses</option>
           {% for value, label in statuses %}
             <option value="{{ value }}" {% if current_status == value %}selected{% endif %}>
@@ -52,8 +52,8 @@
         </select>
       </div>
       <div>
-        <label class="form-label">Supplier</label>
-        <select name="supplier" class="form-select predictive">
+        <label for="supplier" class="form-label">Supplier</label>
+        <select id="supplier" name="supplier" class="form-select predictive" autocomplete="off">
           <option value="">All Suppliers</option>
           {% for supplier in suppliers %}
             <option value="{{ supplier.pk }}" {% if current_supplier == supplier.pk|stringformat:"s" %}selected{% endif %}>
@@ -63,12 +63,12 @@
         </select>
       </div>
       <div>
-        <label class="form-label">Start Date</label>
-        <input type="date" name="start_date" value="{{ start_date }}" class="form-input">
+        <label for="start-date" class="form-label">Start Date</label>
+        <input id="start-date" type="date" name="start_date" value="{{ start_date }}" class="form-input" autocomplete="off">
       </div>
       <div>
-        <label class="form-label">End Date</label>
-        <input type="date" name="end_date" value="{{ end_date }}" class="form-input">
+        <label for="end-date" class="form-label">End Date</label>
+        <input id="end-date" type="date" name="end_date" value="{{ end_date }}" class="form-input" autocomplete="off">
       </div>
       <div class="flex items-end space-x-2">
         <button type="submit" class="btn-primary flex-1">

--- a/templates/inventory/visualizations.html
+++ b/templates/inventory/visualizations.html
@@ -3,12 +3,21 @@
 {% block content %}
   <h1 class="text-h1 font-semibold mb-4">Visualizations</h1>
   <form method="get" class="flex flex-col md:flex-row gap-2 mb-4">
-    <select name="metric" class="form-control">
-      <option value="sales" {% if metric == 'sales' %}selected{% endif %}>Sales</option>
-      <option value="stock" {% if metric == 'stock' %}selected{% endif %}>Stock</option>
-    </select>
-    <input type="date" name="start_date" value="{{ start_date }}" class="form-control" />
-    <input type="date" name="end_date" value="{{ end_date }}" class="form-control" />
+    <div class="flex flex-col">
+      <label for="metric" class="text-sm font-medium">Metric</label>
+      <select id="metric" name="metric" class="form-control" autocomplete="off">
+        <option value="sales" {% if metric == 'sales' %}selected{% endif %}>Sales</option>
+        <option value="stock" {% if metric == 'stock' %}selected{% endif %}>Stock</option>
+      </select>
+    </div>
+    <div class="flex flex-col">
+      <label for="start-date" class="text-sm font-medium">Start Date</label>
+      <input id="start-date" type="date" name="start_date" value="{{ start_date }}" class="form-control" autocomplete="off" />
+    </div>
+    <div class="flex flex-col">
+      <label for="end-date" class="text-sm font-medium">End Date</label>
+      <input id="end-date" type="date" name="end_date" value="{{ end_date }}" class="form-control" autocomplete="off" />
+    </div>
     <button type="submit" class="btn-primary">Apply</button>
   </form>
   <div id="heatmap" class="w-full h-64"></div>


### PR DESCRIPTION
## Summary
- add autocomplete attributes and IDs to filter bar inputs
- ensure inventory forms include labels, IDs, and autocomplete

## Testing
- `pytest`
- `pre-commit run --files templates/components/filter_bar.html templates/inventory/explore.html templates/inventory/history_reports.html templates/inventory/purchase_orders/list.html templates/inventory/visualizations.html` *(failed: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*


------
https://chatgpt.com/codex/tasks/task_e_68b584349efc83268cad106084131e3e