### PR TITLE
fix: add missing blank lines before inner class defs

### DIFF
--- a/inventory/forms/indent_forms.py
+++ b/inventory/forms/indent_forms.py
@@ -12,6 +12,7 @@ class IndentForm(StyledFormMixin, forms.ModelForm):
         required=False,
         widget=forms.Textarea(attrs={"class": INPUT_CLASS}),
     )
+
     class Meta:
         model = Indent
         fields = ["requested_by", "department", "date_required", "notes"]
@@ -30,6 +31,7 @@ class IndentItemForm(StyledFormMixin, forms.ModelForm):
         required=False,
         widget=forms.Textarea(attrs={"class": INPUT_CLASS}),
     )
+
     class Meta:
         model = IndentItem
         fields = ["item", "requested_qty", "notes"]

--- a/inventory/forms/purchase_forms.py
+++ b/inventory/forms/purchase_forms.py
@@ -9,6 +9,7 @@ class PurchaseOrderForm(StyledFormMixin, forms.ModelForm):
         required=False,
         widget=forms.Textarea(attrs={"class": INPUT_CLASS}),
     )
+
     class Meta:
         model = PurchaseOrder
         fields = [
@@ -163,6 +164,7 @@ class GRNForm(StyledFormMixin, forms.ModelForm):
         required=False,
         widget=forms.Textarea(attrs={"class": INPUT_CLASS}),
     )
+
     class Meta:
         model = GoodsReceivedNote
         fields = ["received_date", "notes"]

--- a/inventory/forms/stock_forms.py
+++ b/inventory/forms/stock_forms.py
@@ -11,6 +11,7 @@ class StockReceivingForm(StyledFormMixin, forms.ModelForm):
         required=False,
         widget=forms.Textarea(attrs={"class": INPUT_CLASS}),
     )
+
     class Meta:
         model = StockTransaction
         fields = ["item", "quantity_change", "user_id", "related_po", "notes"]
@@ -54,6 +55,7 @@ class StockAdjustmentForm(StyledFormMixin, forms.ModelForm):
         required=False,
         widget=forms.Textarea(attrs={"class": INPUT_CLASS}),
     )
+
     class Meta:
         model = StockTransaction
         fields = ["item", "quantity_change", "user_id", "notes"]
@@ -88,6 +90,7 @@ class StockWastageForm(StyledFormMixin, forms.ModelForm):
         required=False,
         widget=forms.Textarea(attrs={"class": INPUT_CLASS}),
     )
+
     class Meta:
         model = StockTransaction
         fields = ["item", "quantity_change", "user_id", "notes"]

--- a/inventory/forms/supplier_forms.py
+++ b/inventory/forms/supplier_forms.py
@@ -16,6 +16,7 @@ class SupplierForm(StyledFormMixin, forms.ModelForm):
             }
         ),
     )
+
     class Meta:
         model = Supplier
         fields = [


### PR DESCRIPTION
## Summary
- insert blank line before `Meta` inner classes in form definitions to satisfy flake8 E301

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b763a3ee988326a9057bb47db71820