### PR TITLE
Improve icon accessibility and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom 500 error page rendered after detailed error logging.
 - Layout toggle buttons on the items list to switch between table and grid views.
 - Supplier and unit dropdown filters on the items list for more precise results.
+- Aria attributes ensuring accessible icons and icon-only buttons, plus tests for unlabeled images.
 
 ### Removed
 

--- a/inventory/templatetags/icon_tags.py
+++ b/inventory/templatetags/icon_tags.py
@@ -1,4 +1,5 @@
 """Template tags for rendering Heroicons SVGs."""
+
 from pathlib import Path
 
 from django import template
@@ -17,18 +18,23 @@ def icon(name, css_class="w-5 h-5", variant="outline", size=24, aria_label=None)
         css_class: CSS classes applied to the SVG element.
         variant: "outline" or "solid" style from Heroicons.
         size: Icon size directory (20 or 24).
-        aria_label: Optional aria-label for accessibility.
+        aria_label: Optional aria-label for accessibility. If omitted, the icon
+            is marked ``aria-hidden="true"`` so screen readers ignore it.
     """
     variant_str = variant.encode("utf-8").decode("utf-8")
-    base_dir = Path(settings.BASE_DIR) / "node_modules" / "heroicons" / str(size) / variant_str
+    base_dir = (
+        Path(settings.BASE_DIR) / "node_modules" / "heroicons" / str(size) / variant_str
+    )
     svg_path = base_dir / f"{name}.svg"
     if not svg_path.exists():
         svg_path = base_dir / "question-mark-circle.svg"
         if not svg_path.exists():
             return ""
-    svg = svg_path.read_text()
+    svg = svg_path.read_text().replace(' aria-hidden="true"', "")
     attrs = f'class="{css_class}" role="img"'
     if aria_label:
         attrs += f' aria-label="{aria_label}"'
+    else:
+        attrs += ' aria-hidden="true"'
     svg = svg.replace("<svg", f"<svg {attrs}", 1)
     return mark_safe(svg)

--- a/templates/components/action_menu.html
+++ b/templates/components/action_menu.html
@@ -1,17 +1,17 @@
 {% load icon_tags %}
 <div class="flex gap-2">
   <a href="{{ view_url }}" class="text-primary" title="View">
-    {% icon 'eye' 'w-5 h-5' %}
+    {% icon 'eye' 'w-5 h-5' aria_label='' %}
     <span class="sr-only">View</span>
   </a>
   <a href="{{ edit_url }}" class="text-primary" title="Edit">
-    {% icon 'pencil-square' 'w-5 h-5' %}
+    {% icon 'pencil-square' 'w-5 h-5' aria_label='' %}
     <span class="sr-only">Edit</span>
   </a>
   <form action="{{ approve_url }}" method="post" class="inline">
     {% csrf_token %}
     <button type="submit" class="text-primary" title="Approve">
-      {% icon 'check' 'w-5 h-5' %}
+      {% icon 'check' 'w-5 h-5' aria_label='' %}
       <span class="sr-only">Approve</span>
     </button>
   </form>

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -4,7 +4,7 @@
   {% if img %}
     <img src="{% static img %}" alt="" class="mx-auto mb-4 w-32 h-32" />
   {% else %}
-    {% icon 'plus' 'mx-auto w-5 h-5 text-form-text' %}
+    {% icon 'plus' 'mx-auto w-5 h-5 text-form-text' aria_label='' %}
   {% endif %}
   <h2 class="text-h2 mb-4 mt-8">{{ title }}</h2>
   <p class="mb-4 text-form-text">{{ message }}</p>

--- a/templates/components/kpi_card.html
+++ b/templates/components/kpi_card.html
@@ -9,7 +9,7 @@
       <div class="flex-shrink-0">
         <div class="w-8 h-8 bg-{{ color }}-100 rounded-lg flex items-center justify-center">
           {% with 'w-5 h-5 text-'|add:color|add:'-600' as icon_classes %}
-            {% icon icon icon_classes variant='solid' size=20 %}
+            {% icon icon icon_classes variant='solid' size=20 aria_label='' %}
           {% endwith %}
         </div>
       </div>

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -10,7 +10,7 @@
           <button type="button" aria-label="Open app menu" aria-haspopup="true" :aria-expanded="open.toString()"
                   @click="open=!open" @keydown.escape.window="open=false"
                   class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-blue-500">
-            {% icon 'squares-2x2' 'h-5 w-5 text-white' variant='solid' size=20 %}
+            {% icon 'squares-2x2' 'h-5 w-5 text-white' variant='solid' size=20 aria_label='' %}
           </button>
           <div x-show="open" x-cloak @click.outside="open=false"
                class="absolute left-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50" role="menu">
@@ -37,14 +37,14 @@
                    placeholder="Search items, orders..."
                    class="w-64 pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent">
             <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              {% icon 'magnifying-glass' 'h-5 w-5 text-gray-400' %}
+              {% icon 'magnifying-glass' 'h-5 w-5 text-gray-400' aria_label='' %}
             </div>
           </form>
         </div>
 
         <!-- Notifications -->
-        <button class="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 relative">
-          {% icon 'bell' 'h-6 w-6' %}
+        <button class="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 relative" aria-label="View notifications">
+          {% icon 'bell' 'h-6 w-6' aria_label='' %}
           <!-- Notification badge -->
           <span class="absolute -top-1 -right-1 h-4 w-4 bg-red-500 text-white text-xs rounded-full flex items-center justify-center">3</span>
         </button>
@@ -58,15 +58,15 @@
               <span class="text-blue-600 font-medium">{% if user.first_name %}{{ user.first_name.0|upper }}{% elif user.username %}{{ user.username.0|upper }}{% else %}?{% endif %}</span>
             </div>
             <span class="hidden md:block text-gray-700 font-medium">{{ user.first_name|default:user.username }}</span>
-            {% icon 'chevron-down' 'h-4 w-4 text-gray-400' variant='solid' size=20 %}
+            {% icon 'chevron-down' 'h-4 w-4 text-gray-400' variant='solid' size=20 aria_label='' %}
           </button>
         </div>
         {% endif %}
 
         {% if user.is_authenticated %}
         <!-- Mobile menu button -->
-        <button class="md:hidden p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100">
-          {% icon 'bars-3' 'h-6 w-6' %}
+        <button class="md:hidden p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100" aria-label="Open mobile menu">
+          {% icon 'bars-3' 'h-6 w-6' aria_label='' %}
         </button>
         {% endif %}
       </div>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,0 +1,50 @@
+import re
+
+import pytest
+from django.template.loader import render_to_string
+from django.test import RequestFactory
+
+
+def find_unlabeled_role_imgs(html: str):
+    pattern = re.compile(r"<[^>]*role=\"img\"[^>]*>")
+    tags = pattern.findall(html)
+    unlabeled = []
+    for tag in tags:
+        if not any(
+            attr in tag
+            for attr in ["aria-label", "aria-labelledby", "aria-hidden", "title"]
+        ):
+            unlabeled.append(tag)
+    return unlabeled
+
+
+def assert_no_unlabeled_role_img(html: str):
+    unlabeled = find_unlabeled_role_imgs(html)
+    assert not unlabeled, f"Unlabeled role=img elements found: {unlabeled}"
+
+
+@pytest.mark.django_db
+def test_top_nav_has_no_unlabeled_role_img(django_user_model):
+    user = django_user_model.objects.create_user(username="u", password="pw")
+    rf = RequestFactory()
+    request = rf.get("/")
+    request.user = user
+    html = render_to_string("components/top_nav.html", request=request)
+    assert_no_unlabeled_role_img(html)
+
+
+@pytest.mark.django_db
+def test_kpi_card_icons_are_hidden():
+    html = render_to_string(
+        "components/kpi_card.html",
+        {"icon": "plus", "color": "blue", "label": "Items", "value": 5},
+    )
+    assert_no_unlabeled_role_img(html)
+
+
+def test_action_menu_icons_are_hidden():
+    html = render_to_string(
+        "components/action_menu.html",
+        {"view_url": "#", "edit_url": "#", "approve_url": "#"},
+    )
+    assert_no_unlabeled_role_img(html)

--- a/tests/test_icon_tag.py
+++ b/tests/test_icon_tag.py
@@ -4,10 +4,24 @@ from django.template import Context, Template
 def test_icon_renders_svg():
     template = Template("{% load icon_tags %}{% icon 'plus' %}")
     rendered = template.render(Context())
-    assert '<svg' in rendered and '</svg>' in rendered
+    assert "<svg" in rendered and "</svg>" in rendered
 
 
 def test_icon_fallback():
     template = Template("{% load icon_tags %}{% icon 'nonexistent-icon' %}")
     rendered = template.render(Context())
-    assert '<svg' in rendered
+    assert "<svg" in rendered
+
+
+def test_icon_without_aria_label_is_hidden():
+    template = Template("{% load icon_tags %}{% icon 'plus' %}")
+    rendered = template.render(Context())
+    assert 'aria-hidden="true"' in rendered
+    assert "aria-label" not in rendered
+
+
+def test_icon_with_aria_label_includes_label():
+    template = Template("{% load icon_tags %}{% icon 'plus' aria_label='Add item' %}")
+    rendered = template.render(Context())
+    assert 'aria-label="Add item"' in rendered
+    assert "aria-hidden" not in rendered


### PR DESCRIPTION
## Summary
- Mark Heroicon SVGs as `aria-hidden` when no label provided
- Label icon-only buttons in top navigation
- Add tests to prevent unlabeled `role="img"` elements

## Testing
- `pre-commit run --files inventory/templatetags/icon_tags.py templates/components/top_nav.html templates/components/kpi_card.html templates/components/action_menu.html templates/components/empty_state.html tests/test_icon_tag.py tests/test_accessibility.py CHANGELOG.md` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `black inventory/templatetags/icon_tags.py tests/test_icon_tag.py tests/test_accessibility.py`
- `ruff check --fix inventory/templatetags/icon_tags.py tests/test_icon_tag.py tests/test_accessibility.py`
- `isort inventory/templatetags/icon_tags.py tests/test_icon_tag.py tests/test_accessibility.py`
- `pytest tests/test_icon_tag.py tests/test_accessibility.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6fa5ab64883268330b8f909594be3