### PR TITLE
refactor: remove unused form-compact styles

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -16,16 +16,6 @@
 }
 
 @layer components {
-  /* Compact form spacing */
-  .form-compact .form-label {
-    @apply mb-[0.2rem];
-  }
-  .form-compact .form-input,
-  .form-compact select,
-  .form-compact textarea {
-    @apply py-[0.4rem] px-[0.6rem];
-  }
-
   /* Sticky headers */
   .table-scroll {
     /* Removed fixed height and scroll behavior to allow full-page scrolling */


### PR DESCRIPTION
## Summary
- remove `.form-compact` spacing rules from CSS

## Testing
- `pre-commit run --files static/src/app.css`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8a212be548326a19ddefb8852af74