### PR TITLE
Refactor list layout to use unified heading slot

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -5,12 +5,16 @@
   {% include "components/breadcrumb.html" with list_url=list_url list_title=list_title current_title=current_title %}
 {% endblock %}
 
-{% block heading %}Dashboard{% endblock %}
+{% block page_title %}Dashboard – Inventory App{% endblock %}
+{% block page_heading %}Dashboard{% endblock %}
 
-{% block actions %}
+{% block primary_actions %}
   {% if perms.inventory.add_purchaseorder %}
   <a href="{% url 'purchase_order_create' %}" class="btn-primary">New Purchase Order</a>
   {% endif %}
+{% endblock %}
+
+{% block secondary_actions %}
   <a href="{% url 'grn_list' %}" class="btn-secondary">Record Receipt</a>
 {% endblock %}
 

--- a/templates/components/list_layout.html
+++ b/templates/components/list_layout.html
@@ -1,8 +1,11 @@
 {% extends "_base.html" %}
-{% block title %}List – Inventory App{% endblock %}
+{% block title %}{% block page_title %}List – Inventory App{% endblock %}{% endblock %}
+{% block nav_heading %}{% block page_heading %}{% endblock %}{% endblock %}
+
 {% block content %}
-  <h1 class="text-h1 font-semibold mb-4">{% block heading %}{% endblock %}</h1>
-  <div class="mb-4 flex justify-end gap-2">{% block actions %}{% endblock %}</div>
+  {% block page_subtitle %}{% endblock %}
+  {% block primary_actions %}{% endblock %}
+  {% block secondary_actions %}{% endblock %}
   {% block filter_bar %}{% endblock %}
   {% block extra %}{% endblock %}
   {% block table_container %}
@@ -13,5 +16,11 @@
        hx-indicator="#htmx-spinner">
     {% block table_content %}{% endblock %}
   </div>
+  {% block bulk_actions %}{% endblock %}
+  {% block pagination %}{% endblock %}
   {% endblock %}
+{% endblock %}
+
+{% block extra_js %}
+  {% block page_scripts %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Refactor `list_layout.html` to use `page_title` and `page_heading` slots with optional action blocks
- Update dashboard template to use new layout conventions

## Testing
- `pip install pytest-django`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f3c60b508326bb21d3fcee1b4d53