### PR TITLE
Inline Tailwind utilities for card components

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -44,31 +44,6 @@
     @apply text-blue-600 bg-blue-50 hover:text-blue-700 hover:bg-blue-100;
   }
 
-  /* Card Components */
-  .card {
-    @apply bg-white rounded-xl shadow border border-gray-200 overflow-hidden;
-  }
-  .card-header {
-    @apply px-4 py-3 border-b border-gray-200 bg-gray-50;
-  }
-  .card-body {
-    @apply p-4;
-  }
-  .card-compact {
-    @apply p-4;
-  }
-
-  /* Collapsible Card */
-  .card > details > summary {
-    @apply list-none;
-  }
-  .card > details > summary::-webkit-details-marker {
-    @apply hidden;
-  }
-  .card > details:not([open]) > .card-header {
-    @apply border-b-0;
-  }
-
   /* Form Controls */
   .form-input,
   .form-select {

--- a/templates/components/collapsible.html
+++ b/templates/components/collapsible.html
@@ -1,9 +1,9 @@
-<div class="card mb-4">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden mb-4">
   <details {% block open %}{% endblock %}>
-    <summary class="card-header cursor-pointer">
+    <summary class="px-4 py-3 border-b border-gray-200 bg-gray-50 cursor-pointer">
       <h2 class="text-h2 font-semibold">{% block title %}{% endblock %}</h2>
     </summary>
-    <div class="card-body">
+    <div class="p-4">
       {% block content %}{% endblock %}
     </div>
   </details>

--- a/templates/components/detail_section.html
+++ b/templates/components/detail_section.html
@@ -1,10 +1,10 @@
-<div class="card mb-6">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden mb-6">
   {% if title %}
-  <div class="card-header">
+  <div class="px-4 py-3 border-b border-gray-200 bg-gray-50">
     <h2 class="text-lg font-semibold">{{ title }}</h2>
   </div>
   {% endif %}
-  <div class="card-body">
+  <div class="p-4">
     {% include content_template %}
   </div>
 </div>

--- a/templates/components/kpi_card.html
+++ b/templates/components/kpi_card.html
@@ -1,10 +1,10 @@
 {% load icon_tags %}
 {% if href %}
-<a href="{{ href }}" class="card block">
+<a href="{{ href }}" class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden block">
 {% else %}
-<div class="card">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden">
 {% endif %}
-  <div class="card-compact">
+  <div class="p-4">
     <div class="flex items-center">
       <div class="flex-shrink-0">
         <div class="w-8 h-8 bg-{{ color }}-100 rounded-lg flex items-center justify-center">

--- a/templates/inventory/_bulk_upload_partial.html
+++ b/templates/inventory/_bulk_upload_partial.html
@@ -1,9 +1,9 @@
-<div class="card drawer-panel max-w-[520px]">
-  <div class="card-header flex items-center justify-between">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-[520px]">
+  <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <h3 class="text-lg font-semibold">{{ title|default:"Bulk Upload Items" }}</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
   </div>
-  <div class="card-body">
+  <div class="p-4">
     {% if upload_url %}
     <form method="post" enctype="multipart/form-data" data-modal-form action="{{ upload_url }}">
     {% else %}

--- a/templates/inventory/_item_create_partial.html
+++ b/templates/inventory/_item_create_partial.html
@@ -1,9 +1,9 @@
-<div class="card drawer-panel max-w-[860px]">
-  <div class="card-header flex items-center justify-between">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-[860px]">
+  <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <h3 class="text-lg font-semibold">Add New Item</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
   </div>
-  <div class="card-body">
+  <div class="p-4">
     <form method="post" data-modal-form action="{% url 'items_list' %}">
       {% csrf_token %}
       <input type="hidden" name="partial" value="1"/>

--- a/templates/inventory/_item_detail_partial.html
+++ b/templates/inventory/_item_detail_partial.html
@@ -1,12 +1,12 @@
 {% load icon_tags %}
-<div class="card max-w-[720px]">
-  <div class="card-header flex items-center justify-between">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden max-w-[720px]">
+  <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <div class="font-semibold">{{ item.name }}</div>
     <button type="button" data-modal-close class="inline-flex items-center justify-center w-8 h-8 p-0 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" title="Close" aria-label="Close">
       {% icon 'x-mark' 'w-4 h-4' %}
     </button>
   </div>
-  <div class="card-body">
+  <div class="p-4">
     <dl class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-y-2 gap-x-4">
       {% for label, value in rows %}
       <div>

--- a/templates/inventory/_item_form_partial.html
+++ b/templates/inventory/_item_form_partial.html
@@ -1,9 +1,9 @@
-<div class="card drawer-panel max-w-[860px] max-h-[90vh] overflow-y-auto">
-  <div class="card-header flex items-center justify-between">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-[860px] max-h-[90vh] overflow-y-auto">
+  <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <h3 class="text-lg font-semibold">Edit Item — {{ item.name }}</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
   </div>
-  <div class="card-body">
+  <div class="p-4">
     <form method="post" data-modal-form action="{% url 'item_edit' item.item_id %}?partial=1">
       {% csrf_token %}
       <input type="hidden" name="partial" value="1"/>

--- a/templates/inventory/_supplier_form_partial.html
+++ b/templates/inventory/_supplier_form_partial.html
@@ -1,9 +1,9 @@
-<div class="card drawer-panel max-w-[480px]">
-  <div class="card-header flex items-center justify-between">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-[480px]">
+  <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <h3 class="text-lg font-semibold">{% if is_edit %}Edit Supplier — {{ supplier.name }}{% else %}Add Supplier{% endif %}</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
   </div>
-  <div class="card-body">
+  <div class="p-4">
     <form method="post" data-modal-form action="{% if is_edit %}{% url 'supplier_edit' supplier.supplier_id %}?partial=1{% else %}{% url 'supplier_create' %}?partial=1{% endif %}">
       {% csrf_token %}
       <input type="hidden" name="partial" value="1"/>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -16,8 +16,8 @@
 {# Filter block moved directly above the table within data_container #}
 
 {% block kpis %}
-<div class="card mb-6">
-  <div class="card-body">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden mb-6">
+  <div class="p-4">
     {% url 'items_list' as items_list_url %}
     <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
       {% include "components/kpi_card.html" with icon='cube' color='blue' label='Active Items' value=stats.total_active|default:"0" %}
@@ -45,7 +45,7 @@
 
 {% block data_container %}
 <h2 class="text-lg font-semibold text-gray-900 mb-2">Inventory Items</h2>
-<div class="card">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden">
   <div id="items-filter-bar" class="sticky top-0 z-10 bg-white p-4">
     {% url 'items_table' as items_table_url %}
     <div class="flex items-center justify-between mb-0">

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -37,8 +37,8 @@
 {% endblock %}
 
 {% block filters %}
-<div class="card mb-6">
-  <div class="card-body">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden mb-6">
+  <div class="p-4">
     <form method="get" class="grid grid-cols-1 lg:grid-cols-5 gap-4">
       <div>
         <label for="status" class="form-label">Status</label>
@@ -87,8 +87,8 @@
 {% endblock %}
 
 {% block data_container %}
-<div class="card">
-  <div class="card-header">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden">
+  <div class="px-4 py-3 border-b border-gray-200 bg-gray-50">
     <div class="flex items-center justify-between">
       <h2 class="text-lg font-semibold text-gray-900">Purchase Orders</h2>
       <div class="flex items-center space-x-2">

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -151,7 +151,10 @@ def test_item_create_partial_departments_multiselect_container(client):
     resp = client.get(reverse("item_create_partial"))
     assert resp.status_code == 200
     soup = BeautifulSoup(resp.content, "html.parser")
-    root_div = soup.find("div", class_="card drawer-panel max-w-[860px]")
+    root_div = soup.find(
+        "div",
+        class_="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-[860px]",
+    )
     assert root_div is not None
     container = soup.find("div", {"data-multiselect": "chips"})
     assert container is not None


### PR DESCRIPTION
## Summary
- replace `.card*` usages in templates with equivalent Tailwind utility sets
- drop deprecated card styles from `app.css`
- adjust item form test for new markup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8a640c65c8326ac0a45cc7184a339