### PR TITLE
refactor: replace badge and alert classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simplified purchase order progress bar to set width directly with inline style, removing custom CSS variable
 
 - Replaced `.page-title`, `.page-subtitle`, and `.nav-icon` component classes with inline Tailwind utilities.
+- Replaced `.badge` and `.alert` component classes with inline Tailwind utility sets.
 
 ### Fixed
 

--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -20,13 +20,15 @@ from ..models import Indent
 
 logger = logging.getLogger(__name__)
 
+BADGE_BASE = "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+
 INDENT_STATUS_BADGES = {
-    "PENDING": "badge-warning",
-    "APPROVED": "badge-success",
-    "SUBMITTED": "badge-warning",
-    "PROCESSING": "badge-warning",
-    "COMPLETED": "badge-success",
-    "CANCELLED": "badge-error",
+    "PENDING": f"{BADGE_BASE} bg-yellow-100 text-yellow-700",
+    "APPROVED": f"{BADGE_BASE} bg-green-100 text-green-700",
+    "SUBMITTED": f"{BADGE_BASE} bg-yellow-100 text-yellow-700",
+    "PROCESSING": f"{BADGE_BASE} bg-yellow-100 text-yellow-700",
+    "COMPLETED": f"{BADGE_BASE} bg-green-100 text-green-700",
+    "CANCELLED": f"{BADGE_BASE} bg-red-100 text-red-700",
 }
 
 

--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -44,10 +44,11 @@
     const s = parseFloat(stock);
     const r = parseFloat(rop);
     if (!isNaN(s) && !isNaN(r)) {
-      if (s <= r) return '<span class="badge badge-error">Low Stock</span>';
-      return '<span class="badge badge-success">In Stock</span>';
+      if (s <= r)
+        return '<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">Low Stock</span>';
+      return '<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">In Stock</span>';
     }
-    return '<span class="badge badge-gray">No Data</span>';
+    return '<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700">No Data</span>';
   }
 
   // New: in-row inline editing (no extra row)
@@ -204,8 +205,8 @@
           const statusCell = row.querySelector('td[data-col="status"]');
           if (statusCell) {
             statusCell.innerHTML = active
-              ? '<span class="badge badge-success">Active</span>'
-              : '<span class="badge badge-error">Inactive</span>';
+              ? '<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">Active</span>'
+              : '<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">Inactive</span>';
           }
           if (window.notifications && window.notifications.showToast) {
             window.notifications.showToast(

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -58,46 +58,9 @@
     @apply text-sm text-red-600 mt-1;
   }
 
-  /* Status Badges */
-  .badge {
-    @apply inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium;
-  }
-  .badge-success {
-    @apply bg-green-100 text-green-700;
-  }
-  .badge-warning {
-    @apply bg-yellow-100 text-yellow-700;
-  }
-  .badge-error {
-    @apply bg-red-100 text-red-700;
-  }
-  .badge-info {
-    @apply bg-blue-100 text-blue-700;
-  }
-  .badge-gray {
-    @apply bg-gray-100 text-gray-700;
-  }
-
   /* Legacy styles for compatibility */
   .active {
     @apply font-bold underline;
-  }
-
-  /* Alert component */
-  .alert {
-    @apply p-4 mb-4 border-l-4 rounded-md;
-  }
-  .alert-success {
-    @apply bg-green-100 text-green-700 border-green-500;
-  }
-  .alert-warning {
-    @apply bg-yellow-100 text-yellow-700 border-yellow-500;
-  }
-  .alert-error {
-    @apply bg-red-100 text-red-700 border-red-500;
-  }
-  .alert-info {
-    @apply bg-blue-100 text-blue-700 border-blue-500;
   }
 
   /* Form component styles */
@@ -181,8 +144,5 @@
   }
   h2 {
     @apply text-h2;
-  }
-  .badge {
-    @apply text-badge py-0.5 px-1;
   }
 }

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -1,11 +1,11 @@
 {% for message in messages %}
   {% if 'error' in message.tags %}
-    <div class="alert alert-error" role="alert">{{ message }}</div>
+    <div class="p-4 mb-4 border-l-4 rounded-md bg-red-100 text-red-700 border-red-500" role="alert">{{ message }}</div>
   {% elif 'warning' in message.tags %}
-    <div class="alert alert-warning" role="alert">{{ message }}</div>
+    <div class="p-4 mb-4 border-l-4 rounded-md bg-yellow-100 text-yellow-700 border-yellow-500" role="alert">{{ message }}</div>
   {% elif 'success' in message.tags %}
-    <div class="alert alert-success" role="alert">{{ message }}</div>
+    <div class="p-4 mb-4 border-l-4 rounded-md bg-green-100 text-green-700 border-green-500" role="alert">{{ message }}</div>
   {% else %}
-    <div class="alert alert-info" role="alert">{{ message }}</div>
+    <div class="p-4 mb-4 border-l-4 rounded-md bg-blue-100 text-blue-700 border-blue-500" role="alert">{{ message }}</div>
   {% endif %}
 {% endfor %}

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -21,7 +21,7 @@
     <td class="px-4 py-2">{{ row.department }}</td>
     <td class="px-4 py-2">
       {% with status_upper=row.status|upper %}
-        <span class="{{ badges|get_item:status_upper|default:'badge-warning' }}">{{ row.status }}</span>
+        <span class="{{ badges|get_item:status_upper|default:'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700' }}">{{ row.status }}</span>
       {% endwith %}
     </td>
     <td class="px-4 py-2">

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -155,12 +155,12 @@
         <div class="flex flex-col">
           {% if item.current_stock is not None and item.reorder_point is not None %}
             {% if item.current_stock <= item.reorder_point %}
-              <span class="badge badge-error">Low Stock</span>
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">Low Stock</span>
             {% else %}
-              <span class="badge badge-success">In Stock</span>
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">In Stock</span>
             {% endif %}
           {% else %}
-            <span class="badge badge-gray">No Data</span>
+            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700">No Data</span>
           {% endif %}
           {% if item.reorder_point %}
             <p class="text-xs text-gray-500">Reorder Point: {{ item.reorder_point }}</p>
@@ -170,16 +170,16 @@
       <td data-col="rop" class="px-4 py-2 whitespace-normal break-words">{{ item.reorder_point|default:"—" }}</td>
       <td data-col="departments" class="px-4 py-2 whitespace-normal break-words">
         {% if item.departments.all %} {% for dept in item.departments.all %}
-        <span class="badge badge-info">{{ dept.name }}</span>
+        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">{{ dept.name }}</span>
         {% endfor %} {% else %}
         <span class="text-gray-400">—</span>
         {% endif %}
       </td>
       <td data-col="status" class="px-4 py-2 whitespace-normal break-words">
         {% if item.is_active %}
-        <span class="badge badge-success">Active</span>
+        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">Active</span>
         {% else %}
-        <span class="badge badge-error">Inactive</span>
+        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">Inactive</span>
         {% endif %}
       </td>
       <td class="px-4 py-2 whitespace-normal break-words">

--- a/templates/inventory/_recent_transactions_table.html
+++ b/templates/inventory/_recent_transactions_table.html
@@ -19,9 +19,9 @@
     <td>{{ tx.item.name }}</td>
     <td>
       {% if tx.direction == 'in' %}
-        <span class="badge-success">IN</span>
+        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">IN</span>
       {% else %}
-        <span class="badge-error">OUT</span>
+        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">OUT</span>
       {% endif %}
     </td>
     <td>{{ tx.quantity_change }}</td>

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -59,7 +59,7 @@
               <p class="text-sm">PO {{ grn.purchase_order_id }}</p>
             </div>
             <div class="flex items-center gap-2">
-              <span class="badge-success">Received</span>
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">Received</span>
               <a href="{% url 'grn_export' grn.pk %}" class="text-bodyText" title="Attachments">
                 {% icon 'paper-clip' 'w-5 h-5' %}
               </a>


### PR DESCRIPTION
## Summary
- inline Tailwind utilities for badges and alerts in templates and JS
- remove obsolete badge and alert CSS rule blocks
- document transition in changelog

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8a7b306408326aa21d7f4fa74b6e3