### PR TITLE
Handle zero stock rendering in inventory table

### DIFF
--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -146,9 +146,10 @@
       </td>
       <td data-col="unit" class="px-4 py-2 whitespace-normal break-words">{{ item.unit.base_unit|default:"—" }}</td>
       <td data-col="stock" class="px-4 py-2 whitespace-normal break-words">
-        {% if item.current_stock is not None %} {{ item.current_stock }} {% else
-        %}
-        <span class="text-gray-400">—</span>
+        {% if item.current_stock is not None %}
+          {{ item.current_stock|floatformat:0 }}
+        {% else %}
+          <span class="text-gray-400">—</span>
         {% endif %}
       </td>
       <td data-col="stock_status" class="px-4 py-2 whitespace-normal break-words">

--- a/tests/test_stock_cell.py
+++ b/tests/test_stock_cell.py
@@ -1,0 +1,18 @@
+import re
+from types import SimpleNamespace
+
+import pytest
+from django.template.loader import render_to_string
+
+
+@pytest.mark.django_db
+def test_stock_cell_zero_renders_without_template_markers(item_factory):
+    item = item_factory(current_stock=0)
+    page_obj = SimpleNamespace(object_list=[item])
+    html = render_to_string("inventory/_items_table.html", {"page_obj": page_obj})
+    match = re.search(r'<td data-col="stock"[^>]*>(.*?)</td>', html, re.DOTALL)
+    assert match is not None
+    stock_content = match.group(1).strip()
+    assert stock_content == "0"
+    assert "{{" not in stock_content
+    assert "{%" not in stock_content


### PR DESCRIPTION
## Summary
- format stock quantities in items table using `floatformat` and show a dash when stock is unknown
- add regression test ensuring zero stock renders without template artifacts

## Testing
- `pytest tests/test_stock_cell.py -q`
- `python manage.py shell -c "from types import SimpleNamespace; from django.template.loader import render_to_string; import re
class Depts:
    def all(self):
        return []
item=SimpleNamespace(item_id=1, unit_id=1, category_id=1, name='Test', unit=SimpleNamespace(base_unit='kg'), item_code=None, current_stock=0, reorder_point=None, departments=Depts(), is_active=True)
page_obj=SimpleNamespace(object_list=[item])
html=render_to_string('inventory/_items_table.html', {'page_obj': page_obj})
match=re.search(r'<td data-col=\\"stock\\"[^>]*>(.*?)</td>', html, re.DOTALL)
print(match.group(1).strip())
"`
- `python manage.py shell -c "from types import SimpleNamespace; from django.template.loader import render_to_string; import re
class Depts:
    def all(self):
        return []
item=SimpleNamespace(item_id=1, unit_id=1, category_id=1, name='Test', unit=SimpleNamespace(base_unit='kg'), item_code=None, current_stock=None, reorder_point=None, departments=Depts(), is_active=True)
page_obj=SimpleNamespace(object_list=[item])
html=render_to_string('inventory/_items_table.html', {'page_obj': page_obj})
match=re.search(r'<td data-col=\\"stock\\"[^>]*>(.*?)</td>', html, re.DOTALL)
print(match.group(1).strip())
"`


------
https://chatgpt.com/codex/tasks/task_e_68b94a68859883268b0f11c3a4e12d93