### PR TITLE
Improve items table responsiveness and overflow handling

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -951,6 +951,12 @@ input[list]:after {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(59 130 246 / var(--tw-ring-opacity, 1));
 }
+.cell-content {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-wrap: break-word;
+}
 .sr-only {
   position: absolute;
   width: 1px;
@@ -1245,6 +1251,12 @@ input[list]:after {
   width: -moz-max-content;
   width: max-content;
 }
+.min-w-\[150px\] {
+  min-width: 150px;
+}
+.min-w-\[200px\] {
+  min-width: 200px;
+}
 .max-w-3xl {
   max-width: 48rem;
 }
@@ -1289,9 +1301,6 @@ input[list]:after {
 }
 .table-auto {
   table-layout: auto;
-}
-.table-fixed {
-  table-layout: fixed;
 }
 .translate-x-full {
   --tw-translate-x: 100%;

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -740,6 +740,11 @@
     line-height: 1;
     display: inline-block;
   }
+
+  /* Table cell overflow handling */
+  .cell-content {
+    @apply truncate break-words;
+  }
 }
 
 @layer utilities {

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,7 +1,7 @@
 {% load icon_tags category_tags %}
 <!-- prettier-ignore -->
 <table
-  class="table w-full table-fixed bg-white border border-gray-200 rounded-lg table-sticky"
+  class="table w-full table-auto bg-white border border-gray-200 rounded-lg table-sticky"
   id="items-table"
   data-sortable
 >
@@ -12,7 +12,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2 font-semibold"
+        class="sticky z-10 px-4 py-2 font-semibold min-w-[200px]"
         data-col="name"
         aria-sort="none"
       >
@@ -22,7 +22,7 @@
       </th>
       <th
         scope="col"
-        class="sticky z-10 px-4 py-2 font-semibold"
+        class="sticky z-10 px-4 py-2 font-semibold min-w-[150px]"
         data-col="category"
         aria-sort="none"
       >
@@ -112,7 +112,10 @@
           data-action="select-item"
         />
       </td>
-      <td data-col="name" class="px-4 py-2 whitespace-normal break-words">
+      <td
+        data-col="name"
+        class="px-4 py-2 whitespace-normal break-words min-w-[200px]"
+      >
         <div class="flex items-start gap-2">
           <button
             type="button"
@@ -126,7 +129,7 @@
           </button>
           <div>
             <div
-              class="font-medium text-gray-900"
+              class="font-medium text-gray-900 cell-content"
               id="item-title-{{ item.item_id }}"
             >
               <a
@@ -141,7 +144,10 @@
           </div>
         </div>
       </td>
-      <td data-col="category" class="px-4 py-2 whitespace-normal break-words">
+      <td
+        data-col="category"
+        class="px-4 py-2 min-w-[150px] cell-content"
+      >
         {% format_category item True %}
       </td>
       <td data-col="unit" class="px-4 py-2 whitespace-normal break-words">{{ item.unit.base_unit|default:"—" }}</td>


### PR DESCRIPTION
## Summary
- switch items table to auto layout and enforce minimum widths for key columns
- add reusable overflow utility class to truncate and wrap long cell content
- rebuild Tailwind CSS to include new utilities

## Testing
- `pre-commit run --files templates/inventory/_items_table.html static/src/app.css static/css/app.css`
- `npm run build-css`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b84fc985408326af3bf004524bfd37