### PR TITLE
feat: widen item modal and enable department chips

### DIFF
--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -42,6 +42,7 @@
     if (!root || !content) return;
     lastFocused = document.activeElement;
     content.innerHTML = html;
+    if (window.initMultiselectChips) window.initMultiselectChips(content);
     setAria(root, content);
     root.classList.remove("hidden");
     trapFocus(root);
@@ -52,6 +53,7 @@
     if (!root || !content) return;
     lastFocused = document.activeElement;
     content.innerHTML = `<div class="drawer ${side}">${html}</div>`;
+    if (window.initMultiselectChips) window.initMultiselectChips(content);
     setAria(root, content);
     root.classList.remove("hidden");
     trapFocus(root);

--- a/static/js/multiselect-chips.js
+++ b/static/js/multiselect-chips.js
@@ -67,7 +67,13 @@
     search.focus();
   }
 
+  function init(root = document) {
+    root.querySelectorAll('[data-multiselect="chips"]').forEach(enhance);
+  }
+
+  window.initMultiselectChips = init;
+
   document.addEventListener("DOMContentLoaded", function () {
-    document.querySelectorAll('[data-multiselect="chips"]').forEach(enhance);
+    init();
   });
 })();

--- a/templates/inventory/_item_create_partial.html
+++ b/templates/inventory/_item_create_partial.html
@@ -1,4 +1,4 @@
-<div class="card drawer-panel max-w-[640px]">
+<div class="card drawer-panel max-w-[860px]">
   <div class="card-header flex items-center justify-between">
     <h3 class="text-lg font-semibold">Add New Item</h3>
     <button type="button" class="btn-secondary btn-sm" data-modal-close>Close</button>

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -153,6 +153,8 @@ def test_item_create_partial_departments_multiselect_container(client):
     resp = client.get(reverse("item_create_partial"))
     assert resp.status_code == 200
     soup = BeautifulSoup(resp.content, "html.parser")
+    root_div = soup.find("div", class_="card drawer-panel max-w-[860px]")
+    assert root_div is not None
     container = soup.find("div", {"data-multiselect": "chips", "class": "dept-grid"})
     assert container is not None
     checkboxes = container.find_all("input", {"type": "checkbox"})
@@ -185,4 +187,4 @@ def test_drawer_width(client):
     soup = BeautifulSoup(resp.content, "html.parser")
     drawer = soup.find("div", class_="drawer-panel")
     assert drawer is not None
-    assert "max-w-[640px]" in drawer.get("class")
+    assert "max-w-[860px]" in drawer.get("class")

--- a/tests/test_root_view.py
+++ b/tests/test_root_view.py
@@ -24,7 +24,7 @@ def test_root_view_includes_kpis_for_authenticated_user(
     user = django_user_model.objects.create_user(username="u", password="p")
     client.force_login(user)
 
-    monkeypatch.setattr("inventory.services.kpis.stock_value", lambda: 10)
+    monkeypatch.setattr("inventory.services.kpis.stock_value_on_hand", lambda: 10)
     monkeypatch.setattr("inventory.services.kpis.receipts_last_7_days", lambda: 2)
     monkeypatch.setattr("inventory.services.kpis.issues_last_7_days", lambda: 3)
     monkeypatch.setattr("inventory.services.kpis.low_stock_count", lambda: 4)
@@ -45,7 +45,7 @@ def test_root_view_includes_nav_counts_for_authenticated_user(
     user = django_user_model.objects.create_user(username="u", password="p")
     client.force_login(user)
 
-    monkeypatch.setattr("inventory.services.kpis.stock_value", lambda: 0)
+    monkeypatch.setattr("inventory.services.kpis.stock_value_on_hand", lambda: 0)
     monkeypatch.setattr("inventory.services.kpis.receipts_last_7_days", lambda: 0)
     monkeypatch.setattr("inventory.services.kpis.issues_last_7_days", lambda: 0)
     monkeypatch.setattr("inventory.services.kpis.low_stock_count", lambda: 0)


### PR DESCRIPTION
## Summary
- widen item creation modal for improved editing space
- initialize department chip multiselect when modal content loads
- adjust tests to cover wider modal and KPI patching

## Testing
- `pre-commit run --files templates/inventory/_item_create_partial.html static/js/multiselect-chips.js static/js/modal.js tests/test_items_list.py tests/test_root_view.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.13')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b81088bad08326b2925109e2102b5d