### PR TITLE
Enable HTMX layout switching for items list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `templates/inventory/item_detail_speed.html`
   - `templates/inventory/items_list_speed.html`
   - `templates/inventory/items_list_speed_clean.html`
-  - `templates/inventory/items_list_speed_test.html`
-  - `templates/inventory/_items_table_speed.html`
+
+### Changed
+- Layout toggles now use HTMX requests and persist selection via `localStorage` with improved ARIA updates.
+- `templates/inventory/items_list_speed_test.html`
+- `templates/inventory/_items_table_speed.html`
 
   These were consolidated into the canonical templates (e.g. `item_form.html`, `item_detail.html`, `items_list.html`).
 

--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -203,22 +203,25 @@ class ItemsListView(TemplateView):
 
 
 class ItemsTableView(TemplateView):
-    """Render the paginated table of items."""
-
-    template_name = "components/items_table.html"
+    """Render the paginated table or grid of items."""
 
     def _get_queryset(self):
         qs, params = _filter_and_sort_items(self.request)
         self._filter_params = params
         return qs
 
+    def get_template_names(self):  # pragma: no cover - simple logic
+        layout = (self.request.GET.get("layout") or "table").lower()
+        if layout == "grid":
+            return ["inventory/_items_grid.html"]
+        return ["inventory/_items_table.html"]
+
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         qs = self._get_queryset()
         page_obj, per_page = list_utils.paginate(self.request, qs)
         ctx.update(self._filter_params)
-        layout = (self.request.GET.get("layout") or "table").lower()
-        ctx.update({"page_obj": page_obj, "page_size": per_page, "layout": layout})
+        ctx.update({"page_obj": page_obj, "page_size": per_page})
         return ctx
 
 

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -81,18 +81,18 @@
 <div class="card">
   <div class="table-scroll">
     <div id="items-filter-bar" class="sticky top-0 z-10 bg-white p-4">
+      {% url 'items_table' as items_table_url %}
       <div class="flex items-center justify-between mb-2">
         <div class="text-sm text-gray-600">Filter and explore</div>
         <div class="flex items-center gap-2" role="toolbar" aria-label="Layout options">
-          <button type="button" class="btn-square" data-layout-btn data-value="table" aria-label="Table view"{% if request.GET.layout|default:'table' == 'table' %} aria-pressed="true"{% else %} aria-pressed="false"{% endif %}>
+          <button type="button" class="btn-square" data-layout-btn data-value="table" aria-label="Table view" hx-get="{{ items_table_url }}?layout=table" hx-target="#items-list" hx-include="#filters" hx-indicator="#items-loading" hx-params="not layout"{% if request.GET.layout|default:'table' == 'table' %} aria-pressed="true"{% else %} aria-pressed="false"{% endif %}>
             {% icon 'list-bullet' 'w-4 h-4' %}
           </button>
-          <button type="button" class="btn-square" data-layout-btn data-value="grid" aria-label="Grid view"{% if request.GET.layout == 'grid' %} aria-pressed="true"{% else %} aria-pressed="false"{% endif %}>
+          <button type="button" class="btn-square" data-layout-btn data-value="grid" aria-label="Grid view" hx-get="{{ items_table_url }}?layout=grid" hx-target="#items-list" hx-include="#filters" hx-indicator="#items-loading" hx-params="not layout"{% if request.GET.layout == 'grid' %} aria-pressed="true"{% else %} aria-pressed="false"{% endif %}>
             {% icon 'squares-2x2' 'w-4 h-4' %}
           </button>
         </div>
       </div>
-      {% url 'items_table' as items_table_url %}
       {% include "components/filter_bar.html" with q=request.GET.q filters=filters hx_get=items_table_url hx_target='#items-list' hx_indicator='#items-loading' search_placeholder='e.g., Tomato, Rice' export_url=export_url layout=request.GET.layout|default:'table' %}
     </div>
     <div class="overflow-x-auto" id="items-list">
@@ -154,9 +154,6 @@ document.addEventListener('DOMContentLoaded', function () {
     new ResizeObserver(updateFiltersHeight).observe(bar);
   }
   const listEl = document.getElementById('items-list');
-  if (listEl) {
-    listEl.addEventListener('htmx:afterSwap', updateFiltersHeight);
-  }
   const searchInput = document.querySelector('input[name="q"]');
   if (searchInput) {
     searchInput.addEventListener('keydown', function(e) {
@@ -170,36 +167,47 @@ document.addEventListener('DOMContentLoaded', function () {
       container.setAttribute('data-density', value);
     });
   });
+  const filtersForm = document.getElementById('filters');
   const layoutBtns = document.querySelectorAll('[data-layout-btn]');
+  function applyLayout(value){
+    localStorage.setItem('items_layout', value);
+    const layoutInput = filtersForm?.querySelector('input[name="layout"]');
+    if (layoutInput) layoutInput.value = value;
+    layoutBtns.forEach(btn => {
+      btn.setAttribute('aria-pressed', btn.getAttribute('data-value') === value ? 'true' : 'false');
+    });
+  }
   layoutBtns.forEach(btn => {
     btn.addEventListener('click', () => {
-      const value = btn.getAttribute('data-value');
-      const url = new URL(window.location.href);
-      url.searchParams.set('layout', value);
-      localStorage.setItem('items_layout', value);
-      window.location.assign(url.toString());
+      applyLayout(btn.getAttribute('data-value'));
     });
   });
   const savedLayout = localStorage.getItem('items_layout');
-  if (savedLayout) {
-    const url = new URL(window.location.href);
-    if (url.searchParams.get('layout') !== savedLayout) {
-      url.searchParams.set('layout', savedLayout);
-      window.location.replace(url.toString());
+  const currentLayout = filtersForm?.querySelector('input[name="layout"]')?.value || 'table';
+  if (savedLayout && savedLayout !== currentLayout) {
+    const btn = document.querySelector(`[data-layout-btn][data-value="${savedLayout}"]`);
+    if (btn) btn.click();
+  } else {
+    applyLayout(currentLayout);
+  }
+  function announceCount(){
+    const live = document.getElementById('items-aria-live');
+    if (live) {
+      const count = listEl?.querySelectorAll('.item-row').length || 0;
+      live.textContent = `List updated. ${count} items displayed.`;
     }
   }
-  const currentLayout = new URL(window.location.href).searchParams.get('layout') || 'table';
-  layoutBtns.forEach(btn => {
-    btn.setAttribute('aria-pressed', btn.getAttribute('data-value') === currentLayout ? 'true' : 'false');
-  });
-  // Announce updates
-  const live = document.getElementById('items-aria-live');
-  function announce(text){ if(live){ live.textContent = text; } }
-  const mo = new MutationObserver(()=>{
-    const count = document.querySelectorAll('.item-row').length;
-    announce(`List updated. ${count} items displayed.`);
-  });
-  if (listEl) mo.observe(listEl, { childList: true, subtree: true });
+  announceCount();
+  if (listEl) {
+    listEl.addEventListener('htmx:afterSwap', () => {
+      announceCount();
+      const layoutVal = filtersForm?.querySelector('input[name="layout"]').value || 'table';
+      layoutBtns.forEach(btn => {
+        btn.setAttribute('aria-pressed', btn.getAttribute('data-value') === layoutVal ? 'true' : 'false');
+      });
+      updateFiltersHeight();
+    });
+  }
 
   // Sticky header shadow on scroll
   document.querySelectorAll('.table-scroll').forEach(scroller => {
@@ -211,7 +219,6 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   // Dynamic subcategory filter: update options when category changes
-  const filtersForm = document.getElementById('filters');
   if (filtersForm) {
     const catSel = filtersForm.querySelector('select[name="category"]');
     const subSel = filtersForm.querySelector('select[name="subcategory"]');

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -99,6 +99,18 @@ def test_items_list_kpi_card_links(client):
 
 
 @pytest.mark.django_db
+def test_layout_buttons_use_htmx(client):
+    _create_item()
+    resp = client.get(reverse("items_list"))
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    table_url = reverse("items_table")
+    assert f'hx-get="{table_url}?layout=table"' in html
+    assert f'hx-get="{table_url}?layout=grid"' in html
+    assert 'hx-target="#items-list"' in html
+
+
+@pytest.mark.django_db
 def test_filters_persist_after_table_refresh(client):
     """Filters should remain visible after HTMX table updates."""
     _create_item()


### PR DESCRIPTION
## Summary
- use HTMX on layout toggle buttons and persist selection via localStorage
- return table or grid fragments directly from `items_table` view
- update ARIA states and live region on HTMX swaps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a0c4c25c83268dee6e222ea0eebc