### PR TITLE
refactor: remove orphaned nav styles and use responsive headings

### DIFF
--- a/MODERN_CORPORATE_DESIGN_SYSTEM.md
+++ b/MODERN_CORPORATE_DESIGN_SYSTEM.md
@@ -32,17 +32,6 @@
 
 ### 🧩 **Component System**
 
-#### Navigation Components
-
-```css
-.nav-item {
-  @apply px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-50 rounded-lg transition-all duration-200 no-underline;
-}
-.nav-item-active {
-  @apply text-blue-600 bg-blue-50 hover:text-blue-700 hover:bg-blue-100;
-}
-```
-
 #### Card System
 
 ```css

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -34,16 +34,6 @@
     @apply inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-green-600 text-white hover:bg-green-700 focus:ring-2 focus:ring-green-600 gap-2;
   }
 
-  /* Modern Corporate Design System */
-
-  /* Navigation Components */
-  .nav-item {
-    @apply px-4 py-2 text-sm font-medium text-gray-600 rounded-md transition-colors hover:text-gray-900 hover:bg-gray-50;
-  }
-  .nav-item-active {
-    @apply text-blue-600 bg-blue-50 hover:text-blue-700 hover:bg-blue-100;
-  }
-
   /* Legacy styles for compatibility */
   .active {
     @apply font-bold underline;
@@ -102,11 +92,3 @@
   }
 }
 
-@media (max-width: 768px) {
-  h1 {
-    @apply text-h1;
-  }
-  h2 {
-    @apply text-h2;
-  }
-}

--- a/templates/500.html
+++ b/templates/500.html
@@ -2,7 +2,7 @@
 {% block title %}Server Error{% endblock %}
 {% block content %}
 <div class="max-w-xl mx-auto py-10 text-center">
-  <h1 class="text-4xl font-bold text-gray-900 mb-4">Something went wrong</h1>
+  <h1 class="text-h1 md:text-h2 font-bold text-gray-900 mb-4">Something went wrong</h1>
   <p class="text-gray-700 mb-6">We're working to fix the issue. Please try again later.</p>
   <a href="/" class="text-blue-600 hover:underline">Return to home</a>
 </div>

--- a/templates/components/collapsible.html
+++ b/templates/components/collapsible.html
@@ -1,7 +1,7 @@
 <div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden mb-4">
   <details {% block open %}{% endblock %}>
     <summary class="px-4 py-3 border-b border-gray-200 bg-gray-50 cursor-pointer">
-      <h2 class="text-h2 font-semibold">{% block title %}{% endblock %}</h2>
+      <h2 class="text-h2 md:text-h2 font-semibold">{% block title %}{% endblock %}</h2>
     </summary>
     <div class="p-4">
       {% block content %}{% endblock %}

--- a/templates/components/detail_layout.html
+++ b/templates/components/detail_layout.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block title %}Detail – Inventory App{% endblock %}
 {% block content %}
-  <h1 class="text-h1 font-semibold mb-4">{% block heading %}{% endblock %}</h1>
+  <h1 class="text-h1 md:text-h2 font-semibold mb-4">{% block heading %}{% endblock %}</h1>
   <div class="mb-4 flex justify-end gap-2">{% block actions %}{% endblock %}</div>
   {% block detail_table %}{% endblock %}
   {% block extra_tables %}{% endblock %}

--- a/templates/components/detail_section.html
+++ b/templates/components/detail_section.html
@@ -1,7 +1,7 @@
 <div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden mb-6">
   {% if title %}
   <div class="px-4 py-3 border-b border-gray-200 bg-gray-50">
-    <h2 class="text-lg font-semibold">{{ title }}</h2>
+    <h2 class="text-h2 md:text-lg font-semibold">{{ title }}</h2>
   </div>
   {% endif %}
   <div class="p-4">

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -6,7 +6,7 @@
   {% else %}
     {% icon 'plus' 'mx-auto w-5 h-5 text-form-text' aria_label='' %}
   {% endif %}
-  <h2 class="text-h2 mb-4 mt-8">{{ title }}</h2>
+  <h2 class="text-h2 md:text-h2 mb-4 mt-8">{{ title }}</h2>
   <p class="mb-4 text-form-text">{{ message }}</p>
   <a href="{{ cta_url }}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">{{ cta_label }}</a>
 </div>

--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -2,7 +2,7 @@
 {% block title %}Form – Inventory App{% endblock %}
 {% block content %}
 <div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-h1 font-semibold mb-4">
+  <h1 class="text-h1 md:text-h2 font-semibold mb-4">
     {% block heading %}{% endblock %}
   </h1>
   {% if form %}

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -51,7 +51,7 @@
         </div>
         <a href="{% url 'root' %}" class="ml-3 text-xl font-semibold text-gray-900">Inventory Pro</a>
         {% if nav_heading %}
-        <h1 class="ml-6 text-lg font-semibold text-gray-900">{{ nav_heading }}</h1>
+        <h1 class="ml-6 text-h1 md:text-h2 font-semibold text-gray-900">{{ nav_heading }}</h1>
         {% endif %}
       </div>
 

--- a/templates/inventory/_adjust_form.html
+++ b/templates/inventory/_adjust_form.html
@@ -1,4 +1,4 @@
-<h2 class="text-h2 mb-4 mt-8">Stock Adjustment</h2>
+<h2 class="text-h2 md:text-h2 mb-4 mt-8">Stock Adjustment</h2>
 <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
   {% csrf_token %}
   {% if adjust_form.non_field_errors %}

--- a/templates/inventory/_item_notes.html
+++ b/templates/inventory/_item_notes.html
@@ -1,4 +1,4 @@
 <div>
-  <h2 class="text-h2 mb-4">Notes</h2>
+  <h2 class="text-h2 md:text-h2 mb-4">Notes</h2>
   <p>{{ item.notes }}</p>
 </div>

--- a/templates/inventory/_receive_form.html
+++ b/templates/inventory/_receive_form.html
@@ -1,4 +1,4 @@
-<h2 class="text-h2 mb-4 mt-8">Goods Received</h2>
+<h2 class="text-h2 md:text-h2 mb-4 mt-8">Goods Received</h2>
 <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
   {% csrf_token %}
   {% if receive_form.non_field_errors %}

--- a/templates/inventory/_waste_form.html
+++ b/templates/inventory/_waste_form.html
@@ -1,4 +1,4 @@
-<h2 class="text-h2 mb-4 mt-8">Wastage/Spoilage</h2>
+<h2 class="text-h2 md:text-h2 mb-4 mt-8">Wastage/Spoilage</h2>
 <form method="post" class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
   {% csrf_token %}
   {% if waste_form.non_field_errors %}

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -9,7 +9,7 @@
   {% include "components/detail_table.html" with rows=rows %}
 {% endblock %}
 {% block extra_tables %}
-  <h2 class="text-h2 mb-4 mt-8">Items</h2>
+  <h2 class="text-h2 md:text-h2 mb-4 mt-8">Items</h2>
   {% include "inventory/_indent_items_table.html" with items=items %}
   <div class="mt-4 flex gap-2">
     <form action="{% url 'indent_update_status' indent.indent_id 'PROCESSING' %}" method="post" class="inline">

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -44,7 +44,7 @@
 {% endblock %}
 
 {% block data_container %}
-<h2 class="text-lg font-semibold text-gray-900 mb-2">Inventory Items</h2>
+<h2 class="text-h2 md:text-lg font-semibold text-gray-900 mb-2">Inventory Items</h2>
 <div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden">
   <div id="items-filter-bar" class="sticky top-0 z-10 bg-white p-4">
     {% url 'items_table' as items_table_url %}

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -17,6 +17,6 @@
   {% include "components/detail_table.html" with rows=rows %}
 {% endblock %}
 {% block extra_tables %}
-  <h2 class="text-h2 mb-4 mt-8">Items</h2>
+  <h2 class="text-h2 md:text-h2 mb-4 mt-8">Items</h2>
   {% include "inventory/purchase_orders/_items_table.html" with items=items %}
 {% endblock %}

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -90,7 +90,7 @@
 <div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden">
   <div class="px-4 py-3 border-b border-gray-200 bg-gray-50">
     <div class="flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-gray-900">Purchase Orders</h2>
+      <h2 class="text-h2 md:text-lg font-semibold text-gray-900">Purchase Orders</h2>
       <div class="flex items-center space-x-2">
         <button onclick="toggleBulkActions()" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">
           {% icon 'archive-box' 'w-4 h-4 mr-1' %}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% block title %}Stock Movements – Inventory App{% endblock %}
 {% block content %}
-  <h1 class="text-h1 font-semibold mb-4">Stock Movements</h1>
+  <h1 class="text-h1 md:text-h2 font-semibold mb-4">Stock Movements</h1>
   {% include "inventory/_manual_entry_section.html" %}
   {% include "inventory/_bulk_upload_section.html" %}
   {% include "inventory/_recent_transactions_section.html" %}

--- a/templates/inventory/visualizations.html
+++ b/templates/inventory/visualizations.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block title %}Visualizations – Inventory App{% endblock %}
 {% block content %}
-  <h1 class="text-h1 font-semibold mb-4">Visualizations</h1>
+  <h1 class="text-h1 md:text-h2 font-semibold mb-4">Visualizations</h1>
   <form method="get" class="flex flex-col md:flex-row gap-2 mb-4">
     <div class="flex flex-col">
       <label for="metric" class="text-sm font-medium">Metric</label>

--- a/templates/inventory/what_if_reorder.html
+++ b/templates/inventory/what_if_reorder.html
@@ -13,7 +13,7 @@
     {% for proj in projections %}
       {% with data_id='data-'|add:proj.item.item_id|stringformat:"s" %}
       <div>
-        <h2 class="text-h2 mb-2">{{ proj.item.name }}</h2>
+        <h2 class="text-h2 md:text-h2 mb-2">{{ proj.item.name }}</h2>
         <canvas id="chart-{{ proj.item.item_id }}" class="w-full h-64"></canvas>
         {{ proj.history|json_script:data_id }}
       </div>

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -92,8 +92,8 @@ def test_item_detail_includes_supplier_and_movements(client):
     assert supplier.name in content
     assert tx.transaction_type in content
     assert str(tx.quantity_change) in content
-    assert '<h2 class="text-lg font-semibold">Supplier History</h2>' in content
-    assert '<h2 class="text-lg font-semibold">Stock Movements</h2>' in content
+    assert '<h2 class="text-h2 md:text-lg font-semibold">Supplier History</h2>' in content
+    assert '<h2 class="text-h2 md:text-lg font-semibold">Stock Movements</h2>' in content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- drop unused `.nav-item` styles and clean design guide
- replace media-query typography with responsive classes for `h1`/`h2`
- rebuild Tailwind CSS bundle and adjust tests

## Testing
- `npm test`
- `pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8b1b9ddc88326ba2e753251c1f694