### PR TITLE
Fix Dropzone initialization for bulk item uploads

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -14,6 +14,7 @@
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
     <link rel="stylesheet" href="https://unpkg.com/dropzone@5/dist/min/dropzone.min.css">
   <script src="https://unpkg.com/dropzone@5/dist/min/dropzone.min.js"></script>
+  <script>Dropzone.autoDiscover = false;</script>
   <script src="{% static 'js/predictive-dropdown.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/notifications.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/formset.js' %}?v={{ STATIC_VERSION }}" defer></script>

--- a/templates/inventory/_bulk_upload_section.html
+++ b/templates/inventory/_bulk_upload_section.html
@@ -4,7 +4,7 @@
 {% block title %}Bulk Upload{% endblock %}
 {% block content %}
   <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary">Download sample CSV</a></p>
-  <form method="post" action="" enctype="multipart/form-data" class="dropzone border-dashed border-2 p-4" id="bulk-upload-form">
+  <form method="post" action="{% url 'items_bulk_upload' %}" enctype="multipart/form-data" class="dropzone border-dashed border-2 p-4" id="bulk-upload-form">
     {% csrf_token %}
     <input type="hidden" name="bulk_upload" value="1" />
     {% if bulk_form.non_field_errors %}
@@ -16,6 +16,9 @@
     {% endif %}
     <div class="dz-message" data-dz-message><span>Drop CSV file here or click to upload.</span></div>
   </form>
+  <script>
+    new Dropzone('#bulk-upload-form', { url: '{% url "items_bulk_upload" %}' });
+  </script>
   {% if bulk_success_count is not None %}
     <p class="mt-2">{{ bulk_success_count }} transaction(s) recorded successfully.</p>
   {% endif %}


### PR DESCRIPTION
## Summary
- Disable Dropzone autodiscovery globally
- Initialize Dropzone with bulk upload endpoint on the inventory bulk upload form

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b588e6aaac8326a37ac2235b815361