### PR TITLE
Refactor inventory page to use modal components

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -23,6 +23,11 @@ from .views.items.list import (
     ItemsListView,
     ItemsTableView,
 )
+from .views.items.modals import (
+    AddItemModalView,
+    BulkUploadModalView,
+    ItemsMetricsModalView,
+)
 from .views.items.stock import (
     ItemCreateHTMXView,
     ItemCreatePartialView,
@@ -60,6 +65,17 @@ urlpatterns = [
     path("items/", ItemsListView.as_view(), name="items_list"),
     path("items/table/", ItemsTableView.as_view(), name="items_table"),
     path("items/export/", ItemsExportView.as_view(), name="items_export"),
+    path("items/modal/add/", AddItemModalView.as_view(), name="item_add_modal"),
+    path(
+        "items/modal/bulk-upload/",
+        BulkUploadModalView.as_view(),
+        name="items_bulk_upload_modal",
+    ),
+    path(
+        "items/modal/metrics/",
+        ItemsMetricsModalView.as_view(),
+        name="items_metrics_modal",
+    ),
     path("items/create/", ItemCreateHTMXView.as_view(), name="item_create"),
     path(
         "items/create/partial/",

--- a/inventory/views/items/__init__.py
+++ b/inventory/views/items/__init__.py
@@ -18,6 +18,11 @@ from .stock import (
     PurchaseUnitsView,
     SubcategoriesView,
 )
+from .modals import (
+    AddItemModalView,
+    BulkUploadModalView,
+    ItemsMetricsModalView,
+)
 
 __all__ = [
     "EXCLUDED_FIELDS",
@@ -37,4 +42,7 @@ __all__ = [
     "PurchaseUnitsView",
     "SubcategoriesView",
     "CheckSimilarNamesView",
+    "AddItemModalView",
+    "BulkUploadModalView",
+    "ItemsMetricsModalView",
 ]

--- a/inventory/views/items/modals.py
+++ b/inventory/views/items/modals.py
@@ -1,0 +1,60 @@
+from django.urls import reverse
+from django.views.generic import TemplateView
+
+from ...forms.item_forms import ItemForm
+from ...forms.bulk_forms import BulkUploadForm
+from ...models import Item
+from ...models.departments import Department
+from ...services.units_service import UnitsService
+from ...services.categories_service import CategoriesService
+from ...services import kpis
+
+
+class AddItemModalView(TemplateView):
+    template_name = "components/add_item_modal.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["form"] = ItemForm()
+        ctx["departments_for_form"] = Department.objects.all().order_by("name")
+        ctx["inline_units"] = UnitsService.get_unit_choices_for_forms()
+        ctx["inline_categories"] = CategoriesService.get_category_choices_for_forms()
+        return ctx
+
+
+class BulkUploadModalView(TemplateView):
+    template_name = "components/bulk_upload_modal.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["bulk_form"] = BulkUploadForm()
+        return ctx
+
+
+class ItemsMetricsModalView(TemplateView):
+    template_name = "components/items_metrics_modal.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        try:
+            pending_po_counts = kpis.pending_po_status_counts()
+            pending_orders = sum(pending_po_counts.values())
+        except Exception:  # pragma: no cover
+            pending_orders = 0
+        try:
+            total_value = kpis.stock_value()
+        except Exception:  # pragma: no cover
+            total_value = 0
+        ctx.update(
+            {
+                "stats": {
+                    "low_stock_count": kpis.low_stock_count(),
+                    "pending_orders": pending_orders,
+                    "total_value": total_value,
+                },
+                "items_count": Item.objects.count(),
+                "items_list_url": reverse("items_list"),
+                "po_list_url": reverse("purchase_orders_list"),
+            }
+        )
+        return ctx

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -36,12 +36,23 @@
       root.removeAttribute("aria-labelledby");
     }
   }
+  function runScripts(container) {
+    container.querySelectorAll("script").forEach((oldScript) => {
+      const newScript = document.createElement("script");
+      Array.from(oldScript.attributes).forEach((attr) =>
+        newScript.setAttribute(attr.name, attr.value),
+      );
+      newScript.appendChild(document.createTextNode(oldScript.textContent));
+      oldScript.replaceWith(newScript);
+    });
+  }
   function openModal(html) {
     const root = document.getElementById("modal-root");
     const content = document.getElementById("modal-content");
     if (!root || !content) return;
     lastFocused = document.activeElement;
     content.innerHTML = html;
+    runScripts(content);
     setAria(root, content);
     root.classList.remove("hidden");
     trapFocus(root);
@@ -52,6 +63,7 @@
     if (!root || !content) return;
     lastFocused = document.activeElement;
     content.innerHTML = `<div class="drawer ${side}">${html}</div>`;
+    runScripts(content);
     setAria(root, content);
     root.classList.remove("hidden");
     trapFocus(root);
@@ -93,6 +105,13 @@
           if (window.notifications)
             window.notifications.showToast("Failed to load content", "error");
         });
+    }
+  });
+
+  document.addEventListener("keydown", function (e) {
+    const root = document.getElementById("modal-root");
+    if (e.key === "Escape" && root && !root.classList.contains("hidden")) {
+      closeModal();
     }
   });
 

--- a/templates/components/add_item_modal.html
+++ b/templates/components/add_item_modal.html
@@ -1,0 +1,85 @@
+<h2 class="text-lg font-semibold mb-4">Add Item</h2>
+<form method="post" action="{% url 'items_list' %}" data-modal-form class="grid grid-cols-12 gap-4">
+  {% csrf_token %}
+  <div class="section-panel col-span-12" id="essentials-panel">
+    <h3 class="section-header">Essentials</h3>
+    <div class="grid grid-cols-3 gap-4 items-start">
+      <div class="space-y-1">
+        <label for="{{ form.name.id_for_label }}" class="form-label">Name</label>
+        {{ form.name }}
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="space-y-1">
+        <label for="{{ form.unit_id.id_for_label }}" class="form-label">Unit</label>
+        {{ form.unit_id }}
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="space-y-1">
+        <label for="{{ form.category_id.id_for_label }}" class="form-label">Category</label>
+        {{ form.category_id }}
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="space-y-1">
+        <label for="{{ form.current_stock.id_for_label }}" class="form-label">Current Stock</label>
+        {{ form.current_stock }}
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="space-y-1">
+        <label for="{{ form.reorder_point.id_for_label }}" class="form-label">Reorder Point</label>
+        {{ form.reorder_point }}
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="space-y-1">
+        <label for="{{ form.is_active.id_for_label }}" class="form-label">Status</label>
+        <div class="inline-flex items-center gap-2 text-gray-700 h-[38px]">
+          {{ form.is_active }}
+          <span>Active</span>
+        </div>
+        {% include "forms/feedback.html" %}
+      </div>
+    </div>
+  </div>
+  <div class="section-panel col-span-12" id="advanced-panel">
+    <h3 class="section-header">Advanced</h3>
+    <div class="grid grid-cols-3 gap-4 items-start">
+      <div class="space-y-1">
+        <label for="{{ form.preferred_supplier.id_for_label }}" class="form-label">Preferred Supplier</label>
+        {{ form.preferred_supplier }}
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="space-y-1">
+        <label for="{{ form.initial_purchase_price.id_for_label }}" class="form-label">Initial Purchase Price</label>
+        {{ form.initial_purchase_price }}
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="space-y-1">
+        <label for="{{ form.minimum_order_qty.id_for_label }}" class="form-label">Min Order Qty</label>
+        {{ form.minimum_order_qty }}
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="space-y-1">
+        <label for="{{ form.lead_time_days.id_for_label }}" class="form-label">Lead Time (days)</label>
+        {{ form.lead_time_days }}
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="col-span-3 space-y-1">
+        <label for="{{ form.departments.id_for_label }}" class="form-label">Departments</label>
+        <div class="dept-grid">
+          {{ form.departments }}
+        </div>
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="col-span-3 space-y-1">
+        <label for="{{ form.notes.id_for_label }}" class="form-label">Notes</label>
+        {{ form.notes }}
+        {% include "forms/feedback.html" %}
+      </div>
+    </div>
+  </div>
+  <div class="col-span-12">
+    <div class="form-actions">
+      <button type="reset" class="btn-secondary btn-sm" data-modal-close>Cancel</button>
+      <button type="submit" class="btn-primary btn-sm">Create</button>
+    </div>
+  </div>
+</form>

--- a/templates/components/bulk_upload_modal.html
+++ b/templates/components/bulk_upload_modal.html
@@ -1,0 +1,11 @@
+{% load static %}
+<h2 class="text-lg font-semibold mb-4">Bulk Upload</h2>
+<p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary">Download sample CSV</a></p>
+<form method="post" action="{% url 'items_bulk_upload' %}" enctype="multipart/form-data" data-modal-form class="space-y-4">
+  {% csrf_token %}
+  <input type="file" name="file" accept=".csv" class="file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100" />
+  <div class="flex justify-end gap-2">
+    <button type="button" class="btn-secondary btn-sm" data-modal-close>Cancel</button>
+    <button type="submit" class="btn-primary btn-sm">Upload</button>
+  </div>
+</form>

--- a/templates/components/items_metrics_modal.html
+++ b/templates/components/items_metrics_modal.html
@@ -1,0 +1,12 @@
+<h2 class="text-lg font-semibold mb-4">Key Metrics</h2>
+<div class="grid grid-cols-1 md:grid-cols-4 gap-6">
+  {% include "components/kpi_card.html" with icon='cube' color='blue' label='Items' value=items_count|default:"0" href=items_list_url %}
+  {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low Stock' value=stats.low_stock_count|default:"0" href=items_list_url|add:'?stock_status=low' %}
+  {% include "components/kpi_card.html" with icon='clock' color='yellow' label='Pending' value=stats.pending_orders|default:"0" href=po_list_url|add:'?status=ORDERED' %}
+  {% with total_value_formatted=stats.total_value|floatformat:0|default:"0" %}
+    {% include "components/kpi_card.html" with icon='banknotes' color='green' label='Stock Value' value='$'|add:total_value_formatted href=items_list_url %}
+  {% endwith %}
+</div>
+<div class="flex justify-end mt-4">
+  <button type="button" class="btn-secondary btn-sm" data-modal-close>Close</button>
+</div>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -14,8 +14,9 @@
 {% endblock %}
 
 {% block header_actions %}
-  <button type="button" id="add-item-toggle" aria-controls="add-item-section" aria-expanded="false" class="btn-primary btn-sm">Add Item</button>
-  <button type="button" id="bulk-upload-toggle" aria-controls="bulk-upload-section" aria-expanded="false" class="btn-secondary btn-sm">Bulk Upload</button>
+  <button type="button" class="btn-primary btn-sm" data-modal-url="{% url 'item_add_modal' %}">Add Item</button>
+  <button type="button" class="btn-secondary btn-sm" data-modal-url="{% url 'items_bulk_upload_modal' %}">Bulk Upload</button>
+  <button type="button" class="btn-secondary btn-sm" data-modal-url="{% url 'items_metrics_modal' %}">Metrics</button>
   <div id="dept-options" class="hidden">
     <select id="dept-select-template">
       {% for d in departments_for_form %}
@@ -34,32 +35,11 @@
     </select>
   </div>
 {% endblock %}
-{% block extra_top %}
-  {% include "inventory/_add_item_section.html" with form=form %}
-  {% include "inventory/_bulk_upload_section.html" with bulk_form=bulk_form bulk_success_count=bulk_success_count bulk_errors=bulk_errors %}
-{% endblock %}
+{% block extra_top %}{% endblock %}
 
 {# Filter block moved directly above the table within data_container #}
 
-{% block kpis %}
-<div class="card mb-6">
-  <div class="card-header">
-    <h2 class="text-lg font-semibold">Key Metrics</h2>
-  </div>
-  <div class="card-body">
-    {% url 'items_list' as items_list_url %}
-    {% url 'purchase_orders_list' as po_list_url %}
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
-      {% include "components/kpi_card.html" with icon='cube' color='blue' label='Items' value=page_obj.paginator.count|default:"0" href=items_list_url %}
-      {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low Stock' value=stats.low_stock_count|default:"0" href=items_list_url|add:'?stock_status=low' %}
-      {% include "components/kpi_card.html" with icon='clock' color='yellow' label='Pending' value=stats.pending_orders|default:"0" href=po_list_url|add:'?status=ORDERED' %}
-      {% with total_value_formatted=stats.total_value|floatformat:0|default:"0" %}
-        {% include "components/kpi_card.html" with icon='banknotes' color='green' label='Stock Value' value="$"|add:total_value_formatted href=items_list_url %}
-      {% endwith %}
-    </div>
-  </div>
-</div>
-{% endblock %}
+{% block kpis %}{% endblock %}
 
 {% block data_container %}
 <h2 class="text-lg font-semibold text-gray-900 mb-2">Inventory Items</h2>

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -86,16 +86,30 @@ def test_item_detail_includes_supplier_and_movements(client):
 
 
 @pytest.mark.django_db
-def test_items_list_kpi_card_links(client):
+def test_items_list_has_modal_triggers(client):
     _create_item()
-    url = reverse("items_list")
-    resp = client.get(url)
+    resp = client.get(reverse("items_list"))
+    html = resp.content.decode()
+    assert f'data-modal-url="{reverse("item_add_modal")}"' in html
+    assert f'data-modal-url="{reverse("items_bulk_upload_modal")}"' in html
+    assert f'data-modal-url="{reverse("items_metrics_modal")}"' in html
+
+
+@pytest.mark.django_db
+def test_add_item_modal_view(client):
+    resp = client.get(reverse("item_add_modal"))
     assert resp.status_code == 200
     html = resp.content.decode()
-    po_url = reverse("purchase_orders_list")
-    assert html.count(f'href="{url}"') >= 2
-    assert f'href="{url}?stock_status=low"' in html
-    assert f'href="{po_url}?status=ORDERED"' in html
+    assert "Add Item" in html
+    assert "form" in html
+
+
+@pytest.mark.django_db
+def test_metrics_modal_view(client):
+    resp = client.get(reverse("items_metrics_modal"))
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert "Key Metrics" in html
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Replace inline add item, bulk upload, and KPI sections with modal components
- Add dedicated views and templates for item creation, bulk upload, and metrics
- Enhance modal utility with script execution and Escape key dismissal

## Testing
- `pytest tests/test_items_list.py`

------
https://chatgpt.com/codex/tasks/task_e_68b5a849e9dc8326a8ead67b5334cf88