### PR TITLE
refactor: simplify purchase order progress bar styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Database connections now close after each request (`CONN_MAX_AGE=0`) to prevent idle sessions
 - Render deployment uses two Gunicorn workers by default to limit concurrent connections
 - Example environment files document direct Supabase hosts and optional pooler parameters
+- Simplified purchase order progress bar to set width directly with inline style, removing custom CSS variable
 
 ### Fixed
 

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -21,7 +21,7 @@
   <td class="px-4 py-2"><span class="px-2 py-1 rounded-full text-badge {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
   <td class="px-4 py-2">
     <div class="w-full bg-gray-200 rounded-full h-2" role="progressbar" aria-valuenow="{{ po.progress_percent }}" aria-valuemin="0" aria-valuemax="100">
-      <div class="h-2 bg-primary rounded-full w-[var(--progress)]" style="--progress: {{ po.progress_percent }}%"></div>
+      <div class="h-2 bg-primary rounded-full" style="width: {{ po.progress_percent }}%"></div>
     </div>
     <div class="text-xs text-right mt-1">{{ po.received_total }} / {{ po.ordered_total }}</div>
   </td>

--- a/tests/test_purchase_orders_progress_bar.py
+++ b/tests/test_purchase_orders_progress_bar.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from django.template.loader import render_to_string
+
+
+def test_purchase_order_progress_bar_renders_width():
+    po = SimpleNamespace(
+        pk=1,
+        supplier=SimpleNamespace(name="ACME"),
+        order_date="2023-01-01",
+        badge_class="status-open",
+        get_status_display=lambda: "Open",
+        progress_percent=42,
+        received_total=0,
+        ordered_total=0,
+    )
+    page_obj = SimpleNamespace(
+        has_previous=False,
+        has_next=False,
+        number=1,
+        paginator=SimpleNamespace(num_pages=1, page_range=[1]),
+    )
+    html = render_to_string(
+        "inventory/purchase_orders/_table.html",
+        {"orders": [po], "page_obj": page_obj, "querystring": ""},
+    )
+    assert 'style="width: 42%"' in html
+    assert "--progress" not in html


### PR DESCRIPTION
## Summary
- simplify purchase order progress bar styling to set width inline
- add regression test for purchase order progress bar width

## Testing
- `pytest tests/test_purchase_orders_progress_bar.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b883d597c88326a58ee4fd6e0a58df