### PR TITLE
refactor: inline pagination styles with tailwind

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -102,18 +102,6 @@
     @apply content-['▼'] absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-xs text-gray-500;
   }
 
-  /* Pagination controls */
-  .pagination-active {
-    @apply py-1 px-3 border border-gray-300 rounded-md bg-gray-200;
-  }
-  .pagination-input {
-    @apply border border-gray-300 rounded-md p-1;
-  }
-  .pagination-active:focus,
-  .pagination-input:focus {
-    @apply focus:outline-none focus:ring-2 focus:ring-primary;
-  }
-
   /* Top navigation group focus */
   .top-nav-group button:focus {
     @apply outline-none ring-2 ring-blue-500;

--- a/templates/components/pagination.html
+++ b/templates/components/pagination.html
@@ -7,7 +7,7 @@
     {% endif %}
     {% for num in page_obj.paginator.page_range %}
       {% if num == page_obj.number %}
-        <span class="pagination-active" aria-current="page">{{ num }}</span>
+        <span class="py-1 px-3 border border-gray-300 rounded-md bg-gray-200 focus:outline-none focus:ring-2 focus:ring-primary" aria-current="page">{{ num }}</span>
       {% else %}
         <a href="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}"
            {% if hx_target %}hx-get="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}


### PR DESCRIPTION
## Summary
- inline pagination styles using Tailwind utilities
- drop obsolete `.pagination-active` and `.pagination-input` rules

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8ab0628308326b436fae91d774901