### PR TITLE
feat: add category formatting helper

### DIFF
--- a/inventory/templatetags/category_tags.py
+++ b/inventory/templatetags/category_tags.py
@@ -1,0 +1,26 @@
+from django import template
+from django.utils.html import conditional_escape, format_html
+
+register = template.Library()
+
+
+@register.simple_tag
+def format_category(item, show_placeholder=False):
+    """Return a safe "Category → Subcategory" string for an item.
+
+    If the item has no category and ``show_placeholder`` is True, a muted dash is
+    returned. When ``show_placeholder`` is False, an empty string is returned in
+    this case. Values are escaped to prevent HTML injection.
+    """
+    category_obj = getattr(item, "category", None)
+    if not category_obj:
+        if show_placeholder:
+            return format_html('<span class="text-gray-400">—</span>')
+        return ""
+
+    category = conditional_escape(getattr(category_obj, "category", ""))
+    subcategory = getattr(category_obj, "sub_category", "")
+    if subcategory:
+        subcategory = conditional_escape(subcategory)
+        return format_html("{} → {}", category, subcategory)
+    return category

--- a/templates/inventory/_items_grid.html
+++ b/templates/inventory/_items_grid.html
@@ -1,4 +1,4 @@
-{% load icon_tags %}
+{% load icon_tags category_tags %}
 <!-- Enhanced Items Table with Modern Card-Style Rows -->
 <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-4">
     {% for item in page_obj.object_list %}
@@ -42,12 +42,13 @@
                                     </a>
                                 </div>
                                         <div class="flex items-center flex-wrap gap-3 text-xs text-gray-600 mt-1">
-                                    {% if item.category %}
+                                    {% format_category item as category_text %}
+                                    {% if category_text %}
                                         <span class="badge badge-info inline-flex items-center gap-1">
                                             <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
                                                 <path d="M7 3a1 1 0 000 2h6a1 1 0 100-2H7zM4 7a1 1 0 011-1h10a1 1 0 110 2H5a1 1 0 01-1-1zM2 11a2 2 0 012-2h12a2 2 0 012 2v4a2 2 0 01-2 2H4a2 2 0 01-2-2v-4z"/>
                                             </svg>
-                                            {{ item.category.category }}{% if item.category.sub_category %} → {{ item.category.sub_category }}{% endif %}
+                                            {{ category_text }}
                                         </span>
                                     {% endif %}
                                     {% if item.item_code %}

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,4 +1,4 @@
-{% load icon_tags %}
+{% load icon_tags category_tags %}
 <!-- prettier-ignore -->
 <table class="table w-full bg-white border border-gray-200 rounded-lg table-sticky" id="grid-table">
   <thead class="table-header">
@@ -78,11 +78,7 @@
         </div>
       </td>
       <td data-col="category">
-        {% if item.category %} {{ item.category.category }}{% if
-        item.category.sub_category %} → {{ item.category.sub_category }}{% endif
-        %} {% else %}
-        <span class="text-gray-400">—</span>
-        {% endif %}
+        {% format_category item True %}
       </td>
       <td data-col="unit">{{ item.unit.base_unit|default:"—" }}</td>
       <td data-col="stock">

--- a/tests/test_category_tag.py
+++ b/tests/test_category_tag.py
@@ -1,0 +1,24 @@
+from collections import namedtuple
+
+from django.template import Context, Template
+
+
+Category = namedtuple("Category", ["category", "sub_category"])
+Item = namedtuple("Item", ["category"])
+
+
+def render(template_string, **context):
+    template = Template(template_string)
+    return template.render(Context(context)).strip()
+
+
+def test_format_category_with_subcategory():
+    item = Item(Category("Food", "Fruit"))
+    output = render("{% load category_tags %}{% format_category item %}", item=item)
+    assert output == "Food → Fruit"
+
+
+def test_format_category_placeholder_when_missing():
+    item = Item(None)
+    output = render("{% load category_tags %}{% format_category item True %}", item=item)
+    assert "—" in output


### PR DESCRIPTION
## Summary
- add `format_category` template tag to safely render `Category → Subcategory`
- refactor item grid and table to use helper
- test formatting helper and ensure items list renders grid/table partials

## Testing
- `pytest tests/test_category_tag.py tests/test_item_views.py::test_items_list_layout_query_switches_partials -q`


------
https://chatgpt.com/codex/tasks/task_e_68b611c67e388326bc5d76ab5192ea1a