### PR TITLE
refactor tables to tailwind utilities

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1236,51 +1236,10 @@ a:hover {
   --tw-text-opacity: 1;
   color: rgb(55 65 81 / var(--tw-text-opacity, 1));
 }
-.\!table {
-  min-width: 100% !important;
-  border-spacing: 0 !important;
-}
-.table {
-  min-width: 100%;
-  border-spacing: 0;
-}
-.table-header,
-.table-header th {
-  background-color: #f9fafb;
-}
-.table-header th {
-  padding: 0.625rem 1rem;
-  text-align: left;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #6b7280;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  border-bottom: 1px solid #e5e7eb;
-}
-.table-body {
-  background-color: #fff;
-}
-.table-body td {
-  padding: 0.875rem 1rem;
-  white-space: normal;
-  word-break: break-word;
-  font-size: 0.875rem;
-  color: #111827;
-  border-bottom: 1px solid #e5e7eb;
-}
-.table-row-hover:hover {
-  background-color: #f9fafb;
-}
 .page-subtitle {
   font-size: 0.875rem;
   color: #6b7280;
   margin-top: 0.25rem;
-}
-.page-content {
-  flex: 1;
-  padding: 1.5rem;
-  background-color: #f9fafb;
 }
 .active {
   font-weight: 700;
@@ -1382,50 +1341,6 @@ input[list]:after {
   pointer-events: none;
   font-size: 12px;
   color: #6b7280;
-}
-.\!table {
-  width: 100% !important;
-  border-collapse: separate !important;
-  border-spacing: 0 var(--space-2) !important;
-}
-.table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0 var(--space-2);
-}
-.table td,
-.table th {
-  border: 1px solid #9ca3af;
-  padding: var(--space-4) var(--space-8);
-  text-align: left;
-}
-.\!table td,
-.\!table th {
-  border: 1px solid #9ca3af !important;
-  padding: var(--space-4) var(--space-8) !important;
-  text-align: left !important;
-}
-.\!table thead {
-  background-color: #2563eb !important;
-  color: #fff !important;
-}
-.table thead {
-  background-color: #2563eb;
-  color: #fff;
-}
-.\!table tbody tr {
-  background-color: #fff !important;
-  transition: background-color 0.15s ease-in-out !important;
-}
-.table tbody tr {
-  background-color: #fff;
-  transition: background-color 0.15s ease-in-out;
-}
-.\!table tbody tr:hover {
-  background-color: #f3f4f6 !important;
-}
-.table tbody tr:hover {
-  background-color: #f3f4f6;
 }
 .pagination-active {
   padding: 0.25rem 0.75rem;
@@ -1791,6 +1706,9 @@ input[list]:after {
   width: -moz-max-content;
   width: max-content;
 }
+.min-w-full {
+  min-width: 100%;
+}
 .max-w-3xl {
   max-width: 48rem;
 }
@@ -1955,6 +1873,15 @@ input[list]:after {
   --tw-space-y-reverse: 0;
   margin-top: calc(var(--space-8) * (1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(var(--space-8) * var(--tw-space-y-reverse));
+}
+.divide-y > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-y-reverse: 0;
+  border-top-width: calc(1px * (1 - var(--tw-divide-y-reverse)));
+  border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
+}
+.divide-border > :not([hidden]) ~ :not([hidden]) {
+  --tw-divide-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-divide-opacity, 1));
 }
 .overflow-x-auto {
   overflow-x: auto;
@@ -2160,6 +2087,10 @@ input[list]:after {
   padding-top: var(--space-2);
   padding-bottom: var(--space-2);
 }
+.py-2\.5 {
+  padding-top: 0.625rem;
+  padding-bottom: 0.625rem;
+}
 .py-3 {
   padding-top: 0.75rem;
   padding-bottom: 0.75rem;
@@ -2234,8 +2165,14 @@ input[list]:after {
 .font-semibold {
   font-weight: 600;
 }
+.uppercase {
+  text-transform: uppercase;
+}
 .leading-none {
   line-height: 1;
+}
+.tracking-wider {
+  letter-spacing: 0.05em;
 }
 .text-blue-600 {
   --tw-text-opacity: 1;
@@ -2505,6 +2442,10 @@ input[list]:after {
 .hover\:bg-gray-100:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity, 1));
+}
+.hover\:bg-gray-50:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
 }
 .hover\:text-blue-600:hover {
   --tw-text-opacity: 1;

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -154,47 +154,7 @@
     @apply bg-gray-100 text-gray-700;
   }
 
-  /* Table Components */
-  .table {
-    min-width: 100%;
-    border-collapse: separate;
-    border-spacing: 0;
-  }
-  .table-header {
-    background-color: #f9fafb;
-  }
-  .table-header th {
-    padding: 0.625rem 1rem;
-    text-align: left;
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #6b7280;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    background-color: #f9fafb;
-    border-bottom: 1px solid #e5e7eb;
-  }
-  .table-body {
-    background-color: white;
-  }
-  .table-body td {
-    padding: 0.875rem 1rem;
-    white-space: normal;
-    word-break: break-word;
-    font-size: 0.875rem;
-    color: #111827;
-    border-bottom: 1px solid #e5e7eb;
-  }
-  .table-row-hover:hover {
-    background-color: #f9fafb;
-  }
-
   /* Page Layout */
-  .page-header {
-    background-color: white;
-    border-bottom: 1px solid #e5e7eb;
-    padding: 1rem 1.5rem;
-  }
   .page-title {
     font-size: 1.5rem;
     font-weight: 700;
@@ -205,11 +165,6 @@
     font-size: 0.875rem;
     color: #6b7280;
     margin-top: 0.25rem;
-  }
-  .page-content {
-    flex: 1;
-    padding: 1.5rem;
-    background-color: #f9fafb;
   }
 
   /* Legacy styles for compatibility */
@@ -348,30 +303,6 @@
     pointer-events: none;
     font-size: 12px;
     color: #6b7280;
-  }
-
-  /* Table component styles */
-  .table {
-    width: 100%;
-    border-collapse: separate;
-    border-spacing: 0 var(--space-2);
-  }
-  .table th,
-  .table td {
-    border: 1px solid theme("colors.table.border");
-    padding: var(--space-4) var(--space-8);
-    text-align: left;
-  }
-  .table thead {
-    background-color: theme("colors.primary");
-    color: theme("colors.table.headerText");
-  }
-  .table tbody tr {
-    background-color: theme("colors.form.bg", "#ffffff");
-    transition: background-color 0.15s ease-in-out;
-  }
-  .table tbody tr:hover {
-    background-color: theme("colors.table.hoverBg");
   }
 
   /* Pagination controls */

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -46,8 +46,8 @@
         ></div>
       </div>
 
-      <!-- Page Content -->
-      <main class="page-content">
+        <!-- Page Content -->
+        <main class="flex-1 p-6 bg-gray-50">
         {% block breadcrumbs %}{% endblock %}
         {% if messages %}
           {% include "components/alert.html" %}

--- a/templates/components/basic_table.html
+++ b/templates/components/basic_table.html
@@ -1,11 +1,11 @@
 {% comment %}Basic table component with block areas for headers and rows{% endcomment %}
-<table class="table w-full">
+<table class="min-w-full w-full text-sm">
   <thead>
     <tr>
       {% block headers %}{% endblock %}
     </tr>
   </thead>
-  <tbody>
+  <tbody class="bg-white divide-y divide-border">
     {% block rows %}{% endblock %}
   </tbody>
 </table>

--- a/templates/components/detail_table.html
+++ b/templates/components/detail_table.html
@@ -1,5 +1,5 @@
-<table class="table">
-  <tbody>
+<table class="min-w-full text-sm">
+  <tbody class="bg-white divide-y divide-border">
     {% for label, value in rows %}
     <tr>
       <th scope="row" class="text-left pr-4">{{ label }}</th>

--- a/templates/components/responsive_table.html
+++ b/templates/components/responsive_table.html
@@ -3,14 +3,14 @@ Responsive table component with sticky headers and row hover states.
 {% endcomment %}
 <div{% if container_id %} id="{{ container_id }}"{% endif %} class="max-md:overflow-x-auto">
   {% block actions %}{% endblock %}
-  <table class="table w-full table-auto text-sm"{% if table_id %} id="{{ table_id }}"{% endif %}>
+  <table class="min-w-full w-full table-auto text-sm"{% if table_id %} id="{{ table_id }}"{% endif %}>
     {% block caption %}{% endblock %}
     <thead class="sticky top-0 bg-primary text-white">
       <tr>
         {% block headers %}{% endblock %}
       </tr>
     </thead>
-    <tbody>
+    <tbody class="bg-white divide-y divide-border">
       {% block rows %}{% endblock %}
     </tbody>
   </table>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,18 +1,18 @@
 {% load icon_tags category_tags %}
 <!-- prettier-ignore -->
 <table
-  class="table w-full table-fixed bg-white border border-gray-200 rounded-lg table-sticky"
+  class="min-w-full w-full table-fixed bg-white border border-gray-200 rounded-lg table-sticky"
   id="items-table"
   data-sortable
 >
-  <thead class="table-header">
+  <thead class="text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
     <tr>
-      <th scope="col" class="sticky z-10 w-8 px-4 py-2 font-semibold">
+      <th scope="col" class="sticky z-10 w-8 px-4 py-2.5 bg-gray-50 border-b border-gray-200">
         <input type="checkbox" data-select-all aria-label="Select all" />
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2 font-semibold"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200"
         data-col="name"
         aria-sort="none"
       >
@@ -22,7 +22,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2 font-semibold"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200"
         data-col="category"
         aria-sort="none"
       >
@@ -32,7 +32,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2 font-semibold"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200"
         data-col="unit"
         aria-sort="none"
       >
@@ -42,7 +42,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2 font-semibold"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200"
         data-col="stock"
         aria-sort="none"
       >
@@ -52,7 +52,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2 font-semibold"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200"
         data-col="stock_status"
         aria-sort="none"
       >
@@ -62,7 +62,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2 font-semibold"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200"
         data-col="rop"
         aria-sort="none"
       >
@@ -72,7 +72,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2 font-semibold"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200"
         data-col="departments"
         aria-sort="none"
       >
@@ -82,7 +82,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2 font-semibold"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200"
         data-col="status"
         aria-sort="none"
       >
@@ -90,15 +90,15 @@
           Status<span class="ml-1">⇅</span>
         </button>
       </th>
-      <th scope="col" class="sticky z-10 w-[120px] px-4 py-2 font-semibold">
+      <th scope="col" class="sticky z-10 w-[120px] px-4 py-2.5 bg-gray-50 border-b border-gray-200">
         Actions
       </th>
     </tr>
   </thead>
-  <tbody class="table-body">
+  <tbody class="bg-white divide-y divide-border">
     {% for item in page_obj.object_list %}
     <tr
-      class="table-row-hover item-row odd:bg-gray-50"
+      class="item-row odd:bg-gray-50 hover:bg-gray-50"
       data-item-id="{{ item.item_id }}"
       data-unit-id="{{ item.unit_id }}"
       data-category-id="{{ item.category_id }}"


### PR DESCRIPTION
## Summary
- replace custom table classes with Tailwind utilities
- inline page layout styling for base template
- drop unused table and layout CSS from stylesheet

## Testing
- `pre-commit run --files static/src/app.css static/css/app.css templates/_base.html templates/components/basic_table.html templates/components/detail_table.html templates/components/responsive_table.html templates/inventory/_items_table.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b871933cc88326a7dbe61daf0cd7f2