### PR TITLE
refactor: remove About card from items list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `templates/inventory/item_detail_speed.html`
   - `templates/inventory/items_list_speed.html`
   - `templates/inventory/items_list_speed_clean.html`
+- Removed "About" card from items list page.
 
 ### Changed
 - Layout toggles now use HTMX requests and persist selection via `localStorage` with improved ARIA updates.

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -38,17 +38,6 @@
   </div>
 {% endblock %}
 
-{% block description %}
-<div class="card mb-6">
-  <div class="card-header">
-    <h2 class="text-lg font-semibold">About</h2>
-  </div>
-  <div class="card-body">
-    <p class="text-gray-600">Manage your inventory items: add new items, edit existing ones, and view stock levels.</p>
-  </div>
-</div>
-{% endblock %}
-
 {% block extra_top %}
   {% include "inventory/_add_item_section.html" with form=form %}
   {% include "inventory/_bulk_upload_section.html" with bulk_form=bulk_form bulk_success_count=bulk_success_count bulk_errors=bulk_errors %}


### PR DESCRIPTION
## Summary
- remove obsolete About card from items list template
- document removal in changelog

## Testing
- `flake8` *(fails: E301, W391 in unrelated files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a269f9bc832693791ac06b932c86