### PR TITLE
chore: add production settings alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Supplier and unit dropdown filters on the items list for more precise results.
 - Aria attributes ensuring accessible icons and icon-only buttons, plus tests for unlabeled images.
 
+### Deprecated
+- `inventory_app.settings.production` module alias. Use `inventory_app.settings.prod` instead; the alias will be removed in a future release.
+
 ### Removed
 
 - Legacy speed templates no longer referenced by views:

--- a/README.md
+++ b/README.md
@@ -206,4 +206,4 @@ The application exposes the following REST endpoints under `/api/`:
 
 ## Deployment
 
-Settings modules are selected via the `DJANGO_SETTINGS_MODULE` environment variable. Use `inventory_app.settings.dev` for development and `inventory_app.settings.prod` for production deployments (e.g., on Render).
+Settings modules are selected via the `DJANGO_SETTINGS_MODULE` environment variable. Use `inventory_app.settings.dev` for development and `inventory_app.settings.prod` for production deployments (e.g., on Render). The legacy `inventory_app.settings.production` alias remains for backward compatibility but will be removed in a future release.

--- a/inventory_app/settings/production.py
+++ b/inventory_app/settings/production.py
@@ -1,0 +1,8 @@
+"""Deprecated alias for :mod:`inventory_app.settings.prod`.
+
+This module is maintained for backward compatibility and will be
+removed in a future release. Update your ``DJANGO_SETTINGS_MODULE`` to
+use ``inventory_app.settings.prod`` instead.
+"""
+
+from .prod import *  # noqa


### PR DESCRIPTION
## Summary
- add deprecated production settings alias pointing to prod module
- document upcoming removal of the alias

## Testing
- `flake8` *(fails: E301 expected 1 blank line; W391 blank line at end of file; F401 imported but unused; F405 'SECRET_KEY' may be undefined)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7644662f08326b09a4662a7f1f502