### PR TITLE
refactor: modernize progress indicators

### DIFF
--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -20,18 +20,10 @@
     if (!details || !toggleEl) return;
 
     const expanded = toggleEl.getAttribute("aria-expanded") === "true";
-    if (expanded) {
-      details.classList.add("hidden");
-      toggleEl.setAttribute("aria-expanded", "false");
-      // reset chevron rotation
-      const svg = toggleEl.querySelector("svg");
-      if (svg) svg.classList.remove("rotate-90");
-    } else {
-      details.classList.remove("hidden");
-      toggleEl.setAttribute("aria-expanded", "true");
-      const svg = toggleEl.querySelector("svg");
-      if (svg) svg.classList.add("rotate-90");
-    }
+    details.classList.toggle("hidden", expanded);
+    toggleEl.setAttribute("aria-expanded", expanded ? "false" : "true");
+    const svg = toggleEl.querySelector("svg");
+    if (svg) svg.classList.toggle("rotate-90", !expanded);
   }
 
   function enableInlineEdit(row) {

--- a/static/js/smart-forms.js
+++ b/static/js/smart-forms.js
@@ -94,8 +94,9 @@ class SmartFormManager {
     const progressBar = document.createElement("div");
     progressBar.id = "form-progress";
     progressBar.className = "mb-4 bg-gray-200 rounded-full h-2";
+    progressBar.style.setProperty("--progress", "0%");
     progressBar.innerHTML =
-      '<div class="bg-blue-600 h-2 rounded-full transition-all duration-300" style="width: 0%"></div>';
+      '<div class="bg-blue-600 h-2 rounded-full transition-all duration-300 w-0" style="width: var(--progress)"></div>';
 
     form.insertBefore(progressBar, form.firstChild);
 
@@ -126,9 +127,9 @@ class SmartFormManager {
     const optionalProgress = (filledAll / allFields.length) * 40; // 40% for all fields
     const totalProgress = Math.min(100, requiredProgress + optionalProgress);
 
-    const progressBar = document.querySelector("#form-progress .bg-blue-600");
+    const progressBar = document.getElementById("form-progress");
     if (progressBar) {
-      progressBar.style.width = `${totalProgress}%`;
+      progressBar.style.setProperty("--progress", `${totalProgress}%`);
     }
   }
 }

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -20,11 +20,15 @@
   <td class="px-4 py-2">{{ po.order_date }}</td>
   <td class="px-4 py-2"><span class="px-2 py-1 rounded-full text-badge {{ po.badge_class }}">{{ po.get_status_display }}</span></td>
   <td class="px-4 py-2">
-    <div class="w-full bg-gray-200 rounded-full h-2" role="progressbar" aria-valuenow="{{ po.progress_percent }}" aria-valuemin="0" aria-valuemax="100">
-      <div
-        class="h-2 bg-primary rounded-full"
-        style="width: {{ po.progress_percent }}%"
-      ></div>
+    <div
+      class="w-full bg-gray-200 rounded-full h-2"
+      role="progressbar"
+      aria-valuenow="{{ po.progress_percent }}"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      style="--progress: {{ po.progress_percent }}%"
+    >
+      <div class="h-2 bg-primary rounded-full" style="width: var(--progress)"></div>
     </div>
     <div class="text-xs text-right mt-1">{{ po.received_total }} / {{ po.ordered_total }}</div>
   </td>

--- a/tests/test_purchase_orders_progress_bar.py
+++ b/tests/test_purchase_orders_progress_bar.py
@@ -24,5 +24,6 @@ def test_purchase_order_progress_bar_renders_width():
         "inventory/purchase_orders/_table.html",
         {"orders": [po], "page_obj": page_obj, "querystring": ""},
     )
-    assert 'style="width: 42%"' in html
-    assert "--progress" not in html
+    assert "--progress: 42%" in html
+    assert "width: var(--progress)" in html
+    assert 'style="width: 42%"' not in html


### PR DESCRIPTION
## Summary
- use CSS variables for purchase order and smart form progress bars
- streamline items table action markup and toggle chevron via `classList`

## Testing
- `flake8`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b93d64d5408326a0687aef1031a16b