### PR TITLE
refactor: centralize low stock queries

### DIFF
--- a/core/viewmodels.py
+++ b/core/viewmodels.py
@@ -9,7 +9,7 @@ from django.db.models import QuerySet
 from django.urls import reverse
 
 from inventory.models import Item, Supplier
-from inventory.services import dashboard_service
+from inventory.services.stock_utils import get_low_stock_items
 
 
 @dataclass
@@ -36,7 +36,7 @@ class DashboardContext:
     def as_dict(self) -> dict:
         """Return the assembled context as a dictionary."""
         context = {
-            "low_stock": dashboard_service.get_low_stock_items(),
+            "low_stock": get_low_stock_items(),
             "trend_labels": json.dumps(self.labels),
             "trend_values": json.dumps(self.values),
             "list_url": reverse("dashboard"),

--- a/core/views.py
+++ b/core/views.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 
 from inventory.models import Item, PurchaseOrder, StockTransaction, Supplier
 from inventory.services import counts, kpis
+from inventory.services.stock_utils import get_low_stock_items
 
 from .viewmodels import DashboardContext
 
@@ -35,7 +36,7 @@ def root_view(request):
                 "receipts": kpis.receipts_last_7_days(),
                 "issues": kpis.issues_last_7_days(),
                 "low_stock": kpis.low_stock_count(),
-                "low_stock_items": kpis.low_stock_items(),
+                "low_stock_items": get_low_stock_items(),
                 "high_price_purchases": kpis.high_price_purchases(Decimal("0.1")),
                 "pending_po_status": kpis.pending_po_status_counts(),
                 "pending_indent_status": kpis.pending_indent_counts(),

--- a/inventory/services/__init__.py
+++ b/inventory/services/__init__.py
@@ -16,6 +16,7 @@ from . import (
     units_service,
     supplier_service,
     ui_service,
+    stock_utils,
 )
 
 __all__ = [
@@ -34,4 +35,5 @@ __all__ = [
     "counts",
     "units_service",
     "categories_service",
+    "stock_utils",
 ]

--- a/inventory/services/dashboard_service.py
+++ b/inventory/services/dashboard_service.py
@@ -1,27 +1,4 @@
-from django.db.models import Case, CharField, F, Value, When
+"""Backward compatible dashboard service utilities."""
+from .stock_utils import get_low_stock_items
 
-from inventory.models import Item
-
-from .units_service import UnitsService
-
-
-def get_low_stock_items():
-    """Return items whose current stock is below their reorder point."""
-    qs = Item.objects.only("name", "unit_id", "current_stock", "reorder_point").filter(
-        reorder_point__isnull=False,
-        current_stock__lt=F("reorder_point"),
-        is_active=True,
-    )
-    if hasattr(Item, "is_placeholder"):
-        qs = qs.filter(is_placeholder=False)
-
-    units_map = {u["unit_id"]: u["purchase_unit"] for u in UnitsService.get_all_units()}
-    whens = [When(unit_id=k, then=Value(v)) for k, v in units_map.items()]
-    qs = qs.annotate(
-        uom=Case(
-            *whens,
-            default=Value(""),
-            output_field=CharField(),
-        ),
-    )
-    return qs.order_by("name")
+__all__ = ["get_low_stock_items"]

--- a/inventory/services/kpis.py
+++ b/inventory/services/kpis.py
@@ -14,6 +14,7 @@ from inventory.models import (
     StockTransaction,
 )
 from inventory.models.enums import IndentStatus, PurchaseOrderStatus
+from .stock_utils import get_low_stock_items
 
 
 def stock_value():
@@ -46,22 +47,13 @@ def issues_last_7_days():
 
 def low_stock_count():
     """Number of items below their reorder point."""
-    return Item.objects.filter(
-        reorder_point__isnull=False, current_stock__lt=F("reorder_point")
-    ).count()
+    return get_low_stock_items().count()
 
 
 def low_stock_items(limit: int = 5) -> List[str]:
     """Return names of items that are below their reorder point."""
-    qs = Item.objects.filter(
-        reorder_point__isnull=False,
-        current_stock__lt=F("reorder_point"),
-        is_active=True,
-    )
-    if hasattr(Item, "is_placeholder"):
-        qs = qs.filter(is_placeholder=False)
-    qs = qs.order_by("name")
-    return list(qs.values_list("name", flat=True)[:limit])
+    qs = get_low_stock_items().values_list("name", flat=True)
+    return list(qs[:limit])
 
 
 def high_price_purchases(threshold: Decimal) -> List[GRNItem]:

--- a/inventory/services/stock_utils.py
+++ b/inventory/services/stock_utils.py
@@ -1,0 +1,34 @@
+"""Utility functions for stock-related queries."""
+from __future__ import annotations
+
+from django.db.models import Case, CharField, F, Value, When, QuerySet
+
+from inventory.models import Item
+
+from .units_service import UnitsService
+
+
+def get_low_stock_items() -> QuerySet[Item]:
+    """Return items whose current stock is below their reorder point.
+
+    The returned queryset is annotated with ``uom`` containing the purchase unit
+    display name for each item.
+    """
+    qs = Item.objects.only("name", "unit_id", "current_stock", "reorder_point").filter(
+        reorder_point__isnull=False,
+        current_stock__lt=F("reorder_point"),
+        is_active=True,
+    )
+    if hasattr(Item, "is_placeholder"):
+        qs = qs.filter(is_placeholder=False)
+
+    units_map = {u["unit_id"]: u["purchase_unit"] for u in UnitsService.get_all_units()}
+    whens = [When(unit_id=unit_id, then=Value(uom)) for unit_id, uom in units_map.items()]
+
+    return qs.annotate(
+        uom=Case(
+            *whens,
+            default=Value(""),
+            output_field=CharField(),
+        ),
+    ).order_by("name")

--- a/tests/test_stock_utils.py
+++ b/tests/test_stock_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from inventory.services import dashboard_service
+from inventory.services.stock_utils import get_low_stock_items
 
 
 @pytest.mark.django_db
@@ -9,7 +9,7 @@ def test_get_low_stock_items(item_factory):
     item_factory(name="Low", reorder_point=10, current_stock=5, unit_id=19)
     item_factory(name="Inactive", reorder_point=10, current_stock=5, is_active=False, unit_id=19)
     item_factory(name="High", reorder_point=10, current_stock=15, unit_id=19)
-    items = list(dashboard_service.get_low_stock_items())
+    items = list(get_low_stock_items())
     assert len(items) == 1
     item = items[0]
     assert item.name == "Low"


### PR DESCRIPTION
## Summary
- add `stock_utils.get_low_stock_items` to share annotated low stock item query
- refactor KPIs, core views, and dashboard utilities to reuse the helper
- replace old tests with `test_stock_utils` targeting the shared helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6d352a52883268fb843c566b2582d