### PR TITLE
Add breadcrumb trail across pages

### DIFF
--- a/templates/_base.html
+++ b/templates/_base.html
@@ -48,6 +48,7 @@
 
       <!-- Page Content -->
       <main class="page-content">
+        {% block breadcrumbs %}{% endblock %}
         {% if messages %}
           {% include "components/alert.html" %}
         {% endif %}

--- a/templates/components/breadcrumb.html
+++ b/templates/components/breadcrumb.html
@@ -1,6 +1,16 @@
-{% comment %}Reusable breadcrumb component. Expects list_url, list_title, current_title, optional class{% endcomment %}
+{% comment %}
+  Reusable breadcrumb component.
+  Expects list_url, list_title, current_title, optional class.
+  Always starts with a link back to the Inventory Pro dashboard.
+{% endcomment %}
 <div class="{{ class|default:'flex items-center gap-1 text-sm text-gray-500 mb-4' }}">
+  <a href="{% url 'root' %}" class="text-primary hover:underline">Inventory Pro</a>
+  {% if list_url and list_title and list_title != current_title %}
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <polyline points="9,18 15,12 9,6"></polyline>
+  </svg>
   <a href="{{ list_url }}" class="text-primary hover:underline">{{ list_title }}</a>
+  {% endif %}
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
     <polyline points="9,18 15,12 9,6"></polyline>
   </svg>

--- a/templates/components/create_manage_layout.html
+++ b/templates/components/create_manage_layout.html
@@ -5,7 +5,6 @@
 {% block nav_heading %}{% block page_heading %}{% endblock %}{% endblock %}
 
 {% block content %}
-  {% block breadcrumbs %}{% endblock %}
   {% block page_subtitle %}{% endblock %}
   {% block filter_bar %}
     {% block filters %}{% endblock %}

--- a/templates/components/detail_layout.html
+++ b/templates/components/detail_layout.html
@@ -1,7 +1,6 @@
 {% extends "_base.html" %}
 {% block title %}Detail – Inventory App{% endblock %}
 {% block content %}
-  {% block breadcrumbs %}{% endblock %}
   <h1 class="text-h1 font-semibold mb-4">{% block heading %}{% endblock %}</h1>
   <div class="mb-4 flex justify-end gap-2">{% block actions %}{% endblock %}</div>
   {% block detail_table %}{% endblock %}

--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -1,7 +1,6 @@
 {% extends "_base.html" %}
 {% block title %}Form – Inventory App{% endblock %}
 {% block content %}
-  {% block breadcrumbs %}{% endblock %}
 <div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
   <h1 class="text-h1 font-semibold mb-4">
     {% block heading %}{% endblock %}

--- a/templates/components/list_layout.html
+++ b/templates/components/list_layout.html
@@ -1,7 +1,6 @@
 {% extends "_base.html" %}
 {% block title %}List – Inventory App{% endblock %}
 {% block content %}
-  {% block breadcrumbs %}{% endblock %}
   <h1 class="text-h1 font-semibold mb-4">{% block heading %}{% endblock %}</h1>
   <div class="mb-4 flex justify-end gap-2">{% block actions %}{% endblock %}</div>
   {% block filter_bar %}{% endblock %}

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -1,0 +1,31 @@
+import pytest
+from django.template.loader import render_to_string
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_breadcrumb_component_includes_root(django_user_model):
+    html = render_to_string(
+        "components/breadcrumb.html",
+        {
+            "list_url": reverse("items_list"),
+            "list_title": "Inventory",
+            "current_title": "Item 1",
+        },
+    )
+    assert f'href="{reverse("root")}"' in html
+    assert "Inventory Pro" in html
+    assert "Inventory" in html
+    assert "Item 1" in html
+
+
+@pytest.mark.django_db
+def test_dashboard_page_displays_breadcrumb(client, django_user_model):
+    user = django_user_model.objects.create_user(username="u", password="pw")
+    client.force_login(user)
+    resp = client.get(reverse("dashboard"))
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert "Inventory Pro" in html
+    assert "Dashboard" in html
+    assert "flex items-center gap-1 text-sm text-gray-500 mb-4" in html


### PR DESCRIPTION
## Summary
- show breadcrumb block on all pages via base template
- include Inventory Pro root link in breadcrumb component
- add tests for breadcrumb rendering

## Testing
- `pre-commit run --files templates/_base.html templates/components/create_manage_layout.html templates/components/list_layout.html templates/components/form_layout.html templates/components/detail_layout.html templates/components/breadcrumb.html tests/test_breadcrumbs.py` (failed: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')
- `pytest tests/test_breadcrumbs.py`


------
https://chatgpt.com/codex/tasks/task_e_68b60b593b7c8326bb3f641a396b2604