### PR TITLE
chore: replace build-css script with build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Aria attributes ensuring accessible icons and icon-only buttons, plus tests for unlabeled images.
 - Display reorder point beneath stock badges in item table view.
 - High-contrast department chips with accessible remove buttons for improved keyboard and screen-reader usability.
-- `build-css` npm script for dedicated Tailwind CSS builds.
+- `build` npm script for dedicated Tailwind CSS builds.
 
 ### Deprecated
 
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   These were consolidated into the canonical templates (e.g. `item_form.html`, `item_detail.html`, `items_list.html`).
 
-- Build and deployment scripts now run `npm run build-css` to generate Tailwind CSS bundle.
+- Build and deployment scripts now run `npm run build` to generate Tailwind CSS bundle.
 - `static/js/smart-navigation.js` - removed unused navigation enhancements
 
 - Deprecated `.kpi-grid` and `.kpi` styles in favor of new card-based KPI component

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ pip install -r requirements.txt
 Build the Tailwind CSS bundle and collect static files:
 
 ```bash
-npm run build-css
+npm run build
 python manage.py collectstatic --noinput
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ echo "📦 Installing Node.js dependencies..."
 npm install
 
 echo "🎨 Building Tailwind CSS..."
-npm run build-css
+npm run build
 
 # Collect static files
 echo "📂 Collecting static files..."

--- a/docs/deployment/FINAL_DEPLOYMENT_STATUS.md
+++ b/docs/deployment/FINAL_DEPLOYMENT_STATUS.md
@@ -147,7 +147,7 @@ pip install -r requirements.txt
 
 # Install Node.js dependencies & build CSS
 npm install
-npm run build-css
+npm run build
 
 # Collect static files
 python manage.py collectstatic --noinput

--- a/docs/deployment/LOGIN_ISSUE_RESOLUTION.md
+++ b/docs/deployment/LOGIN_ISSUE_RESOLUTION.md
@@ -70,7 +70,7 @@ Your Render deployment will now:
 buildCommand: |
   pip install -r requirements.txt
   npm install
-  npm run build-css
+  npm run build
   python manage.py collectstatic --noinput
   python manage.py migrate
   python manage.py create_default_superuser

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Django Inventory Management Application",
   "scripts": {
     "build": "mkdir -p static/css && tailwindcss -i ./static/src/app.css -o ./static/css/app.css --minify",
-    "build-css": "npm run build",
     "dev-css": "tailwindcss -i ./static/src/app.css -o ./static/css/app.css --watch",
     "test": "jest"
   },

--- a/render.yaml
+++ b/render.yaml
@@ -11,7 +11,7 @@ services:
     buildCommand: |
       pip install -r requirements.txt
       npm install
-      npm run build-css
+      npm run build
       python manage.py collectstatic --noinput
       python manage.py migrate
       python manage.py setup_cache


### PR DESCRIPTION
## Summary
- remove deprecated build-css script and update docs and deployment configs to use build
- document new build command in deployment guides

## Testing
- `npm run build`
- `pytest`
- `npm test`
- `./build.sh` *(fails: sqlite3.OperationalError near "EXTENSION": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68b898b1d2088326ac9b56f1e8b2085b