### PR TITLE
refactor: use tailwind tokens for colors and spacing

### DIFF
--- a/static/core/dashboard.js
+++ b/static/core/dashboard.js
@@ -1,6 +1,9 @@
 document.addEventListener("DOMContentLoaded", () => {
   const ctx = document.getElementById("stock-trend-chart").getContext("2d");
   const placeholder = document.getElementById("stock-trend-placeholder");
+  const primaryColor = getComputedStyle(document.documentElement)
+    .getPropertyValue("--color-primary")
+    .trim();
   let chart;
 
   async function fetchData() {
@@ -27,7 +30,7 @@ document.addEventListener("DOMContentLoaded", () => {
         {
           label: metric,
           data: data.values,
-          borderColor: "#3b82f6",
+          borderColor: primaryColor,
           fill: false,
           tension: 0.1,
         },

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -4,6 +4,9 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    --color-primary: theme("colors.primary");
+  }
   body {
     @apply bg-body text-bodyText font-sans;
   }
@@ -21,7 +24,7 @@
     /* Removed fixed height and scroll behavior to allow full-page scrolling */
   }
   .table-sticky thead th {
-    @apply sticky top-0 bg-gray-50 z-20 shadow-[0_1px_0_0_#e5e7eb];
+    @apply sticky top-0 bg-gray-50 z-20 border-b border-border;
   }
 
   /* Spacing below the filter bar */
@@ -70,7 +73,7 @@
 
   /* Emoji icon sizing */
   .emoji-icon {
-    @apply text-[18px] leading-none inline-block;
+    @apply text-lg leading-none inline-block;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -76,6 +76,17 @@ module.exports = {
         4: "1rem",
         6: "1.5rem",
         8: "2rem",
+        9.5: "2.375rem",
+        30: "7.5rem",
+      },
+      maxWidth: {
+        "drawer-sm": "30rem",
+        "drawer-md": "32.5rem",
+        "drawer-lg": "45rem",
+        "drawer-xl": "53.75rem",
+      },
+      maxHeight: {
+        "screen-90": "90vh",
       },
       fontSize: {
         base: ["clamp(1rem, 0.5vw + 0.9rem, 1.25rem)", { lineHeight: "1.5" }],

--- a/templates/inventory/_add_item_section.html
+++ b/templates/inventory/_add_item_section.html
@@ -38,7 +38,7 @@
           </div>
           <div class="space-y-1">
             <label for="{{ form.is_active.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">Status</label>
-            <div class="inline-flex items-center gap-2 text-gray-700 h-[38px]">
+            <div class="inline-flex items-center gap-2 text-gray-700 h-9.5">
               {{ form.is_active }}
               <span>Active</span>
             </div>

--- a/templates/inventory/_bulk_upload_partial.html
+++ b/templates/inventory/_bulk_upload_partial.html
@@ -1,4 +1,4 @@
-<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-[520px]">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-drawer-md">
   <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <h3 class="text-lg font-semibold">{{ title|default:"Bulk Upload Items" }}</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" data-modal-close>Close</button>

--- a/templates/inventory/_history_chart.html
+++ b/templates/inventory/_history_chart.html
@@ -5,6 +5,7 @@
   const labels = JSON.parse(document.getElementById('history-chart-labels').textContent);
   const data = JSON.parse(document.getElementById('history-chart-data').textContent);
   const ctx = document.getElementById('history-chart').getContext('2d');
+  const primaryColor = getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim();
   new Chart(ctx, {
     type: 'line',
     data: {
@@ -12,7 +13,7 @@
       datasets: [{
         label: 'Stock Change',
         data: data,
-        borderColor: '#3b82f6',
+        borderColor: primaryColor,
         fill: false,
         tension: 0.1
       }]

--- a/templates/inventory/_item_create_partial.html
+++ b/templates/inventory/_item_create_partial.html
@@ -1,4 +1,4 @@
-<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-[860px]">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-drawer-xl">
   <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <h3 class="text-lg font-semibold">Add New Item</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" data-modal-close>Close</button>

--- a/templates/inventory/_item_detail_partial.html
+++ b/templates/inventory/_item_detail_partial.html
@@ -1,5 +1,5 @@
 {% load icon_tags %}
-<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden max-w-[720px]">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden max-w-drawer-lg">
   <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <div class="font-semibold">{{ item.name }}</div>
     <button type="button" data-modal-close class="inline-flex items-center justify-center w-8 h-8 p-0 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" title="Close" aria-label="Close">

--- a/templates/inventory/_item_form_partial.html
+++ b/templates/inventory/_item_form_partial.html
@@ -1,4 +1,4 @@
-<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-[860px] max-h-[90vh] overflow-y-auto">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-drawer-xl max-h-screen-90 overflow-y-auto">
   <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <h3 class="text-lg font-semibold">Edit Item — {{ item.name }}</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
@@ -39,7 +39,7 @@
             </div>
             <div class="space-y-1">
               <label for="{{ form.is_active.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">Status</label>
-              <div class="inline-flex items-center gap-2 text-gray-700 h-[38px]">
+              <div class="inline-flex items-center gap-2 text-gray-700 h-9.5">
                 {{ form.is_active }}
                 <span>Active</span>
               </div>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -90,7 +90,7 @@
           Status<span class="ml-1">⇅</span>
         </button>
       </th>
-      <th scope="col" class="sticky z-10 w-[120px] px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md">
+      <th scope="col" class="sticky z-10 w-30 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md">
         Actions
       </th>
     </tr>

--- a/templates/inventory/_supplier_form_partial.html
+++ b/templates/inventory/_supplier_form_partial.html
@@ -1,4 +1,4 @@
-<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-[480px]">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-drawer-sm">
   <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <h3 class="text-lg font-semibold">{% if is_edit %}Edit Supplier — {{ supplier.name }}{% else %}Add Supplier{% endif %}</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" data-modal-close>Close</button>

--- a/templates/inventory/what_if_reorder.html
+++ b/templates/inventory/what_if_reorder.html
@@ -21,6 +21,7 @@
     {% endfor %}
   </div>
   <script>
+  const primaryColor = getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim();
   {% for proj in projections %}
     const data{{ proj.item.item_id }} = JSON.parse(document.getElementById('data-{{ proj.item.item_id }}').textContent);
     const ctx{{ proj.item.item_id }} = document.getElementById('chart-{{ proj.item.item_id }}').getContext('2d');
@@ -31,7 +32,7 @@
         datasets: [{
           label: 'Stock',
           data: data{{ proj.item.item_id }},
-          borderColor: '#3b82f6',
+          borderColor: primaryColor,
           fill: false,
           tension: 0.1
         }]

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -92,8 +92,12 @@ def test_item_detail_includes_supplier_and_movements(client):
     assert supplier.name in content
     assert tx.transaction_type in content
     assert str(tx.quantity_change) in content
-    assert '<h2 class="text-h2 md:text-lg font-semibold">Supplier History</h2>' in content
-    assert '<h2 class="text-h2 md:text-lg font-semibold">Stock Movements</h2>' in content
+    assert (
+        '<h2 class="text-h2 md:text-lg font-semibold">Supplier History</h2>' in content
+    )
+    assert (
+        '<h2 class="text-h2 md:text-lg font-semibold">Stock Movements</h2>' in content
+    )
 
 
 @pytest.mark.django_db
@@ -153,7 +157,7 @@ def test_item_create_partial_departments_multiselect_container(client):
     soup = BeautifulSoup(resp.content, "html.parser")
     root_div = soup.find(
         "div",
-        class_="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-[860px]",
+        class_="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-drawer-xl",
     )
     assert root_div is not None
     container = soup.find("div", {"data-multiselect": "chips"})
@@ -190,4 +194,4 @@ def test_drawer_width(client):
     soup = BeautifulSoup(resp.content, "html.parser")
     drawer = soup.find("div", class_="drawer-panel")
     assert drawer is not None
-    assert "max-w-[860px]" in drawer.get("class")
+    assert "max-w-drawer-xl" in drawer.get("class")


### PR DESCRIPTION
## Summary
- add design tokens for drawer widths, spacing, and max height
- expose primary color via CSS var and use in charts
- replace ad-hoc widths/heights with Tailwind utilities

## Testing
- `pre-commit run --files static/core/dashboard.js static/src/app.css tailwind.config.js templates/inventory/_add_item_section.html templates/inventory/_bulk_upload_partial.html templates/inventory/_history_chart.html templates/inventory/_item_create_partial.html templates/inventory/_item_detail_partial.html templates/inventory/_item_form_partial.html templates/inventory/_items_table.html templates/inventory/_supplier_form_partial.html templates/inventory/what_if_reorder.html tests/test_items_list.py`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b94422377c83268d70f51395a8f1ed