### PR TITLE
feat: add fluid typography tokens

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -89,9 +89,6 @@ module.exports = {
         "screen-90": "90vh",
       },
       fontSize: {
-        base: ["clamp(1rem, 0.5vw + 0.9rem, 1.25rem)", { lineHeight: "1.5" }],
-        h1: ["clamp(1.6rem, 1vw + 1.3rem, 2.5rem)", { lineHeight: "1.25" }],
-        h2: ["clamp(1.3rem, 0.75vw + 1.1rem, 2rem)", { lineHeight: "1.3" }],
         badge: ["clamp(0.8rem, 0.3vw + 0.7rem, 1rem)", { lineHeight: "1" }],
       },
       fontFamily: {
@@ -103,5 +100,33 @@ module.exports = {
       },
     },
   },
-  plugins: [require("tailwindcss-fluid-type"), require("@tailwindcss/forms")],
+  plugins: [
+    require("tailwindcss-fluid-type")({
+      settings: {
+        fontSizeMin: 1,
+        fontSizeMax: 1.25,
+        ratioMin: 1.2,
+        ratioMax: 1.333,
+        screenMin: 20,
+        screenMax: 96,
+        unit: "rem",
+        prefix: "",
+        extendValues: true,
+      },
+      values: {
+        xs: [-2, 1.6],
+        sm: [-1, 1.6],
+        base: [0, 1.6],
+        lg: [1, 1.6],
+        xl: [2, 1.4],
+        h1: [5, 1.2],
+        h2: [4, 1.3],
+        h3: [3, 1.4],
+        label: [-1, 1.6],
+        body: [0, 1.6],
+        caption: [-2, 1.6],
+      },
+    }),
+    require("@tailwindcss/forms"),
+  ],
 };

--- a/templates/components/basic_table.html
+++ b/templates/components/basic_table.html
@@ -1,5 +1,5 @@
 {% comment %}Basic table component with block areas for headers and rows{% endcomment %}
-<table class="min-w-full w-full text-sm">
+<table class="min-w-full w-full text-label">
   <thead>
     <tr>
       {% block headers %}{% endblock %}

--- a/templates/components/breadcrumb.html
+++ b/templates/components/breadcrumb.html
@@ -3,7 +3,7 @@
   Expects list_url, list_title, current_title, optional class.
   Always starts with a link back to the Inventory Pro dashboard.
 {% endcomment %}
-<div class="{{ class|default:'flex items-center gap-1 text-sm text-gray-500 mb-4' }}">
+<div class="{{ class|default:'flex items-center gap-1 text-label text-gray-500 mb-4' }}">
   <a href="{% url 'root' %}" class="text-primary hover:underline">Inventory Pro</a>
   {% if list_url and list_title and list_title != current_title %}
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/templates/components/button.html
+++ b/templates/components/button.html
@@ -3,7 +3,7 @@ Generic button component. Use `href` for links or rely on `type` for button elem
 Supported variants: primary, secondary, danger, icon, etc.
 Optional `extra_classes` to append additional Tailwind classes.
 {% endcomment %}
-{% with base_classes="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed" %}
+{% with base_classes="inline-flex items-center px-4 py-2 text-label font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed" %}
   {% if href %}
     <a href="{{ href }}" id="{{ id }}" class="{{ base_classes }} {% if variant == 'secondary' %}bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary{% elif variant == 'danger' %}bg-danger text-white hover:bg-dangerHover focus:ring-2 focus:ring-primary{% elif variant == 'square' %}justify-center w-8 h-8 p-0 bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary{% else %}bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary{% endif %} {{ extra_classes }}">{{ label }}</a>
   {% else %}

--- a/templates/components/detail_section.html
+++ b/templates/components/detail_section.html
@@ -1,7 +1,7 @@
 <div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden mb-6">
   {% if title %}
   <div class="px-4 py-3 border-b border-gray-200 bg-gray-50">
-    <h2 class="text-h2 md:text-lg font-semibold">{{ title }}</h2>
+    <h2 class="text-h2 md:text-h3 font-semibold">{{ title }}</h2>
   </div>
   {% endif %}
   <div class="p-4">

--- a/templates/components/detail_table.html
+++ b/templates/components/detail_table.html
@@ -1,4 +1,4 @@
-<table class="min-w-full text-sm">
+<table class="min-w-full text-label">
   <tbody class="bg-white divide-y divide-border">
     {% for label, value in rows %}
     <tr>

--- a/templates/components/empty_state.html
+++ b/templates/components/empty_state.html
@@ -7,6 +7,6 @@
     {% icon 'plus' 'mx-auto w-5 h-5 text-form-text' aria_label='' %}
   {% endif %}
   <h2 class="text-h2 md:text-h2 mb-4 mt-8">{{ title }}</h2>
-  <p class="mb-4 text-form-text">{{ message }}</p>
-  <a href="{{ cta_url }}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">{{ cta_label }}</a>
+  <p class="mb-4 text-form-text text-body">{{ message }}</p>
+  <a href="{{ cta_url }}" class="inline-flex items-center px-4 py-2 text-label font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">{{ cta_label }}</a>
 </div>

--- a/templates/components/filter_bar.html
+++ b/templates/components/filter_bar.html
@@ -1,6 +1,6 @@
 <form id="filters" class="flex flex-wrap gap-4 items-end mb-0" method="get">
     <div class="flex flex-col">
-      <label for="filter-q" class="text-sm font-medium">{{ search_label|default:'Search' }}</label>
+      <label for="filter-q" class="text-label font-medium">{{ search_label|default:'Search' }}</label>
       <input
         id="filter-q"
         type="text"
@@ -18,7 +18,7 @@
     </div>
     {% for f in filters %}
       <div class="flex flex-col">
-        <label for="{{ f.id|default:f.name }}" class="text-sm font-medium">{{ f.label|default:f.name|capfirst }}</label>
+        <label for="{{ f.id|default:f.name }}" class="text-label font-medium">{{ f.label|default:f.name|capfirst }}</label>
         <select
           name="{{ f.name }}"
           class="block w-full p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
@@ -40,8 +40,8 @@
     {% endfor %}
     {% if export_url %}
       <div class="flex flex-col">
-        <span class="text-sm font-medium">&nbsp;</span>
-        <button type="submit" {% if export_param_name and export_param_value %}name="{{ export_param_name }}" value="{{ export_param_value }}"{% endif %} formaction="{{ export_url }}" formmethod="get" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary w-full">{{ export_label|default:'Export' }}</button>
+        <span class="text-label font-medium">&nbsp;</span>
+        <button type="submit" {% if export_param_name and export_param_value %}name="{{ export_param_name }}" value="{{ export_param_value }}"{% endif %} formaction="{{ export_url }}" formmethod="get" class="inline-flex items-center px-4 py-2 text-label font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary w-full">{{ export_label|default:'Export' }}</button>
       </div>
     {% endif %}
   {% if layout %}<input type="hidden" name="layout" value="{{ layout }}">{% endif %}
@@ -50,7 +50,7 @@
   {% if direction %}<input type="hidden" name="direction" value="{{ direction|default:'asc' }}">{% endif %}
   <noscript>
     <div class="mt-2">
-      <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">Apply</button>
+      <button type="submit" class="inline-flex items-center px-4 py-2 text-label font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">Apply</button>
     </div>
   </noscript>
 </form>

--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -1,6 +1,6 @@
 {% load form_tags %}
 <div class="{% if container_class %}{{ container_class }} {% endif %}space-y-1">
-  <label for="{{ field.id_for_label }}" class="block mb-1 text-sm font-medium">{{ field.label }}</label>
+  <label for="{{ field.id_for_label }}" class="block mb-1 text-label font-medium">{{ field.label }}</label>
   {% if field.field.widget.attrs.class %}
     {{ field }}
   {% elif field.field.widget.input_type == "checkbox" %}
@@ -12,10 +12,10 @@
   {% endif %}
   {% include "forms/feedback.html" %}
   {% if field.help_text %}
-    <p class="text-sm text-gray-500">{{ field.help_text }}</p>
+    <p class="text-label text-gray-500">{{ field.help_text }}</p>
   {% endif %}
   {% if field.errors %}
-    <ul class="text-sm text-red-600 list-disc pl-5">
+    <ul class="text-label text-red-600 list-disc pl-5">
       {% for error in field.errors %}
         <li>{{ error }}</li>
       {% endfor %}

--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -15,8 +15,8 @@
     {% endif %}
     {% block fields %}{% endblock %}
     <div class="flex gap-2">
-      <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">{% block submit_text %}Save{% endblock %}</button>
-      <a href="{% block back_url %}{% endblock %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">{% block back_text %}Cancel{% endblock %}</a>
+      <button type="submit" class="inline-flex items-center px-4 py-2 text-label font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">{% block submit_text %}Save{% endblock %}</button>
+      <a href="{% block back_url %}{% endblock %}" class="inline-flex items-center px-4 py-2 text-label font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">{% block back_text %}Cancel{% endblock %}</a>
     </div>
   </form>
   {% block extra %}{% endblock %}

--- a/templates/components/image_uploader.html
+++ b/templates/components/image_uploader.html
@@ -5,5 +5,5 @@
     <img src="{{ image_url }}" alt="Current thumbnail" class="h-24 w-24 object-cover rounded" />
   {% endif %}
   <input type="file" name="thumbnail" id="id_thumbnail" accept="image/*" class="block" />
-  <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">Upload</button>
+  <button type="submit" class="inline-flex items-center px-4 py-2 text-label font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">Upload</button>
 </form>

--- a/templates/components/kpi_card.html
+++ b/templates/components/kpi_card.html
@@ -14,7 +14,7 @@
         </div>
       </div>
       <div class="ml-4">
-        <p class="text-sm font-medium text-gray-500">{{ label }}</p>
+        <p class="text-label font-medium text-gray-500">{{ label }}</p>
         <p class="text-2xl font-semibold text-gray-900">{{ value }}</p>
       </div>
     </div>

--- a/templates/components/login_modal.html
+++ b/templates/components/login_modal.html
@@ -9,7 +9,7 @@
       {% for field in form %}
         {% include "components/form_field.html" with field=field %}
       {% endfor %}
-      <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary w-full">Login</button>
+      <button type="submit" class="inline-flex items-center px-4 py-2 text-label font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary w-full">Login</button>
     </form>
   </div>
 </div>

--- a/templates/components/pagination.html
+++ b/templates/components/pagination.html
@@ -3,7 +3,7 @@
     {% if page_obj.has_previous %}
       <a href="{{ base_url }}?page={{ page_obj.previous_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}"
          {% if hx_target %}hx-get="{{ base_url }}?page={{ page_obj.previous_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
-         class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" aria-label="Previous page">Prev</a>
+         class="inline-flex items-center px-3 py-1.5 text-caption font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" aria-label="Previous page">Prev</a>
     {% endif %}
     {% for num in page_obj.paginator.page_range %}
       {% if num == page_obj.number %}
@@ -11,13 +11,13 @@
       {% else %}
         <a href="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}"
            {% if hx_target %}hx-get="{{ base_url }}?page={{ num }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
-           class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">{{ num }}</a>
+           class="inline-flex items-center px-3 py-1.5 text-caption font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">{{ num }}</a>
       {% endif %}
     {% endfor %}
     {% if page_obj.has_next %}
       <a href="{{ base_url }}?page={{ page_obj.next_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}"
          {% if hx_target %}hx-get="{{ base_url }}?page={{ page_obj.next_page_number }}{% if extra_query %}&{{ extra_query }}{% endif %}" hx-target="{{ hx_target }}"{% if hx_include %} hx-include="{{ hx_include }}"{% endif %}{% if hx_indicator %} hx-indicator="{{ hx_indicator }}"{% endif %}{% endif %}
-         class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" aria-label="Next page">Next</a>
+         class="inline-flex items-center px-3 py-1.5 text-caption font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary" aria-label="Next page">Next</a>
     {% endif %}
     <span class="ml-2">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
   </div>

--- a/templates/components/responsive_table.html
+++ b/templates/components/responsive_table.html
@@ -3,7 +3,7 @@ Responsive table component with sticky headers and row hover states.
 {% endcomment %}
 <div{% if container_id %} id="{{ container_id }}"{% endif %} class="max-md:overflow-x-auto">
   {% block actions %}{% endblock %}
-  <table class="min-w-full w-full table-auto text-sm"{% if table_id %} id="{{ table_id }}"{% endif %}>
+  <table class="min-w-full w-full table-auto text-label"{% if table_id %} id="{{ table_id }}"{% endif %}>
     {% block caption %}{% endblock %}
     <thead class="sticky top-0 bg-primary text-white">
       <tr>

--- a/templates/components/toast.html
+++ b/templates/components/toast.html
@@ -1,5 +1,5 @@
 {% if message %}
-<div id="{{ toast_id|default:'toast' }}" class="absolute left-0 top-full mt-1 z-10 w-max max-w-xs bg-blue-100 text-blue-800 text-sm px-3 py-2 rounded shadow flex items-start gap-2" role="status" aria-live="polite">
+<div id="{{ toast_id|default:'toast' }}" class="absolute left-0 top-full mt-1 z-10 w-max max-w-xs bg-blue-100 text-blue-800 text-label px-3 py-2 rounded shadow flex items-start gap-2" role="status" aria-live="polite">
   <span class="flex-1">{{ message }}</span>
   <button type="button" class="text-blue-800 focus:outline-none focus:ring-2 focus:ring-primary" aria-label="Dismiss" onclick="this.parentElement.remove()">&times;</button>
 </div>

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -30,7 +30,7 @@
             <div class="border-t border-gray-100 first:border-t-0 top-nav-group" data-nav-group>
               <button
                 type="button"
-                class="w-full flex justify-between items-center px-4 py-2 text-sm font-semibold text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary"
+                class="w-full flex justify-between items-center px-4 py-2 text-label font-semibold text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary"
                 aria-expanded="false"
               >
                 <span>{{ group.category }}</span>
@@ -40,7 +40,7 @@
                 {% for link in group.links %}
                 <a
                   href="{{ link.url }}"
-                  class="block px-6 py-2 text-sm text-gray-700 hover:bg-gray-100 no-underline focus:outline-none focus:ring-2 focus:ring-primary"
+                  class="block px-6 py-2 text-label text-gray-700 hover:bg-gray-100 no-underline focus:outline-none focus:ring-2 focus:ring-primary"
                   role="menuitem"
                 >{{ link.title }}</a>
                 {% endfor %}
@@ -75,14 +75,14 @@
         <button class="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 relative focus:outline-none focus:ring-2 focus:ring-primary" aria-label="View notifications">
           {% icon 'bell' 'h-6 w-6' aria_label='' %}
           <!-- Notification badge -->
-          <span class="absolute -top-1 -right-1 h-4 w-4 bg-red-500 text-white text-xs rounded-full flex items-center justify-center">3</span>
+          <span class="absolute -top-1 -right-1 h-4 w-4 bg-red-500 text-white text-caption rounded-full flex items-center justify-center">3</span>
         </button>
         {% endif %}
 
         <!-- User Menu -->
         {% if user.is_authenticated %}
         <div class="relative">
-          <button class="flex items-center space-x-3 text-sm rounded-lg p-2 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary">
+          <button class="flex items-center space-x-3 text-label rounded-lg p-2 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary">
             <div class="h-8 w-8 bg-blue-100 rounded-full flex items-center justify-center">
               <span class="text-blue-600 font-medium">{% if user.first_name %}{{ user.first_name.0|upper }}{% elif user.username %}{{ user.username.0|upper }}{% else %}?{% endif %}</span>
             </div>

--- a/templates/forms/feedback.html
+++ b/templates/forms/feedback.html
@@ -1,2 +1,2 @@
-<p class="text-sm text-success mt-1 hidden" data-feedback="success"></p>
-<p class="text-sm text-red-600 mt-1 hidden" data-feedback="error"></p>
+<p class="text-label text-success mt-1 hidden" data-feedback="success"></p>
+<p class="text-label text-red-600 mt-1 hidden" data-feedback="error"></p>

--- a/tests/test_breadcrumbs.py
+++ b/tests/test_breadcrumbs.py
@@ -28,4 +28,4 @@ def test_dashboard_page_displays_breadcrumb(client, django_user_model):
     html = resp.content.decode()
     assert "Inventory Pro" in html
     assert "Dashboard" in html
-    assert "flex items-center gap-1 text-sm text-gray-500 mb-4" in html
+    assert "flex items-center gap-1 text-label text-gray-500 mb-4" in html

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -93,10 +93,10 @@ def test_item_detail_includes_supplier_and_movements(client):
     assert tx.transaction_type in content
     assert str(tx.quantity_change) in content
     assert (
-        '<h2 class="text-h2 md:text-lg font-semibold">Supplier History</h2>' in content
+        '<h2 class="text-h2 md:text-h3 font-semibold">Supplier History</h2>' in content
     )
     assert (
-        '<h2 class="text-h2 md:text-lg font-semibold">Stock Movements</h2>' in content
+        '<h2 class="text-h2 md:text-h3 font-semibold">Stock Movements</h2>' in content
     )
 
 


### PR DESCRIPTION
## Summary
- add fluid typography scales and semantic text tokens via `tailwindcss-fluid-type`
- replace hard-coded template sizes with `text-label`, `text-body`, and `text-caption`
- adjust tests for new font size utilities

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b94d3f214c83268484fbff965f1b7c