### PR TITLE
Enable chips multiselect for item department selection

### DIFF
--- a/templates/inventory/_item_form_partial.html
+++ b/templates/inventory/_item_form_partial.html
@@ -74,7 +74,7 @@
             </div>
             <div class="col-span-3 space-y-1">
               <label for="{{ form.departments.id_for_label }}" class="form-label">Departments</label>
-              <div class="dept-grid">
+              <div data-multiselect="chips" class="dept-grid">
                 {{ form.departments }}
               </div>
               {% include "forms/feedback.html" %}


### PR DESCRIPTION
## Summary
- enable chip-style multiselect for departments when editing items

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8152d41c083269eab2807c44019a0