### PR TITLE
fix: rely on css var for sticky table headers

### DIFF
--- a/static/js/table-sticky.test.js
+++ b/static/js/table-sticky.test.js
@@ -1,0 +1,19 @@
+/** @jest-environment jsdom */
+const fs = require('fs');
+const path = require('path');
+
+describe('table sticky header', () => {
+  test('CSS rule exists with variable top', () => {
+    const css = fs.readFileSync(path.resolve(__dirname, '../src/app.css'), 'utf8');
+    expect(css).toMatch(/\.table-sticky thead th\s*{[^}]*top: var\(--filters-height, 0\)/);
+  });
+
+  test('filters height variable updates', () => {
+    document.body.innerHTML = '<div class="table-scroll"><div id="bar"></div></div>';
+    const bar = document.getElementById('bar');
+    Object.defineProperty(bar, 'offsetHeight', { configurable: true, value: 40 });
+    const scroller = bar.closest('.table-scroll');
+    scroller.style.setProperty('--filters-height', bar.offsetHeight + 'px');
+    expect(scroller.style.getPropertyValue('--filters-height')).toBe('40px');
+  });
+});

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -136,32 +136,32 @@
 <table class="table w-full bg-white border border-gray-200 rounded-lg table-sticky" id="grid-table">
   <thead class="table-header">
     <tr>
-      <th scope="col" class="sticky top-0 z-10 bg-white w-8">
+      <th scope="col" class="sticky z-10 bg-white w-8">
         <input type="checkbox" data-select-all aria-label="Select all" />
       </th>
-      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="name">
+      <th scope="col" class="sticky z-10 bg-white" data-col="name">
         Name
       </th>
-      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="category">
+      <th scope="col" class="sticky z-10 bg-white" data-col="category">
         Category
       </th>
-      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="unit">
+      <th scope="col" class="sticky z-10 bg-white" data-col="unit">
         Unit
       </th>
-      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="stock">
+      <th scope="col" class="sticky z-10 bg-white" data-col="stock">
         Stock
       </th>
-      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="stock_status">
+      <th scope="col" class="sticky z-10 bg-white" data-col="stock_status">
         Stock Status
       </th>
-      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="rop">ROP</th>
-      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="departments">
+      <th scope="col" class="sticky z-10 bg-white" data-col="rop">ROP</th>
+      <th scope="col" class="sticky z-10 bg-white" data-col="departments">
         Departments
       </th>
-      <th scope="col" class="sticky top-0 z-10 bg-white" data-col="status">
+      <th scope="col" class="sticky z-10 bg-white" data-col="status">
         Status
       </th>
-      <th scope="col" class="sticky top-0 z-10 bg-white w-[120px]">Actions</th>
+      <th scope="col" class="sticky z-10 bg-white w-[120px]">Actions</th>
     </tr>
   </thead>
   <tbody class="table-body">

--- a/tests/test_items_table_header.py
+++ b/tests/test_items_table_header.py
@@ -1,0 +1,8 @@
+import re
+from pathlib import Path
+
+
+def test_items_table_header_has_no_top_zero():
+    content = Path('templates/inventory/_items_table.html').read_text()
+    header = re.search(r'<thead.*?</thead>', content, re.DOTALL).group(0)
+    assert 'top-0' not in header


### PR DESCRIPTION
## Summary
- remove `top-0` classes from inventory table headers
- rely on `.table-sticky thead th` CSS for sticky offset
- add tests covering absence of `top-0` and filter-bar height variable

## Testing
- `npm run build-css`
- `npm test`
- `pytest tests/test_items_table_header.py tests/test_items_list.py::test_item_link_in_table_layout -q`


------
https://chatgpt.com/codex/tasks/task_e_68b58bf42c308326889ec1769f99364e