### PR TITLE
feat: render branded 500 page on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Custom 500 error page rendered after detailed error logging.
 - Layout toggle buttons on the items list to switch between table and grid views.
 - Supplier and unit dropdown filters on the items list for more precise results.
 

--- a/core/error_logging_middleware.py
+++ b/core/error_logging_middleware.py
@@ -1,6 +1,8 @@
 import logging
 import traceback
 
+from django.shortcuts import render
+
 logger = logging.getLogger(__name__)
 
 
@@ -49,5 +51,4 @@ class DetailedErrorLoggingMiddleware:
         logger.error(traceback.format_exc())
         logger.error("🚨 END ERROR REPORT 🚨")
 
-        # Don't return a response - let Django handle it normally
-        return None
+        return render(request, "500.html", status=500)

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,9 @@
+{% extends "_base.html" %}
+{% block title %}Server Error{% endblock %}
+{% block content %}
+<div class="max-w-xl mx-auto py-10 text-center">
+  <h1 class="text-4xl font-bold text-gray-900 mb-4">Something went wrong</h1>
+  <p class="text-gray-700 mb-6">We're working to fix the issue. Please try again later.</p>
+  <a href="/" class="text-blue-600 hover:underline">Return to home</a>
+</div>
+{% endblock %}

--- a/tests/test_error_logging_middleware.py
+++ b/tests/test_error_logging_middleware.py
@@ -38,3 +38,21 @@ def test_middleware_redacts_sensitive_info(caplog):
     assert "/test/" in log_output
     assert "POST" in log_output
     assert "dummyuser" in log_output
+
+
+def test_process_exception_returns_custom_500_and_logs(caplog):
+    middleware = DetailedErrorLoggingMiddleware(lambda req: None)
+    rf = RequestFactory()
+    request = rf.get("/error/")
+    request.user = DummyUser()
+
+    with caplog.at_level(logging.ERROR):
+        response = middleware.process_exception(request, ValueError("boom"))
+
+    assert response.status_code == 500
+    content = response.content.decode()
+    assert "Something went wrong" in content
+
+    log_output = " ".join(record.getMessage() for record in caplog.records)
+    assert "🚨 DETAILED ERROR REPORT 🚨" in log_output
+    assert "Exception Message: boom" in log_output


### PR DESCRIPTION
## Summary
- display branded 500 template for server errors
- log exceptions then render the error page in DetailedErrorLoggingMiddleware
- test middleware logging and error page rendering

## Testing
- `pytest tests/test_error_logging_middleware.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6a4f6ed988326b4ed42bcd05f59ff