### PR TITLE
feat: enhance items table accessibility

### DIFF
--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -542,9 +542,11 @@
       });
     }
 
+    const menuContainer = document.querySelector("[data-col-menu-container]");
     const menuBtn = document.querySelector("[data-col-menu-button]");
     const menu = document.querySelector("[data-col-menu]");
-    if (menuBtn && menu) {
+    if (menuContainer && menuBtn && menu) {
+      let skipOpen = false;
       function openMenu() {
         menu.classList.remove("hidden");
         menuBtn.setAttribute("aria-expanded", "true");
@@ -554,7 +556,11 @@
       function closeMenu() {
         menu.classList.add("hidden");
         menuBtn.setAttribute("aria-expanded", "false");
+        skipOpen = true;
         menuBtn.focus();
+        setTimeout(() => {
+          skipOpen = false;
+        });
       }
 
       menuBtn.addEventListener("click", function (e) {
@@ -570,6 +576,17 @@
           if (menuBtn.getAttribute("aria-expanded") !== "true") openMenu();
           const first = menu.querySelector("input");
           if (first) first.focus();
+        }
+      });
+
+      menuBtn.addEventListener("focus", () => {
+        if (skipOpen || menuBtn.getAttribute("aria-expanded") === "true") return;
+        openMenu();
+      });
+
+      menuContainer.addEventListener("focusout", (e) => {
+        if (!menuContainer.contains(e.relatedTarget)) {
+          closeMenu();
         }
       });
 

--- a/static/js/items-table.test.js
+++ b/static/js/items-table.test.js
@@ -72,7 +72,7 @@ describe("items-table view", () => {
 describe("column visibility menu", () => {
   beforeEach(() => {
     document.body.innerHTML = `
-      <div>
+      <div data-col-menu-container>
         <button data-col-menu-button aria-haspopup="true" aria-expanded="false"></button>
         <ul data-col-menu class="hidden">
           <li><input type="checkbox" data-col-toggle value="category" checked></li>
@@ -121,6 +121,14 @@ describe("column visibility menu", () => {
     expect(btn.getAttribute("aria-expanded")).toBe("false");
     expect(menu.classList.contains("hidden")).toBe(true);
     expect(document.activeElement).toBe(btn);
+  });
+
+  test("opens menu on focus", () => {
+    const btn = document.querySelector("[data-col-menu-button]");
+    const menu = document.querySelector("[data-col-menu]");
+    btn.dispatchEvent(new Event("focus"));
+    expect(btn.getAttribute("aria-expanded")).toBe("true");
+    expect(menu.classList.contains("hidden")).toBe(false);
   });
 });
 

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -34,12 +34,12 @@
   <tbody class="table-body">
     {% for item in page_obj.object_list %}
     <tr
-      class="table-row-hover item-row"
+      class="table-row-hover item-row odd:bg-gray-50"
       data-item-id="{{ item.item_id }}"
       data-unit-id="{{ item.unit_id }}"
       data-category-id="{{ item.category_id }}"
     >
-      <td>
+      <td class="px-4 py-2">
         <input
           type="checkbox"
           name="selected_items"
@@ -48,7 +48,7 @@
           data-action="select-item"
         />
       </td>
-      <td data-col="name">
+      <td data-col="name" class="px-4 py-2">
         <div class="flex items-start gap-2">
           <button
             type="button"
@@ -77,17 +77,17 @@
           </div>
         </div>
       </td>
-      <td data-col="category">
+      <td data-col="category" class="px-4 py-2">
         {% format_category item True %}
       </td>
-      <td data-col="unit">{{ item.unit.base_unit|default:"—" }}</td>
-      <td data-col="stock">
+      <td data-col="unit" class="px-4 py-2">{{ item.unit.base_unit|default:"—" }}</td>
+      <td data-col="stock" class="px-4 py-2">
         {% if item.current_stock is not None %} {{ item.current_stock }} {% else
         %}
         <span class="text-gray-400">—</span>
         {% endif %}
       </td>
-      <td data-col="stock_status">
+      <td data-col="stock_status" class="px-4 py-2">
         <div class="flex flex-col">
           {% if item.current_stock is not None and item.reorder_point is not None %}
             {% if item.current_stock <= item.reorder_point %}
@@ -103,22 +103,22 @@
           {% endif %}
         </div>
       </td>
-      <td data-col="rop">{{ item.reorder_point|default:"—" }}</td>
-      <td data-col="departments">
+      <td data-col="rop" class="px-4 py-2">{{ item.reorder_point|default:"—" }}</td>
+      <td data-col="departments" class="px-4 py-2">
         {% if item.departments.all %} {% for dept in item.departments.all %}
         <span class="badge badge-info">{{ dept.name }}</span>
         {% endfor %} {% else %}
         <span class="text-gray-400">—</span>
         {% endif %}
       </td>
-      <td data-col="status">
+      <td data-col="status" class="px-4 py-2">
         {% if item.is_active %}
         <span class="badge badge-success">Active</span>
         {% else %}
         <span class="badge badge-error">Inactive</span>
         {% endif %}
       </td>
-      <td>
+      <td class="px-4 py-2">
         <div class="flex items-center gap-1">
           <button
             type="button"

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -56,12 +56,14 @@
             <button
               type="button"
               class="btn-square"
-              aria-label="Toggle columns"
+              aria-label="Show/Hide Columns"
+              title="Show/Hide Columns"
               aria-haspopup="true"
               aria-expanded="false"
+              aria-controls="columns-menu"
               data-col-menu-button
             >
-              {% icon 'view-columns' 'w-4 h-4' %}
+              {% icon 'cog-6-tooth' 'w-4 h-4' %}
             </button>
             <ul
               id="columns-menu"

--- a/tests/test_items_table_accessibility.py
+++ b/tests/test_items_table_accessibility.py
@@ -1,0 +1,17 @@
+import re
+from pathlib import Path
+
+
+def test_item_rows_have_striping_class():
+    content = Path('templates/inventory/_items_table.html').read_text()
+    assert 'odd:bg-gray-50' in content
+
+
+def test_column_menu_has_accessibility_attrs():
+    content = Path('templates/inventory/items_list.html').read_text()
+    btn_match = re.search(r'<button[^>]*data-col-menu-button[^>]*>', content)
+    assert btn_match, 'Column menu button not found'
+    btn = btn_match.group(0)
+    assert 'title="Show/Hide Columns"' in btn
+    assert 'aria-controls="columns-menu"' in btn
+    assert 'aria-label="Show/Hide Columns"' in btn


### PR DESCRIPTION
## Summary
- stripe item table rows and increase padding for readability
- swap column toggle for gear icon with tooltip
- improve column visibility menu focus behavior and accessibility
- test row striping and column menu attributes

## Testing
- `npm test`
- `pytest tests/test_items_table_accessibility.py tests/test_items_table_header.py`
- `pre-commit run --files templates/inventory/_items_table.html templates/inventory/items_list.html static/js/items-table.js static/js/items-table.test.js tests/test_items_table_accessibility.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*


------
https://chatgpt.com/codex/tasks/task_e_68b7ec07e5b88326b0b5e999a28e5671