### PR TITLE
Use Tailwind classes and class-based rotation in items table

### DIFF
--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -19,12 +19,12 @@
       toggleEl.setAttribute("aria-expanded", "false");
       // reset chevron rotation
       const svg = toggleEl.querySelector("svg");
-      if (svg) svg.style.transform = "rotate(0deg)";
+      if (svg) svg.classList.remove("rotate-90");
     } else {
       details.classList.remove("hidden");
       toggleEl.setAttribute("aria-expanded", "true");
       const svg = toggleEl.querySelector("svg");
-      if (svg) svg.style.transform = "rotate(90deg)";
+      if (svg) svg.classList.add("rotate-90");
     }
   }
 
@@ -122,7 +122,7 @@
       stockCell.innerHTML = `<input type="number" step="0.01" name="current_stock" class="form-input" value="${escapeHtml(currentStock)}" placeholder="0">`;
     ropCell.innerHTML = `<input type="number" step="0.01" name="reorder_point" class="form-input" value="${escapeHtml(currentRop)}">`;
     statusCell.innerHTML = `<label class="inline-flex items-center gap-2"><input type="checkbox" name="is_active" ${isActive ? "checked" : ""} class="form-checkbox"><span>Active</span></label>`;
-    actionsCell.innerHTML = `<div class="flex items-center" style="gap:.25rem"><button type="button" data-action="save-row" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">Save</button><button type="button" data-action="cancel-row" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">Cancel</button></div>`;
+    actionsCell.innerHTML = `<div class="flex items-center gap-1"><button type="button" data-action="save-row" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">Save</button><button type="button" data-action="cancel-row" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">Cancel</button></div>`;
   }
 
   function restoreRow(row) {

--- a/static/js/items-table.test.js
+++ b/static/js/items-table.test.js
@@ -217,11 +217,44 @@ describe("details toggle", () => {
     const row = document.querySelector(".item-row");
     const panel = document.getElementById("details-1");
     const btn = row.querySelector('[data-action="toggle-details"]');
+    const svg = btn.querySelector("svg");
     window.itemsTable.toggleDetails(row);
     expect(panel.classList.contains("hidden")).toBe(false);
     expect(btn.getAttribute("aria-expanded")).toBe("true");
+    expect(svg.classList.contains("rotate-90")).toBe(true);
     window.itemsTable.toggleDetails(row);
     expect(panel.classList.contains("hidden")).toBe(true);
     expect(btn.getAttribute("aria-expanded")).toBe("false");
+    expect(svg.classList.contains("rotate-90")).toBe(false);
+  });
+});
+
+describe("inline row edit", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <table>
+        <tr class="item-row" data-item-id="1" data-category-id="2" data-unit-id="3">
+          <td data-col="name"><span class="font-medium">Item</span></td>
+          <td data-col="rop">5</td>
+          <td data-col="category">Cat</td>
+          <td data-col="unit">Unit</td>
+          <td data-col="stock">10</td>
+          <td data-col="status">Active</td>
+          <td><button data-action="quick-edit">Edit</button></td>
+        </tr>
+      </table>`;
+    jest.isolateModules(() => {
+      require("./items-table.js");
+    });
+  });
+
+  test("renders actions with gap class", () => {
+    const btn = document.querySelector('[data-action="quick-edit"]');
+    btn.click();
+    const actionsDiv = document.querySelector("tr.item-row td:last-child div");
+    expect(actionsDiv).not.toBeNull();
+    expect(actionsDiv.classList.contains("gap-1")).toBe(true);
+    expect(actionsDiv.classList.contains("flex")).toBe(true);
+    expect(actionsDiv.getAttribute("style")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Replace inline style gap with `gap-1` Tailwind utility in row edit actions
- Toggle detail chevron rotation via `classList` instead of inline transforms
- Extend tests for rotation class and row edit actions

## Testing
- `pre-commit run --files static/js/items-table.js static/js/items-table.test.js`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8ad4556a083269be6870c6e0e9f15