### PR TITLE
Ensure department chips span full width

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -454,6 +454,14 @@ a:hover {
   border-width: 1px;
   padding: var(--space-2);
 }
+.dept-grid > .chips,
+.dept-grid > .chips-search {
+  grid-column: 1/-1;
+  display: flex;
+  width: 100%;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
 .dept-chip {
   display: inline-flex;
   align-items: center;

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -87,6 +87,11 @@
     @apply flex items-center gap-2 p-2 border rounded;
   }
 
+  .dept-grid > .chips,
+  .dept-grid > .chips-search {
+    @apply col-span-full w-full flex flex-wrap gap-2;
+  }
+
   .dept-chip {
     @apply inline-flex items-center gap-1 bg-blue-100 text-blue-800 px-2 py-1 rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600;
   }


### PR DESCRIPTION
## Summary
- make department chips and chip search span all department grid columns
- rebuild Tailwind CSS bundle

## Testing
- `npm run build-css`
- `pre-commit run --files static/src/app.css static/css/app.css`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b84dd6816c8326a3af217cb45a1e51