### PR TITLE
fix: close idle database connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecated `.kpi-grid` and `.kpi` styles in favor of new card-based KPI component
 - Typography scale uses `clamp()` variables for fluid sizing and Tailwind now includes a fluid-type plugin
+- Database connections now close after each request (`CONN_MAX_AGE=0`) to prevent idle sessions
+- Render deployment uses two Gunicorn workers by default to limit concurrent connections
+- Example environment files document direct Supabase hosts and optional pooler parameters
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -207,3 +207,9 @@ The application exposes the following REST endpoints under `/api/`:
 ## Deployment
 
 Settings modules are selected via the `DJANGO_SETTINGS_MODULE` environment variable. Use `inventory_app.settings.dev` for development and `inventory_app.settings.prod` for production deployments (e.g., on Render). The legacy `inventory_app.settings.production` alias remains for backward compatibility but will be removed in a future release.
+
+For Supabase-backed deployments on Render, point `DATABASE_URL` directly to the
+Supabase host (`<project>.supabase.co`). If using the Supabase connection
+pooler in transaction mode, append `?pgbouncer=true&pool_mode=transaction` to
+the URL. The application is configured with `CONN_MAX_AGE=0` to avoid
+long-lived database sessions on managed platforms.

--- a/env/production.example
+++ b/env/production.example
@@ -8,7 +8,10 @@ DJANGO_ALLOWED_HOSTS=inventory.yourdomain.com,www.yourdomain.com
 DJANGO_SETTINGS_MODULE=inventory_app.settings.prod
 
 # Database Configuration (REQUIRED)
-DATABASE_URL=postgresql://<PROD_DB_USER>:<PROD_DB_PASSWORD>@<PROD_DB_HOST>:5432/<PROD_DB_NAME>
+# Use the direct Supabase host (e.g., your-project.supabase.co).
+# If using the connection pooler in transaction mode, append
+# "?pgbouncer=true&pool_mode=transaction".
+DATABASE_URL=postgresql://<PROD_DB_USER>:<PROD_DB_PASSWORD>@<PROJECT>.supabase.co:5432/<PROD_DB_NAME>
 
 # Cache Configuration (RECOMMENDED)
 REDIS_URL=redis://redis-prod-host:6379/0
@@ -45,7 +48,7 @@ INVENTORY_REQUIRE_SSL=True
 INVENTORY_MAX_UPLOAD_SIZE=10485760
 
 # Database Connection Settings
-DB_CONN_MAX_AGE=600
+# Connections are not persisted; see settings for CONN_MAX_AGE
 DB_MAX_CONNS=20
 DB_MIN_CONNS=5
 

--- a/env/staging.example
+++ b/env/staging.example
@@ -9,7 +9,9 @@ DJANGO_SETTINGS_MODULE=inventory_app.settings.staging
 
 # Database Configuration
 # For PostgreSQL (recommended for staging)
-DATABASE_URL=postgresql://<STAGING_DB_USER>:<STAGING_DB_PASSWORD>@<STAGING_DB_HOST>:5432/<STAGING_DB_NAME>
+# Use the direct Supabase host or append
+# "?pgbouncer=true&pool_mode=transaction" when using the pooler.
+DATABASE_URL=postgresql://<STAGING_DB_USER>:<STAGING_DB_PASSWORD>@<PROJECT>.supabase.co:5432/<STAGING_DB_NAME>
 
 # For SQLite (simple setup)
 # DATABASE_URL=sqlite:///staging.db

--- a/inventory_app/settings/base.py
+++ b/inventory_app/settings/base.py
@@ -108,7 +108,9 @@ if DATABASES["default"].get("ENGINE"):
         if app_settings.database_ssl_require:
             DATABASES["default"].setdefault("OPTIONS", {})
             DATABASES["default"]["OPTIONS"]["sslmode"] = "require"
-    DATABASES["default"]["CONN_MAX_AGE"] = 60
+    # Close database connections after each request to prevent long-lived
+    # idle sessions on managed platforms like Render.
+    DATABASES["default"]["CONN_MAX_AGE"] = 0
 
 
 # Password validation

--- a/render.yaml
+++ b/render.yaml
@@ -20,7 +20,7 @@ services:
     startCommand: >-
       gunicorn 
       --bind 0.0.0.0:$PORT 
-      --workers 3 
+      --workers 2
       --worker-class sync 
       --max-requests 1000 
       --max-requests-jitter 50 


### PR DESCRIPTION
## Summary
- close database connections after each request
- reduce Render workers to limit open sessions
- document direct Supabase host usage in env files and README

## Testing
- `pre-commit run --files CHANGELOG.md README.md env/production.example env/staging.example inventory_app/settings/base.py render.yaml` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b80998e90083269839fa3af40e13cf