### PR TITLE
Add caching and invalidation hooks

### DIFF
--- a/inventory/services/README.md
+++ b/inventory/services/README.md
@@ -9,3 +9,19 @@ Key points:
 - Use `item_service.get_unit_display_name(unit_id)` for unit labels.
 - Keep imports at module scope; move logic into services to avoid circulars.
 - Categories and units data come from `categories_service` and `units_service`.
+
+Caching
+-------
+
+Read-heavy service helpers use Python's built-in `functools.lru_cache` for
+in-process caching. Each cached function exposes a `.clear()` method (alias of
+`cache_clear`) to invalidate results after any write operation.
+
+Example:
+
+```python
+from inventory.services.stock_utils import get_low_stock_items
+
+items = get_low_stock_items()  # First call queries the database
+get_low_stock_items.clear()    # Clear cache after stock updates
+```

--- a/inventory/services/item_service.py
+++ b/inventory/services/item_service.py
@@ -19,6 +19,7 @@ from django.db.models import Sum
 from django.db.models.functions import Coalesce
 
 from inventory.models import Item
+from .stock_utils import get_low_stock_items
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,7 @@ def add_new_item(details: Dict[str, Any]) -> Tuple[bool, str]:
         item = Item.objects.create(**params)
         get_all_items_with_stock.clear()
         get_distinct_departments_from_items.clear()
+        get_low_stock_items.clear()
         return True, f"Item '{item.name}' added with ID {item.pk}."
     except IntegrityError:
         return (
@@ -227,6 +229,7 @@ def add_items_bulk(items: List[Dict[str, Any]]) -> Tuple[int, List[str]]:
         Item.objects.bulk_create(objs)
         get_all_items_with_stock.clear()
         get_distinct_departments_from_items.clear()
+        get_low_stock_items.clear()
         return len(objs), []
     except IntegrityError as e:
         return 0, [str(e)]
@@ -302,6 +305,7 @@ def update_item(item_id: int, updates: Dict[str, Any]) -> Tuple[bool, str]:
         item.save()
         get_all_items_with_stock.clear()
         get_distinct_departments_from_items.clear()
+        get_low_stock_items.clear()
         return True, f"Item ID {item_id} updated successfully."
     except IntegrityError:
         return (
@@ -326,6 +330,7 @@ def deactivate_item(item_id: int) -> Tuple[bool, str]:
     if updated:
         get_all_items_with_stock.clear()
         get_distinct_departments_from_items.clear()
+        get_low_stock_items.clear()
         return True, "Item deactivated successfully."
     return False, "Item not found or already inactive."
 
@@ -338,6 +343,7 @@ def reactivate_item(item_id: int) -> Tuple[bool, str]:
     if updated:
         get_all_items_with_stock.clear()
         get_distinct_departments_from_items.clear()
+        get_low_stock_items.clear()
         return True, "Item reactivated successfully."
     return False, "Item not found or already active."
 

--- a/inventory/services/kpis.py
+++ b/inventory/services/kpis.py
@@ -47,13 +47,12 @@ def issues_last_7_days():
 
 def low_stock_count():
     """Number of items below their reorder point."""
-    return get_low_stock_items().count()
+    return len(get_low_stock_items())
 
 
 def low_stock_items(limit: int = 5) -> List[str]:
     """Return names of items that are below their reorder point."""
-    qs = get_low_stock_items().values_list("name", flat=True)
-    return list(qs[:limit])
+    return [item.name for item in get_low_stock_items()[:limit]]
 
 
 def high_price_purchases(threshold: Decimal) -> List[GRNItem]:

--- a/inventory/services/recipe_service.py
+++ b/inventory/services/recipe_service.py
@@ -11,6 +11,7 @@ from inventory.constants import PLACEHOLDER_SELECT_COMPONENT
 
 from ..models import Item, Recipe, RecipeComponent, SaleTransaction, StockTransaction
 from .item_service import get_unit_display_name
+from .stock_utils import get_low_stock_items
 
 logger = logging.getLogger(__name__)
 
@@ -388,6 +389,7 @@ def record_sale(
                     user_id=user_id_clean,
                     notes=f"Recipe {recipe_id} sale",
                 )
+        get_low_stock_items.cache_clear()
         return True, "Sale recorded."
     except Recipe.DoesNotExist:
         return False, "Recipe not found."

--- a/inventory/services/stock_service.py
+++ b/inventory/services/stock_service.py
@@ -9,6 +9,7 @@ from django.db.models import F
 from inventory.models import Item, StockTransaction
 
 from .exceptions import StockServiceError
+from .stock_utils import get_low_stock_items
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,7 @@ def record_stock_transaction(
                     related_po_id=related_po_id,
                     notes=notes,
                 )
+            get_low_stock_items.cache_clear()
             return
         except OperationalError as exc:  # pragma: no cover - retry on lock
             logger.error("Error recording stock transaction: %s", exc)
@@ -84,6 +86,7 @@ def record_stock_transactions_bulk(transactions: List[Dict[str, Any]]) -> bool:
                     related_po_id=tx.get("related_po_id"),
                     notes=tx.get("notes"),
                 )
+        get_low_stock_items.cache_clear()
         return True
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("Bulk stock transaction failed: %s", exc)
@@ -107,6 +110,7 @@ def remove_stock_transactions_bulk(transaction_ids: List[int]) -> bool:
                 )
                 item.save(update_fields=["current_stock"])
             StockTransaction.objects.filter(transaction_id__in=transaction_ids).delete()
+        get_low_stock_items.cache_clear()
         return True
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("Error removing stock transactions: %s", exc)

--- a/inventory/services/stock_utils.py
+++ b/inventory/services/stock_utils.py
@@ -1,18 +1,24 @@
 """Utility functions for stock-related queries."""
 from __future__ import annotations
 
-from django.db.models import Case, CharField, F, Value, When, QuerySet
+from functools import lru_cache
+from typing import List
+
+from django.db.models import Case, CharField, F, Value, When
 
 from inventory.models import Item
 
 from .units_service import UnitsService
 
 
-def get_low_stock_items() -> QuerySet[Item]:
+@lru_cache(maxsize=1)
+def get_low_stock_items() -> List[Item]:
     """Return items whose current stock is below their reorder point.
 
-    The returned queryset is annotated with ``uom`` containing the purchase unit
-    display name for each item.
+    The returned list is cached to reduce database load. The list is annotated
+    with ``uom`` containing the purchase unit display name for each item. Use
+    :func:`get_low_stock_items.clear` to invalidate the cache after any
+    operation that mutates item stock levels or reorder points.
     """
     qs = Item.objects.only("name", "unit_id", "current_stock", "reorder_point").filter(
         reorder_point__isnull=False,
@@ -25,10 +31,16 @@ def get_low_stock_items() -> QuerySet[Item]:
     units_map = {u["unit_id"]: u["purchase_unit"] for u in UnitsService.get_all_units()}
     whens = [When(unit_id=unit_id, then=Value(uom)) for unit_id, uom in units_map.items()]
 
-    return qs.annotate(
+    qs = qs.annotate(
         uom=Case(
             *whens,
             default=Value(""),
             output_field=CharField(),
         ),
     ).order_by("name")
+
+    return list(qs)
+
+
+# expose a ``clear`` method consistent with other cached helpers
+get_low_stock_items.clear = get_low_stock_items.cache_clear  # type: ignore[attr-defined]

--- a/inventory/services/supplier_service.py
+++ b/inventory/services/supplier_service.py
@@ -1,4 +1,5 @@
 import logging
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple
 
 from django.db import IntegrityError, transaction
@@ -27,6 +28,7 @@ def add_supplier(details: Dict[str, Any]) -> Supplier:
             notes=(details.get("notes") or "").strip() or None,
             is_active=details.get("is_active", True),
         )
+        get_all_suppliers.cache_clear()
         return supplier
     except IntegrityError as exc:
         raise SupplierServiceError(
@@ -39,6 +41,7 @@ def add_supplier(details: Dict[str, Any]) -> Supplier:
         ) from exc
 
 
+@lru_cache(maxsize=None)
 def get_all_suppliers(include_inactive: bool = False) -> List[Dict[str, Any]]:
     qs = Supplier.objects.all()
     if not include_inactive:
@@ -55,6 +58,10 @@ def get_all_suppliers(include_inactive: bool = False) -> List[Dict[str, Any]]:
             "is_active",
         )
     )
+
+
+# expose a convenient clear method
+get_all_suppliers.clear = get_all_suppliers.cache_clear  # type: ignore[attr-defined]
 
 
 def get_supplier_details(supplier_id: int) -> Optional[Dict[str, Any]]:
@@ -96,6 +103,7 @@ def update_supplier(supplier_id: int, updates: Dict[str, Any]) -> Tuple[bool, st
             setattr(supplier, field, val)
     try:
         supplier.save()
+        get_all_suppliers.cache_clear()
         return True, f"Supplier ID {supplier_id} updated successfully."
     except IntegrityError:
         return (
@@ -110,6 +118,7 @@ def update_supplier(supplier_id: int, updates: Dict[str, Any]) -> Tuple[bool, st
 def deactivate_supplier(supplier_id: int) -> Tuple[bool, str]:
     count = Supplier.objects.filter(pk=supplier_id).update(is_active=False)
     if count:
+        get_all_suppliers.cache_clear()
         return True, "Supplier deactivated successfully."
     return False, "Supplier not found or already inactive."
 
@@ -117,5 +126,6 @@ def deactivate_supplier(supplier_id: int) -> Tuple[bool, str]:
 def reactivate_supplier(supplier_id: int) -> Tuple[bool, str]:
     count = Supplier.objects.filter(pk=supplier_id).update(is_active=True)
     if count:
+        get_all_suppliers.cache_clear()
         return True, "Supplier reactivated successfully."
     return False, "Supplier not found or already active."

--- a/tests/test_kpis_service.py
+++ b/tests/test_kpis_service.py
@@ -15,10 +15,12 @@ from inventory.models import (
 )
 from inventory.models.enums import IndentStatus, PurchaseOrderStatus
 from inventory.services import kpis
+from inventory.services.stock_utils import get_low_stock_items
 
 
 @pytest.mark.django_db
 def test_low_stock_items_excludes_inactive(item_factory):
+    get_low_stock_items.clear()
     item_factory(name="Active", reorder_point=10, current_stock=5)
     item_factory(name="Inactive", reorder_point=10, current_stock=5, is_active=False)
     assert kpis.low_stock_items() == ["Active"]

--- a/tests/test_stock_utils.py
+++ b/tests/test_stock_utils.py
@@ -1,18 +1,42 @@
 import pytest
 
 from inventory.services.stock_utils import get_low_stock_items
+from inventory.services import stock_service
 
 
 @pytest.mark.django_db
 def test_get_low_stock_items(item_factory):
+    get_low_stock_items.clear()
     # Use unit_id=19 which maps to "KG" instead of unit_id=1 which maps to "2 KG"
     item_factory(name="Low", reorder_point=10, current_stock=5, unit_id=19)
     item_factory(name="Inactive", reorder_point=10, current_stock=5, is_active=False, unit_id=19)
     item_factory(name="High", reorder_point=10, current_stock=15, unit_id=19)
-    items = list(get_low_stock_items())
+    items = get_low_stock_items()
     assert len(items) == 1
     item = items[0]
     assert item.name == "Low"
     assert item.uom == "KG"  # unit_id=19 maps to purchase_unit="KG"
     assert item.current_stock == 5
     assert item.reorder_point == 10
+
+
+@pytest.mark.django_db
+def test_get_low_stock_items_cache_invalidation(
+    item_factory, django_assert_num_queries
+):
+    get_low_stock_items.clear()
+    item = item_factory(name="Low", reorder_point=10, current_stock=5, unit_id=19)
+
+    # Prime cache
+    get_low_stock_items()
+    with django_assert_num_queries(0):
+        get_low_stock_items()
+
+    # Increase stock to invalidate cache
+    stock_service.record_stock_transaction(
+        item_id=item.item_id, quantity_change=10, transaction_type="RECEIVING"
+    )
+
+    with django_assert_num_queries(1):
+        items = get_low_stock_items()
+    assert items == []

--- a/tests/test_supplier_service_django.py
+++ b/tests/test_supplier_service_django.py
@@ -58,6 +58,7 @@ def test_deactivate_and_reactivate_supplier():
 
 @pytest.mark.django_db
 def test_get_all_suppliers_returns_list_of_dicts():
+    supplier_service.get_all_suppliers.clear()
     Supplier.objects.create(name="Vendor D", is_active=True)
     Supplier.objects.create(name="Vendor E", is_active=False)
     active_only = supplier_service.get_all_suppliers()
@@ -107,3 +108,17 @@ def test_toggle_supplier_post(client):
     assert resp.status_code == 200
     supplier.refresh_from_db()
     assert supplier.is_active is True
+
+
+@pytest.mark.django_db
+def test_get_all_suppliers_cache_invalidation(django_assert_num_queries):
+    supplier_service.get_all_suppliers.clear()
+    supplier_service.add_supplier({"name": "A"})
+    supplier_service.get_all_suppliers()  # prime cache
+    with django_assert_num_queries(0):
+        supplier_service.get_all_suppliers()
+
+    supplier_service.add_supplier({"name": "B"})  # clears cache
+    with django_assert_num_queries(1):
+        names = {s["name"] for s in supplier_service.get_all_suppliers()}
+    assert {"A", "B"}.issubset(names)


### PR DESCRIPTION
## Summary
- document use of functools.lru_cache for service-layer caching
- cache low-stock and supplier lookups with invalidation on data changes
- test cache hits and automatic clearing after mutations

## Testing
- ⚠️ `flake8` (style errors in unrelated files)
- ✅ `flake8 inventory/services/stock_utils.py inventory/services/supplier_service.py inventory/services/stock_service.py inventory/services/item_service.py inventory/services/recipe_service.py inventory/services/kpis.py tests/test_stock_utils.py tests/test_supplier_service_django.py tests/test_kpis_service.py`
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f019d298832681de1a33d850667e