### PR TITLE
Use Tailwind badge styling on GRN list page

### DIFF
--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -66,7 +66,7 @@
             </div>
           </div>
           <div class="mt-2">
-            <a href="?supplier={{ grn.supplier.pk }}" class="badge-secondary">{{ grn.supplier.name }}</a>
+            <a href="?supplier={{ grn.supplier.pk }}" class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700">{{ grn.supplier.name }}</a>
           </div>
           <details class="mt-2">
             <summary class="cursor-pointer text-sm text-primary">Line Items</summary>


### PR DESCRIPTION
## Summary
- replace legacy `badge-secondary` class with Tailwind utility classes on GRN list view
- verify no lingering badge styles remain in Tailwind source

## Testing
- `npm test`
- `npm run build`
- `pytest`
- `pre-commit run --files templates/inventory/grns/list.html`


------
https://chatgpt.com/codex/tasks/task_e_68b8b40ad6e083268eac34f98e0917a8