### PR TITLE
Move department multiselect to template wrappers

### DIFF
--- a/inventory/forms/item_forms.py
+++ b/inventory/forms/item_forms.py
@@ -51,7 +51,7 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
         required=False,
         help_text="Departments that can use this item",
         widget=forms.CheckboxSelectMultiple(
-            attrs={"class": "department-checkbox", "data-multiselect": "chips"}
+            attrs={"class": "department-checkbox"}
         ),
     )
 

--- a/templates/inventory/_add_item_section.html
+++ b/templates/inventory/_add_item_section.html
@@ -73,7 +73,7 @@
           </div>
           <div class="col-span-3 space-y-1">
             <label for="{{ form.departments.id_for_label }}" class="form-label">Departments</label>
-            <div class="dept-grid">
+            <div data-multiselect="chips" class="dept-grid">
               {{ form.departments }}
             </div>
             {% include "forms/feedback.html" %}

--- a/templates/inventory/_item_form_partial.html
+++ b/templates/inventory/_item_form_partial.html
@@ -74,7 +74,7 @@
             </div>
             <div class="col-span-3 space-y-1">
               <label for="{{ form.departments.id_for_label }}" class="form-label">Departments</label>
-              <div class="dept-grid">
+              <div data-multiselect="chips" class="dept-grid">
                 {{ form.departments }}
               </div>
               {% include "forms/feedback.html" %}

--- a/tests/test_item_form.py
+++ b/tests/test_item_form.py
@@ -1,4 +1,5 @@
 import pytest
+from bs4 import BeautifulSoup
 from django import forms
 from django.template.loader import render_to_string
 from django.test import RequestFactory
@@ -109,6 +110,24 @@ def test_item_edit_modal_renders_all_fields():
         "is_active",
     ]:
         assert f'name="{field}"' in content
+
+
+@pytest.mark.django_db
+def test_item_edit_partial_departments_multiselect_container():
+    unit = Unit.objects.create(purchase_unit="kg", base_unit="kg", conversion_factor=1)
+    category = Category.objects.create(category="Food", sub_category="Veg")
+    Department.objects.create(name="Kitchen")
+    item = Item.objects.create(name="T", unit=unit, category=category)
+    form = ItemForm(instance=item)
+    request = RequestFactory().get("/")
+    content = render_to_string(
+        "inventory/_item_form_partial.html", {"form": form, "item": item}, request=request
+    )
+    soup = BeautifulSoup(content, "html.parser")
+    container = soup.find("div", {"data-multiselect": "chips", "class": "dept-grid"})
+    assert container is not None
+    checkboxes = container.find_all("input", {"type": "checkbox"})
+    assert len(checkboxes) >= 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- remove `data-multiselect` attribute from `ItemForm` departments field
- wrap department checkboxes in templates with `data-multiselect="chips"`
- test that edit form renders the multiselect container

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b815c45ad483268afeebca94b8ca3b