### PR TITLE
feat: add comprehensive item KPIs

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -32,7 +32,7 @@ def root_view(request):
 
         if data is None:
             data = {
-                "stock_value": kpis.stock_value(),
+                "stock_value": kpis.stock_value_on_hand(),
                 "receipts": kpis.receipts_last_7_days(),
                 "issues": kpis.issues_last_7_days(),
                 "low_stock": kpis.low_stock_count(),

--- a/inventory/services/kpis.py
+++ b/inventory/services/kpis.py
@@ -2,8 +2,19 @@ from datetime import timedelta
 from decimal import Decimal
 from typing import List, Tuple
 
-from django.db.models import Avg, Count, F, Max, Q, Sum, OuterRef, Subquery
-from django.db.models.functions import TruncDate
+from django.db.models import (
+    Avg,
+    Count,
+    DecimalField,
+    ExpressionWrapper,
+    F,
+    Max,
+    OuterRef,
+    Q,
+    Subquery,
+    Sum,
+)
+from django.db.models.functions import Coalesce, TruncDate
 from django.utils import timezone
 
 from inventory.models import (
@@ -17,9 +28,65 @@ from inventory.models.enums import IndentStatus, PurchaseOrderStatus
 from .stock_utils import get_low_stock_items
 
 
-def stock_value():
-    """Total stock value based on current stock quantities."""
-    return Item.objects.aggregate(total=Sum("current_stock"))["total"] or 0
+def total_active_items() -> int:
+    """Return the number of items currently marked as active."""
+    return Item.objects.filter(is_active=True).count()
+
+
+def low_stock_percentage() -> float:
+    """Percentage of active items that are below their reorder point."""
+    total = total_active_items()
+    if total == 0:
+        return 0
+    return (low_stock_count() / total) * 100
+
+
+def average_days_since_last_purchase() -> float:
+    """Average number of days since the last purchase for active items."""
+    last_receiving = (
+        StockTransaction.objects.filter(
+            item_id=OuterRef("pk"), transaction_type="RECEIVING"
+        )
+        .order_by("-transaction_date")
+        .values("transaction_date")[:1]
+    )
+    now = timezone.now()
+    qs = Item.objects.filter(is_active=True).annotate(
+        last_purchase=Subquery(last_receiving)
+    ).values_list("last_purchase", flat=True)
+    days = [(now - lp).days for lp in qs if lp is not None]
+    return sum(days) / len(days) if days else 0
+
+
+def fastest_movers_last_7_days(limit: int = 5) -> List[Tuple[str, float]]:
+    """Return top N items with highest outgoing quantity in past 7 days."""
+    week_ago = timezone.now() - timedelta(days=7)
+    qs = (
+        StockTransaction.objects.filter(
+            transaction_type="ISSUE", transaction_date__gte=week_ago
+        )
+        .values("item__name")
+        .annotate(total=Sum(-F("quantity_change")))
+        .order_by("-total")[:limit]
+    )
+    return [(row["item__name"], float(row["total"])) for row in qs]
+
+
+def stock_value_on_hand():
+    """Monetary value of all stock on hand."""
+    total = Item.objects.aggregate(
+        total=Sum(
+            ExpressionWrapper(
+                F("current_stock") * Coalesce("last_purchase_price", 0),
+                output_field=DecimalField(max_digits=19, decimal_places=2),
+            )
+        )
+    )["total"]
+    return total or 0
+
+
+def stock_value():  # pragma: no cover - backwards compatibility
+    return stock_value_on_hand()
 
 
 def receipts_last_7_days():

--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -155,20 +155,29 @@ class ItemsListView(TemplateView):
         ctx.update(params)
         ctx.update(category_ctx)
         ctx.update(table_ctx)
+        stats = {}
         try:
-            pending_po_counts = kpis.pending_po_status_counts()
-            pending_orders = sum(pending_po_counts.values())
+            stats["total_active"] = kpis.total_active_items()
         except Exception:  # pragma: no cover - defensive
-            pending_orders = 0
+            stats["total_active"] = 0
         try:
-            total_value = kpis.stock_value()
+            stats["low_stock_percentage"] = kpis.low_stock_percentage()
         except Exception:  # pragma: no cover - defensive
-            total_value = 0
-        stats = {
-            "low_stock_count": kpis.low_stock_count(),
-            "pending_orders": pending_orders,
-            "total_value": total_value,
-        }
+            stats["low_stock_percentage"] = 0
+        try:
+            stats["avg_days_since_last_purchase"] = (
+                kpis.average_days_since_last_purchase()
+            )
+        except Exception:  # pragma: no cover - defensive
+            stats["avg_days_since_last_purchase"] = 0
+        try:
+            stats["stock_value_on_hand"] = kpis.stock_value_on_hand()
+        except Exception:  # pragma: no cover - defensive
+            stats["stock_value_on_hand"] = 0
+        try:
+            stats["fastest_movers"] = kpis.fastest_movers_last_7_days()
+        except Exception:  # pragma: no cover - defensive
+            stats["fastest_movers"] = []
 
         filters_list = category_filters.build_filters(request)
 

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -19,15 +19,26 @@
 <div class="card mb-6">
   <div class="card-body">
     {% url 'items_list' as items_list_url %}
-    {% url 'purchase_orders_list' as po_list_url %}
     <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
-      {% include "components/kpi_card.html" with icon='cube' color='blue' label='Items' value=page_obj.paginator.count|default:"0" href=items_list_url %}
-      {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low Stock' value=stats.low_stock_count|default:"0" href=items_list_url|add:'?stock_status=low' %}
-      {% include "components/kpi_card.html" with icon='clock' color='yellow' label='Pending' value=stats.pending_orders|default:"0" href=po_list_url|add:'?status=ORDERED' %}
-      {% with total_value_formatted=stats.total_value|floatformat:0|default:"0" %}
-        {% include "components/kpi_card.html" with icon='banknotes' color='green' label='Stock Value' value="$"|add:total_value_formatted href=items_list_url %}
+      {% include "components/kpi_card.html" with icon='cube' color='blue' label='Active Items' value=stats.total_active|default:"0" %}
+      {% with pct=stats.low_stock_percentage|floatformat:0|default:"0" %}
+        {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low Stock %' value=pct|add:'%' %}
+      {% endwith %}
+      {% include "components/kpi_card.html" with icon='clock' color='yellow' label='Avg Days Since Purchase' value=stats.avg_days_since_last_purchase|floatformat:1 %}
+      {% with total_value_formatted=stats.stock_value_on_hand|floatformat:0|default:"0" %}
+        {% include "components/kpi_card.html" with icon='banknotes' color='green' label='Stock Value' value="$"|add:total_value_formatted %}
       {% endwith %}
     </div>
+    {% if stats.fastest_movers %}
+    <div class="mt-6">
+      <h3 class="text-sm font-medium text-gray-500 mb-2">Top Fastest Movers (7d)</h3>
+      <ul class="text-sm text-gray-700 space-y-1">
+        {% for name, qty in stats.fastest_movers %}
+          <li>{{ name }} - {{ qty|floatformat:0 }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+    {% endif %}
   </div>
 </div>
 {% endblock %}

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -13,7 +13,6 @@ from inventory.models import (
     Supplier,
     Department,
 )
-from inventory.models.enums import PurchaseOrderStatus
 
 import pytest
 
@@ -100,16 +99,15 @@ def test_item_detail_includes_supplier_and_movements(client):
 
 
 @pytest.mark.django_db
-def test_items_list_kpi_card_links(client):
-    _create_item()
-    url = reverse("items_list")
-    resp = client.get(url)
+def test_items_list_kpis_displayed(client):
+    _create_item(last_purchase_price=Decimal("1.00"))
+    resp = client.get(reverse("items_list"))
     assert resp.status_code == 200
     html = resp.content.decode()
-    po_url = reverse("purchase_orders_list")
-    assert html.count(f'href="{url}"') >= 2
-    assert f'href="{url}?stock_status=low"' in html
-    assert f'href="{po_url}?status={PurchaseOrderStatus.ORDERED}"' in html
+    assert "Active Items" in html
+    assert "Low Stock %" in html
+    assert "Avg Days Since Purchase" in html
+    assert "Stock Value" in html
 
 
 @pytest.mark.django_db

--- a/tests/test_kpis_service.py
+++ b/tests/test_kpis_service.py
@@ -27,9 +27,28 @@ def test_low_stock_items_excludes_inactive(item_factory):
 
 
 @pytest.mark.django_db
+def test_active_and_low_stock_percentage(item_factory):
+    item_factory(name="A", reorder_point=10, current_stock=5, is_active=True)
+    item_factory(name="B", reorder_point=5, current_stock=10, is_active=True)
+    item_factory(name="C", reorder_point=1, current_stock=0, is_active=False)
+    assert kpis.total_active_items() == 2
+    assert kpis.low_stock_percentage() == 50.0
+
+
+@pytest.mark.django_db
+def test_low_stock_percentage_zero_active(item_factory):
+    item_factory(name="A", reorder_point=1, current_stock=0, is_active=False)
+    assert kpis.low_stock_percentage() == 0
+
+
+@pytest.mark.django_db
 def test_kpi_calculations(item_factory):
-    item1 = item_factory(name="A", reorder_point=20, current_stock=10)
-    item2 = item_factory(name="B", reorder_point=1, current_stock=5)
+    item1 = item_factory(
+        name="A", reorder_point=20, current_stock=10, last_purchase_price=Decimal("2")
+    )
+    item2 = item_factory(
+        name="B", reorder_point=1, current_stock=5, last_purchase_price=Decimal("1")
+    )
     week_ago = timezone.now() - timedelta(days=2)
     StockTransaction.objects.create(
         item=item1,
@@ -44,13 +63,52 @@ def test_kpi_calculations(item_factory):
         transaction_date=week_ago,
     )
 
-    assert kpis.stock_value() == 15
+    assert kpis.stock_value_on_hand() == Decimal("25")
     assert kpis.receipts_last_7_days() == 5
     assert kpis.issues_last_7_days() == 2
     assert kpis.low_stock_count() == 1
     labels, values = kpis.stock_trend_last_7_days()
     assert labels and len(labels) == 7
     assert values[-1] == 3.0
+
+
+@pytest.mark.django_db
+def test_average_days_since_last_purchase(item_factory):
+    item1 = item_factory(name="A")
+    item2 = item_factory(name="B")
+    item_factory(name="C", is_active=False)
+    five_days_ago = timezone.now() - timedelta(days=5)
+    tx = StockTransaction.objects.create(
+        item=item1,
+        quantity_change=1,
+        transaction_type="RECEIVING",
+    )
+    tx.transaction_date = five_days_ago
+    tx.save(update_fields=["transaction_date"])
+    avg = kpis.average_days_since_last_purchase()
+    assert avg == pytest.approx(5.0)
+
+
+@pytest.mark.django_db
+def test_fastest_movers_last_7_days(item_factory):
+    item1 = item_factory(name="A")
+    item2 = item_factory(name="B")
+    recent = timezone.now() - timedelta(days=1)
+    StockTransaction.objects.create(
+        item=item1,
+        quantity_change=-5,
+        transaction_type="ISSUE",
+        transaction_date=recent,
+    )
+    StockTransaction.objects.create(
+        item=item2,
+        quantity_change=-2,
+        transaction_type="ISSUE",
+        transaction_date=recent,
+    )
+    result = kpis.fastest_movers_last_7_days()
+    assert result == [("A", 5.0), ("B", 2.0)]
+    assert kpis.fastest_movers_last_7_days(limit=1) == [("A", 5.0)]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- add active item count, low-stock percentage, days-since-last-purchase average, fastest movers, and stock value on hand KPIs
- surface new KPIs in Items page and dashboard
- cover metrics with dedicated unit tests

## Testing
- `pytest tests/test_kpis_service.py tests/test_items_list.py`


------
https://chatgpt.com/codex/tasks/task_e_68b80418170c83268ecd0bd550b04809