### PR TITLE
Move page heading into navigation and clean up items list

### DIFF
--- a/inventory/forms/item_forms.py
+++ b/inventory/forms/item_forms.py
@@ -117,6 +117,7 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
         error_messages = {
             "name": {"required": "Item name is required."},
         }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -148,4 +149,3 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
             instance.save()
             self.save_m2m()
         return instance
-

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -26,7 +26,7 @@
   </head>
   <body class="min-h-screen bg-gray-50">
     <!-- Top Navigation -->
-    {% include "components/top_nav.html" %}
+    {% include "components/top_nav.html" with nav_heading=block.nav_heading %}
 
     <!-- Main Content Area -->
     <div class="min-h-screen">

--- a/templates/components/create_manage_layout.html
+++ b/templates/components/create_manage_layout.html
@@ -2,21 +2,11 @@
 {% load static %}
 
 {% block title %}{% block page_title %}Manage{% endblock %}{% endblock %}
+{% block nav_heading %}{% block page_heading %}{% endblock %}{% endblock %}
 
 {% block content %}
   {% block breadcrumbs %}{% endblock %}
-  <div class="page-header">
-    <div class="flex items-center justify-between">
-      <div>
-        <h1 class="page-title">{% block page_heading %}{% endblock %}</h1>
-        {% block page_subtitle %}{% endblock %}
-      </div>
-      <div class="flex items-center space-x-3">
-        {% block header_actions %}{% endblock %}
-      </div>
-    </div>
-  </div>
-
+  {% block page_subtitle %}{% endblock %}
   {% block filter_bar %}
     {% block filters %}{% endblock %}
   {% endblock %}

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -21,6 +21,9 @@
           </div>
         </div>
         <a href="{% url 'root' %}" class="ml-3 text-xl font-semibold text-gray-900">Inventory Pro</a>
+        {% if nav_heading %}
+        <h1 class="ml-6 text-lg font-semibold text-gray-900">{{ nav_heading }}</h1>
+        {% endif %}
       </div>
 
       <!-- Right side: User menu and actions -->

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -13,27 +13,6 @@
   </div>
 {% endblock %}
 
-{% block header_actions %}
-  <button type="button" id="add-item-toggle" aria-controls="add-item-section" aria-expanded="false" class="btn-primary btn-sm">Add Item</button>
-  <button type="button" id="bulk-upload-toggle" aria-controls="bulk-upload-section" aria-expanded="false" class="btn-secondary btn-sm">Bulk Upload</button>
-  <div id="dept-options" class="hidden">
-    <select id="dept-select-template">
-      {% for d in departments_for_form %}
-      <option value="{{ d.id }}">{{ d.name }}</option>
-      {% endfor %}
-    </select>
-    <select id="unit-select-template">
-      {% for val,label in inline_units %}
-      <option value="{{ val }}">{{ label }}</option>
-      {% endfor %}
-    </select>
-    <select id="category-id-select-template">
-      {% for val,label in inline_categories %}
-      <option value="{{ val }}">{{ label }}</option>
-      {% endfor %}
-    </select>
-  </div>
-{% endblock %}
 {% block extra_top %}
   {% include "inventory/_add_item_section.html" with form=form %}
   {% include "inventory/_bulk_upload_section.html" with bulk_form=bulk_form bulk_success_count=bulk_success_count bulk_errors=bulk_errors %}
@@ -227,21 +206,6 @@ document.addEventListener('DOMContentLoaded', function () {
       });
     }
   }
-  function setupToggle(btnId, sectionId) {
-    const btn = document.getElementById(btnId);
-    const section = document.getElementById(sectionId);
-    if (btn && section) {
-      btn.addEventListener('click', () => {
-        section.open = !section.open;
-        btn.setAttribute('aria-expanded', section.open ? 'true' : 'false');
-        if (section.open) {
-          section.scrollIntoView({ behavior: 'smooth' });
-        }
-      });
-    }
-  }
-  setupToggle('add-item-toggle', 'add-item-section');
-  setupToggle('bulk-upload-toggle', 'bulk-upload-section');
 });
 
 window.addEventListener('load', updateFiltersHeight);

--- a/tests/test_units_categories_services.py
+++ b/tests/test_units_categories_services.py
@@ -57,4 +57,3 @@ def test_get_category_info_uses_orm(monkeypatch):
         "category": "Grocery",
         "sub_category": "Juices And Purees",
     }
-


### PR DESCRIPTION
## Summary
- show page-specific heading inside top navigation
- drop Add Item and Bulk Upload buttons from Items List and related script
- fix minor flake8 warnings

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5ad7994408326920968ac19d8013d