### PR TITLE
build: generate css at deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 package-lock.json
-# Compiled CSS bundle
-static/css/app.css
+# Compiled CSS bundle generated at build time
+static/css/
 
 # IDE / OS files
 .vscode/

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ npm run build
 python manage.py collectstatic --noinput
 ```
 
+The compiled bundle `static/css/app.css` is generated during this step and is
+excluded from version control. CI/CD pipelines and deployment scripts run
+`npm run build` to ensure the CSS is available at runtime.
+
 ## Configuration
 
 Configuration is controlled via environment variables. Template files live in the `env/` directory. Copy `env/dev.example` to `.env` for local development and set values for your database and other settings:

--- a/deploy-production.sh
+++ b/deploy-production.sh
@@ -194,6 +194,13 @@ create_backup() {
 deploy() {
     log "Deploying to production environment..."
 
+    # Build frontend assets
+    log "Installing Node.js dependencies..."
+    npm install
+
+    log "Building Tailwind CSS bundle..."
+    npm run build
+
     # Pull latest images
     log "Pulling latest base images..."
     dc pull db redis nginx monitoring

--- a/deploy-staging.sh
+++ b/deploy-staging.sh
@@ -114,6 +114,13 @@ create_backup() {
 deploy() {
     log "Building and deploying application..."
 
+    # Build frontend assets
+    log "Installing Node.js dependencies..."
+    npm install
+
+    log "Building Tailwind CSS bundle..."
+    npm run build
+
     # Pull latest images
     log "Pulling latest base images..."
     dc pull db redis nginx


### PR DESCRIPTION
## Summary
- ignore compiled CSS bundle
- build Tailwind CSS in staging and production deploy scripts
- document CSS build step in README

## Testing
- `pre-commit run --files .gitignore README.md deploy-production.sh deploy-staging.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89f3f0024832685df122bf585e078