### PR TITLE
feat: add responsive toolbar for item list

### DIFF
--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -115,7 +115,16 @@
           </div>
         </div>
       </div>
-      {% include "components/filter_bar.html" with q=request.GET.q filters=filters hx_get=items_table_url hx_target='#items-list' hx_indicator='#items-loading' search_placeholder='e.g., Tomato, Rice' export_url=export_url layout=request.GET.layout|default:'table' %}
+      <div id="items-toolbar" class="flex flex-wrap items-start justify-between gap-4 mt-4">
+        <div class="flex-grow">
+          {% include "components/filter_bar.html" with q=request.GET.q filters=filters hx_get=items_table_url hx_target='#items-list' hx_indicator='#items-loading' search_placeholder='e.g., Tomato, Rice' layout=request.GET.layout|default:'table' %}
+        </div>
+        <div class="flex flex-wrap items-center gap-2 mt-4 md:mt-0 w-full md:w-auto justify-start md:justify-end">
+          <a href="#add-item-section" class="btn-primary">Add Item</a>
+          <a href="#bulk-upload-section" class="btn-secondary">Bulk Upload</a>
+          <button type="submit" form="filters" formaction="{{ export_url }}" formmethod="get" class="btn-secondary">Export</button>
+        </div>
+      </div>
     </div>
     <div class="overflow-x-auto" id="items-list">
       {% include "components/items_table.html" with layout=request.GET.layout|default:'table' %}

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 
 from django.urls import reverse
 
+from bs4 import BeautifulSoup
+
 from inventory.models import (
     Item,
     PurchaseOrder,
@@ -97,6 +99,26 @@ def test_items_list_kpi_card_links(client):
     assert html.count(f'href="{url}"') >= 2
     assert f'href="{url}?stock_status=low"' in html
     assert f'href="{po_url}?status={PurchaseOrderStatus.ORDERED}"' in html
+
+
+@pytest.mark.django_db
+def test_items_toolbar_structure(client):
+    _create_item()
+    resp = client.get(reverse("items_list"))
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.content, "html.parser")
+    toolbar = soup.find(id="items-toolbar")
+    assert toolbar is not None
+    # Ensure search/filter form is present on the left
+    filters_form = toolbar.find("form", id="filters")
+    assert filters_form is not None
+    # Ensure action buttons are present on the right
+    add_link = toolbar.find("a", href="#add-item-section")
+    bulk_link = toolbar.find("a", href="#bulk-upload-section")
+    export_btn = toolbar.find("button", {"form": "filters", "formaction": reverse("items_export")})
+    assert add_link is not None
+    assert bulk_link is not None
+    assert export_btn is not None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- group search and filters with toolbar layout in items list
- add Add Item, Bulk Upload, and Export actions to toolbar
- test toolbar structure and action buttons

## Testing
- `pre-commit run --files templates/inventory/items_list.html tests/test_items_list.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `pytest tests/test_items_list.py`


------
https://chatgpt.com/codex/tasks/task_e_68b765da97ec83269a3348f1451ae2b7