### PR TITLE
Queue ABC classification asynchronously

### DIFF
--- a/inventory/services/ml.py
+++ b/inventory/services/ml.py
@@ -142,3 +142,33 @@ def abc_classification() -> Dict[int, str]:
             cls = "C"
         classifications[item.pk] = cls
     return classifications
+
+
+def abc_classification_task(cache_key: str, ttl: int) -> bool:
+    """Compute ABC classifications and store results in cache.
+
+    Returns ``True`` on success and ``False`` if an exception is raised.
+    """
+    try:
+        cache.set(cache_key, abc_classification(), ttl)
+        return True
+    except Exception:  # pragma: no cover - defensive catch-all
+        logger.exception("Failed to compute ABC classifications")
+        return False
+
+
+def queue_abc_classification(
+    *, cache_key: str = "ml_abc_classification", ttl: int = 300, sync: bool = False
+) -> str:
+    """Queue classification task and store results in cache when complete.
+
+    Args:
+        cache_key: Cache key to store classifications.
+        ttl: Cache time-to-live in seconds.
+        sync: If ``True`` the task runs synchronously (used in tests).
+
+    Returns:
+        The ID of the queued task.
+    """
+
+    return async_task(abc_classification_task, cache_key, ttl, sync=sync)

--- a/inventory/views/ml.py
+++ b/inventory/views/ml.py
@@ -26,8 +26,8 @@ def ml_dashboard(request):
 
     classifications = cache.get("ml_abc_classification")
     if classifications is None:
-        classifications = ml.abc_classification()
-        cache.set("ml_abc_classification", classifications, ttl)
+        ml.queue_abc_classification(ttl=ttl)
+        classifications = {}
 
     results = []
     for item in Item.objects.all():

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -80,30 +80,35 @@ def test_ml_dashboard_uses_cache(client):
         caches[cache_name].clear()
 
     with (
-        patch("inventory.services.ml.queue_train_models") as mock_queue,
-        patch("inventory.services.ml.abc_classification", return_value={}) as mock_abc,
+        patch("inventory.services.ml.queue_train_models") as mock_train_queue,
+        patch("inventory.services.ml.queue_abc_classification") as mock_cls_queue,
     ):
-        # When queue_train_models is called we synchronously populate the cache to
-        # emulate the background worker completing its task.
-        mock_queue.side_effect = (
+        # When the background tasks are queued we synchronously populate the cache
+        # to emulate the worker completing its job.
+        mock_train_queue.side_effect = (
             lambda periods=1, cache_key="ml_train_models", ttl=300: cache.set(
+                cache_key, {}, ttl
+            )
+        )
+        mock_cls_queue.side_effect = (
+            lambda cache_key="ml_abc_classification", ttl=300: cache.set(
                 cache_key, {}, ttl
             )
         )
 
         response = client.get(reverse("ml_dashboard"))
         assert response.status_code == 200
-        assert mock_queue.call_count == 1
-        assert mock_abc.call_count == 1
+        assert mock_train_queue.call_count == 1
+        assert mock_cls_queue.call_count == 1
 
         client.get(reverse("ml_dashboard"))
-        assert mock_queue.call_count == 1
-        assert mock_abc.call_count == 1
+        assert mock_train_queue.call_count == 1
+        assert mock_cls_queue.call_count == 1
 
         cache.clear()
         client.get(reverse("ml_dashboard"))
-        assert mock_queue.call_count == 2
-        assert mock_abc.call_count == 2
+        assert mock_train_queue.call_count == 2
+        assert mock_cls_queue.call_count == 2
 
 
 def test_queue_train_models_updates_cache(db):
@@ -124,3 +129,23 @@ def test_queue_train_models_logs_exception(db, monkeypatch, caplog):
         ml.queue_train_models(periods=1, cache_key=cache_key, ttl=300, sync=True)
     assert cache.get(cache_key) is None
     assert "Failed to train forecasting models" in caplog.text
+
+
+def test_queue_abc_classification_updates_cache(db):
+    cache_key = "test_ml_abc_classification"
+    cache.delete(cache_key)
+    ml.queue_abc_classification(cache_key=cache_key, ttl=300, sync=True)
+    assert cache.get(cache_key) is not None
+
+
+def test_queue_abc_classification_logs_exception(db, monkeypatch, caplog):
+    def bad_cls():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(ml, "abc_classification", bad_cls)
+    cache_key = "test_ml_abc_classification_error"
+    cache.delete(cache_key)
+    with caplog.at_level("ERROR"):
+        ml.queue_abc_classification(cache_key=cache_key, ttl=300, sync=True)
+    assert cache.get(cache_key) is None
+    assert "Failed to compute ABC classifications" in caplog.text


### PR DESCRIPTION
## Summary
- add background task helpers to compute and cache ABC classifications
- invoke async classification queue from ML dashboard view
- test queuing and caching for training and classification tasks

## Testing
- `pytest tests/test_ml.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6eba1ed4c832685fd2202b74da6c7