### PR TITLE
Centralize dashboard context building

### DIFF
--- a/core/viewmodels.py
+++ b/core/viewmodels.py
@@ -1,0 +1,50 @@
+"""Helper dataclasses for views."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+from django.db.models import QuerySet
+from django.urls import reverse
+
+from inventory.models import Item, Supplier
+from inventory.services import dashboard_service
+
+
+@dataclass
+class DashboardContext:
+    """Assemble context data for dashboard templates.
+
+    Parameters
+    ----------
+    labels:
+        List of labels for trend chart.
+    values:
+        Corresponding values for trend chart.
+    items:
+        Optional queryset of active items for filter dropdown.
+    suppliers:
+        Optional queryset of active suppliers for filter dropdown.
+    """
+
+    labels: list[str]
+    values: list[float]
+    items: Optional[QuerySet[Item]] = None
+    suppliers: Optional[QuerySet[Supplier]] = None
+
+    def as_dict(self) -> dict:
+        """Return the assembled context as a dictionary."""
+        context = {
+            "low_stock": dashboard_service.get_low_stock_items(),
+            "trend_labels": json.dumps(self.labels),
+            "trend_values": json.dumps(self.values),
+            "list_url": reverse("dashboard"),
+            "list_title": "Dashboard",
+            "current_title": "Dashboard",
+        }
+        if self.items is not None:
+            context["items"] = self.items
+        if self.suppliers is not None:
+            context["suppliers"] = self.suppliers
+        return context

--- a/core/views.py
+++ b/core/views.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from datetime import timedelta
 from decimal import Decimal
@@ -8,14 +7,15 @@ from django.contrib.auth import login
 from django.contrib.auth.forms import AuthenticationForm
 from django.core.cache import cache
 from django.db.models import DecimalField, ExpressionWrapper, F, Sum
-from django.db.models.functions import TruncDate, Coalesce
+from django.db.models.functions import Coalesce, TruncDate
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
-from django.urls import reverse
 from django.utils import timezone
 
 from inventory.models import Item, PurchaseOrder, StockTransaction, Supplier
-from inventory.services import counts, dashboard_service, kpis
+from inventory.services import counts, kpis
+
+from .viewmodels import DashboardContext
 
 logger = logging.getLogger(__name__)
 
@@ -74,14 +74,7 @@ def health_check(request):
 def dashboard(request):
     """Render dashboard shell; KPI cards are loaded asynchronously."""
     labels, values = kpis.stock_trend_last_7_days()
-    context = {
-        "low_stock": dashboard_service.get_low_stock_items(),
-        "trend_labels": json.dumps(labels),
-        "trend_values": json.dumps(values),
-        "list_url": reverse("dashboard"),
-        "list_title": "Dashboard",
-        "current_title": "Dashboard",
-    }
+    context = DashboardContext(labels, values).as_dict()
     return render(request, "core/dashboard.html", context)
 
 
@@ -153,16 +146,12 @@ def interactive_dashboard(request):
     start = end - timedelta(days=days - 1)
 
     labels, values = _stock_trend_data(item_id, supplier_id, start, end, metric)
-    context = {
-        "low_stock": dashboard_service.get_low_stock_items(),
-        "trend_labels": json.dumps(labels),
-        "trend_values": json.dumps(values),
-        "items": Item.objects.filter(is_active=True),
-        "suppliers": Supplier.objects.filter(is_active=True),
-        "list_url": reverse("dashboard"),
-        "list_title": "Dashboard",
-        "current_title": "Dashboard",
-    }
+    context = DashboardContext(
+        labels,
+        values,
+        items=Item.objects.filter(is_active=True),
+        suppliers=Supplier.objects.filter(is_active=True),
+    ).as_dict()
     return render(request, "core/dashboard.html", context)
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,9 +1,22 @@
+import json
+
 import pytest
 from django.contrib.auth.models import Permission
 from django.urls import reverse
 from django.utils import timezone
 
+from core.viewmodels import DashboardContext
 from inventory.models import Indent, StockTransaction, Supplier
+
+
+@pytest.mark.django_db
+def test_dashboard_context_basic():
+    ctx = DashboardContext(labels=["2024-01-01"], values=[1])
+    data = ctx.as_dict()
+    assert data["trend_labels"] == json.dumps(["2024-01-01"])
+    assert data["trend_values"] == json.dumps([1])
+    assert data["list_title"] == "Dashboard"
+    assert "items" not in data and "suppliers" not in data
 
 
 @pytest.mark.django_db

--- a/tests/test_interactive_dashboard.py
+++ b/tests/test_interactive_dashboard.py
@@ -2,7 +2,22 @@ import pytest
 from django.urls import reverse
 from django.utils import timezone
 
-from inventory.models import PurchaseOrder, StockTransaction, Supplier
+from core.viewmodels import DashboardContext
+from inventory.models import Item, PurchaseOrder, StockTransaction, Supplier
+
+
+@pytest.mark.django_db
+def test_dashboard_context_with_filters(item_factory):
+    item_factory(name="Foo")
+    Supplier.objects.create(name="Supp", is_active=True)
+    ctx = DashboardContext(
+        labels=[],
+        values=[],
+        items=Item.objects.filter(is_active=True),
+        suppliers=Supplier.objects.filter(is_active=True),
+    ).as_dict()
+    assert ctx["items"].count() == 1
+    assert ctx["suppliers"].count() == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- add `DashboardContext` dataclass to assemble dashboard view data
- refactor `dashboard` and `interactive_dashboard` views to use the new helper
- extend tests to validate `DashboardContext` usage

## Testing
- `pytest tests/test_dashboard.py tests/test_interactive_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6a0d2bc8c8326a225ec219ca15e55