### PR TITLE
Remove ROP column from items table

### DIFF
--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -56,7 +56,6 @@
     row.dataset.origHtml = row.innerHTML; // for cancel/restore
 
     const nameCell = row.querySelector('td[data-col="name"]');
-    const ropCell = row.querySelector('td[data-col="rop"]');
     const categoryCell = row.querySelector('td[data-col="category"]');
     const unitCell = row.querySelector('td[data-col="unit"]');
     const stockCell = row.querySelector('td[data-col="stock"]');
@@ -66,8 +65,6 @@
     const currentName = (
       nameCell?.querySelector(".font-medium")?.textContent || ""
     ).trim();
-    const ropText = (ropCell?.textContent || "").trim();
-    const currentRop = /^[-+]?[0-9]*\.?[0-9]+$/.test(ropText) ? ropText : "";
     const currentCategory = (categoryCell?.textContent || "")
       .trim()
       .split("→")[0]
@@ -118,7 +115,6 @@
     }
     if (stockCell)
       stockCell.innerHTML = `<input type="number" step="0.01" name="current_stock" class="${INPUT_CLASSES}" value="${escapeHtml(currentStock)}" placeholder="0">`;
-    ropCell.innerHTML = `<input type="number" step="0.01" name="reorder_point" class="${INPUT_CLASSES}" value="${escapeHtml(currentRop)}">`;
     statusCell.innerHTML = `<label class="inline-flex items-center gap-2"><input type="checkbox" name="is_active" ${isActive ? "checked" : ""} class="${CHECKBOX_CLASSES}"><span>Active</span></label>`;
     actionsCell.innerHTML = `<div class="flex items-center gap-1"><button type="button" data-action="save-row" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">Save</button><button type="button" data-action="cancel-row" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">Cancel</button></div>`;
   }
@@ -134,7 +130,6 @@
     if (!row) return;
     const itemId = row.dataset.itemId;
     const name = row.querySelector('input[name="name"]')?.value || "";
-    const rop = row.querySelector('input[name="reorder_point"]')?.value || "";
     const categoryId =
       row.querySelector('select[name="category_id"]')?.value || "";
     const unitId = row.querySelector('select[name="unit_id"]')?.value || "";
@@ -145,7 +140,6 @@
 
     const fd = new FormData();
     fd.append("name", name);
-    if (rop !== "") fd.append("reorder_point", rop);
     if (categoryId !== "") fd.append("category_id", categoryId);
     if (unitId !== "") fd.append("unit_id", unitId);
     if (currentStock !== "") fd.append("current_stock", currentStock);
@@ -168,8 +162,6 @@
             'td[data-col="name"] .font-medium',
           );
           if (nameCell && name) nameCell.textContent = name;
-          const ropCell = row.querySelector('td[data-col="rop"]');
-          if (ropCell && rop !== "") ropCell.textContent = rop;
           const categoryCell = row.querySelector('td[data-col="category"]');
           if (categoryCell && categoryId !== "") {
             const sel = document.getElementById("category-id-select-template");
@@ -198,8 +190,10 @@
           const stockStatusCell = row.querySelector(
             'td[data-col="stock_status"]',
           );
-          if (stockStatusCell)
+          if (stockStatusCell) {
+            const rop = row.getAttribute("data-rop") || "";
             stockStatusCell.innerHTML = renderStockStatus(currentStock, rop);
+          }
           const statusCell = row.querySelector('td[data-col="status"]');
           if (statusCell) {
             statusCell.innerHTML = active

--- a/static/js/items-table.test.js
+++ b/static/js/items-table.test.js
@@ -235,7 +235,6 @@ describe("inline row edit", () => {
       <table>
         <tr class="item-row" data-item-id="1" data-category-id="2" data-unit-id="3">
           <td data-col="name"><span class="font-medium">Item</span></td>
-          <td data-col="rop">5</td>
           <td data-col="category">Cat</td>
           <td data-col="unit">Unit</td>
           <td data-col="stock">10</td>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -63,20 +63,10 @@
       <th
         scope="col"
         class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md"
-        data-col="rop"
-        aria-sort="none"
-      >
-        <button class="sort flex items-center focus:outline-none focus:ring-2 focus:ring-primary" data-sort="col6">
-          ROP<span class="ml-1">⇅</span>
-        </button>
-      </th>
-      <th
-        scope="col"
-        class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md"
         data-col="departments"
         aria-sort="none"
       >
-        <button class="sort flex items-center focus:outline-none focus:ring-2 focus:ring-primary" data-sort="col7">
+        <button class="sort flex items-center focus:outline-none focus:ring-2 focus:ring-primary" data-sort="col6">
           Departments<span class="ml-1">⇅</span>
         </button>
       </th>
@@ -86,7 +76,7 @@
         data-col="status"
         aria-sort="none"
       >
-        <button class="sort flex items-center focus:outline-none focus:ring-2 focus:ring-primary" data-sort="col8">
+        <button class="sort flex items-center focus:outline-none focus:ring-2 focus:ring-primary" data-sort="col7">
           Status<span class="ml-1">⇅</span>
         </button>
       </th>
@@ -102,6 +92,7 @@
       data-item-id="{{ item.item_id }}"
       data-unit-id="{{ item.unit_id }}"
       data-category-id="{{ item.category_id }}"
+      data-rop="{{ item.reorder_point|default:'' }}"
     >
       <td class="px-4 py-2 whitespace-normal break-words">
         <input
@@ -167,7 +158,6 @@
           {% endif %}
         </div>
       </td>
-      <td data-col="rop" class="px-4 py-2 whitespace-normal break-words">{{ item.reorder_point|default:"—" }}</td>
       <td data-col="departments" class="px-4 py-2 whitespace-normal break-words">
         {% if item.departments.all %} {% for dept in item.departments.all %}
         <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">{{ dept.name }}</span>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -96,12 +96,6 @@
             </li>
             <li role="none">
               <label class="flex items-center gap-2" role="menuitemcheckbox" tabindex="-1">
-                <input type="checkbox" data-col-toggle value="rop" checked class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" />
-                <span>ROP</span>
-              </label>
-            </li>
-            <li role="none">
-              <label class="flex items-center gap-2" role="menuitemcheckbox" tabindex="-1">
                 <input type="checkbox" data-col-toggle value="departments" checked class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" />
                 <span>Dept</span>
               </label>

--- a/tests/test_items_table_header.py
+++ b/tests/test_items_table_header.py
@@ -19,6 +19,8 @@ def test_items_table_header_top_zero_and_structure():
     assert not re.search(r"<table[^>]*>\s*<tr", table)
     assert "data-sortable" in table
 
+    assert 'data-col="rop"' not in tpl
+
     ths = re.findall(r"<th[^>]*>.*?</th>", header, re.DOTALL)
     assert "data-sort" not in ths[0]
     assert "data-sort" not in ths[-1]


### PR DESCRIPTION
## Summary
- drop ROP column and its toggle entry from inventory tables
- streamline inline edit JS by removing ROP selectors and using dataset for stock status
- update tests for new column set

## Testing
- `npm test static/js/items-table.test.js`
- `pytest tests/test_items_table_header.py`


------
https://chatgpt.com/codex/tasks/task_e_68b94c56d0c88326b06d8cf0bfa292ea