### PR TITLE
chore: alias build-css to build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display reorder point beneath stock badges in item table view.
 - High-contrast department chips with accessible remove buttons for improved keyboard and screen-reader usability.
 - `build` npm script for dedicated Tailwind CSS builds.
+- `build-css` npm script alias that proxies to `npm run build` for backwards compatibility.
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Django Inventory Management Application",
   "scripts": {
     "build": "mkdir -p static/css && tailwindcss -i ./static/src/app.css -o ./static/css/app.css --minify",
+    "build-css": "npm run build",
     "dev-css": "tailwindcss -i ./static/src/app.css -o ./static/css/app.css --watch",
     "test": "jest"
   },


### PR DESCRIPTION
## Summary
- alias `build-css` npm script to `npm run build` for compatibility
- document new alias in changelog

## Testing
- `pre-commit run --files package.json CHANGELOG.md --color never`
- `npm test`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89b2cceac8326aec479d8f8e9a65b