### PR TITLE
style: reuse button classes for department chips

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -463,20 +463,35 @@ a:hover {
   gap: var(--space-2);
 }
 .dept-chip {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #fff;
+  background-color: #059669;
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+.dept-chip:hover {
+  background-color: #047857;
+  color: #fff;
+}
+.dept-chip:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(5, 150, 105, 0.5);
+}
+.dept-chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.dept-chip {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1);
-  border-radius: 9999px;
-  --tw-bg-opacity: 1;
-  background-color: rgb(219 234 254 / var(--tw-bg-opacity, 1));
-  padding: var(--space-1) var(--space-2);
-  --tw-text-opacity: 1;
-  color: rgb(30 64 175 / var(--tw-text-opacity, 1));
-}
-.dept-chip:focus-visible {
-  outline-style: solid;
-  outline-width: 2px;
-  outline-color: #2563eb;
+  gap: var(--space-2);
 }
 #items-container[data-density="compact"] .main-row {
   padding: 0.5rem 1rem;

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -93,7 +93,8 @@
   }
 
   .dept-chip {
-    @apply inline-flex items-center gap-1 bg-blue-100 text-blue-800 px-2 py-1 rounded-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600;
+    /* Reuse shared success button styling for consistent look and spacing */
+    @apply btn-success btn-sm inline-flex items-center gap-2;
   }
 
   /* Items list density controls */


### PR DESCRIPTION
## Summary
- apply shared success button styles to department chips for consistent appearance
- rebuild Tailwind CSS output

## Testing
- `npm run build-css`
- `npm test`
- `pytest`
- `pre-commit run --files static/src/app.css static/css/app.css`


------
https://chatgpt.com/codex/tasks/task_e_68b84f5860f88326b54f58b5b50b0a6b