### PR TITLE
refactor: remove obsolete page classes for tailwind utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   These were consolidated into the canonical templates (e.g. `item_form.html`, `item_detail.html`, `items_list.html`).
 - Build and deployment scripts now run `npm run build` to generate Tailwind CSS bundle.
-
 - `static/js/smart-navigation.js` - removed unused navigation enhancements
 
 - Deprecated `.kpi-grid` and `.kpi` styles in favor of new card-based KPI component
@@ -49,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Render deployment uses two Gunicorn workers by default to limit concurrent connections
 - Example environment files document direct Supabase hosts and optional pooler parameters
 - Simplified purchase order progress bar to set width directly with inline style, removing custom CSS variable
+
+- Replaced `.page-title`, `.page-subtitle`, and `.nav-icon` component classes with inline Tailwind utilities.
 
 ### Fixed
 

--- a/MODERN_CORPORATE_DESIGN_SYSTEM.md
+++ b/MODERN_CORPORATE_DESIGN_SYSTEM.md
@@ -132,12 +132,6 @@
 .page-header {
   @apply bg-white border-b border-gray-200 px-6 py-4;
 }
-.page-title {
-  @apply text-2xl font-bold text-gray-900;
-}
-.page-subtitle {
-  @apply text-sm text-gray-600 mt-1;
-}
 .page-content {
   @apply flex-1 p-6 bg-gray-50;
 }
@@ -166,8 +160,8 @@
 <div class="page-header">
   <div class="flex items-center justify-between">
     <div>
-      <h1 class="page-title">Page Title</h1>
-      <p class="page-subtitle">Descriptive subtitle</p>
+      <h1 class="text-2xl font-bold text-gray-900">Page Title</h1>
+      <p class="text-sm text-gray-600 mt-1">Descriptive subtitle</p>
     </div>
     <div class="flex items-center space-x-3">
       <!-- Action buttons -->

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -142,14 +142,6 @@
     @apply bg-gray-100 text-gray-700;
   }
 
-  /* Page Layout */
-  .page-title {
-    @apply text-2xl font-bold text-gray-900 leading-snug;
-  }
-  .page-subtitle {
-    @apply text-sm text-gray-500 mt-1;
-  }
-
   /* Legacy styles for compatibility */
   .active {
     @apply font-bold underline;
@@ -221,11 +213,6 @@
   .pagination-active:focus,
   .pagination-input:focus {
     @apply focus:outline-none focus:ring-2 focus:ring-primary;
-  }
-
-  /* Navigation icon sizing fix */
-  .nav-icon {
-    @apply !text-sm mr-2 inline-block w-4 text-center;
   }
 
   /* Top navigation group focus */

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -9,7 +9,7 @@
 {% block page_title %}Purchase Orders - Inventory Pro{% endblock %}
 
 {% block page_heading %}Purchase Orders{% endblock %}
-{% block description %}<p class="page-subtitle">Manage your purchase orders and supplier relationships</p>{% endblock %}
+{% block description %}<p class="text-sm text-gray-500 mt-1">Manage your purchase orders and supplier relationships</p>{% endblock %}
 
 {% block primary_actions %}
   <a href="{% url 'purchase_order_create' %}" class="btn btn-primary">


### PR DESCRIPTION
## Summary
- drop deprecated `.page-title`, `.page-subtitle`, and `.nav-icon` classes
- render page subtitle using Tailwind utility classes directly
- document updated page header pattern in design system

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8885f7d2c8326884016ee1ec9ac8f