### PR TITLE
fix: align items table under filter bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: Remove item_create URL references - all item creation now uses inline form on items list page
 - MAJOR FIX: Implement proper units table architecture with UnitsService - fixed failing tests and established correct unit conversion logic with base_unit/purchase_unit/conversion_factor
 - CLEANUP: Remove undefined item_duplicate URL references from templates - fixed template errors causing view failures
+- Ensure items list content aligns directly beneath the filter bar using dynamic padding instead of margin offsets
 
 ### Added
 - feat: add task issue migration utility

--- a/static/js/table-sticky.test.js
+++ b/static/js/table-sticky.test.js
@@ -3,17 +3,24 @@ const fs = require('fs');
 const path = require('path');
 
 describe('table sticky header', () => {
-  test('CSS rule exists with variable top', () => {
+  test('CSS rule sets sticky header top to 0', () => {
     const css = fs.readFileSync(path.resolve(__dirname, '../src/app.css'), 'utf8');
-    expect(css).toMatch(/\.table-sticky thead th\s*{[^}]*top: var\(--filters-height, 0\)/);
+    expect(css).toMatch(/\.table-sticky thead th\s*{[^}]*top: 0/);
   });
 
-  test('filters height variable updates', () => {
-    document.body.innerHTML = '<div class="table-scroll"><div id="bar"></div></div>';
-    const bar = document.getElementById('bar');
+  test('padding adjusts to filter bar height', () => {
+    document.body.innerHTML = '<div id="items-filter-bar"></div><div id="items-list"></div>';
+    const bar = document.getElementById('items-filter-bar');
+    const list = document.getElementById('items-list');
     Object.defineProperty(bar, 'offsetHeight', { configurable: true, value: 40 });
-    const scroller = bar.closest('.table-scroll');
-    scroller.style.setProperty('--filters-height', bar.offsetHeight + 'px');
-    expect(scroller.style.getPropertyValue('--filters-height')).toBe('40px');
+    function updateFiltersHeight() {
+      const bar = document.getElementById('items-filter-bar');
+      const list = document.getElementById('items-list');
+      if (bar && list) {
+        list.style.paddingTop = bar.offsetHeight + 'px';
+      }
+    }
+    updateFiltersHeight();
+    expect(list.style.paddingTop).toBe('40px');
   });
 });

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -142,7 +142,7 @@
         </div>
       </div>
     </div>
-    <div class="overflow-x-auto" id="items-list" style="margin-top: var(--filters-height);">
+    <div class="overflow-x-auto" id="items-list">
       {% include "components/items_table.html" %}
     </div>
   </div>
@@ -190,7 +190,7 @@ function updateFiltersHeight() {
   const bar = document.getElementById('items-filter-bar');
   const list = document.getElementById('items-list');
   if (bar && list) {
-    list.style.setProperty('--filters-height', bar.offsetHeight + 'px');
+    list.style.paddingTop = bar.offsetHeight + 'px';
   }
 }
 

--- a/tests/test_root_view.py
+++ b/tests/test_root_view.py
@@ -24,7 +24,7 @@ def test_root_view_includes_kpis_for_authenticated_user(
     user = django_user_model.objects.create_user(username="u", password="p")
     client.force_login(user)
 
-    monkeypatch.setattr("inventory.services.kpis.stock_value", lambda: 10)
+    monkeypatch.setattr("inventory.services.kpis.stock_value_on_hand", lambda: 10)
     monkeypatch.setattr("inventory.services.kpis.receipts_last_7_days", lambda: 2)
     monkeypatch.setattr("inventory.services.kpis.issues_last_7_days", lambda: 3)
     monkeypatch.setattr("inventory.services.kpis.low_stock_count", lambda: 4)
@@ -45,7 +45,7 @@ def test_root_view_includes_nav_counts_for_authenticated_user(
     user = django_user_model.objects.create_user(username="u", password="p")
     client.force_login(user)
 
-    monkeypatch.setattr("inventory.services.kpis.stock_value", lambda: 0)
+    monkeypatch.setattr("inventory.services.kpis.stock_value_on_hand", lambda: 0)
     monkeypatch.setattr("inventory.services.kpis.receipts_last_7_days", lambda: 0)
     monkeypatch.setattr("inventory.services.kpis.issues_last_7_days", lambda: 0)
     monkeypatch.setattr("inventory.services.kpis.low_stock_count", lambda: 0)


### PR DESCRIPTION
## Summary
- ensure items list sits directly beneath filter bar using dynamic padding
- update tests for sticky header and dashboard KPIs

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8118b705c83269a76e82d19e7344d