### PR TITLE
fix: keep filters visible on items page

### DIFF
--- a/templates/components/create_manage_layout.html
+++ b/templates/components/create_manage_layout.html
@@ -26,11 +26,7 @@
   {% block extra_top %}{% endblock %}
 
   {% block table_container %}
-  <div id="{% block table_id %}{% endblock %}"
-       hx-get="{% block hx_get %}{% endblock %}"
-       hx-trigger="load"
-       hx-include="#filters"
-       hx-indicator="#htmx-spinner">
+  <div id="{% block table_id %}{% endblock %}">
     {% block data_container %}{% endblock %}
   </div>
   {% block bulk_actions %}{% endblock %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -2,7 +2,6 @@
 {% load static icon_tags %}
 
 {% block table_id %}items-container{% endblock %}
-{% block hx_get %}{% url 'items_table' %}{% endblock %}
 
 {% block breadcrumbs %}
   {% include "components/breadcrumb.html" with list_url=list_url list_title=list_title current_title=current_title %}

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -96,3 +96,22 @@ def test_items_list_kpi_card_links(client):
     assert html.count(f'href="{url}"') >= 2
     assert f'href="{url}?stock_status=low"' in html
     assert f'href="{po_url}?status=ORDERED"' in html
+
+
+@pytest.mark.django_db
+def test_filters_persist_after_table_refresh(client):
+    """Filters should remain visible after HTMX table updates."""
+    _create_item()
+    # Initial page load contains the filter bar
+    resp = client.get(reverse("items_list"))
+    assert resp.status_code == 200
+    initial_html = resp.content.decode()
+    assert 'id="items-filter-bar"' in initial_html
+
+    # Simulate an HTMX request to refresh the table
+    table_resp = client.get(reverse("items_table"), HTTP_HX_REQUEST="true")
+    assert table_resp.status_code == 200
+    table_html = table_resp.content.decode()
+
+    # The table partial should not contain the filter bar
+    assert 'items-filter-bar' not in table_html


### PR DESCRIPTION
## Summary
- stop automatic HTMX reload on manage layout containers
- keep items page filters outside the table swap area
- add regression test ensuring filters persist after table refreshes

## Testing
- `pytest tests/test_items_list.py::test_item_link_in_table_layout tests/test_items_list.py::test_item_link_in_grid_layout tests/test_items_list.py::test_filters_persist_after_table_refresh tests/test_item_views.py::test_items_list_view_renders_layout_buttons -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59b3b24348326b64b47cc2fb2f27f