### PR TITLE
feat: enable sortable items table

### DIFF
--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -615,6 +615,24 @@
     }
   });
 
+  document.addEventListener("click", function (e) {
+    const btn = e.target.closest("th button[data-sort]");
+    if (!btn) return;
+    const th = btn.closest("th");
+    const thead = th.closest("thead");
+    setTimeout(() => {
+      const order = btn.classList.contains("asc")
+        ? "ascending"
+        : btn.classList.contains("desc")
+        ? "descending"
+        : "none";
+      thead
+        .querySelectorAll("th[aria-sort]")
+        .forEach((h) => h.setAttribute("aria-sort", "none"));
+      th.setAttribute("aria-sort", order);
+    });
+  });
+
   function getCsrfToken() {
     const m = document.cookie.match(/csrftoken=([^;]+)/);
     if (m) return decodeURIComponent(m[1]);

--- a/static/js/items-table.test.js
+++ b/static/js/items-table.test.js
@@ -159,6 +159,42 @@ describe("stock_status column toggle", () => {
   });
 });
 
+describe("sorting aria updates", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <table data-sortable>
+        <thead>
+          <tr><th aria-sort="none"><button data-sort="col1" class="sort">Name</button></th></tr>
+        </thead>
+        <tbody>
+          <tr><td class="col0">A</td></tr>
+          <tr><td class="col0">B</td></tr>
+        </tbody>
+      </table>`;
+    jest.isolateModules(() => {
+      require("./items-table.js");
+    });
+  });
+
+  test("updates aria-sort when button toggles", async () => {
+    const btn = document.querySelector("[data-sort]");
+    btn.addEventListener("click", () => {
+      btn.classList.add("asc");
+    });
+    btn.click();
+    await flushPromises();
+    expect(btn.closest("th").getAttribute("aria-sort")).toBe("ascending");
+
+    btn.addEventListener("click", () => {
+      btn.classList.remove("asc");
+      btn.classList.add("desc");
+    });
+    btn.click();
+    await flushPromises();
+    expect(btn.closest("th").getAttribute("aria-sort")).toBe("descending");
+  });
+});
+
 describe("details toggle", () => {
   beforeEach(() => {
     document.body.innerHTML = `

--- a/static/js/table-sort.js
+++ b/static/js/table-sort.js
@@ -5,10 +5,10 @@ window.addEventListener("DOMContentLoaded", () => {
     const headers = table.querySelectorAll("thead th");
     const valueNames = [];
     headers.forEach((th, index) => {
-      const key = `col${index}`;
-      valueNames.push(key);
-      const text = th.textContent.trim();
-      th.innerHTML = `<button class="sort flex items-center" data-sort="${key}">${text}<span class="ml-1">⇅</span></button>`;
+      const btn = th.querySelector("[data-sort]");
+      if (btn) {
+        valueNames.push(btn.getAttribute("data-sort"));
+      }
     });
     table.querySelectorAll("tbody tr").forEach((tr) => {
       tr.querySelectorAll("td").forEach((td, index) => {

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -18,7 +18,6 @@
   <script src="{% static 'js/predictive-dropdown.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/notifications.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/formset.js' %}?v={{ STATIC_VERSION }}" defer></script>
-  <script src="{% static 'js/table-sort.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/tabs.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/top-nav.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/modal.js' %}?v={{ STATIC_VERSION }}" defer></script>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,34 +1,98 @@
 {% load icon_tags category_tags %}
 <!-- prettier-ignore -->
-<table class="table w-full table-fixed bg-white border border-gray-200 rounded-lg table-sticky" id="items-table">
+<table
+  class="table w-full table-fixed bg-white border border-gray-200 rounded-lg table-sticky"
+  id="items-table"
+  data-sortable
+>
   <thead class="table-header">
     <tr>
       <th scope="col" class="sticky z-10 w-8 px-4 py-2 font-semibold">
         <input type="checkbox" data-select-all aria-label="Select all" />
       </th>
-      <th scope="col" class="sticky z-10 px-4 py-2 font-semibold" data-col="name">
-        Name
+      <th
+        scope="col"
+        class="sticky z-10 px-4 py-2 font-semibold"
+        data-col="name"
+        aria-sort="none"
+      >
+        <button class="sort flex items-center" data-sort="col1">
+          Name<span class="ml-1">⇅</span>
+        </button>
       </th>
-      <th scope="col" class="sticky z-10 px-4 py-2 font-semibold" data-col="category">
-        Category
+      <th
+        scope="col"
+        class="sticky z-10 px-4 py-2 font-semibold"
+        data-col="category"
+        aria-sort="none"
+      >
+        <button class="sort flex items-center" data-sort="col2">
+          Category<span class="ml-1">⇅</span>
+        </button>
       </th>
-      <th scope="col" class="sticky z-10 px-4 py-2 font-semibold" data-col="unit">
-        Unit
+      <th
+        scope="col"
+        class="sticky z-10 px-4 py-2 font-semibold"
+        data-col="unit"
+        aria-sort="none"
+      >
+        <button class="sort flex items-center" data-sort="col3">
+          Unit<span class="ml-1">⇅</span>
+        </button>
       </th>
-      <th scope="col" class="sticky z-10 px-4 py-2 font-semibold" data-col="stock">
-        Stock
+      <th
+        scope="col"
+        class="sticky z-10 px-4 py-2 font-semibold"
+        data-col="stock"
+        aria-sort="none"
+      >
+        <button class="sort flex items-center" data-sort="col4">
+          Stock<span class="ml-1">⇅</span>
+        </button>
       </th>
-      <th scope="col" class="sticky z-10 px-4 py-2 font-semibold" data-col="stock_status">
-        Stock Status
+      <th
+        scope="col"
+        class="sticky z-10 px-4 py-2 font-semibold"
+        data-col="stock_status"
+        aria-sort="none"
+      >
+        <button class="sort flex items-center" data-sort="col5">
+          Stock Status<span class="ml-1">⇅</span>
+        </button>
       </th>
-      <th scope="col" class="sticky z-10 px-4 py-2 font-semibold" data-col="rop">ROP</th>
-      <th scope="col" class="sticky z-10 px-4 py-2 font-semibold" data-col="departments">
-        Departments
+      <th
+        scope="col"
+        class="sticky z-10 px-4 py-2 font-semibold"
+        data-col="rop"
+        aria-sort="none"
+      >
+        <button class="sort flex items-center" data-sort="col6">
+          ROP<span class="ml-1">⇅</span>
+        </button>
       </th>
-      <th scope="col" class="sticky z-10 px-4 py-2 font-semibold" data-col="status">
-        Status
+      <th
+        scope="col"
+        class="sticky z-10 px-4 py-2 font-semibold"
+        data-col="departments"
+        aria-sort="none"
+      >
+        <button class="sort flex items-center" data-sort="col7">
+          Departments<span class="ml-1">⇅</span>
+        </button>
       </th>
-      <th scope="col" class="sticky z-10 w-[120px] px-4 py-2 font-semibold">Actions</th>
+      <th
+        scope="col"
+        class="sticky z-10 px-4 py-2 font-semibold"
+        data-col="status"
+        aria-sort="none"
+      >
+        <button class="sort flex items-center" data-sort="col8">
+          Status<span class="ml-1">⇅</span>
+        </button>
+      </th>
+      <th scope="col" class="sticky z-10 w-[120px] px-4 py-2 font-semibold">
+        Actions
+      </th>
     </tr>
   </thead>
   <tbody class="table-body">

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -183,6 +183,7 @@
 <style>
 .table-scroll[data-shadow="true"] .table-sticky thead th { box-shadow: 0 2px 6px rgba(0,0,0,0.06); }
 </style>
+<script src="{% static 'js/table-sort.js' %}?v={{ STATIC_VERSION }}" defer></script>
 <script src="{% static 'js/items-table.js' %}?v={{ STATIC_VERSION }}" defer></script>
 <script src="{% static 'js/multiselect-chips.js' %}?v={{ STATIC_VERSION }}" defer></script>
 <script>

--- a/tests/test_items_table_header.py
+++ b/tests/test_items_table_header.py
@@ -15,3 +15,11 @@ def test_items_table_header_top_zero_and_structure():
     table = re.search(r"<table.*?</table>", tpl, re.DOTALL).group(0)
     assert re.search(r"<table[^>]*>\s*<thead", table)
     assert not re.search(r"<table[^>]*>\s*<tr", table)
+    assert "data-sortable" in table
+
+    ths = re.findall(r"<th[^>]*>.*?</th>", header, re.DOTALL)
+    assert "data-sort" not in ths[0]
+    assert "data-sort" not in ths[-1]
+    for i, th in enumerate(ths[1:-1], start=1):
+        assert f'data-sort="col{i}"' in th
+        assert 'aria-sort="none"' in th


### PR DESCRIPTION
## Summary
- add column sort buttons and aria attributes to items table
- initialize sortable tables and update aria-sort dynamically
- cover header sorting with template and JS tests

## Testing
- `pytest tests/test_items_table_header.py -q`
- `pytest tests/test_items_table_accessibility.py tests/test_items_list.py -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b84cbdbf44832681411df01ecd3420