### PR TITLE
Refactor item grid toggle interaction

### DIFF
--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -10,7 +10,7 @@
     const itemId = row?.dataset.itemId;
     if (!itemId) return;
     const details = document.getElementById(`details-${itemId}`);
-    const toggleEl = row.querySelector(".main-row");
+    const toggleEl = row.querySelector('[data-action="toggle-details"]');
     if (!details || !toggleEl) return;
 
     const expanded = toggleEl.getAttribute("aria-expanded") === "true";
@@ -606,16 +606,6 @@
     const inp = document.querySelector('input[name="csrfmiddlewaretoken"]');
     return inp ? inp.value : "";
   }
-
-  // Keyboard accessibility for toggle button
-  document.addEventListener("keydown", function (e) {
-    if (e.key !== "Enter" && e.key !== " ") return;
-    const target = e.target.closest('[data-action="toggle-details"]');
-    if (!target) return;
-    e.preventDefault();
-    const row = findRow(target);
-    toggleDetails(row);
-  });
 
   // Expose minimal API for debugging
   window.itemsTable = { toggleDetails, enableInlineEdit, cancelInlineEdit };

--- a/static/js/items-table.test.js
+++ b/static/js/items-table.test.js
@@ -172,9 +172,12 @@ describe("details toggle", () => {
   test("shows and hides details panel", () => {
     const row = document.querySelector('.item-row');
     const panel = document.getElementById("details-1");
+    const btn = row.querySelector('[data-action="toggle-details"]');
     window.itemsTable.toggleDetails(row);
     expect(panel.classList.contains("hidden")).toBe(false);
+    expect(btn.getAttribute("aria-expanded")).toBe("true");
     window.itemsTable.toggleDetails(row);
     expect(panel.classList.contains("hidden")).toBe(true);
+    expect(btn.getAttribute("aria-expanded")).toBe("false");
   });
 });

--- a/templates/inventory/_items_grid.html
+++ b/templates/inventory/_items_grid.html
@@ -4,14 +4,17 @@
     {% for item in page_obj.object_list %}
     <div class="item-row bg-white rounded-xl shadow-sm hover:shadow-md transition-all duration-200 border border-gray-200 hover:border-gray-300 overflow-hidden h-full" data-item-id="{{ item.item_id }}">
         <!-- Main Row -->
-    <div class="main-row w-full text-left px-5 py-5 hover:bg-gradient-to-r hover:from-gray-50 hover:to-white transition-all duration-200 cursor-pointer" data-action="toggle-details" aria-label="Toggle details" aria-expanded="false" aria-controls="details-{{ item.item_id }}" role="button" tabindex="0">
+    <div class="main-row w-full text-left px-5 py-5 hover:bg-gradient-to-r hover:from-gray-50 hover:to-white transition-all duration-200">
             <div class="flex items-center justify-between">
                 <!-- Left side - Item info -->
                 <div class="flex items-center space-x-4 flex-1">
                     <!-- Expand/Collapse Icon -->
                     <button class="expand-icon text-gray-400 hover:text-blue-600 transition-all duration-200 p-1 rounded-lg hover:bg-blue-50"
                             type="button"
-                            data-action="toggle-details">
+                            data-action="toggle-details"
+                            aria-expanded="false"
+                            aria-controls="details-{{ item.item_id }}"
+                            aria-label="Toggle details for {{ item.name }}">
                         <svg class="w-4 h-4 transform transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
                         </svg>


### PR DESCRIPTION
## Summary
- use dedicated button to toggle item grid details
- update JS handlers to target button and drop unused keyboard listener
- extend unit test for aria-expanded state

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b59f4113788326b46444ad957f3f53