### PR TITLE
refactor: apply tailwind styles to forms

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -75,6 +75,11 @@
   .emoji-icon {
     @apply text-lg leading-none inline-block;
   }
+
+  /* Dropzone component styling */
+  #bulk-upload-form .dz-message {
+    @apply text-gray-500 text-center;
+  }
 }
 
 @layer utilities {

--- a/templates/components/filter_bar.html
+++ b/templates/components/filter_bar.html
@@ -1,5 +1,4 @@
-<form id="filters" class="filters-inline mb-0" method="get">
-  <div class="flex flex-wrap items-end gap-4">
+<form id="filters" class="flex flex-wrap gap-4 items-end mb-0" method="get">
     <div class="flex flex-col">
       <label for="filter-q" class="text-sm font-medium">{{ search_label|default:'Search' }}</label>
       <input
@@ -45,7 +44,6 @@
         <button type="submit" {% if export_param_name and export_param_value %}name="{{ export_param_name }}" value="{{ export_param_value }}"{% endif %} formaction="{{ export_url }}" formmethod="get" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary w-full">{{ export_label|default:'Export' }}</button>
       </div>
     {% endif %}
-  </div>
   {% if layout %}<input type="hidden" name="layout" value="{{ layout }}">{% endif %}
   {% if page_size %}<input type="hidden" name="page_size" value="{{ page_size|default:25 }}">{% endif %}
   {% if sort %}<input type="hidden" name="sort" value="{{ sort|default:'name' }}">{% endif %}

--- a/templates/inventory/_add_item_section.html
+++ b/templates/inventory/_add_item_section.html
@@ -8,8 +8,8 @@
 
     <div class="grid grid-cols-12 gap-4">
       <!-- Essentials -->
-      <div class="section-panel col-span-12" id="essentials-panel">
-        <h3 class="section-header">Essentials</h3>
+      <div class="col-span-12 bg-white p-4 rounded shadow" id="essentials-panel">
+        <h3 class="text-lg font-semibold mb-2">Essentials</h3>
         <div class="grid grid-cols-3 gap-4 items-start">
           <div class="space-y-1">
             <label for="{{ form.name.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">Name</label>
@@ -48,8 +48,8 @@
       </div>
 
       <!-- Advanced -->
-      <div class="section-panel col-span-12" id="advanced-panel">
-        <h3 class="section-header">Advanced</h3>
+      <div class="col-span-12 bg-white p-4 rounded shadow" id="advanced-panel">
+        <h3 class="text-lg font-semibold mb-2">Advanced</h3>
         <div class="grid grid-cols-3 gap-4 items-start">
           <div class="space-y-1">
             <label for="{{ form.preferred_supplier.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">Preferred Supplier</label>
@@ -87,7 +87,7 @@
       </div>
       <!-- Actions below Advanced -->
       <div class="col-span-12">
-        <div class="form-actions">
+        <div class="flex gap-2 justify-end">
           <button type="reset" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">Clear</button>
           <button type="submit" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">Create</button>
         </div>

--- a/templates/inventory/_bulk_upload_section.html
+++ b/templates/inventory/_bulk_upload_section.html
@@ -4,7 +4,7 @@
 {% block title %}Bulk Upload{% endblock %}
 {% block content %}
   <p class="mb-2">Download the CSV template and fill it with your stock transactions before uploading. <a href="{% static 'sample_stock_upload.csv' %}" class="text-primary">Download sample CSV</a></p>
-  <form method="post" action="{% url 'items_bulk_upload' %}" enctype="multipart/form-data" class="dropzone border-dashed border-2 p-4" id="bulk-upload-form">
+  <form method="post" action="{% url 'items_bulk_upload' %}" enctype="multipart/form-data" class="flex flex-col items-center justify-center border-2 border-dashed border-border p-4 rounded" id="bulk-upload-form">
     {% csrf_token %}
     <input type="hidden" name="bulk_upload" value="1" />
     {% if bulk_form.non_field_errors %}

--- a/templates/inventory/_item_form_partial.html
+++ b/templates/inventory/_item_form_partial.html
@@ -1,4 +1,4 @@
-<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-drawer-xl max-h-screen-90 overflow-y-auto">
+<div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden max-w-drawer-xl max-h-screen-90 overflow-y-auto flex flex-col">
   <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
     <h3 class="text-lg font-semibold">Edit Item — {{ item.name }}</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
@@ -9,8 +9,8 @@
       <input type="hidden" name="partial" value="1"/>
       <div class="grid grid-cols-12 gap-4">
         <!-- Essentials -->
-        <div class="section-panel col-span-12" id="essentials-panel">
-          <h3 class="section-header">Essentials</h3>
+        <div class="col-span-12 bg-gray-50 p-4 rounded border border-gray-200" id="essentials-panel">
+          <h3 class="text-lg font-semibold mb-2">Essentials</h3>
           <div class="grid grid-cols-3 gap-4 items-start">
             <div class="space-y-1">
               <label for="{{ form.name.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">Name</label>
@@ -49,8 +49,8 @@
         </div>
 
         <!-- Advanced -->
-        <div class="section-panel col-span-12" id="advanced-panel">
-          <h3 class="section-header">Advanced</h3>
+        <div class="col-span-12 bg-gray-50 p-4 rounded border border-gray-200" id="advanced-panel">
+          <h3 class="text-lg font-semibold mb-2">Advanced</h3>
           <div class="grid grid-cols-3 gap-4 items-start">
             <div class="space-y-1">
               <label for="{{ form.preferred_supplier.id_for_label }}" class="block text-sm font-medium text-gray-700 mb-1">Preferred Supplier</label>
@@ -89,7 +89,7 @@
 
         <!-- Actions -->
         <div class="col-span-12">
-          <div class="form-actions">
+          <div class="flex gap-2 justify-end">
             <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" data-modal-close>Cancel</button>
             <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">Save</button>
           </div>

--- a/templates/inventory/_quick_indent_form.html
+++ b/templates/inventory/_quick_indent_form.html
@@ -1,7 +1,7 @@
 {% extends "components/collapsible.html" %}
 {% block title %}Quick Indent{% endblock %}
 {% block content %}
-  <form method="post">
+  <form method="post" class="space-y-4">
     {% csrf_token %}
     <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
       {% for field in quick_form %}

--- a/templates/inventory/purchase_orders/_quick_form.html
+++ b/templates/inventory/purchase_orders/_quick_form.html
@@ -1,7 +1,7 @@
 {% extends "components/collapsible.html" %}
 {% block title %}Quick Purchase Order{% endblock %}
 {% block content %}
-<form method="post">
+<form method="post" class="space-y-4">
   {% csrf_token %}
   <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
     {% include "components/form_field.html" with field=quick_form.supplier %}


### PR DESCRIPTION
## Summary
- replace custom filter wrapper with Tailwind utilities
- style bulk upload dropzone with Tailwind and dedicated component rule
- rebuild item forms using Tailwind spacing and layout helpers

## Testing
- `pre-commit run --files static/src/app.css templates/components/filter_bar.html templates/inventory/_add_item_section.html templates/inventory/_bulk_upload_section.html templates/inventory/_item_form_partial.html templates/inventory/_quick_indent_form.html templates/inventory/purchase_orders/_quick_form.html`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b946e3334083268683c139fa540ad5