### PR TITLE
refactor: apply table header shadow via utility class

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -33,9 +33,6 @@
   .table-sticky thead th {
     @apply sticky top-0 bg-gray-50 z-20 shadow-[0_1px_0_0_#e5e7eb];
   }
-  .table-header-shadow {
-    @apply group-data-[shadow=true]:shadow-[0_2px_6px_rgba(0,0,0,0.06)];
-  }
 
   /* Spacing below the filter bar */
   #items-list {

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -7,12 +7,12 @@
 >
   <thead class="text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
     <tr>
-      <th scope="col" class="sticky z-10 w-8 px-4 py-2.5 bg-gray-50 border-b border-gray-200 table-header-shadow">
+      <th scope="col" class="sticky z-10 w-8 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md">
         <input type="checkbox" data-select-all aria-label="Select all" />
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 table-header-shadow"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md"
         data-col="name"
         aria-sort="none"
       >
@@ -22,7 +22,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 table-header-shadow"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md"
         data-col="category"
         aria-sort="none"
       >
@@ -32,7 +32,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 table-header-shadow"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md"
         data-col="unit"
         aria-sort="none"
       >
@@ -42,7 +42,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 table-header-shadow"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md"
         data-col="stock"
         aria-sort="none"
       >
@@ -52,7 +52,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 table-header-shadow"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md"
         data-col="stock_status"
         aria-sort="none"
       >
@@ -62,7 +62,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 table-header-shadow"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md"
         data-col="rop"
         aria-sort="none"
       >
@@ -72,7 +72,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 table-header-shadow"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md"
         data-col="departments"
         aria-sort="none"
       >
@@ -82,7 +82,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 table-header-shadow"
+        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md"
         data-col="status"
         aria-sort="none"
       >
@@ -90,7 +90,7 @@
           Status<span class="ml-1">⇅</span>
         </button>
       </th>
-      <th scope="col" class="sticky z-10 w-[120px] px-4 py-2.5 bg-gray-50 border-b border-gray-200 table-header-shadow">
+      <th scope="col" class="sticky z-10 w-[120px] px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md">
         Actions
       </th>
     </tr>


### PR DESCRIPTION
## Summary
- remove table-header-shadow custom style
- apply Tailwind `group-data-[shadow=true]:shadow-md` to table headers

## Testing
- `npm run build`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b894f81a84832698fbd6e6e7b21046