### PR TITLE
fix: improve multiselect chip filter accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MAJOR FIX: Implement proper units table architecture with UnitsService - fixed failing tests and established correct unit conversion logic with base_unit/purchase_unit/conversion_factor
 - CLEANUP: Remove undefined item_duplicate URL references from templates - fixed template errors causing view failures
 - Ensure items list content aligns directly beneath the filter bar using dynamic padding instead of margin offsets
+- Use `hidden` utility class with Tailwind safelist for multiselect chip filtering to improve accessibility and build stability
 
 ### Added
 

--- a/static/js/multiselect-chips.js
+++ b/static/js/multiselect-chips.js
@@ -61,7 +61,9 @@
       const qq = q.toLowerCase();
       items.forEach((li) => {
         const text = li.textContent.toLowerCase();
-        li.style.display = text.includes(qq) ? "" : "none";
+        const shouldHide = !text.includes(qq);
+        li.classList.toggle("hidden", shouldHide);
+        li.setAttribute("aria-hidden", shouldHide ? "true" : "false");
       });
     }
 

--- a/static/js/multiselect-chips.test.js
+++ b/static/js/multiselect-chips.test.js
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+
+describe("multiselect chips filter", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div data-multiselect="chips">
+        <ul>
+          <li><label><input type="checkbox" value="alpha">Alpha</label></li>
+          <li><label><input type="checkbox" value="beta">Beta</label></li>
+        </ul>
+      </div>`;
+
+    jest.isolateModules(() => {
+      require("./multiselect-chips.js");
+    });
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+  });
+
+  test("filters list and maintains accessibility", () => {
+    const search = document.querySelector(".chips-search input");
+    const items = document.querySelectorAll("li");
+
+    // search input should receive focus for keyboard accessibility
+    expect(document.activeElement).toBe(search);
+
+    // filter for "beta"
+    search.value = "beta";
+    search.dispatchEvent(new Event("input", { bubbles: true }));
+
+    // first item hidden
+    expect(items[0].classList.contains("hidden")).toBe(true);
+    expect(items[0].getAttribute("aria-hidden")).toBe("true");
+    // second item visible
+    expect(items[1].classList.contains("hidden")).toBe(false);
+    expect(items[1].getAttribute("aria-hidden")).toBe("false");
+  });
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   content: ["./templates/**/*.{html,js}", "./static/js/**/*.js"],
+  safelist: ["hidden"],
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
## Summary
- use Tailwind `hidden` class instead of inline styles for chip filtering
- safelist `hidden` utility so production builds retain it
- add accessibility-focused tests for multiselect chip filtering

## Testing
- `npm test`
- `pytest`
- `pre-commit run --files static/js/multiselect-chips.js static/js/multiselect-chips.test.js tailwind.config.js CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68b93da195a88326a184c02957e535c3