### PR TITLE
Refactor navigation links to use URL reversing

### DIFF
--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -1,3 +1,13 @@
+"""Utilities for navigation links used throughout the application."""
+
+from typing import List
+
+from django.urls import NoReverseMatch, reverse
+
+
+# Definitions of navigation links by URL name. The actual URLs are resolved
+# dynamically to ensure that any changes to URL patterns are detected at run
+# time.
 NAVIGATION_LINKS = [
     {"title": "Home", "url_name": "root"},
     {"title": "Dashboard", "url_name": "dashboard"},
@@ -8,6 +18,24 @@ NAVIGATION_LINKS = [
 ]
 
 
+def get_navigation_links() -> List[dict]:
+    """Build the list of navigation links with resolved URLs.
+
+    Any links that reference a URL pattern that does not exist are skipped to
+    prevent broken navigation entries.
+    """
+
+    resolved_links = []
+    for link in NAVIGATION_LINKS:
+        try:
+            url = reverse(link["url_name"])
+        except NoReverseMatch:
+            # Ignore links that point to missing routes
+            continue
+        resolved_links.append({"title": link["title"], "url": url})
+    return resolved_links
+
+
 def primary_navigation(request):
     """Provide primary navigation links for the top navigation bar."""
-    return {"primary_navigation": NAVIGATION_LINKS}
+    return {"primary_navigation": get_navigation_links()}

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -15,7 +15,7 @@
           <div x-show="open" x-cloak @click.outside="open=false"
                class="absolute left-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50" role="menu">
             {% for link in primary_navigation %}
-            <a href="{% url link.url_name %}"
+            <a href="{{ link.url }}"
                class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">{{ link.title }}</a>
             {% endfor %}
           </div>

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -2,6 +2,7 @@ import pytest
 from django.template.loader import render_to_string
 from django.test import RequestFactory
 from django.urls import reverse
+import inventory_app.navigation as navigation
 
 
 @pytest.mark.django_db
@@ -61,3 +62,12 @@ def test_home_page_contains_nav_links(client, django_user_model):
     ]
     for text in expected:
         assert text in html
+
+
+def test_invalid_navigation_link_is_ignored(monkeypatch):
+    """Ensure navigation links referencing missing routes are omitted."""
+    bad_links = navigation.NAVIGATION_LINKS + [{"title": "Bad", "url_name": "does_not_exist"}]
+    monkeypatch.setattr(navigation, "NAVIGATION_LINKS", bad_links)
+    links = navigation.get_navigation_links()
+    titles = [link["title"] for link in links]
+    assert "Bad" not in titles


### PR DESCRIPTION
## Summary
- add `get_navigation_links` utility to resolve URLs and skip bad routes
- update top navigation template and context processor to use resolved links
- test navigation to ensure invalid links are ignored

## Testing
- `pytest tests/test_navigation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6a885f5248326a9606022e29984b2