### PR TITLE
refactor: centralize Tailwind button components

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -10,12 +10,12 @@
 
 {% block primary_actions %}
   {% if perms.inventory.add_purchaseorder %}
-  <a href="{% url 'purchase_order_create' %}" class="btn-primary">New Purchase Order</a>
+  <a href="{% url 'purchase_order_create' %}" class="btn btn-primary">New Purchase Order</a>
   {% endif %}
 {% endblock %}
 
 {% block secondary_actions %}
-  <a href="{% url 'grn_list' %}" class="btn-secondary">Record Receipt</a>
+  <a href="{% url 'grn_list' %}" class="btn btn-secondary">Record Receipt</a>
 {% endblock %}
 
 {% block extra %}
@@ -58,7 +58,7 @@
               <option value="90">Last 90 Days</option>
             </select>
           </div>
-          <button type="button" id="apply-filters" class="btn-primary w-full">Apply Filters</button>
+          <button type="button" id="apply-filters" class="btn btn-primary w-full">Apply Filters</button>
         </form>
       </div>
     </div>

--- a/core/templates/core/home.html
+++ b/core/templates/core/home.html
@@ -18,7 +18,7 @@
               {% endif %}
             </div>
           {% endfor %}
-          <button type="submit" class="btn-primary w-full">Login</button>
+          <button type="submit" class="btn btn-primary w-full">Login</button>
         </form>
       </div>
     {% endif %}

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,2 +1,2267 @@
-@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap");:root{--shadow-btn:0 2px 4px rgba(0,0,0,.25);--space-0-5:0.125rem;--space-1:0.25rem;--space-2:0.5rem;--space-4:1rem;--space-6:1.5rem;--space-8:2rem}*,:after,:before{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgba(59,130,246,.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }::backdrop{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgba(59,130,246,.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }
-/*! tailwindcss v3.4.17 | MIT License | https://tailwindcss.com*/*,:after,:before{box-sizing:border-box;border:0 solid #e5e7eb}:after,:before{--tw-content:""}:host,html{line-height:1.5;-webkit-text-size-adjust:100%;-moz-tab-size:4;-o-tab-size:4;tab-size:4;font-family:Roboto,sans-serif;font-feature-settings:normal;font-variation-settings:normal;-webkit-tap-highlight-color:transparent}body{margin:0;line-height:inherit}hr{height:0;color:inherit;border-top-width:1px}abbr:where([title]){-webkit-text-decoration:underline dotted;text-decoration:underline dotted}h1,h2,h3,h4,h5,h6{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}b,strong{font-weight:bolder}code,kbd,pre,samp{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;font-feature-settings:normal;font-variation-settings:normal;font-size:1em}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}table{text-indent:0;border-color:inherit;border-collapse:collapse}button,input,optgroup,select,textarea{font-family:inherit;font-feature-settings:inherit;font-variation-settings:inherit;font-size:100%;font-weight:inherit;line-height:inherit;letter-spacing:inherit;color:inherit;margin:0;padding:0}button,select{text-transform:none}button,input:where([type=button]),input:where([type=reset]),input:where([type=submit]){-webkit-appearance:button;background-color:transparent;background-image:none}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}progress{vertical-align:baseline}::-webkit-inner-spin-button,::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}blockquote,dd,dl,figure,h1,h2,h3,h4,h5,h6,hr,p,pre{margin:0}fieldset{margin:0}fieldset,legend{padding:0}menu,ol,ul{list-style:none;margin:0;padding:0}dialog{padding:0}textarea{resize:vertical}input::-moz-placeholder,textarea::-moz-placeholder{opacity:1;color:#9ca3af}input::placeholder,textarea::placeholder{opacity:1;color:#9ca3af}[role=button],button{cursor:pointer}:disabled{cursor:default}audio,canvas,embed,iframe,img,object,svg,video{display:block;vertical-align:middle}img,video{max-width:100%;height:auto}[hidden]:where(:not([hidden=until-found])){display:none}body{--tw-bg-opacity:1;background-color:rgb(255 255 255/var(--tw-bg-opacity,1));font-family:Roboto,sans-serif;color:rgb(17 24 39/var(--tw-text-opacity,1))}a,body{--tw-text-opacity:1}a{color:rgb(37 99 235/var(--tw-text-opacity,1));text-decoration-line:underline}a:visited{color:#581c87}a:focus,a:hover{--tw-text-opacity:1;color:rgb(30 58 138/var(--tw-text-opacity,1))}.\!container{width:100%!important;margin-right:auto!important;margin-left:auto!important;padding-right:var(--space-8)!important;padding-left:var(--space-8)!important}.container{width:100%;margin-right:auto;margin-left:auto;padding-right:var(--space-8);padding-left:var(--space-8)}@media (min-width:640px){.\!container{max-width:640px!important}.container{max-width:640px}}@media (min-width:768px){.\!container{max-width:768px!important}.container{max-width:768px}}@media (min-width:1024px){.\!container{max-width:1024px!important}.container{max-width:1024px}}@media (min-width:1280px){.\!container{max-width:1280px!important}.container{max-width:1280px}}@media (min-width:1536px){.\!container{max-width:1536px!important}.container{max-width:1536px}}.form-compact .form-label{margin-bottom:.2rem}.form-compact .form-input,.form-compact select,.form-compact textarea{padding:.4rem .6rem}.table-sticky thead th{position:sticky;top:0;background:#f9fafb;z-index:20;box-shadow:0 1px 0 0 #e5e7eb}.table-scroll[data-shadow=true] .table-sticky thead th{box-shadow:0 2px 6px rgba(0,0,0,.06)}#items-list{margin-top:1rem}.dept-chip{padding:.5rem 1rem;font-size:.875rem;font-weight:500;color:#fff;background-color:#059669;border:1px solid transparent;border-radius:.5rem;text-decoration:none;transition:all .2s ease;cursor:pointer}.dept-chip:hover{background-color:#047857;color:#fff}.dept-chip:focus{outline:none;box-shadow:0 0 0 2px rgba(5,150,105,.5)}.dept-chip:disabled{opacity:.5;cursor:not-allowed}.dept-chip{padding:.375rem .75rem;font-size:.75rem;display:inline-flex;align-items:center;gap:var(--space-2)}.card{background-color:#fff;border-radius:.75rem;box-shadow:0 1px 2px 0 rgba(0,0,0,.05);border:1px solid #e5e7eb;overflow:hidden}.card-header{padding:.875rem 1rem;border-bottom:1px solid #9ca3af;background-color:#f9fafb}.card-body,.card-compact{padding:1rem}.card>details>summary{list-style:none}.card>details>summary::-webkit-details-marker{display:none}.card>details:not([open])>.card-header{border-bottom:0}.btn-primary{display:inline-flex;align-items:center;padding:.5rem .875rem;font-size:.85rem;font-weight:500;color:#fff;background-color:#2563eb;border:1px solid transparent;border-radius:.375rem;text-decoration:none;transition:all .15s ease;cursor:pointer}.btn-primary:hover{background-color:#1d4ed8;color:#fff}.btn-primary:focus{outline:none;box-shadow:0 0 0 2px rgba(37,99,235,.5)}.btn-primary:disabled{opacity:.5;cursor:not-allowed}.btn-secondary{display:inline-flex;align-items:center;padding:.5rem .875rem;font-size:.85rem;font-weight:500;color:#374151;background-color:#fff;border:1px solid #9ca3af;border-radius:.375rem;text-decoration:none;transition:all .15s ease;cursor:pointer}.btn-secondary:hover{background-color:#f9fafb;color:#374151}.btn-secondary:focus{outline:none;box-shadow:0 0 0 2px rgba(37,99,235,.5)}.btn-secondary:disabled{opacity:.5;cursor:not-allowed}.btn-danger{display:inline-flex;align-items:center;padding:.5rem 1rem;font-size:.875rem;font-weight:500;color:#fff;background-color:#dc2626;border:1px solid transparent;border-radius:.5rem;text-decoration:none;transition:all .2s ease;cursor:pointer}.btn-danger:hover{background-color:#b91c1c;color:#fff}.btn-danger:focus{outline:none;box-shadow:0 0 0 2px rgba(220,38,38,.5)}.btn-danger:disabled{opacity:.5;cursor:not-allowed}.btn-sm{padding:.375rem .75rem;font-size:.75rem}.btn-square{display:inline-flex;align-items:center;justify-content:center;width:2rem;height:2rem;padding:.25rem;font-size:.75rem;color:#374151;background-color:#fff;border:1px solid #9ca3af;border-radius:.375rem;transition:all .15s ease}.btn-square:hover{background-color:#f9fafb;color:#374151}.btn-square:focus{outline:none;box-shadow:0 0 0 2px rgba(37,99,235,.5)}.btn-square:disabled{opacity:.5;cursor:not-allowed}.form-input{display:block;width:100%;padding:.5rem .625rem;border:1px solid #9ca3af;border-radius:.375rem;font-size:.9rem;transition:all .15s ease}.form-input:focus{outline:none;border-color:#2563eb;box-shadow:0 0 0 2px rgba(37,99,235,.2)}.form-select{display:block;width:100%;padding:.5rem .75rem;border:1px solid #d1d5db;border-radius:.5rem;font-size:.875rem;background-color:#fff;transition:all .2s ease}.form-select:focus{outline:none;border-color:#2563eb;box-shadow:0 0 0 2px rgba(37,99,235,.2)}.form-label{display:block;font-size:.875rem;font-weight:500;color:#374151;margin-bottom:.25rem}.badge{display:inline-flex;align-items:center;padding:.125rem .625rem;border-radius:9999px;font-size:.75rem;font-weight:500}.badge-success{background-color:#dcfce7;color:#166534}.badge-warning{background-color:#fef3c7;color:#92400e}.badge-error{background-color:#fecaca;color:#991b1b}.badge-info{background-color:#dbeafe;color:#1e40af}.badge-gray{background-color:#f3f4f6;color:#374151}.\!table{min-width:100%!important;border-spacing:0!important}.table{min-width:100%;border-spacing:0}.table-header,.table-header th{background-color:#f9fafb}.table-header th{padding:.625rem 1rem;text-align:left;font-size:.75rem;font-weight:600;color:#6b7280;text-transform:uppercase;letter-spacing:.05em;border-bottom:1px solid #e5e7eb}.table-body{background-color:#fff}.table-body td{padding:.875rem 1rem;white-space:normal;word-break:break-word;font-size:.875rem;color:#111827;border-bottom:1px solid #e5e7eb}.table-row-hover:hover{background-color:#f9fafb}.page-subtitle{font-size:.875rem;color:#6b7280;margin-top:.25rem}.page-content{flex:1;padding:1.5rem;background-color:#f9fafb}.active{font-weight:700;text-decoration:underline}.toast{position:absolute;left:0;top:100%;margin-top:.25rem;z-index:10}.btn-danger,.btn-primary,.btn-secondary{box-shadow:var(--shadow-btn)}.alert{padding:1rem 2rem;margin-bottom:1rem;border-left:4px solid;border-radius:.375rem}@media (max-width:768px){.alert{padding:1rem 1.5rem}}@media (max-width:640px){.alert{padding:1rem}}.alert-success{background-color:#dcfce7;color:#15803d;border-color:#22c55e}.alert-warning{background-color:#fef3c7;color:#a16207;border-color:#eab308}.alert-error{background-color:#fecaca;color:#b91c1c;border-color:#ef4444}.alert-info{background-color:#dbeafe;color:#1d4ed8;border-color:#3b82f6}form label{display:block;margin-bottom:.5rem}.form-control,form input:not([type=checkbox]):not([type=radio]),form select,form textarea{font-family:Roboto,sans-serif;border:1px solid #9ca3af;background-color:#fff;color:#111827;padding:var(--space-2);border-radius:var(--space-1);width:100%}.form-control:focus,form input:not([type=checkbox]):not([type=radio]):focus,form select:focus,form textarea:focus{outline:none;border-color:#2563eb;box-shadow:0 1px 3px 0 rgba(0,0,0,.1)}.form-checkbox{border:1px solid #9ca3af;border-radius:var(--space-1)}.form-checkbox,.form-radio{background-color:#fff;color:#111827}.form-radio{border:1px solid #9ca3af;border-radius:9999px;accent-color:#2563eb}input[list]::-webkit-calendar-picker-indicator{display:none!important}input[list]{position:relative}input[list]:after{content:"▼";position:absolute;right:8px;top:50%;transform:translateY(-50%);pointer-events:none;font-size:12px;color:#6b7280}.\!table{width:100%!important;border-collapse:separate!important;border-spacing:0 var(--space-2)!important}.table{width:100%;border-collapse:separate;border-spacing:0 var(--space-2)}.table td,.table th{border:1px solid #9ca3af;padding:var(--space-4) var(--space-8);text-align:left}.\!table td,.\!table th{border:1px solid #9ca3af!important;padding:var(--space-4) var(--space-8)!important;text-align:left!important}.\!table thead{background-color:#2563eb!important;color:#fff!important}.table thead{background-color:#2563eb;color:#fff}.\!table tbody tr{background-color:#fff!important;transition:background-color .15s ease-in-out!important}.table tbody tr{background-color:#fff;transition:background-color .15s ease-in-out}.\!table tbody tr:hover{background-color:#f3f4f6!important}.table tbody tr:hover{background-color:#f3f4f6}.pagination-active{padding:.25rem .75rem;border:1px solid #d1d5db;border-radius:.375rem;background-color:#e5e7eb}.pagination-active:focus,.pagination-input:focus{outline:none;box-shadow:0 0 0 2px #2563eb}.hidden{display:none!important}.skeleton-row{height:44px;border-radius:.5rem;background:linear-gradient(90deg,#f3f4f6 25%,#e5e7eb 37%,#f3f4f6 63%);background-size:400% 100%;margin-bottom:.5rem;animation:shimmer 1.2s infinite}@keyframes shimmer{0%{background-position:100% 0}to{background-position:-100% 0}}.w-3{width:.75rem}.h-3{height:.75rem}.w-4{width:1rem}.h-4{height:1rem}.w-5{width:1.25rem}.h-5{height:1.25rem}.p-2{padding:.5rem}.rounded-lg{border-radius:.5rem}.text-gray-400{color:#9ca3af}.top-nav-group button:focus{outline:2px solid transparent;outline-offset:2px;--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000);--tw-ring-opacity:1;--tw-ring-color:rgb(59 130 246/var(--tw-ring-opacity,1))}.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border-width:0}.pointer-events-none{pointer-events:none}.visible{visibility:visible}.static{position:static}.fixed{position:fixed}.absolute{position:absolute}.relative{position:relative}.sticky{position:sticky}.inset-0{inset:0}.inset-y-0{top:0;bottom:0}.-left-1\.5{left:-.375rem}.-right-1{right:calc(var(--space-1)*-1)}.-top-1{top:calc(var(--space-1)*-1)}.bottom-6{bottom:var(--space-6)}.left-0{left:0}.right-0{right:0}.right-2{right:var(--space-2)}.right-4{right:var(--space-4)}.right-6{right:var(--space-6)}.top-0{top:0}.top-2{top:var(--space-2)}.top-20{top:5rem}.top-4{top:var(--space-4)}.z-10{z-index:10}.z-20{z-index:20}.z-40{z-index:40}.z-50{z-index:50}.col-span-12{grid-column:span 12/span 12}.col-span-2{grid-column:span 2/span 2}.col-span-3{grid-column:span 3/span 3}.col-span-full{grid-column:1/-1}.mx-auto{margin-left:auto;margin-right:auto}.my-4{margin-top:var(--space-4);margin-bottom:var(--space-4)}.-mb-px{margin-bottom:-1px}.mb-0{margin-bottom:0}.mb-1{margin-bottom:var(--space-1)}.mb-10{margin-bottom:2.5rem}.mb-2{margin-bottom:var(--space-2)}.mb-3{margin-bottom:.75rem}.mb-4{margin-bottom:var(--space-4)}.mb-6{margin-bottom:var(--space-6)}.mb-8{margin-bottom:var(--space-8)}.ml-1{margin-left:var(--space-1)}.ml-2{margin-left:var(--space-2)}.ml-3{margin-left:.75rem}.ml-4{margin-left:var(--space-4)}.ml-6{margin-left:var(--space-6)}.mr-1{margin-right:var(--space-1)}.mr-2{margin-right:var(--space-2)}.mt-0\.5{margin-top:var(--space-0-5)}.mt-1{margin-top:var(--space-1)}.mt-2{margin-top:var(--space-2)}.mt-3{margin-top:.75rem}.mt-4{margin-top:var(--space-4)}.mt-6{margin-top:var(--space-6)}.mt-8{margin-top:var(--space-8)}.block{display:block}.inline{display:inline}.flex{display:flex}.inline-flex{display:inline-flex}.\!table{display:table!important}.table{display:table}.grid{display:grid}.hidden{display:none}.h-12{height:3rem}.h-16{height:4rem}.h-2{height:var(--space-2)}.h-24{height:6rem}.h-3{height:.75rem}.h-32{height:8rem}.h-4{height:var(--space-4)}.h-40{height:10rem}.h-5{height:1.25rem}.h-6{height:var(--space-6)}.h-64{height:16rem}.h-8{height:var(--space-8)}.h-\[38px\]{height:38px}.max-h-60{max-height:15rem}.max-h-\[90vh\]{max-height:90vh}.max-h-screen{max-height:100vh}.min-h-screen{min-height:100vh}.w-12{width:3rem}.w-24{width:6rem}.w-3{width:.75rem}.w-32{width:8rem}.w-4{width:var(--space-4)}.w-5{width:1.25rem}.w-56{width:14rem}.w-6{width:var(--space-6)}.w-64{width:16rem}.w-8{width:var(--space-8)}.w-\[120px\]{width:120px}.w-full{width:100%}.w-max{width:-moz-max-content;width:max-content}.max-w-3xl{max-width:48rem}.max-w-4xl{max-width:56rem}.max-w-7xl{max-width:80rem}.max-w-\[480px\]{max-width:480px}.max-w-\[520px\]{max-width:520px}.max-w-\[720px\]{max-width:720px}.max-w-\[860px\]{max-width:860px}.max-w-md{max-width:28rem}.max-w-sm{max-width:24rem}.max-w-xl{max-width:36rem}.max-w-xs{max-width:20rem}.flex-1{flex:1 1 0%}.flex-shrink-0{flex-shrink:0}.flex-grow{flex-grow:1}.table-auto{table-layout:auto}.table-fixed{table-layout:fixed}.translate-x-full{--tw-translate-x:100%}.transform,.translate-x-full{transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}@keyframes spin{to{transform:rotate(1turn)}}.animate-spin{animation:spin 1s linear infinite}.cursor-pointer{cursor:pointer}.list-disc{list-style-type:disc}.grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.grid-cols-12{grid-template-columns:repeat(12,minmax(0,1fr))}.grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr))}.flex-col{flex-direction:column}.flex-wrap{flex-wrap:wrap}.items-start{align-items:flex-start}.items-end{align-items:flex-end}.items-center{align-items:center}.justify-start{justify-content:flex-start}.justify-end{justify-content:flex-end}.justify-center{justify-content:center}.justify-between{justify-content:space-between}.gap-1{gap:var(--space-1)}.gap-2{gap:var(--space-2)}.gap-3{gap:.75rem}.gap-4{gap:var(--space-4)}.gap-6{gap:var(--space-6)}.gap-x-4{-moz-column-gap:var(--space-4);column-gap:var(--space-4)}.gap-y-2{row-gap:var(--space-2)}.space-x-2>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(var(--space-2)*var(--tw-space-x-reverse));margin-left:calc(var(--space-2)*(1 - var(--tw-space-x-reverse)))}.space-x-3>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(.75rem*var(--tw-space-x-reverse));margin-left:calc(.75rem*(1 - var(--tw-space-x-reverse)))}.space-x-4>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-right:calc(var(--space-4)*var(--tw-space-x-reverse));margin-left:calc(var(--space-4)*(1 - var(--tw-space-x-reverse)))}.space-y-1>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(var(--space-1)*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(var(--space-1)*var(--tw-space-y-reverse))}.space-y-2>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(var(--space-2)*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(var(--space-2)*var(--tw-space-y-reverse))}.space-y-8>:not([hidden])~:not([hidden]){--tw-space-y-reverse:0;margin-top:calc(var(--space-8)*(1 - var(--tw-space-y-reverse)));margin-bottom:calc(var(--space-8)*var(--tw-space-y-reverse))}.overflow-x-auto{overflow-x:auto}.overflow-y-auto{overflow-y:auto}.whitespace-normal{white-space:normal}.break-words{overflow-wrap:break-word}.rounded{border-radius:.25rem}.rounded-full{border-radius:9999px}.rounded-lg{border-radius:.5rem}.rounded-md{border-radius:.375rem}.rounded-t-lg{border-top-left-radius:.5rem;border-top-right-radius:.5rem}.border{border-width:1px}.border-2{border-width:2px}.border-4{border-width:4px}.border-b{border-bottom-width:1px}.border-b-2{border-bottom-width:2px}.border-l{border-left-width:1px}.border-t{border-top-width:1px}.border-dashed{border-style:dashed}.border-blue-600{--tw-border-opacity:1;border-color:rgb(37 99 235/var(--tw-border-opacity,1))}.border-border{--tw-border-opacity:1;border-color:rgb(156 163 175/var(--tw-border-opacity,1))}.border-danger{--tw-border-opacity:1;border-color:rgb(220 38 38/var(--tw-border-opacity,1))}.border-form-border{--tw-border-opacity:1;border-color:rgb(156 163 175/var(--tw-border-opacity,1))}.border-gray-100{--tw-border-opacity:1;border-color:rgb(243 244 246/var(--tw-border-opacity,1))}.border-gray-200{--tw-border-opacity:1;border-color:rgb(229 231 235/var(--tw-border-opacity,1))}.border-gray-300{--tw-border-opacity:1;border-color:rgb(209 213 219/var(--tw-border-opacity,1))}.border-primary{--tw-border-opacity:1;border-color:rgb(37 99 235/var(--tw-border-opacity,1))}.border-transparent{border-color:transparent}.border-white{--tw-border-opacity:1;border-color:rgb(255 255 255/var(--tw-border-opacity,1))}.border-yellow-200{--tw-border-opacity:1;border-color:rgb(254 240 138/var(--tw-border-opacity,1))}.border-t-transparent{border-top-color:transparent}.bg-black\/25{background-color:rgba(0,0,0,.25)}.bg-black\/50{background-color:rgba(0,0,0,.5)}.bg-blue-100{--tw-bg-opacity:1;background-color:rgb(219 234 254/var(--tw-bg-opacity,1))}.bg-blue-500{--tw-bg-opacity:1;background-color:rgb(59 130 246/var(--tw-bg-opacity,1))}.bg-blue-600{--tw-bg-opacity:1;background-color:rgb(37 99 235/var(--tw-bg-opacity,1))}.bg-body,.bg-form-bg{--tw-bg-opacity:1;background-color:rgb(255 255 255/var(--tw-bg-opacity,1))}.bg-gray-200{--tw-bg-opacity:1;background-color:rgb(229 231 235/var(--tw-bg-opacity,1))}.bg-gray-50{--tw-bg-opacity:1;background-color:rgb(249 250 251/var(--tw-bg-opacity,1))}.bg-green-50{--tw-bg-opacity:1;background-color:rgb(240 253 244/var(--tw-bg-opacity,1))}.bg-green-500{--tw-bg-opacity:1;background-color:rgb(34 197 94/var(--tw-bg-opacity,1))}.bg-primary{--tw-bg-opacity:1;background-color:rgb(37 99 235/var(--tw-bg-opacity,1))}.bg-red-500{--tw-bg-opacity:1;background-color:rgb(239 68 68/var(--tw-bg-opacity,1))}.bg-white{--tw-bg-opacity:1;background-color:rgb(255 255 255/var(--tw-bg-opacity,1))}.bg-yellow-50{--tw-bg-opacity:1;background-color:rgb(254 252 232/var(--tw-bg-opacity,1))}.bg-yellow-500{--tw-bg-opacity:1;background-color:rgb(234 179 8/var(--tw-bg-opacity,1))}.object-cover{-o-object-fit:cover;object-fit:cover}.p-2{padding:var(--space-2)}.p-3{padding:.75rem}.p-4{padding:var(--space-4)}.p-6{padding:var(--space-6)}.p-8{padding:var(--space-8)}.px-2{padding-left:var(--space-2);padding-right:var(--space-2)}.px-3{padding-left:.75rem;padding-right:.75rem}.px-4{padding-left:var(--space-4);padding-right:var(--space-4)}.px-6{padding-left:var(--space-6);padding-right:var(--space-6)}.py-1{padding-top:var(--space-1);padding-bottom:var(--space-1)}.py-10{padding-top:2.5rem;padding-bottom:2.5rem}.py-2{padding-top:var(--space-2);padding-bottom:var(--space-2)}.py-3{padding-top:.75rem;padding-bottom:.75rem}.pl-10{padding-left:2.5rem}.pl-3{padding-left:.75rem}.pl-5{padding-left:1.25rem}.pr-4{padding-right:var(--space-4)}.text-left{text-align:left}.text-center{text-align:center}.text-right{text-align:right}.text-2xl{font-size:1.5rem;line-height:2rem}.text-4xl{font-size:2.25rem;line-height:2.5rem}.text-badge{font-size:clamp(.8rem,.3vw + .7rem,1rem);line-height:1}.text-base{font-size:clamp(1rem,.5vw + .9rem,1.25rem);line-height:1.5}.text-h1{font-size:clamp(1.6rem,1vw + 1.3rem,2.5rem);line-height:1.25}.text-h2{font-size:clamp(1.3rem,.75vw + 1.1rem,2rem);line-height:1.3}.text-lg{font-size:1.125rem;line-height:1.75rem}.text-sm{font-size:.875rem;line-height:1.25rem}.text-xl{font-size:1.25rem;line-height:1.75rem}.text-xs{font-size:.75rem;line-height:1rem}.font-bold{font-weight:700}.font-medium{font-weight:500}.font-semibold{font-weight:600}.leading-none{line-height:1}.text-blue-600{--tw-text-opacity:1;color:rgb(37 99 235/var(--tw-text-opacity,1))}.text-blue-800{--tw-text-opacity:1;color:rgb(30 64 175/var(--tw-text-opacity,1))}.text-bodyText,.text-form-text{--tw-text-opacity:1;color:rgb(17 24 39/var(--tw-text-opacity,1))}.text-gray-400{--tw-text-opacity:1;color:rgb(156 163 175/var(--tw-text-opacity,1))}.text-gray-500{--tw-text-opacity:1;color:rgb(107 114 128/var(--tw-text-opacity,1))}.text-gray-600{--tw-text-opacity:1;color:rgb(75 85 99/var(--tw-text-opacity,1))}.text-gray-700{--tw-text-opacity:1;color:rgb(55 65 81/var(--tw-text-opacity,1))}.text-gray-900{--tw-text-opacity:1;color:rgb(17 24 39/var(--tw-text-opacity,1))}.text-green-600{--tw-text-opacity:1;color:rgb(22 163 74/var(--tw-text-opacity,1))}.text-green-700{--tw-text-opacity:1;color:rgb(21 128 61/var(--tw-text-opacity,1))}.text-navText{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity,1))}.text-primary{--tw-text-opacity:1;color:rgb(37 99 235/var(--tw-text-opacity,1))}.text-red-600{--tw-text-opacity:1;color:rgb(220 38 38/var(--tw-text-opacity,1))}.text-red-700{--tw-text-opacity:1;color:rgb(185 28 28/var(--tw-text-opacity,1))}.text-secondary{--tw-text-opacity:1;color:rgb(21 128 61/var(--tw-text-opacity,1))}.text-white{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity,1))}.text-yellow-600{--tw-text-opacity:1;color:rgb(202 138 4/var(--tw-text-opacity,1))}.text-yellow-700{--tw-text-opacity:1;color:rgb(161 98 7/var(--tw-text-opacity,1))}.text-yellow-800{--tw-text-opacity:1;color:rgb(133 77 14/var(--tw-text-opacity,1))}.opacity-0{opacity:0}.opacity-70{opacity:.7}.shadow{--tw-shadow:0 1px 3px 0 rgba(0,0,0,.1),0 1px 2px -1px rgba(0,0,0,.1);--tw-shadow-colored:0 1px 3px 0 var(--tw-shadow-color),0 1px 2px -1px var(--tw-shadow-color)}.shadow,.shadow-lg{box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.shadow-lg{--tw-shadow:0 10px 15px -3px rgba(0,0,0,.1),0 4px 6px -4px rgba(0,0,0,.1);--tw-shadow-colored:0 10px 15px -3px var(--tw-shadow-color),0 4px 6px -4px var(--tw-shadow-color)}.shadow-md{--tw-shadow:0 4px 6px -1px rgba(0,0,0,.1),0 2px 4px -2px rgba(0,0,0,.1);--tw-shadow-colored:0 4px 6px -1px var(--tw-shadow-color),0 2px 4px -2px var(--tw-shadow-color)}.shadow-md,.shadow-sm{box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.shadow-sm{--tw-shadow:0 1px 2px 0 rgba(0,0,0,.05);--tw-shadow-colored:0 1px 2px 0 var(--tw-shadow-color)}.ring-1{--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000)}.ring-black{--tw-ring-opacity:1;--tw-ring-color:rgb(0 0 0/var(--tw-ring-opacity,1))}.ring-opacity-5{--tw-ring-opacity:0.05}.blur{--tw-blur:blur(8px)}.blur,.filter{filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)}.transition-all{transition-property:all;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.transition-transform{transition-property:transform;transition-timing-function:cubic-bezier(.4,0,.2,1);transition-duration:.15s}.duration-200{transition-duration:.2s}.duration-300{transition-duration:.3s}.text-xs{font-size:clamp(.8680555555555557rem,calc(.86257rem + .02741vw),.8888888888888888rem);line-height:1.6}.text-sm{font-size:clamp(1rem,calc(.98904rem + .05482vw),1.0416666666666667rem);line-height:1.6}.text-base{font-size:clamp(1.125rem,calc(1.09211rem + .16447vw),1.25rem);line-height:1.6}.text-lg{font-size:clamp(1.265625rem,calc(1.20395rem + .30839vw),1.5rem);line-height:1.6}.text-xl{font-size:clamp(1.423828125rem,calc(1.32484rem + .49496vw),1.7999999999999998rem);line-height:1.2}.text-2xl{font-size:clamp(1.601806640625rem,calc(1.45491rem + .73446vw),2.1599999999999997rem);line-height:1.2}.text-4xl{font-size:clamp(2.0272865295410156rem,calc(1.74226rem + 1.42515vw),3.1103999999999994rem);line-height:1.1}@media (prefers-reduced-motion:reduce){*,:after,:before{animation:none!important;transition:none!important;scroll-behavior:auto!important}}@media (max-width:768px){h1{font-size:clamp(1.6rem,1vw + 1.3rem,2.5rem);line-height:1.25}h2{font-size:clamp(1.3rem,.75vw + 1.1rem,2rem);line-height:1.3}.badge-error,.badge-success,.badge-warning{font-size:clamp(.8rem,.3vw + .7rem,1rem);line-height:1;padding:var(--space-0-5) var(--space-1)}}@media (min-width:768px){.md\:hidden{display:none!important}}@media (max-width:639px){.max-sm\:p-2{padding:.5rem}}.first\:border-t-0:first-child{border-top-width:0}.last\:border-b-0:last-child{border-bottom-width:0}.odd\:bg-gray-50:nth-child(odd){--tw-bg-opacity:1;background-color:rgb(249 250 251/var(--tw-bg-opacity,1))}.odd\:bg-white:nth-child(odd){--tw-bg-opacity:1;background-color:rgb(255 255 255/var(--tw-bg-opacity,1))}.even\:bg-gray-50:nth-child(2n){--tw-bg-opacity:1;background-color:rgb(249 250 251/var(--tw-bg-opacity,1))}.hover\:-translate-y-1:hover{--tw-translate-y:calc(var(--space-1)*-1);transform:translate(var(--tw-translate-x),var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}.hover\:bg-blue-50:hover{--tw-bg-opacity:1;background-color:rgb(239 246 255/var(--tw-bg-opacity,1))}.hover\:bg-gray-100:hover{--tw-bg-opacity:1;background-color:rgb(243 244 246/var(--tw-bg-opacity,1))}.hover\:text-blue-600:hover{--tw-text-opacity:1;color:rgb(37 99 235/var(--tw-text-opacity,1))}.hover\:text-gray-600:hover{--tw-text-opacity:1;color:rgb(75 85 99/var(--tw-text-opacity,1))}.hover\:text-green-600:hover{--tw-text-opacity:1;color:rgb(22 163 74/var(--tw-text-opacity,1))}.hover\:text-primary:hover{--tw-text-opacity:1;color:rgb(37 99 235/var(--tw-text-opacity,1))}.hover\:text-red-600:hover{--tw-text-opacity:1;color:rgb(220 38 38/var(--tw-text-opacity,1))}.hover\:text-yellow-600:hover{--tw-text-opacity:1;color:rgb(202 138 4/var(--tw-text-opacity,1))}.hover\:underline:hover{text-decoration-line:underline}.hover\:opacity-100:hover{opacity:1}.hover\:shadow-xl:hover{--tw-shadow:0 20px 25px -5px rgba(0,0,0,.1),0 8px 10px -6px rgba(0,0,0,.1);--tw-shadow-colored:0 20px 25px -5px var(--tw-shadow-color),0 8px 10px -6px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.focus\:border-transparent:focus{border-color:transparent}.focus\:outline-none:focus{outline:2px solid transparent;outline-offset:2px}.focus\:ring-2:focus{--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow),var(--tw-ring-shadow),var(--tw-shadow,0 0 #0000)}.focus\:ring-blue-500:focus{--tw-ring-opacity:1;--tw-ring-color:rgb(59 130 246/var(--tw-ring-opacity,1))}.focus\:ring-primary:focus{--tw-ring-opacity:1;--tw-ring-color:rgb(37 99 235/var(--tw-ring-opacity,1))}@media (min-width:640px){.sm\:w-64{width:16rem}.sm\:grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.sm\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.sm\:flex-row{flex-direction:row}.sm\:items-end{align-items:flex-end}.sm\:px-6{padding-left:var(--space-6);padding-right:var(--space-6)}}@media (min-width:768px){.md\:col-span-3{grid-column:span 3/span 3}.md\:mt-0{margin-top:0}.md\:block{display:block}.md\:hidden{display:none}.md\:w-64{width:16rem}.md\:w-auto{width:auto}.md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.md\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.md\:grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr))}.md\:flex-row{flex-direction:row}.md\:items-end{align-items:flex-end}.md\:justify-end{justify-content:flex-end}}@media (min-width:1024px){.lg\:block{display:block}.lg\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.lg\:grid-cols-3{grid-template-columns:repeat(3,minmax(0,1fr))}.lg\:grid-cols-5{grid-template-columns:repeat(5,minmax(0,1fr))}.lg\:px-8{padding-left:var(--space-8);padding-right:var(--space-8)}}@media (max-width:639px){.max-sm\:max-w-md{max-width:28rem}.max-sm\:grid-cols-1{grid-template-columns:repeat(1,minmax(0,1fr))}.max-sm\:p-2{padding:var(--space-2)}.max-sm\:p-4{padding:var(--space-4)}}@media (max-width:767px){.max-md\:max-w-xl{max-width:36rem}.max-md\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.max-md\:overflow-x-auto{overflow-x:auto}}@media (max-width:1023px){.max-lg\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}.max-lg\:grid-cols-4{grid-template-columns:repeat(4,minmax(0,1fr))}}
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap");
+:root {
+  --shadow-btn: 0 2px 4px rgba(0, 0, 0, 0.25);
+  --space-0-5: 0.125rem;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+}
+*,
+:after,
+:before {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
+  --tw-contain-size: ;
+  --tw-contain-layout: ;
+  --tw-contain-paint: ;
+  --tw-contain-style: ;
+}
+::backdrop {
+  --tw-border-spacing-x: 0;
+  --tw-border-spacing-y: 0;
+  --tw-translate-x: 0;
+  --tw-translate-y: 0;
+  --tw-rotate: 0;
+  --tw-skew-x: 0;
+  --tw-skew-y: 0;
+  --tw-scale-x: 1;
+  --tw-scale-y: 1;
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
+  --tw-scroll-snap-strictness: proximity;
+  --tw-gradient-from-position: ;
+  --tw-gradient-via-position: ;
+  --tw-gradient-to-position: ;
+  --tw-ordinal: ;
+  --tw-slashed-zero: ;
+  --tw-numeric-figure: ;
+  --tw-numeric-spacing: ;
+  --tw-numeric-fraction: ;
+  --tw-ring-inset: ;
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: rgba(59, 130, 246, 0.5);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  --tw-ring-shadow: 0 0 #0000;
+  --tw-shadow: 0 0 #0000;
+  --tw-shadow-colored: 0 0 #0000;
+  --tw-blur: ;
+  --tw-brightness: ;
+  --tw-contrast: ;
+  --tw-grayscale: ;
+  --tw-hue-rotate: ;
+  --tw-invert: ;
+  --tw-saturate: ;
+  --tw-sepia: ;
+  --tw-drop-shadow: ;
+  --tw-backdrop-blur: ;
+  --tw-backdrop-brightness: ;
+  --tw-backdrop-contrast: ;
+  --tw-backdrop-grayscale: ;
+  --tw-backdrop-hue-rotate: ;
+  --tw-backdrop-invert: ;
+  --tw-backdrop-opacity: ;
+  --tw-backdrop-saturate: ;
+  --tw-backdrop-sepia: ;
+  --tw-contain-size: ;
+  --tw-contain-layout: ;
+  --tw-contain-paint: ;
+  --tw-contain-style: ;
+}
+/*! tailwindcss v3.4.17 | MIT License | https://tailwindcss.com*/
+*,
+:after,
+:before {
+  box-sizing: border-box;
+  border: 0 solid #e5e7eb;
+}
+:after,
+:before {
+  --tw-content: "";
+}
+:host,
+html {
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  font-family: Roboto, sans-serif;
+  font-feature-settings: normal;
+  font-variation-settings: normal;
+  -webkit-tap-highlight-color: transparent;
+}
+body {
+  margin: 0;
+  line-height: inherit;
+}
+hr {
+  height: 0;
+  color: inherit;
+  border-top-width: 1px;
+}
+abbr:where([title]) {
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+b,
+strong {
+  font-weight: bolder;
+}
+code,
+kbd,
+pre,
+samp {
+  font-family:
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    Liberation Mono,
+    Courier New,
+    monospace;
+  font-feature-settings: normal;
+  font-variation-settings: normal;
+  font-size: 1em;
+}
+small {
+  font-size: 80%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sub {
+  bottom: -0.25em;
+}
+sup {
+  top: -0.5em;
+}
+table {
+  text-indent: 0;
+  border-color: inherit;
+  border-collapse: collapse;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  font-feature-settings: inherit;
+  font-variation-settings: inherit;
+  font-size: 100%;
+  font-weight: inherit;
+  line-height: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+  margin: 0;
+  padding: 0;
+}
+button,
+select {
+  text-transform: none;
+}
+button,
+input:where([type="button"]),
+input:where([type="reset"]),
+input:where([type="submit"]) {
+  -webkit-appearance: button;
+  background-color: transparent;
+  background-image: none;
+}
+:-moz-focusring {
+  outline: auto;
+}
+:-moz-ui-invalid {
+  box-shadow: none;
+}
+progress {
+  vertical-align: baseline;
+}
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+[type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+summary {
+  display: list-item;
+}
+blockquote,
+dd,
+dl,
+figure,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+p,
+pre {
+  margin: 0;
+}
+fieldset {
+  margin: 0;
+}
+fieldset,
+legend {
+  padding: 0;
+}
+menu,
+ol,
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+dialog {
+  padding: 0;
+}
+textarea {
+  resize: vertical;
+}
+input::-moz-placeholder,
+textarea::-moz-placeholder {
+  opacity: 1;
+  color: #9ca3af;
+}
+input::placeholder,
+textarea::placeholder {
+  opacity: 1;
+  color: #9ca3af;
+}
+[role="button"],
+button {
+  cursor: pointer;
+}
+:disabled {
+  cursor: default;
+}
+audio,
+canvas,
+embed,
+iframe,
+img,
+object,
+svg,
+video {
+  display: block;
+  vertical-align: middle;
+}
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+[hidden]:where(:not([hidden="until-found"])) {
+  display: none;
+}
+body {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+  font-family: Roboto, sans-serif;
+  color: rgb(17 24 39 / var(--tw-text-opacity, 1));
+}
+a,
+body {
+  --tw-text-opacity: 1;
+}
+a {
+  color: rgb(37 99 235 / var(--tw-text-opacity, 1));
+  text-decoration-line: underline;
+}
+a:visited {
+  color: #581c87;
+}
+a:focus,
+a:hover {
+  --tw-text-opacity: 1;
+  color: rgb(30 58 138 / var(--tw-text-opacity, 1));
+}
+.\!container {
+  width: 100% !important;
+  margin-right: auto !important;
+  margin-left: auto !important;
+  padding-right: var(--space-8) !important;
+  padding-left: var(--space-8) !important;
+}
+.container {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--space-8);
+  padding-left: var(--space-8);
+}
+@media (min-width: 640px) {
+  .\!container {
+    max-width: 640px !important;
+  }
+  .container {
+    max-width: 640px;
+  }
+}
+@media (min-width: 768px) {
+  .\!container {
+    max-width: 768px !important;
+  }
+  .container {
+    max-width: 768px;
+  }
+}
+@media (min-width: 1024px) {
+  .\!container {
+    max-width: 1024px !important;
+  }
+  .container {
+    max-width: 1024px;
+  }
+}
+@media (min-width: 1280px) {
+  .\!container {
+    max-width: 1280px !important;
+  }
+  .container {
+    max-width: 1280px;
+  }
+}
+@media (min-width: 1536px) {
+  .\!container {
+    max-width: 1536px !important;
+  }
+  .container {
+    max-width: 1536px;
+  }
+}
+.form-compact .form-label {
+  margin-bottom: 0.2rem;
+}
+.form-compact .form-input,
+.form-compact select,
+.form-compact textarea {
+  padding: 0.4rem 0.6rem;
+}
+.table-sticky thead th {
+  position: sticky;
+  top: 0;
+  background: #f9fafb;
+  z-index: 20;
+  box-shadow: 0 1px 0 0 #e5e7eb;
+}
+.table-scroll[data-shadow="true"] .table-sticky thead th {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+}
+#items-list {
+  margin-top: 1rem;
+}
+.dept-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.375rem;
+  padding: var(--space-2) var(--space-4);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  transition-property:
+    color,
+    background-color,
+    border-color,
+    text-decoration-color,
+    fill,
+    stroke,
+    opacity,
+    box-shadow,
+    transform,
+    filter,
+    -webkit-backdrop-filter;
+  transition-property:
+    color, background-color, border-color, text-decoration-color, fill, stroke,
+    opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property:
+    color,
+    background-color,
+    border-color,
+    text-decoration-color,
+    fill,
+    stroke,
+    opacity,
+    box-shadow,
+    transform,
+    filter,
+    backdrop-filter,
+    -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 0.15s;
+  font-size: clamp(1rem, calc(0.98904rem + 0.05482vw), 1.0416666666666667rem);
+  line-height: 1.6;
+}
+.dept-chip:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+.dept-chip:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.dept-chip {
+  --tw-bg-opacity: 1;
+  background-color: rgb(22 163 74 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+.dept-chip:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(21 128 61 / var(--tw-bg-opacity, 1));
+}
+.dept-chip:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow:
+    var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(22 163 74 / var(--tw-ring-opacity, 1));
+}
+.dept-chip {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-size: clamp(
+    0.8680555555555557rem,
+    calc(0.86257rem + 0.02741vw),
+    0.8888888888888888rem
+  );
+  line-height: 1.6;
+  gap: var(--space-2);
+}
+.card {
+  overflow: hidden;
+  border-radius: 0.75rem;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+  --tw-shadow:
+    0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+  --tw-shadow-colored:
+    0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
+  box-shadow:
+    var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow);
+}
+.card-header {
+  border-bottom-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+  padding-left: var(--space-4);
+  padding-right: var(--space-4);
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+.card-body,
+.card-compact {
+  padding: var(--space-4);
+}
+.card > details > summary {
+  list-style-type: none;
+}
+.card > details > summary::-webkit-details-marker {
+  display: none;
+}
+.card > details:not([open]) > .card-header {
+  border-bottom-width: 0;
+}
+.\!btn {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.375rem;
+  padding: var(--space-2) var(--space-4);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  transition-property:
+    color,
+    background-color,
+    border-color,
+    text-decoration-color,
+    fill,
+    stroke,
+    opacity,
+    box-shadow,
+    transform,
+    filter,
+    -webkit-backdrop-filter;
+  transition-property:
+    color, background-color, border-color, text-decoration-color, fill, stroke,
+    opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property:
+    color,
+    background-color,
+    border-color,
+    text-decoration-color,
+    fill,
+    stroke,
+    opacity,
+    box-shadow,
+    transform,
+    filter,
+    backdrop-filter,
+    -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 0.15s;
+  font-size: clamp(1rem, calc(0.98904rem + 0.05482vw), 1.0416666666666667rem);
+  line-height: 1.6;
+}
+.\!btn:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+.\!btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 0.375rem;
+  padding: var(--space-2) var(--space-4);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  transition-property:
+    color,
+    background-color,
+    border-color,
+    text-decoration-color,
+    fill,
+    stroke,
+    opacity,
+    box-shadow,
+    transform,
+    filter,
+    -webkit-backdrop-filter;
+  transition-property:
+    color, background-color, border-color, text-decoration-color, fill, stroke,
+    opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property:
+    color,
+    background-color,
+    border-color,
+    text-decoration-color,
+    fill,
+    stroke,
+    opacity,
+    box-shadow,
+    transform,
+    filter,
+    backdrop-filter,
+    -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 0.15s;
+  font-size: clamp(1rem, calc(0.98904rem + 0.05482vw), 1.0416666666666667rem);
+  line-height: 1.6;
+}
+.btn:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.btn-primary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+.btn-primary:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(29 78 216 / var(--tw-bg-opacity, 1));
+}
+.btn-primary:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow:
+    var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(37 99 235 / var(--tw-ring-opacity, 1));
+}
+.btn-secondary {
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+.btn-secondary:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+}
+.btn-secondary:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow:
+    var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(37 99 235 / var(--tw-ring-opacity, 1));
+}
+.btn-danger {
+  --tw-bg-opacity: 1;
+  background-color: rgb(220 38 38 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+.btn-danger:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(185 28 28 / var(--tw-bg-opacity, 1));
+}
+.btn-danger:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow:
+    var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(220 38 38 / var(--tw-ring-opacity, 1));
+}
+.btn-sm {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-size: clamp(
+    0.8680555555555557rem,
+    calc(0.86257rem + 0.02741vw),
+    0.8888888888888888rem
+  );
+  line-height: 1.6;
+}
+.btn-square {
+  height: var(--space-8);
+  width: var(--space-8);
+  justify-content: center;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+  padding: 0;
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+.btn-square:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+}
+.btn-square:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow:
+    var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(37 99 235 / var(--tw-ring-opacity, 1));
+}
+.form-input {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid #9ca3af;
+  border-radius: 0.375rem;
+  font-size: 0.9rem;
+  transition: all 0.15s ease;
+}
+.form-input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+}
+.form-select {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  background-color: #fff;
+  transition: all 0.2s ease;
+}
+.form-select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+}
+.form-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+  margin-bottom: 0.25rem;
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem 0.625rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+.badge-success {
+  background-color: #dcfce7;
+  color: #166534;
+}
+.badge-warning {
+  background-color: #fef3c7;
+  color: #92400e;
+}
+.badge-error {
+  background-color: #fecaca;
+  color: #991b1b;
+}
+.badge-info {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+.badge-gray {
+  background-color: #f3f4f6;
+  color: #374151;
+}
+.\!table {
+  min-width: 100% !important;
+  border-spacing: 0 !important;
+}
+.table {
+  min-width: 100%;
+  border-spacing: 0;
+}
+.table-header,
+.table-header th {
+  background-color: #f9fafb;
+}
+.table-header th {
+  padding: 0.625rem 1rem;
+  text-align: left;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid #e5e7eb;
+}
+.table-body {
+  background-color: #fff;
+}
+.table-body td {
+  padding: 0.875rem 1rem;
+  white-space: normal;
+  word-break: break-word;
+  font-size: 0.875rem;
+  color: #111827;
+  border-bottom: 1px solid #e5e7eb;
+}
+.table-row-hover:hover {
+  background-color: #f9fafb;
+}
+.page-subtitle {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin-top: 0.25rem;
+}
+.page-content {
+  flex: 1;
+  padding: 1.5rem;
+  background-color: #f9fafb;
+}
+.active {
+  font-weight: 700;
+  text-decoration: underline;
+}
+.toast {
+  position: absolute;
+  left: 0;
+  top: 100%;
+  margin-top: 0.25rem;
+  z-index: 10;
+}
+.alert {
+  padding: 1rem 2rem;
+  margin-bottom: 1rem;
+  border-left: 4px solid;
+  border-radius: 0.375rem;
+}
+@media (max-width: 768px) {
+  .alert {
+    padding: 1rem 1.5rem;
+  }
+}
+@media (max-width: 640px) {
+  .alert {
+    padding: 1rem;
+  }
+}
+.alert-success {
+  background-color: #dcfce7;
+  color: #15803d;
+  border-color: #22c55e;
+}
+.alert-warning {
+  background-color: #fef3c7;
+  color: #a16207;
+  border-color: #eab308;
+}
+.alert-error {
+  background-color: #fecaca;
+  color: #b91c1c;
+  border-color: #ef4444;
+}
+.alert-info {
+  background-color: #dbeafe;
+  color: #1d4ed8;
+  border-color: #3b82f6;
+}
+form label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+.form-control,
+form input:not([type="checkbox"]):not([type="radio"]),
+form select,
+form textarea {
+  font-family: Roboto, sans-serif;
+  border: 1px solid #9ca3af;
+  background-color: #fff;
+  color: #111827;
+  padding: var(--space-2);
+  border-radius: var(--space-1);
+  width: 100%;
+}
+.form-control:focus,
+form input:not([type="checkbox"]):not([type="radio"]):focus,
+form select:focus,
+form textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+}
+.form-checkbox {
+  border: 1px solid #9ca3af;
+  border-radius: var(--space-1);
+}
+.form-checkbox,
+.form-radio {
+  background-color: #fff;
+  color: #111827;
+}
+.form-radio {
+  border: 1px solid #9ca3af;
+  border-radius: 9999px;
+  accent-color: #2563eb;
+}
+input[list]::-webkit-calendar-picker-indicator {
+  display: none !important;
+}
+input[list] {
+  position: relative;
+}
+input[list]:after {
+  content: "▼";
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  font-size: 12px;
+  color: #6b7280;
+}
+.\!table {
+  width: 100% !important;
+  border-collapse: separate !important;
+  border-spacing: 0 var(--space-2) !important;
+}
+.table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 var(--space-2);
+}
+.table td,
+.table th {
+  border: 1px solid #9ca3af;
+  padding: var(--space-4) var(--space-8);
+  text-align: left;
+}
+.\!table td,
+.\!table th {
+  border: 1px solid #9ca3af !important;
+  padding: var(--space-4) var(--space-8) !important;
+  text-align: left !important;
+}
+.\!table thead {
+  background-color: #2563eb !important;
+  color: #fff !important;
+}
+.table thead {
+  background-color: #2563eb;
+  color: #fff;
+}
+.\!table tbody tr {
+  background-color: #fff !important;
+  transition: background-color 0.15s ease-in-out !important;
+}
+.table tbody tr {
+  background-color: #fff;
+  transition: background-color 0.15s ease-in-out;
+}
+.\!table tbody tr:hover {
+  background-color: #f3f4f6 !important;
+}
+.table tbody tr:hover {
+  background-color: #f3f4f6;
+}
+.pagination-active {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  background-color: #e5e7eb;
+}
+.pagination-active:focus,
+.pagination-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #2563eb;
+}
+.hidden {
+  display: none !important;
+}
+.skeleton-row {
+  height: 44px;
+  border-radius: 0.5rem;
+  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 37%, #f3f4f6 63%);
+  background-size: 400% 100%;
+  margin-bottom: 0.5rem;
+  animation: shimmer 1.2s infinite;
+}
+@keyframes shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  to {
+    background-position: -100% 0;
+  }
+}
+.w-3 {
+  width: 0.75rem;
+}
+.h-3 {
+  height: 0.75rem;
+}
+.w-4 {
+  width: 1rem;
+}
+.h-4 {
+  height: 1rem;
+}
+.w-5 {
+  width: 1.25rem;
+}
+.h-5 {
+  height: 1.25rem;
+}
+.p-2 {
+  padding: 0.5rem;
+}
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+.text-gray-400 {
+  color: #9ca3af;
+}
+.top-nav-group button:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow:
+    var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+.pointer-events-none {
+  pointer-events: none;
+}
+.visible {
+  visibility: visible;
+}
+.static {
+  position: static;
+}
+.fixed {
+  position: fixed;
+}
+.absolute {
+  position: absolute;
+}
+.relative {
+  position: relative;
+}
+.sticky {
+  position: sticky;
+}
+.inset-0 {
+  inset: 0;
+}
+.inset-y-0 {
+  top: 0;
+  bottom: 0;
+}
+.-left-1\.5 {
+  left: -0.375rem;
+}
+.-right-1 {
+  right: calc(var(--space-1) * -1);
+}
+.-top-1 {
+  top: calc(var(--space-1) * -1);
+}
+.bottom-6 {
+  bottom: var(--space-6);
+}
+.left-0 {
+  left: 0;
+}
+.right-0 {
+  right: 0;
+}
+.right-2 {
+  right: var(--space-2);
+}
+.right-4 {
+  right: var(--space-4);
+}
+.right-6 {
+  right: var(--space-6);
+}
+.top-0 {
+  top: 0;
+}
+.top-2 {
+  top: var(--space-2);
+}
+.top-20 {
+  top: 5rem;
+}
+.top-4 {
+  top: var(--space-4);
+}
+.z-10 {
+  z-index: 10;
+}
+.z-20 {
+  z-index: 20;
+}
+.z-40 {
+  z-index: 40;
+}
+.z-50 {
+  z-index: 50;
+}
+.col-span-12 {
+  grid-column: span 12 / span 12;
+}
+.col-span-2 {
+  grid-column: span 2 / span 2;
+}
+.col-span-3 {
+  grid-column: span 3 / span 3;
+}
+.col-span-full {
+  grid-column: 1/-1;
+}
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+.my-4 {
+  margin-top: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+.-mb-px {
+  margin-bottom: -1px;
+}
+.mb-0 {
+  margin-bottom: 0;
+}
+.mb-1 {
+  margin-bottom: var(--space-1);
+}
+.mb-10 {
+  margin-bottom: 2.5rem;
+}
+.mb-2 {
+  margin-bottom: var(--space-2);
+}
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+.mb-4 {
+  margin-bottom: var(--space-4);
+}
+.mb-6 {
+  margin-bottom: var(--space-6);
+}
+.mb-8 {
+  margin-bottom: var(--space-8);
+}
+.ml-1 {
+  margin-left: var(--space-1);
+}
+.ml-2 {
+  margin-left: var(--space-2);
+}
+.ml-3 {
+  margin-left: 0.75rem;
+}
+.ml-4 {
+  margin-left: var(--space-4);
+}
+.ml-6 {
+  margin-left: var(--space-6);
+}
+.mr-1 {
+  margin-right: var(--space-1);
+}
+.mr-2 {
+  margin-right: var(--space-2);
+}
+.mt-0\.5 {
+  margin-top: var(--space-0-5);
+}
+.mt-1 {
+  margin-top: var(--space-1);
+}
+.mt-2 {
+  margin-top: var(--space-2);
+}
+.mt-3 {
+  margin-top: 0.75rem;
+}
+.mt-4 {
+  margin-top: var(--space-4);
+}
+.mt-6 {
+  margin-top: var(--space-6);
+}
+.mt-8 {
+  margin-top: var(--space-8);
+}
+.block {
+  display: block;
+}
+.inline {
+  display: inline;
+}
+.flex {
+  display: flex;
+}
+.inline-flex {
+  display: inline-flex;
+}
+.\!table {
+  display: table !important;
+}
+.table {
+  display: table;
+}
+.grid {
+  display: grid;
+}
+.hidden {
+  display: none;
+}
+.h-12 {
+  height: 3rem;
+}
+.h-16 {
+  height: 4rem;
+}
+.h-2 {
+  height: var(--space-2);
+}
+.h-24 {
+  height: 6rem;
+}
+.h-3 {
+  height: 0.75rem;
+}
+.h-32 {
+  height: 8rem;
+}
+.h-4 {
+  height: var(--space-4);
+}
+.h-40 {
+  height: 10rem;
+}
+.h-5 {
+  height: 1.25rem;
+}
+.h-6 {
+  height: var(--space-6);
+}
+.h-64 {
+  height: 16rem;
+}
+.h-8 {
+  height: var(--space-8);
+}
+.h-\[38px\] {
+  height: 38px;
+}
+.max-h-60 {
+  max-height: 15rem;
+}
+.max-h-\[90vh\] {
+  max-height: 90vh;
+}
+.max-h-screen {
+  max-height: 100vh;
+}
+.min-h-screen {
+  min-height: 100vh;
+}
+.w-12 {
+  width: 3rem;
+}
+.w-24 {
+  width: 6rem;
+}
+.w-3 {
+  width: 0.75rem;
+}
+.w-32 {
+  width: 8rem;
+}
+.w-4 {
+  width: var(--space-4);
+}
+.w-5 {
+  width: 1.25rem;
+}
+.w-56 {
+  width: 14rem;
+}
+.w-6 {
+  width: var(--space-6);
+}
+.w-64 {
+  width: 16rem;
+}
+.w-8 {
+  width: var(--space-8);
+}
+.w-\[120px\] {
+  width: 120px;
+}
+.w-full {
+  width: 100%;
+}
+.w-max {
+  width: -moz-max-content;
+  width: max-content;
+}
+.max-w-3xl {
+  max-width: 48rem;
+}
+.max-w-4xl {
+  max-width: 56rem;
+}
+.max-w-7xl {
+  max-width: 80rem;
+}
+.max-w-\[480px\] {
+  max-width: 480px;
+}
+.max-w-\[520px\] {
+  max-width: 520px;
+}
+.max-w-\[720px\] {
+  max-width: 720px;
+}
+.max-w-\[860px\] {
+  max-width: 860px;
+}
+.max-w-md {
+  max-width: 28rem;
+}
+.max-w-sm {
+  max-width: 24rem;
+}
+.max-w-xl {
+  max-width: 36rem;
+}
+.max-w-xs {
+  max-width: 20rem;
+}
+.flex-1 {
+  flex: 1 1 0%;
+}
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+.flex-grow {
+  flex-grow: 1;
+}
+.table-auto {
+  table-layout: auto;
+}
+.table-fixed {
+  table-layout: fixed;
+}
+.translate-x-full {
+  --tw-translate-x: 100%;
+}
+.transform,
+.translate-x-full {
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y))
+    rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
+    scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+@keyframes spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+.animate-spin {
+  animation: spin 1s linear infinite;
+}
+.cursor-pointer {
+  cursor: pointer;
+}
+.list-disc {
+  list-style-type: disc;
+}
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+.grid-cols-12 {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+}
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.grid-cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.flex-col {
+  flex-direction: column;
+}
+.flex-wrap {
+  flex-wrap: wrap;
+}
+.items-start {
+  align-items: flex-start;
+}
+.items-end {
+  align-items: flex-end;
+}
+.items-center {
+  align-items: center;
+}
+.justify-start {
+  justify-content: flex-start;
+}
+.justify-end {
+  justify-content: flex-end;
+}
+.justify-center {
+  justify-content: center;
+}
+.justify-between {
+  justify-content: space-between;
+}
+.gap-1 {
+  gap: var(--space-1);
+}
+.gap-2 {
+  gap: var(--space-2);
+}
+.gap-3 {
+  gap: 0.75rem;
+}
+.gap-4 {
+  gap: var(--space-4);
+}
+.gap-6 {
+  gap: var(--space-6);
+}
+.gap-x-4 {
+  -moz-column-gap: var(--space-4);
+  column-gap: var(--space-4);
+}
+.gap-y-2 {
+  row-gap: var(--space-2);
+}
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(var(--space-2) * var(--tw-space-x-reverse));
+  margin-left: calc(var(--space-2) * (1 - var(--tw-space-x-reverse)));
+}
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.75rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.75rem * (1 - var(--tw-space-x-reverse)));
+}
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(var(--space-4) * var(--tw-space-x-reverse));
+  margin-left: calc(var(--space-4) * (1 - var(--tw-space-x-reverse)));
+}
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(var(--space-1) * (1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(var(--space-1) * var(--tw-space-y-reverse));
+}
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(var(--space-2) * (1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(var(--space-2) * var(--tw-space-y-reverse));
+}
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-y-reverse: 0;
+  margin-top: calc(var(--space-8) * (1 - var(--tw-space-y-reverse)));
+  margin-bottom: calc(var(--space-8) * var(--tw-space-y-reverse));
+}
+.overflow-x-auto {
+  overflow-x: auto;
+}
+.overflow-y-auto {
+  overflow-y: auto;
+}
+.whitespace-normal {
+  white-space: normal;
+}
+.break-words {
+  overflow-wrap: break-word;
+}
+.rounded {
+  border-radius: 0.25rem;
+}
+.rounded-full {
+  border-radius: 9999px;
+}
+.rounded-lg {
+  border-radius: 0.5rem;
+}
+.rounded-md {
+  border-radius: 0.375rem;
+}
+.rounded-t-lg {
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+.border {
+  border-width: 1px;
+}
+.border-2 {
+  border-width: 2px;
+}
+.border-4 {
+  border-width: 4px;
+}
+.border-b {
+  border-bottom-width: 1px;
+}
+.border-b-2 {
+  border-bottom-width: 2px;
+}
+.border-l {
+  border-left-width: 1px;
+}
+.border-t {
+  border-top-width: 1px;
+}
+.border-dashed {
+  border-style: dashed;
+}
+.border-blue-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(37 99 235 / var(--tw-border-opacity, 1));
+}
+.border-border {
+  --tw-border-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-border-opacity, 1));
+}
+.border-danger {
+  --tw-border-opacity: 1;
+  border-color: rgb(220 38 38 / var(--tw-border-opacity, 1));
+}
+.border-form-border {
+  --tw-border-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-border-opacity, 1));
+}
+.border-gray-100 {
+  --tw-border-opacity: 1;
+  border-color: rgb(243 244 246 / var(--tw-border-opacity, 1));
+}
+.border-gray-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+}
+.border-gray-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
+}
+.border-primary {
+  --tw-border-opacity: 1;
+  border-color: rgb(37 99 235 / var(--tw-border-opacity, 1));
+}
+.border-transparent {
+  border-color: transparent;
+}
+.border-white {
+  --tw-border-opacity: 1;
+  border-color: rgb(255 255 255 / var(--tw-border-opacity, 1));
+}
+.border-yellow-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(254 240 138 / var(--tw-border-opacity, 1));
+}
+.border-t-transparent {
+  border-top-color: transparent;
+}
+.bg-black\/25 {
+  background-color: rgba(0, 0, 0, 0.25);
+}
+.bg-black\/50 {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+.bg-blue-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(219 234 254 / var(--tw-bg-opacity, 1));
+}
+.bg-blue-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(59 130 246 / var(--tw-bg-opacity, 1));
+}
+.bg-blue-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+}
+.bg-body,
+.bg-form-bg {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+}
+.bg-gray-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
+}
+.bg-gray-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+}
+.bg-green-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(240 253 244 / var(--tw-bg-opacity, 1));
+}
+.bg-green-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(34 197 94 / var(--tw-bg-opacity, 1));
+}
+.bg-primary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(37 99 235 / var(--tw-bg-opacity, 1));
+}
+.bg-red-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 68 68 / var(--tw-bg-opacity, 1));
+}
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+}
+.bg-yellow-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 252 232 / var(--tw-bg-opacity, 1));
+}
+.bg-yellow-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(234 179 8 / var(--tw-bg-opacity, 1));
+}
+.object-cover {
+  -o-object-fit: cover;
+  object-fit: cover;
+}
+.p-2 {
+  padding: var(--space-2);
+}
+.p-3 {
+  padding: 0.75rem;
+}
+.p-4 {
+  padding: var(--space-4);
+}
+.p-6 {
+  padding: var(--space-6);
+}
+.p-8 {
+  padding: var(--space-8);
+}
+.px-2 {
+  padding-left: var(--space-2);
+  padding-right: var(--space-2);
+}
+.px-3 {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+.px-4 {
+  padding-left: var(--space-4);
+  padding-right: var(--space-4);
+}
+.px-6 {
+  padding-left: var(--space-6);
+  padding-right: var(--space-6);
+}
+.py-1 {
+  padding-top: var(--space-1);
+  padding-bottom: var(--space-1);
+}
+.py-10 {
+  padding-top: 2.5rem;
+  padding-bottom: 2.5rem;
+}
+.py-2 {
+  padding-top: var(--space-2);
+  padding-bottom: var(--space-2);
+}
+.py-3 {
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+.pl-10 {
+  padding-left: 2.5rem;
+}
+.pl-3 {
+  padding-left: 0.75rem;
+}
+.pl-5 {
+  padding-left: 1.25rem;
+}
+.pr-4 {
+  padding-right: var(--space-4);
+}
+.text-left {
+  text-align: left;
+}
+.text-center {
+  text-align: center;
+}
+.text-right {
+  text-align: right;
+}
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+.text-4xl {
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+}
+.text-badge {
+  font-size: clamp(0.8rem, 0.3vw + 0.7rem, 1rem);
+  line-height: 1;
+}
+.text-base {
+  font-size: clamp(1rem, 0.5vw + 0.9rem, 1.25rem);
+  line-height: 1.5;
+}
+.text-h1 {
+  font-size: clamp(1.6rem, 1vw + 1.3rem, 2.5rem);
+  line-height: 1.25;
+}
+.text-h2 {
+  font-size: clamp(1.3rem, 0.75vw + 1.1rem, 2rem);
+  line-height: 1.3;
+}
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+.font-bold {
+  font-weight: 700;
+}
+.font-medium {
+  font-weight: 500;
+}
+.font-semibold {
+  font-weight: 600;
+}
+.leading-none {
+  line-height: 1;
+}
+.text-blue-600 {
+  --tw-text-opacity: 1;
+  color: rgb(37 99 235 / var(--tw-text-opacity, 1));
+}
+.text-blue-800 {
+  --tw-text-opacity: 1;
+  color: rgb(30 64 175 / var(--tw-text-opacity, 1));
+}
+.text-bodyText,
+.text-form-text {
+  --tw-text-opacity: 1;
+  color: rgb(17 24 39 / var(--tw-text-opacity, 1));
+}
+.text-gray-400 {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+.text-gray-500 {
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+.text-gray-600 {
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+}
+.text-gray-700 {
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+.text-gray-900 {
+  --tw-text-opacity: 1;
+  color: rgb(17 24 39 / var(--tw-text-opacity, 1));
+}
+.text-green-600 {
+  --tw-text-opacity: 1;
+  color: rgb(22 163 74 / var(--tw-text-opacity, 1));
+}
+.text-green-700 {
+  --tw-text-opacity: 1;
+  color: rgb(21 128 61 / var(--tw-text-opacity, 1));
+}
+.text-navText {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+.text-primary {
+  --tw-text-opacity: 1;
+  color: rgb(37 99 235 / var(--tw-text-opacity, 1));
+}
+.text-red-600 {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity, 1));
+}
+.text-red-700 {
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
+}
+.text-secondary {
+  --tw-text-opacity: 1;
+  color: rgb(21 128 61 / var(--tw-text-opacity, 1));
+}
+.text-white {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+.text-yellow-600 {
+  --tw-text-opacity: 1;
+  color: rgb(202 138 4 / var(--tw-text-opacity, 1));
+}
+.text-yellow-700 {
+  --tw-text-opacity: 1;
+  color: rgb(161 98 7 / var(--tw-text-opacity, 1));
+}
+.text-yellow-800 {
+  --tw-text-opacity: 1;
+  color: rgb(133 77 14 / var(--tw-text-opacity, 1));
+}
+.opacity-0 {
+  opacity: 0;
+}
+.opacity-70 {
+  opacity: 0.7;
+}
+.shadow {
+  --tw-shadow:
+    0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
+  --tw-shadow-colored:
+    0 1px 3px 0 var(--tw-shadow-color), 0 1px 2px -1px var(--tw-shadow-color);
+}
+.shadow,
+.shadow-lg {
+  box-shadow:
+    var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow);
+}
+.shadow-lg {
+  --tw-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+  --tw-shadow-colored:
+    0 10px 15px -3px var(--tw-shadow-color),
+    0 4px 6px -4px var(--tw-shadow-color);
+}
+.shadow-md {
+  --tw-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  --tw-shadow-colored:
+    0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+}
+.shadow-md,
+.shadow-sm {
+  box-shadow:
+    var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow);
+}
+.shadow-sm {
+  --tw-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+}
+.ring-1 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow:
+    var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+}
+.ring-black {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(0 0 0 / var(--tw-ring-opacity, 1));
+}
+.ring-opacity-5 {
+  --tw-ring-opacity: 0.05;
+}
+.blur {
+  --tw-blur: blur(8px);
+}
+.blur,
+.filter {
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast)
+    var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate)
+    var(--tw-sepia) var(--tw-drop-shadow);
+}
+.transition-all {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 0.15s;
+}
+.transition-transform {
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 0.15s;
+}
+.duration-200 {
+  transition-duration: 0.2s;
+}
+.duration-300 {
+  transition-duration: 0.3s;
+}
+.text-xs {
+  font-size: clamp(
+    0.8680555555555557rem,
+    calc(0.86257rem + 0.02741vw),
+    0.8888888888888888rem
+  );
+  line-height: 1.6;
+}
+.text-sm {
+  font-size: clamp(1rem, calc(0.98904rem + 0.05482vw), 1.0416666666666667rem);
+  line-height: 1.6;
+}
+.text-base {
+  font-size: clamp(1.125rem, calc(1.09211rem + 0.16447vw), 1.25rem);
+  line-height: 1.6;
+}
+.text-lg {
+  font-size: clamp(1.265625rem, calc(1.20395rem + 0.30839vw), 1.5rem);
+  line-height: 1.6;
+}
+.text-xl {
+  font-size: clamp(
+    1.423828125rem,
+    calc(1.32484rem + 0.49496vw),
+    1.7999999999999998rem
+  );
+  line-height: 1.2;
+}
+.text-2xl {
+  font-size: clamp(
+    1.601806640625rem,
+    calc(1.45491rem + 0.73446vw),
+    2.1599999999999997rem
+  );
+  line-height: 1.2;
+}
+.text-4xl {
+  font-size: clamp(
+    2.0272865295410156rem,
+    calc(1.74226rem + 1.42515vw),
+    3.1103999999999994rem
+  );
+  line-height: 1.1;
+}
+@media (prefers-reduced-motion: reduce) {
+  *,
+  :after,
+  :before {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}
+@media (max-width: 768px) {
+  h1 {
+    font-size: clamp(1.6rem, 1vw + 1.3rem, 2.5rem);
+    line-height: 1.25;
+  }
+  h2 {
+    font-size: clamp(1.3rem, 0.75vw + 1.1rem, 2rem);
+    line-height: 1.3;
+  }
+  .badge-error,
+  .badge-success,
+  .badge-warning {
+    font-size: clamp(0.8rem, 0.3vw + 0.7rem, 1rem);
+    line-height: 1;
+    padding: var(--space-0-5) var(--space-1);
+  }
+}
+@media (min-width: 768px) {
+  .md\:hidden {
+    display: none !important;
+  }
+}
+@media (max-width: 639px) {
+  .max-sm\:p-2 {
+    padding: 0.5rem;
+  }
+}
+.first\:border-t-0:first-child {
+  border-top-width: 0;
+}
+.last\:border-b-0:last-child {
+  border-bottom-width: 0;
+}
+.odd\:bg-gray-50:nth-child(odd) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+}
+.odd\:bg-white:nth-child(odd) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+}
+.even\:bg-gray-50:nth-child(2n) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+}
+.hover\:-translate-y-1:hover {
+  --tw-translate-y: calc(var(--space-1) * -1);
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y))
+    rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
+    scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+.hover\:bg-blue-50:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
+}
+.hover\:bg-gray-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
+}
+.hover\:text-blue-600:hover {
+  --tw-text-opacity: 1;
+  color: rgb(37 99 235 / var(--tw-text-opacity, 1));
+}
+.hover\:text-gray-600:hover {
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+}
+.hover\:text-green-600:hover {
+  --tw-text-opacity: 1;
+  color: rgb(22 163 74 / var(--tw-text-opacity, 1));
+}
+.hover\:text-primary:hover {
+  --tw-text-opacity: 1;
+  color: rgb(37 99 235 / var(--tw-text-opacity, 1));
+}
+.hover\:text-red-600:hover {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity, 1));
+}
+.hover\:text-yellow-600:hover {
+  --tw-text-opacity: 1;
+  color: rgb(202 138 4 / var(--tw-text-opacity, 1));
+}
+.hover\:underline:hover {
+  text-decoration-line: underline;
+}
+.hover\:opacity-100:hover {
+  opacity: 1;
+}
+.hover\:shadow-xl:hover {
+  --tw-shadow:
+    0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+  --tw-shadow-colored:
+    0 20px 25px -5px var(--tw-shadow-color),
+    0 8px 10px -6px var(--tw-shadow-color);
+  box-shadow:
+    var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow);
+}
+.focus\:border-transparent:focus {
+  border-color: transparent;
+}
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+.focus\:ring-2:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
+    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
+    calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow:
+    var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
+    var(--tw-shadow, 0 0 #0000);
+}
+.focus\:ring-blue-500:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
+}
+.focus\:ring-primary:focus {
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(37 99 235 / var(--tw-ring-opacity, 1));
+}
+@media (min-width: 640px) {
+  .sm\:w-64 {
+    width: 16rem;
+  }
+  .sm\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .sm\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .sm\:flex-row {
+    flex-direction: row;
+  }
+  .sm\:items-end {
+    align-items: flex-end;
+  }
+  .sm\:px-6 {
+    padding-left: var(--space-6);
+    padding-right: var(--space-6);
+  }
+}
+@media (min-width: 768px) {
+  .md\:col-span-3 {
+    grid-column: span 3 / span 3;
+  }
+  .md\:mt-0 {
+    margin-top: 0;
+  }
+  .md\:block {
+    display: block;
+  }
+  .md\:hidden {
+    display: none;
+  }
+  .md\:w-64 {
+    width: 16rem;
+  }
+  .md\:w-auto {
+    width: auto;
+  }
+  .md\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .md\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .md\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .md\:flex-row {
+    flex-direction: row;
+  }
+  .md\:items-end {
+    align-items: flex-end;
+  }
+  .md\:justify-end {
+    justify-content: flex-end;
+  }
+}
+@media (min-width: 1024px) {
+  .lg\:block {
+    display: block;
+  }
+  .lg\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .lg\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .lg\:grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+  .lg\:px-8 {
+    padding-left: var(--space-8);
+    padding-right: var(--space-8);
+  }
+}
+@media (max-width: 639px) {
+  .max-sm\:max-w-md {
+    max-width: 28rem;
+  }
+  .max-sm\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .max-sm\:p-2 {
+    padding: var(--space-2);
+  }
+  .max-sm\:p-4 {
+    padding: var(--space-4);
+  }
+}
+@media (max-width: 767px) {
+  .max-md\:max-w-xl {
+    max-width: 36rem;
+  }
+  .max-md\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .max-md\:overflow-x-auto {
+    overflow-x: auto;
+  }
+}
+@media (max-width: 1023px) {
+  .max-lg\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .max-lg\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}

--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -121,7 +121,7 @@
       stockCell.innerHTML = `<input type="number" step="0.01" name="current_stock" class="form-input" value="${escapeHtml(currentStock)}" placeholder="0">`;
     ropCell.innerHTML = `<input type="number" step="0.01" name="reorder_point" class="form-input" value="${escapeHtml(currentRop)}">`;
     statusCell.innerHTML = `<label class="inline-flex items-center gap-2"><input type="checkbox" name="is_active" ${isActive ? "checked" : ""} class="form-checkbox"><span>Active</span></label>`;
-    actionsCell.innerHTML = `<div class="flex items-center" style="gap:.25rem"><button type="button" data-action="save-row" class="btn-primary btn-sm">Save</button><button type="button" data-action="cancel-row" class="btn-secondary btn-sm">Cancel</button></div>`;
+    actionsCell.innerHTML = `<div class="flex items-center" style="gap:.25rem"><button type="button" data-action="save-row" class="btn btn-primary btn-sm">Save</button><button type="button" data-action="cancel-row" class="btn btn-secondary btn-sm">Cancel</button></div>`;
   }
 
   function restoreRow(row) {
@@ -624,8 +624,8 @@
       const order = btn.classList.contains("asc")
         ? "ascending"
         : btn.classList.contains("desc")
-        ? "descending"
-        : "none";
+          ? "descending"
+          : "none";
       thead
         .querySelectorAll("th[aria-sort]")
         .forEach((h) => h.setAttribute("aria-sort", "none"));
@@ -679,7 +679,7 @@
       window.location.assign(url.toString());
     } else if (action === "deactivate") {
       const html = `
-        <div class=\"card\" style=\"max-width:420px\">\n          <div class=\"card-header\"><strong>Deactivate ${ids.length} item(s)?</strong></div>\n          <div class=\"card-body\">\n            <p class=\"mb-3\">Items will be marked Inactive. You can reactivate later.</p>\n            <div class=\"flex\" style=\"gap:.5rem; justify-content:flex-end\">\n              <button type=\"button\" class=\"btn-secondary\" data-modal-close>Cancel</button>\n              <button type=\"button\" class=\"btn-primary\" data-action=\"confirm-bulk\" data-action-type=\"deactivate\">Confirm</button>\n            </div>\n          </div>\n        </div>`;
+        <div class=\"card\" style=\"max-width:420px\">\n          <div class=\"card-header\"><strong>Deactivate ${ids.length} item(s)?</strong></div>\n          <div class=\"card-body\">\n            <p class=\"mb-3\">Items will be marked Inactive. You can reactivate later.</p>\n            <div class=\"flex\" style=\"gap:.5rem; justify-content:flex-end\">\n              <button type=\"button\" class=\"btn btn-secondary\" data-modal-close>Cancel</button>\n              <button type=\"button\" class=\"btn btn-primary\" data-action=\"confirm-bulk\" data-action-type=\"deactivate\">Confirm</button>\n            </div>\n          </div>\n        </div>`;
       if (window.modal) window.modal.open(html);
     } else if (action === "assign") {
       const tpl = document.getElementById("dept-select-template");
@@ -690,7 +690,7 @@
           )
         : '<input id=\"bulk-dept-select\" placeholder=\"Dept ID\">';
       const html = `
-        <div class=\"card\" style=\"max-width:480px\">\n          <div class=\"card-header\"><strong>Assign Department</strong></div>\n          <div class=\"card-body\">\n            <label class=\"form-label\">Department</label>\n            ${selectHtml}\n            <div class=\"mt-3 flex\" style=\"gap:.5rem; justify-content:flex-end\">\n              <button type=\"button\" class=\"btn-secondary\" data-modal-close>Cancel</button>\n              <button type=\"button\" class=\"btn-primary\" data-action=\"confirm-bulk\" data-action-type=\"assign_dept\">Assign</button>\n            </div>\n          </div>\n        </div>`;
+        <div class=\"card\" style=\"max-width:480px\">\n          <div class=\"card-header\"><strong>Assign Department</strong></div>\n          <div class=\"card-body\">\n            <label class=\"form-label\">Department</label>\n            ${selectHtml}\n            <div class=\"mt-3 flex\" style=\"gap:.5rem; justify-content:flex-end\">\n              <button type=\"button\" class=\"btn btn-secondary\" data-modal-close>Cancel</button>\n              <button type=\"button\" class=\"btn btn-primary\" data-action=\"confirm-bulk\" data-action-type=\"assign_dept\">Assign</button>\n            </div>\n          </div>\n        </div>`;
       if (window.modal) window.modal.open(html);
     }
   });

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -50,7 +50,7 @@
 
   .dept-chip {
     /* Reuse shared success button styling for consistent look and spacing */
-    @apply btn-success btn-sm inline-flex items-center gap-2;
+    @apply btn btn-success btn-sm gap-2;
   }
 
   /* Modern Corporate Design System */
@@ -89,148 +89,29 @@
   }
 
   /* Button System */
+  .btn {
+    @apply inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed;
+  }
   .btn-primary {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.5rem 0.875rem;
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: #fff;
-    background-color: theme("colors.primary");
-    border: 1px solid transparent;
-    border-radius: 0.375rem;
-    text-decoration: none;
-    transition: all 0.15s ease;
-    cursor: pointer;
+    @apply bg-primary text-white hover:bg-blue-700 focus:ring-2 focus:ring-primary;
   }
-  .btn-primary:hover {
-    background-color: #1d4ed8;
-    color: white;
-  }
-  .btn-primary:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.5);
-  }
-  .btn-primary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
   .btn-secondary {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.5rem 0.875rem;
-    font-size: 0.85rem;
-    font-weight: 500;
-    color: #374151;
-    background-color: #fff;
-    border: 1px solid theme("colors.border");
-    border-radius: 0.375rem;
-    text-decoration: none;
-    transition: all 0.15s ease;
-    cursor: pointer;
+    @apply bg-white text-gray-700 border border-border hover:bg-gray-50 focus:ring-2 focus:ring-primary;
   }
-  .btn-secondary:hover {
-    background-color: #f9fafb;
-    color: #374151;
-  }
-  .btn-secondary:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.5);
-  }
-  .btn-secondary:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
   .btn-success {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: white;
-    background-color: #059669;
-    border: 1px solid transparent;
-    border-radius: 0.5rem;
-    text-decoration: none;
-    transition: all 0.2s ease;
-    cursor: pointer;
+    @apply bg-green-600 text-white hover:bg-green-700 focus:ring-2 focus:ring-green-600;
   }
-  .btn-success:hover {
-    background-color: #047857;
-    color: white;
-  }
-  .btn-success:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(5, 150, 105, 0.5);
-  }
-  .btn-success:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
   .btn-danger {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: white;
-    background-color: #dc2626;
-    border: 1px solid transparent;
-    border-radius: 0.5rem;
-    text-decoration: none;
-    transition: all 0.2s ease;
-    cursor: pointer;
+    @apply bg-danger text-white hover:bg-red-700 focus:ring-2 focus:ring-danger;
   }
-  .btn-danger:hover {
-    background-color: #b91c1c;
-    color: white;
-  }
-  .btn-danger:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.5);
-  }
-  .btn-danger:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
   .btn-sm {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.75rem;
+    @apply px-3 py-1.5 text-xs;
   }
   .btn-lg {
-    padding: 0.75rem 1.5rem;
-    font-size: 1rem;
+    @apply px-6 py-3 text-base;
   }
-
   .btn-square {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2rem;
-    height: 2rem;
-    padding: 0.25rem;
-    font-size: 0.75rem;
-    color: #374151;
-    background-color: #fff;
-    border: 1px solid theme("colors.border");
-    border-radius: 0.375rem;
-    transition: all 0.15s ease;
-  }
-  .btn-square:hover {
-    background-color: #f9fafb;
-    color: #374151;
-  }
-  .btn-square:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.5);
-  }
-  .btn-square:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+    @apply justify-center w-8 h-8 p-0 bg-white text-gray-700 border border-border hover:bg-gray-50 focus:ring-2 focus:ring-primary;
   }
 
   /* Form Controls */
@@ -380,13 +261,6 @@
     top: 100%;
     margin-top: 0.25rem;
     z-index: 10;
-  }
-
-  /* Button styles */
-  .btn-primary,
-  .btn-secondary,
-  .btn-danger {
-    box-shadow: var(--shadow-btn);
   }
 
   /* Navigation button styles */

--- a/templates/components/button.html
+++ b/templates/components/button.html
@@ -4,7 +4,7 @@ Supported variants: primary, secondary, danger, icon, etc.
 Optional `extra_classes` to append additional Tailwind classes.
 {% endcomment %}
 {% if href %}
-<a href="{{ href }}" id="{{ id }}" class="btn-{{ variant|default:'primary' }} {{ extra_classes }}">{{ label }}</a>
+<a href="{{ href }}" id="{{ id }}" class="btn btn-{{ variant|default:'primary' }} {{ extra_classes }}">{{ label }}</a>
 {% else %}
-<button id="{{ id }}" name="{{ name }}" type="{{ type|default:'button' }}" class="btn-{{ variant|default:'primary' }} {{ extra_classes }}">{{ label }}</button>
+<button id="{{ id }}" name="{{ name }}" type="{{ type|default:'button' }}" class="btn btn-{{ variant|default:'primary' }} {{ extra_classes }}">{{ label }}</button>
 {% endif %}

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -8,5 +8,5 @@
   {% endif %}
   <h2 class="text-h2 mb-4 mt-8">{{ title }}</h2>
   <p class="mb-4 text-form-text">{{ message }}</p>
-  <a href="{{ cta_url }}" class="btn-primary">{{ cta_label }}</a>
+  <a href="{{ cta_url }}" class="btn btn-primary">{{ cta_label }}</a>
 </div>

--- a/templates/components/filter_bar.html
+++ b/templates/components/filter_bar.html
@@ -42,7 +42,7 @@
     {% if export_url %}
       <div class="flex flex-col">
         <span class="text-sm font-medium">&nbsp;</span>
-        <button type="submit" {% if export_param_name and export_param_value %}name="{{ export_param_name }}" value="{{ export_param_value }}"{% endif %} formaction="{{ export_url }}" formmethod="get" class="btn-secondary w-full">{{ export_label|default:'Export' }}</button>
+        <button type="submit" {% if export_param_name and export_param_value %}name="{{ export_param_name }}" value="{{ export_param_value }}"{% endif %} formaction="{{ export_url }}" formmethod="get" class="btn btn-secondary w-full">{{ export_label|default:'Export' }}</button>
       </div>
     {% endif %}
   </div>
@@ -52,7 +52,7 @@
   {% if direction %}<input type="hidden" name="direction" value="{{ direction|default:'asc' }}">{% endif %}
   <noscript>
     <div class="mt-2">
-      <button type="submit" class="btn-primary">Apply</button>
+      <button type="submit" class="btn btn-primary">Apply</button>
     </div>
   </noscript>
 </form>

--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -15,8 +15,8 @@
     {% endif %}
     {% block fields %}{% endblock %}
     <div class="flex gap-2">
-      <button type="submit" class="btn-primary">{% block submit_text %}Save{% endblock %}</button>
-      <a href="{% block back_url %}{% endblock %}" class="btn-secondary">{% block back_text %}Cancel{% endblock %}</a>
+      <button type="submit" class="btn btn-primary">{% block submit_text %}Save{% endblock %}</button>
+      <a href="{% block back_url %}{% endblock %}" class="btn btn-secondary">{% block back_text %}Cancel{% endblock %}</a>
     </div>
   </form>
   {% block extra %}{% endblock %}

--- a/templates/components/image_uploader.html
+++ b/templates/components/image_uploader.html
@@ -5,5 +5,5 @@
     <img src="{{ image_url }}" alt="Current thumbnail" class="h-24 w-24 object-cover rounded" />
   {% endif %}
   <input type="file" name="thumbnail" id="id_thumbnail" accept="image/*" class="block" />
-  <button type="submit" class="btn-secondary">Upload</button>
+  <button type="submit" class="btn btn-secondary">Upload</button>
 </form>

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -9,7 +9,7 @@
       {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}
-      <button type="submit" class="btn-primary w-full">Login</button>
+      <button type="submit" class="btn btn-primary w-full">Login</button>
     </form>
   </div>
 </div>

--- a/templates/components/pagination.html
+++ b/templates/components/pagination.html
@@ -3,7 +3,7 @@
     {% if page_obj.has_previous %}
       <a href="{{ base_url }}?page={{ page_obj.previous_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}"
          {% if hx_target %}hx-get="{{ base_url }}?page={{ page_obj.previous_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
-         class="btn-secondary btn-sm" aria-label="Previous page">Prev</a>
+         class="btn btn-secondary btn-sm" aria-label="Previous page">Prev</a>
     {% endif %}
     {% for num in page_obj.paginator.page_range %}
       {% if num == page_obj.number %}
@@ -11,13 +11,13 @@
       {% else %}
         <a href="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}"
            {% if hx_target %}hx-get="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
-           class="btn-secondary btn-sm">{{ num }}</a>
+           class="btn btn-secondary btn-sm">{{ num }}</a>
       {% endif %}
     {% endfor %}
     {% if page_obj.has_next %}
       <a href="{{ base_url }}?page={{ page_obj.next_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}"
          {% if hx_target %}hx-get="{{ base_url }}?page={{ page_obj.next_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
-         class="btn-secondary btn-sm" aria-label="Next page">Next</a>
+         class="btn btn-secondary btn-sm" aria-label="Next page">Next</a>
     {% endif %}
     <span class="ml-2">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
   </div>

--- a/templates/inventory/_add_item_section.html
+++ b/templates/inventory/_add_item_section.html
@@ -88,8 +88,8 @@
       <!-- Actions below Advanced -->
       <div class="col-span-12">
         <div class="form-actions">
-          <button type="reset" class="btn-secondary btn-sm">Clear</button>
-          <button type="submit" class="btn-primary btn-sm">Create</button>
+          <button type="reset" class="btn btn-secondary btn-sm">Clear</button>
+          <button type="submit" class="btn btn-primary btn-sm">Create</button>
         </div>
       </div>
     </div>

--- a/templates/inventory/_adjust_form.html
+++ b/templates/inventory/_adjust_form.html
@@ -16,6 +16,6 @@
     {% endif %}
   {% endfor %}
   <div class="col-span-2">
-    <button type="submit" name="submit_adjust" class="btn-primary">Record</button>
+    <button type="submit" name="submit_adjust" class="btn btn-primary">Record</button>
   </div>
 </form>

--- a/templates/inventory/_bulk_upload_partial.html
+++ b/templates/inventory/_bulk_upload_partial.html
@@ -1,7 +1,7 @@
 <div class="card drawer-panel max-w-[520px]">
   <div class="card-header flex items-center justify-between">
     <h3 class="text-lg font-semibold">{{ title|default:"Bulk Upload Items" }}</h3>
-    <button type="button" class="btn-secondary btn-sm" data-modal-close>Close</button>
+    <button type="button" class="btn btn-secondary btn-sm" data-modal-close>Close</button>
   </div>
   <div class="card-body">
     {% if upload_url %}
@@ -18,8 +18,8 @@
         {% include "forms/feedback.html" %}
       </div>
       <div class="flex items-center justify-end gap-2">
-        <button type="button" class="btn-secondary" data-modal-close>Cancel</button>
-        <button type="submit" class="btn-primary">Upload</button>
+        <button type="button" class="btn btn-secondary" data-modal-close>Cancel</button>
+        <button type="submit" class="btn btn-primary">Upload</button>
       </div>
     </form>
     <p class="text-sm text-gray-600 mt-3">{{ help_text|default:"CSV must include headers compatible with the item form fields." }}</p>

--- a/templates/inventory/_indent_items_form_table.html
+++ b/templates/inventory/_indent_items_form_table.html
@@ -15,7 +15,7 @@
     <td>{% include "components/form_field.html" with field=item_form.item %}</td>
     <td>{% include "components/form_field.html" with field=item_form.requested_qty %}</td>
     <td>{% include "components/form_field.html" with field=item_form.notes %}</td>
-    <td><button type="button" class="remove-row btn-danger">Remove</button></td>
+    <td><button type="button" class="remove-row btn btn-danger">Remove</button></td>
   </tr>
   {% endfor %}
 {% endblock %}

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -34,7 +34,7 @@
   <tr>
     <td colspan="6" class="px-4 py-2 text-center">
       0 indents yet.
-      <a href="{% url 'indent_create' %}" class="btn-primary ml-2">New Indent</a>
+      <a href="{% url 'indent_create' %}" class="btn btn-primary ml-2">New Indent</a>
     </td>
   </tr>
   {% endfor %}

--- a/templates/inventory/_item_create_partial.html
+++ b/templates/inventory/_item_create_partial.html
@@ -1,7 +1,7 @@
 <div class="card drawer-panel max-w-[860px]">
   <div class="card-header flex items-center justify-between">
     <h3 class="text-lg font-semibold">Add New Item</h3>
-    <button type="button" class="btn-secondary btn-sm" data-modal-close>Close</button>
+    <button type="button" class="btn btn-secondary btn-sm" data-modal-close>Close</button>
   </div>
   <div class="card-body">
     <form method="post" data-modal-form action="{% url 'items_list' %}">
@@ -69,8 +69,8 @@
             {% include "forms/feedback.html" %}
           </div>
           <div>
-            <button type="button" class="btn-secondary" data-modal-close>Cancel</button>
-            <button type="submit" class="btn-primary">Create</button>
+            <button type="button" class="btn btn-secondary" data-modal-close>Cancel</button>
+            <button type="submit" class="btn btn-primary">Create</button>
           </div>
         </div>
       </div>

--- a/templates/inventory/_item_detail_partial.html
+++ b/templates/inventory/_item_detail_partial.html
@@ -2,7 +2,7 @@
 <div class="card max-w-[720px]">
   <div class="card-header flex items-center justify-between">
     <div class="font-semibold">{{ item.name }}</div>
-    <button type="button" data-modal-close class="btn-square" title="Close" aria-label="Close">
+    <button type="button" data-modal-close class="btn btn-square" title="Close" aria-label="Close">
       {% icon 'x-mark' 'w-4 h-4' %}
     </button>
   </div>

--- a/templates/inventory/_item_form_partial.html
+++ b/templates/inventory/_item_form_partial.html
@@ -1,7 +1,7 @@
 <div class="card drawer-panel max-w-[860px] max-h-[90vh] overflow-y-auto">
   <div class="card-header flex items-center justify-between">
     <h3 class="text-lg font-semibold">Edit Item — {{ item.name }}</h3>
-    <button type="button" class="btn-secondary btn-sm" data-modal-close>Close</button>
+    <button type="button" class="btn btn-secondary btn-sm" data-modal-close>Close</button>
   </div>
   <div class="card-body">
     <form method="post" data-modal-form action="{% url 'item_edit' item.item_id %}?partial=1">
@@ -90,8 +90,8 @@
         <!-- Actions -->
         <div class="col-span-12">
           <div class="form-actions">
-            <button type="button" class="btn-secondary" data-modal-close>Cancel</button>
-            <button type="submit" class="btn-primary">Save</button>
+            <button type="button" class="btn btn-secondary" data-modal-close>Cancel</button>
+            <button type="submit" class="btn btn-primary">Save</button>
           </div>
         </div>
       </div>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -187,7 +187,7 @@
           <button
             type="button"
             data-action="quick-edit"
-            class="btn-square btn-sm text-gray-400 hover:text-blue-600"
+            class="btn btn-square btn-sm text-gray-400 hover:text-blue-600"
             title="Quick Edit"
             aria-label="Quick edit {{ item.name }}"
           >
@@ -196,7 +196,7 @@
           <a
             href="{% url 'item_edit' item.item_id %}"
             data-modal-url="{% url 'item_edit' item.item_id %}?partial=1"
-            class="btn-square btn-sm text-gray-400 hover:text-blue-600"
+            class="btn btn-square btn-sm text-gray-400 hover:text-blue-600"
             title="Edit"
             aria-label="Edit {{ item.name }}"
           >
@@ -206,7 +206,7 @@
             href="{% url 'item_detail' item.item_id %}"
             data-action="view"
             data-href="{% url 'item_detail' item.item_id %}?partial=1"
-            class="btn-square btn-sm text-gray-400 hover:text-green-600"
+            class="btn btn-square btn-sm text-gray-400 hover:text-green-600"
             title="View Details"
             aria-label="View details {{ item.name }}"
           >
@@ -215,7 +215,7 @@
           <button
             type="button"
             data-action="archive"
-            class="btn-square btn-sm text-gray-400 hover:text-yellow-600"
+            class="btn btn-square btn-sm text-gray-400 hover:text-yellow-600"
             title="{% if item.is_active %}Archive{% else %}Activate{% endif %}"
             aria-label="{% if item.is_active %}Archive{% else %}Activate{% endif %} {{ item.name }}"
           >
@@ -223,7 +223,7 @@
           </button>
           <button
             type="button"
-            class="btn-square btn-sm text-gray-400 hover:text-red-600"
+            class="btn btn-square btn-sm text-gray-400 hover:text-red-600"
             title="Delete"
             aria-label="Delete {{ item.name }}"
             data-action="delete"

--- a/templates/inventory/_quick_indent_form.html
+++ b/templates/inventory/_quick_indent_form.html
@@ -9,7 +9,7 @@
       {% endfor %}
     </div>
     <div class="mt-4">
-      <button type="submit" class="btn-primary">Submit</button>
+      <button type="submit" class="btn btn-primary">Submit</button>
     </div>
   </form>
 {% endblock %}

--- a/templates/inventory/_supplier_form_collapsible.html
+++ b/templates/inventory/_supplier_form_collapsible.html
@@ -9,8 +9,8 @@
       {% endfor %}
     </div>
     <div class="form-actions mt-4">
-      <button type="reset" class="btn-secondary btn-sm">Clear</button>
-      <button type="submit" class="btn-primary btn-sm">Create</button>
+      <button type="reset" class="btn btn-secondary btn-sm">Clear</button>
+      <button type="submit" class="btn btn-primary btn-sm">Create</button>
     </div>
   </form>
 {% endblock %}

--- a/templates/inventory/_supplier_form_partial.html
+++ b/templates/inventory/_supplier_form_partial.html
@@ -1,7 +1,7 @@
 <div class="card drawer-panel max-w-[480px]">
   <div class="card-header flex items-center justify-between">
     <h3 class="text-lg font-semibold">{% if is_edit %}Edit Supplier — {{ supplier.name }}{% else %}Add Supplier{% endif %}</h3>
-    <button type="button" class="btn-secondary btn-sm" data-modal-close>Close</button>
+    <button type="button" class="btn btn-secondary btn-sm" data-modal-close>Close</button>
   </div>
   <div class="card-body">
     <form method="post" data-modal-form action="{% if is_edit %}{% url 'supplier_edit' supplier.supplier_id %}?partial=1{% else %}{% url 'supplier_create' %}?partial=1{% endif %}">
@@ -16,8 +16,8 @@
         </div>
         {% endfor %}
         <div class="col-span-2 flex justify-between items-center gap-2">
-          <button type="button" class="btn-secondary" data-modal-close>Cancel</button>
-          <button type="submit" class="btn-primary">{% if is_edit %}Save{% else %}Create{% endif %}</button>
+          <button type="button" class="btn btn-secondary" data-modal-close>Cancel</button>
+          <button type="submit" class="btn btn-primary">{% if is_edit %}Save{% else %}Create{% endif %}</button>
         </div>
       </div>
     </form>

--- a/templates/inventory/_waste_form.html
+++ b/templates/inventory/_waste_form.html
@@ -16,6 +16,6 @@
     {% endif %}
   {% endfor %}
   <div class="col-span-2">
-    <button type="submit" name="submit_waste" class="btn-primary">Record</button>
+    <button type="submit" name="submit_waste" class="btn btn-primary">Record</button>
   </div>
 </form>

--- a/templates/inventory/grns/detail.html
+++ b/templates/inventory/grns/detail.html
@@ -2,7 +2,7 @@
 {% block title %}GRN Detail – Inventory App{% endblock %}
 {% block heading %}GRN {{ grn.pk }}{% endblock %}
 {% block actions %}
-  <a href="{% url 'grn_list' %}" class="btn-secondary">Back</a>
+  <a href="{% url 'grn_list' %}" class="btn btn-secondary">Back</a>
 {% endblock %}
 {% block detail_table %}
   {% include "components/detail_table.html" with rows=rows %}

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -37,7 +37,7 @@
       {% include "forms/feedback.html" %}
     </div>
     <div class="space-y-1">
-      <button type="submit" class="btn-primary w-full">Filter</button>
+      <button type="submit" class="btn btn-primary w-full">Filter</button>
     </div>
   </form>
 {% endblock %}

--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -27,12 +27,12 @@
       <div class="flex gap-2">
         <a
           href="{{ history_url }}{% if query_string %}?{{ query_string }}&{% else %}?{% endif %}export=csv"
-          class="btn-secondary"
+          class="btn btn-secondary"
           >Download CSV</a
         >
         <a
           href="{{ history_url }}{% if query_string %}?{{ query_string }}&{% else %}?{% endif %}export=pdf"
-          class="btn-secondary"
+          class="btn btn-secondary"
           >Download PDF</a
         >
       </div>

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -2,8 +2,8 @@
 {% block title %}Indent Detail – Inventory App{% endblock %}
 {% block heading %}Indent {{ indent.indent_id }}{% endblock %}
 {% block actions %}
-  <a href="{% url 'indent_pdf' indent.indent_id %}" class="btn-secondary">Download PDF</a>
-  <a href="{% url 'indents_list' %}" class="btn-secondary">Back</a>
+  <a href="{% url 'indent_pdf' indent.indent_id %}" class="btn btn-secondary">Download PDF</a>
+  <a href="{% url 'indents_list' %}" class="btn btn-secondary">Back</a>
 {% endblock %}
 {% block detail_table %}
   {% include "components/detail_table.html" with rows=rows %}
@@ -14,15 +14,15 @@
   <div class="mt-4 flex gap-2">
     <form action="{% url 'indent_update_status' indent.indent_id 'PROCESSING' %}" method="post" class="inline">
       {% csrf_token %}
-      <button type="submit" class="btn-secondary">Mark Processing</button>
+      <button type="submit" class="btn btn-secondary">Mark Processing</button>
     </form>
     <form action="{% url 'indent_update_status' indent.indent_id 'COMPLETED' %}" method="post" class="inline">
       {% csrf_token %}
-      <button type="submit" class="btn-secondary">Mark Completed</button>
+      <button type="submit" class="btn btn-secondary">Mark Completed</button>
     </form>
     <form action="{% url 'indent_update_status' indent.indent_id 'CANCELLED' %}" method="post" class="inline">
       {% csrf_token %}
-      <button type="submit" class="btn-danger">Cancel</button>
+      <button type="submit" class="btn btn-danger">Cancel</button>
     </form>
   </div>
 {% endblock %}

--- a/templates/inventory/indent_form.html
+++ b/templates/inventory/indent_form.html
@@ -19,7 +19,7 @@
   {% include "inventory/_indent_items_form_table.html" with formset=formset table_id="items-table" %}
   <datalist id="item-options"></datalist>
   <div>
-    <button type="button" id="add-row" class="btn-secondary mt-2">Add Item</button>
+    <button type="button" id="add-row" class="btn btn-secondary mt-2">Add Item</button>
   </div>
 {% endblock %}
 {% block submit_text %}Submit{% endblock %}

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -6,7 +6,7 @@
 {% block page_heading %}Indents ({{ total_indents }}){% endblock %}
 
 {% block primary_actions %}
-  <a href="{% url 'indent_create' %}" class="btn-primary">New Indent</a>
+  <a href="{% url 'indent_create' %}" class="btn btn-primary">New Indent</a>
 {% endblock %}
 
 {% block filters %}

--- a/templates/inventory/item_detail.html
+++ b/templates/inventory/item_detail.html
@@ -7,14 +7,14 @@
 {% block heading %}{{ item.name }}{% endblock %}
 
 {% block actions %}
-  <a href="{% url 'item_edit' item.item_id %}" class="btn-secondary">Edit</a>
+  <a href="{% url 'item_edit' item.item_id %}" class="btn btn-secondary">Edit</a>
   <form action="{% url 'item_toggle_active' item.item_id %}" method="post" class="inline">
     {% csrf_token %}
-    <button type="submit" class="btn-secondary">
+    <button type="submit" class="btn btn-secondary">
       {% if item.is_active %}Archive{% else %}Activate{% endif %}
     </button>
   </form>
-  <a href="{% url 'item_delete' item.item_id %}" class="btn-danger">Delete</a>
+  <a href="{% url 'item_delete' item.item_id %}" class="btn btn-danger">Delete</a>
 {% endblock %}
 
 {% block detail_table %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -54,7 +54,7 @@
         <div class="relative" data-col-menu-container>
           <button
             type="button"
-            class="btn-square"
+            class="btn btn-square"
             aria-label="Show/Hide Columns"
             title="Show/Hide Columns"
             aria-haspopup="true"
@@ -123,7 +123,7 @@
       <div class="flex flex-wrap items-center gap-2 mt-4 md:mt-0 w-full md:w-auto justify-start md:justify-end">
         <button
           type="button"
-          class="btn-primary"
+          class="btn btn-primary"
           data-modal-url="{% url 'item_create_partial' %}"
           data-modal-type="drawer"
         >
@@ -131,13 +131,13 @@
         </button>
         <button
           type="button"
-          class="btn-secondary"
+          class="btn btn-secondary"
           data-modal-url="{% url 'items_bulk_upload' %}?partial=1"
           data-modal-type="drawer"
         >
           Bulk Upload
         </button>
-        <button type="submit" form="filters" formaction="{{ export_url }}" formmethod="get" class="btn-secondary">Export</button>
+        <button type="submit" form="filters" formaction="{{ export_url }}" formmethod="get" class="btn btn-secondary">Export</button>
       </div>
     </div>
   </div>
@@ -164,13 +164,13 @@
   <div class="flex items-center gap-2">
     {% if page_obj.has_previous %}
       <a href="?page={{ page_obj.previous_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.category %}&category={{ request.GET.category }}{% endif %}{% if request.GET.stock_status %}&stock_status={{ request.GET.stock_status }}{% endif %}{% if request.GET.show_inactive %}&show_inactive=1{% endif %}"
-         class="btn-secondary btn-sm">
+         class="btn btn-secondary btn-sm">
         Previous
       </a>
     {% endif %}
     {% if page_obj.has_next %}
       <a href="?page={{ page_obj.next_page_number }}{% if request.GET.q %}&q={{ request.GET.q }}{% endif %}{% if request.GET.category %}&category={{ request.GET.category }}{% endif %}{% if request.GET.stock_status %}&stock_status={{ request.GET.stock_status }}{% endif %}{% if request.GET.show_inactive %}&show_inactive=1{% endif %}"
-         class="btn-secondary btn-sm">
+         class="btn btn-secondary btn-sm">
         Next
       </a>
     {% endif %}

--- a/templates/inventory/purchase_orders/_quick_form.html
+++ b/templates/inventory/purchase_orders/_quick_form.html
@@ -9,7 +9,7 @@
   </div>
   <input type="hidden" name="{{ quick_form.prefix }}-status" value="DRAFT">
   <div class="mt-4 flex justify-end">
-    <button type="submit" class="btn-primary">Create</button>
+    <button type="submit" class="btn btn-primary">Create</button>
   </div>
   <datalist id="supplier-options"></datalist>
 </form>

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -8,10 +8,10 @@
 {% endblock %}
 {% block heading %}Purchase Order {{ po.pk }}{% endblock %}
 {% block actions %}
-  <a href="{% url 'purchase_order_edit' po.pk %}" class="btn-primary">Edit</a>
-  <a href="{% url 'purchase_order_receive' po.pk %}" class="btn-primary">Receive Goods</a>
-  <a href="{% url 'grn_list' %}" class="btn-primary">View GRNs</a>
-  <a href="{% url 'purchase_orders_list' %}" class="btn-secondary">Back</a>
+  <a href="{% url 'purchase_order_edit' po.pk %}" class="btn btn-primary">Edit</a>
+  <a href="{% url 'purchase_order_receive' po.pk %}" class="btn btn-primary">Receive Goods</a>
+  <a href="{% url 'grn_list' %}" class="btn btn-primary">View GRNs</a>
+  <a href="{% url 'purchase_orders_list' %}" class="btn btn-secondary">Back</a>
 {% endblock %}
 {% block detail_table %}
   {% include "components/detail_table.html" with rows=rows %}

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -33,7 +33,7 @@
   </div>
   <datalist id="item-options"></datalist>
   <div>
-    <button type="button" id="add-item" class="btn-secondary">Add Item</button>
+    <button type="button" id="add-item" class="btn btn-secondary">Add Item</button>
   </div>
 {% endblock %}
 {% block submit_text %}Save{% endblock %}

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -12,14 +12,14 @@
 {% block description %}<p class="page-subtitle">Manage your purchase orders and supplier relationships</p>{% endblock %}
 
 {% block primary_actions %}
-  <a href="{% url 'purchase_order_create' %}" class="btn-primary">
+  <a href="{% url 'purchase_order_create' %}" class="btn btn-primary">
     {% icon 'plus' 'w-4 h-4 mr-2' %}
     New Purchase Order
   </a>
 {% endblock %}
 
 {% block secondary_actions %}
-  <a href="{% url 'grn_list' %}" class="btn-secondary">
+  <a href="{% url 'grn_list' %}" class="btn btn-secondary">
     {% icon 'archive-box-arrow-down' 'w-4 h-4 mr-2' %}
     GRNs
   </a>
@@ -71,11 +71,11 @@
         <input id="end-date" type="date" name="end_date" value="{{ end_date }}" class="form-input" autocomplete="off">
       </div>
       <div class="flex items-end space-x-2">
-        <button type="submit" class="btn-primary flex-1">
+        <button type="submit" class="btn btn-primary flex-1">
           {% icon 'funnel' 'w-4 h-4 mr-2' %}
           Filter
         </button>
-        <a href="{% url 'purchase_orders_list' %}" class="btn-secondary">Clear</a>
+        <a href="{% url 'purchase_orders_list' %}" class="btn btn-secondary">Clear</a>
       </div>
     </form>
 </div>
@@ -92,7 +92,7 @@
     <div class="flex items-center justify-between">
       <h2 class="text-lg font-semibold text-gray-900">Purchase Orders</h2>
       <div class="flex items-center space-x-2">
-        <button onclick="toggleBulkActions()" class="btn-sm btn-secondary">
+        <button onclick="toggleBulkActions()" class="btn btn-sm btn-secondary">
           {% icon 'archive-box' 'w-4 h-4 mr-1' %}
           Bulk Actions
         </button>
@@ -114,7 +114,7 @@
   </div>
   <div class="flex items-center space-x-2">
     {% if page_obj.has_previous %}
-      <a href="?page={{ page_obj.previous_page_number }}{% if current_status %}&status={{ current_status }}{% endif %}{% if current_supplier %}&supplier={{ current_supplier }}{% endif %}{% if start_date %}&start_date={{ start_date }}{% endif %}{% if end_date %}&end_date={{ end_date }}{% endif %}" class="btn-secondary btn-sm">
+      <a href="?page={{ page_obj.previous_page_number }}{% if current_status %}&status={{ current_status }}{% endif %}{% if current_supplier %}&supplier={{ current_supplier }}{% endif %}{% if start_date %}&start_date={{ start_date }}{% endif %}{% if end_date %}&end_date={{ end_date }}{% endif %}" class="btn btn-secondary btn-sm">
         Previous
       </a>
     {% endif %}
@@ -124,7 +124,7 @@
     </span>
 
     {% if page_obj.has_next %}
-      <a href="?page={{ page_obj.next_page_number }}{% if current_status %}&status={{ current_status }}{% endif %}{% if current_supplier %}&supplier={{ current_supplier }}{% endif %}{% if start_date %}&start_date={{ start_date }}{% endif %}{% if end_date %}&end_date={{ end_date }}{% endif %}" class="btn-secondary btn-sm">
+      <a href="?page={{ page_obj.next_page_number }}{% if current_status %}&status={{ current_status }}{% endif %}{% if current_supplier %}&supplier={{ current_supplier }}{% endif %}{% if start_date %}&start_date={{ start_date }}{% endif %}{% if end_date %}&end_date={{ end_date }}{% endif %}" class="btn btn-secondary btn-sm">
         Next
       </a>
     {% endif %}

--- a/templates/inventory/recipes/_components_form_table.html
+++ b/templates/inventory/recipes/_components_form_table.html
@@ -20,7 +20,7 @@
     <td>{% include "components/form_field.html" with field=cform.unit %}</td>
     <td>{% include "components/form_field.html" with field=cform.loss_pct %}</td>
     <td>
-      {{ cform.DELETE }}<button type="button" class="remove-row btn-danger">Remove</button>
+      {{ cform.DELETE }}<button type="button" class="remove-row btn btn-danger">Remove</button>
     </td>
   </tr>
   {% endfor %}

--- a/templates/inventory/recipes/_recipe_create_section.html
+++ b/templates/inventory/recipes/_recipe_create_section.html
@@ -6,7 +6,7 @@
     {% csrf_token %}
     {% include "inventory/recipes/_form_fields.html" with form=form %}
     <div class="flex gap-2">
-      <button type="submit" class="btn-primary">Save</button>
+      <button type="submit" class="btn btn-primary">Save</button>
     </div>
   </form>
 {% endblock %}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -14,7 +14,7 @@
   {% endif %}
   {% include "inventory/recipes/_components_form_table.html" with formset=formset table_id="components-table" %}
   <div class="mt-2">
-    <button type="button" id="add-row" class="btn-secondary">Add Component</button>
+    <button type="button" id="add-row" class="btn btn-secondary">Add Component</button>
   </div>
 {% endblock %}
 {% block submit_text %}Save{% endblock %}

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -6,7 +6,7 @@
 {% block page_heading %}Recipes{% endblock %}
 
 {% block primary_actions %}
-  <a class="btn-primary" href="{% url 'recipe_create' %}">New Recipe</a>
+  <a class="btn btn-primary" href="{% url 'recipe_create' %}">New Recipe</a>
 {% endblock %}
 
 {% block filters %}

--- a/templates/inventory/visualizations.html
+++ b/templates/inventory/visualizations.html
@@ -18,7 +18,7 @@
       <label for="end-date" class="text-sm font-medium">End Date</label>
       <input id="end-date" type="date" name="end_date" value="{{ end_date }}" class="form-control" autocomplete="off" />
     </div>
-    <button type="submit" class="btn-primary">Apply</button>
+    <button type="submit" class="btn btn-primary">Apply</button>
   </form>
   <div id="heatmap" class="w-full h-64"></div>
   <div id="scatter" class="w-full h-64 mt-4"></div>


### PR DESCRIPTION
## Summary
- replace legacy button CSS with Tailwind component classes
- apply new `.btn` utilities across templates and JS
- regenerate compiled Tailwind CSS

## Testing
- `npm run build-css`
- `pre-commit run --files $(git diff --name-only)`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b86c5b20008326b9a39132f4d27edb