### PR TITLE
chore: add postcss build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ pip install -r requirements.txt
 
 ## Static Assets
 
-Build the Tailwind CSS bundle and collect static files:
+CSS is processed with PostCSS using Tailwind CSS, Autoprefixer and cssnano for minification. Install Node dependencies and build the bundle before collecting static files:
 
 ```bash
+npm install
 npm run build
 python manage.py collectstatic --noinput
 ```

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "description": "Django Inventory Management Application",
   "scripts": {
-    "build": "mkdir -p static/css && tailwindcss -i ./static/src/app.css -o ./static/css/app.css --minify",
+    "build": "mkdir -p static/css && postcss static/src/app.css -o static/css/app.css --env production",
     "build-css": "npm run build",
-    "dev-css": "tailwindcss -i ./static/src/app.css -o ./static/css/app.css --watch",
+    "dev-css": "postcss static/src/app.css -o static/css/app.css --watch",
     "test": "jest"
   },
   "devDependencies": {
@@ -13,7 +13,11 @@
     "jest-environment-jsdom": "^29.7.0",
     "tailwindcss": "^3.4.0",
     "tailwindcss-fluid-type": "^2.0.7",
-    "@tailwindcss/forms": "^0.5.7"
+    "@tailwindcss/forms": "^0.5.7",
+    "postcss": "^8.4.31",
+    "postcss-cli": "^10.1.0",
+    "autoprefixer": "^10.4.16",
+    "cssnano": "^6.1.2"
   },
   "dependencies": {
     "heroicons": "^2.1.4"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: [
+    require("tailwindcss"),
+    require("autoprefixer"),
+    require("cssnano")({ preset: "default" }),
+  ],
+};


### PR DESCRIPTION
## Summary
- build CSS bundle with PostCSS, Autoprefixer and cssnano
- document asset build steps in README

## Testing
- `npm run build`
- `npm test`
- `pytest`
- `pre-commit run --files package.json postcss.config.js README.md`


------
https://chatgpt.com/codex/tasks/task_e_68b89c9cb734832686200aa2334b4e89