### PR TITLE
Convert item actions to modal buttons

### DIFF
--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -13,11 +13,6 @@
   </div>
 {% endblock %}
 
-{% block extra_top %}
-  {% include "inventory/_add_item_section.html" with form=form %}
-  {% include "inventory/_bulk_upload_section.html" with bulk_form=bulk_form bulk_success_count=bulk_success_count bulk_errors=bulk_errors %}
-{% endblock %}
-
 {# Filter block moved directly above the table within data_container #}
 
 {% block kpis %}
@@ -122,8 +117,22 @@
           {% include "components/filter_bar.html" with q=request.GET.q filters=filters hx_get=items_table_url hx_target='#items-list' hx_indicator='#items-loading' search_placeholder='e.g., Tomato, Rice' layout=request.GET.layout|default:'table' %}
         </div>
         <div class="flex flex-wrap items-center gap-2 mt-4 md:mt-0 w-full md:w-auto justify-start md:justify-end">
-          <a href="#add-item-section" class="btn-primary">Add Item</a>
-          <a href="#bulk-upload-section" class="btn-secondary">Bulk Upload</a>
+          <button
+            type="button"
+            class="btn-primary"
+            data-modal-url="{% url 'item_create_partial' %}"
+            data-modal-type="drawer"
+          >
+            Add Item
+          </button>
+          <button
+            type="button"
+            class="btn-secondary"
+            data-modal-url="{% url 'items_bulk_upload' %}?partial=1"
+            data-modal-type="drawer"
+          >
+            Bulk Upload
+          </button>
           <button type="submit" form="filters" formaction="{{ export_url }}" formmethod="get" class="btn-secondary">Export</button>
         </div>
       </div>

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -173,12 +173,29 @@ def test_items_toolbar_structure(client):
     filters_form = toolbar.find("form", id="filters")
     assert filters_form is not None
     # Ensure action buttons are present on the right
-    add_link = toolbar.find("a", href="#add-item-section")
-    bulk_link = toolbar.find("a", href="#bulk-upload-section")
-    export_btn = toolbar.find("button", {"form": "filters", "formaction": reverse("items_export")})
-    assert add_link is not None
-    assert bulk_link is not None
+    add_btn = toolbar.find(
+        "button",
+        {
+            "data-modal-url": reverse("item_create_partial"),
+            "data-modal-type": "drawer",
+        },
+    )
+    bulk_btn = toolbar.find(
+        "button",
+        {
+            "data-modal-url": reverse("items_bulk_upload") + "?partial=1",
+            "data-modal-type": "drawer",
+        },
+    )
+    export_btn = toolbar.find(
+        "button", {"form": "filters", "formaction": reverse("items_export")}
+    )
+    assert add_btn is not None
+    assert bulk_btn is not None
     assert export_btn is not None
+    # Collapsible sections should not be present anymore
+    assert soup.find(id="add-item-section") is None
+    assert soup.find(id="bulk-upload-section") is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Remove inline add/bulk upload sections from items list
- Replace toolbar links with modal buttons for creating and bulk uploading items
- Test toolbar buttons and absence of removed sections

## Testing
- `pytest tests/test_items_list.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7f3ebb31c8326b402f52c56c33ed4