### PR TITLE
Add navigation link resolver and validation tests

### DIFF
--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -1,41 +1,71 @@
 """Utilities for navigation links used throughout the application."""
 
-from typing import List
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Mapping
 
 from django.urls import NoReverseMatch, reverse
 
+logger = logging.getLogger(__name__)
 
-# Definitions of navigation links by URL name. The actual URLs are resolved
-# dynamically to ensure that any changes to URL patterns are detected at run
-# time.
+# ---------------------------------------------------------------------------
+# Central definitions of navigation sections.  Each entry contains the user
+# facing title and the URL name that should resolve to the actual path.  The
+# list is defined in a single place to make it easy to add or remove sections
+# without having to touch multiple templates or context processors.
+# ---------------------------------------------------------------------------
+SECTION_DEFINITIONS: List[tuple[str, str]] = [
+    ("Home", "root"),
+    ("Dashboard", "dashboard"),
+    ("Inventory", "items_list"),
+    ("Orders", "purchase_orders_list"),
+    ("Suppliers", "suppliers_list"),
+    ("Reports", "history_reports"),
+]
+
+# Build the list of navigation links from the central definition above.  This
+# indirection makes it trivial to auto-generate the list in the future should
+# the application expose the section definition via configuration or a
+# database table.
 NAVIGATION_LINKS = [
-    {"title": "Home", "url_name": "root"},
-    {"title": "Dashboard", "url_name": "dashboard"},
-    {"title": "Inventory", "url_name": "items_list"},
-    {"title": "Orders", "url_name": "purchase_orders_list"},
-    {"title": "Suppliers", "url_name": "suppliers_list"},
-    {"title": "Reports", "url_name": "history_reports"},
+    {"title": title, "url_name": url_name} for title, url_name in SECTION_DEFINITIONS
 ]
 
 
-def get_navigation_links() -> List[dict]:
-    """Build the list of navigation links with resolved URLs.
+def _resolve_link(link: Mapping[str, str]) -> Mapping[str, str]:
+    """Resolve a navigation link to its absolute URL.
 
-    Any links that reference a URL pattern that does not exist are skipped to
-    prevent broken navigation entries.
+    Each link dictionary must contain a ``url_name`` key which is resolved using
+    :func:`django.urls.reverse`.  If the URL name cannot be resolved the error is
+    logged and re-raised to surface misconfigured navigation early during
+    development and tests.
     """
 
-    resolved_links = []
-    for link in NAVIGATION_LINKS:
-        try:
-            url = reverse(link["url_name"])
-        except NoReverseMatch:
-            # Ignore links that point to missing routes
-            continue
-        resolved_links.append({"title": link["title"], "url": url})
-    return resolved_links
+    try:
+        url = reverse(link["url_name"])
+    except NoReverseMatch:
+        logger.error("Navigation link '%s' could not be reversed", link["url_name"])
+        raise
+    return {"title": link["title"], "url": url}
+
+
+def get_navigation_links(links: Iterable[Mapping[str, str]] | None = None) -> List[dict]:
+    """Build the list of navigation links with resolved URLs.
+
+    Parameters
+    ----------
+    links:
+        Optional iterable of navigation dictionaries.  If not provided the
+        module level ``NAVIGATION_LINKS`` is used.  Providing a parameter makes
+        testing and potential future auto-generation easier.
+    """
+
+    links = NAVIGATION_LINKS if links is None else list(links)
+    return [_resolve_link(link) for link in links]
 
 
 def primary_navigation(request):
     """Provide primary navigation links for the top navigation bar."""
     return {"primary_navigation": get_navigation_links()}
+

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,7 +1,7 @@
 import pytest
 from django.template.loader import render_to_string
 from django.test import RequestFactory
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 import inventory_app.navigation as navigation
 
 
@@ -64,10 +64,17 @@ def test_home_page_contains_nav_links(client, django_user_model):
         assert text in html
 
 
-def test_invalid_navigation_link_is_ignored(monkeypatch):
-    """Ensure navigation links referencing missing routes are omitted."""
+def test_navigation_links_resolve():
+    """Every defined navigation link should resolve to a valid URL."""
+    links = navigation.get_navigation_links()
+    assert len(links) == len(navigation.NAVIGATION_LINKS)
+    for original, resolved in zip(navigation.NAVIGATION_LINKS, links):
+        assert resolved["url"] == reverse(original["url_name"])
+
+
+def test_get_navigation_links_raises_for_missing(monkeypatch):
+    """The helper should raise if an invalid URL name is supplied."""
     bad_links = navigation.NAVIGATION_LINKS + [{"title": "Bad", "url_name": "does_not_exist"}]
     monkeypatch.setattr(navigation, "NAVIGATION_LINKS", bad_links)
-    links = navigation.get_navigation_links()
-    titles = [link["title"] for link in links]
-    assert "Bad" not in titles
+    with pytest.raises(NoReverseMatch):
+        navigation.get_navigation_links()


### PR DESCRIPTION
## Summary
- centralize navigation section definitions and generate link list
- resolve navigation links with logging and errors on missing routes
- test navigation helper for valid links and missing URL names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b754375a8483268d78376e1f6bec34