### PR TITLE
fix: improve form field vertical spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLEANUP: Remove undefined item_duplicate URL references from templates - fixed template errors causing view failures
 - Ensure items list content aligns directly beneath the filter bar using dynamic padding instead of margin offsets
 - Use `hidden` utility class with Tailwind safelist for multiselect chip filtering to improve accessibility and build stability
+- Prevent vertical overflow on large viewports by increasing form field padding and enforcing consistent `leading-normal` line-height
 
 ### Added
 

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -45,12 +45,12 @@
   /* Form component styles */
   /* Form label styles */
   form label {
-    @apply block mb-2;
+    @apply block mb-2 leading-normal;
   }
   form input:not([type="checkbox"]):not([type="radio"]),
   form select,
   form textarea {
-    @apply font-sans border border-form-border bg-form-bg text-form-text p-2 rounded w-full;
+    @apply font-sans border border-form-border bg-form-bg text-form-text px-3 py-2.5 rounded w-full leading-normal;
   }
   form input:not([type="checkbox"]):not([type="radio"]):focus,
   form select:focus,

--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -1,23 +1,23 @@
 {% load form_tags %}
 <div class="{% if container_class %}{{ container_class }} {% endif %}space-y-1">
-  <label for="{{ field.id_for_label }}" class="block mb-1 text-label font-medium">{{ field.label }}</label>
+  <label for="{{ field.id_for_label }}" class="block mb-1 text-label font-medium leading-normal">{{ field.label }}</label>
   {% if field.field.widget.attrs.class %}
-    {{ field }}
+    {{ field|add_class:"leading-normal" }}
   {% elif field.field.widget.input_type == "checkbox" %}
     {{ field|add_class:"h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" }}
   {% elif field.field.widget.input_type == "radio" %}
     {{ field|add_class:"h-4 w-4 rounded-full border-gray-300 text-primary focus:ring-primary" }}
   {% else %}
-    {{ field|add_class:"block w-full p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary" }}
+    {{ field|add_class:"block w-full px-3 py-2.5 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary leading-normal" }}
   {% endif %}
   {% include "forms/feedback.html" %}
   {% if field.help_text %}
-    <p class="text-label text-gray-500">{{ field.help_text }}</p>
+    <p class="text-label text-gray-500 leading-normal">{{ field.help_text }}</p>
   {% endif %}
   {% if field.errors %}
-    <ul class="text-label text-red-600 list-disc pl-5">
+    <ul class="text-label text-red-600 list-disc pl-5 leading-normal">
       {% for error in field.errors %}
-        <li>{{ error }}</li>
+        <li class="leading-normal">{{ error }}</li>
       {% endfor %}
     </ul>
   {% endif %}

--- a/tests/frontend/form_layout.test.js
+++ b/tests/frontend/form_layout.test.js
@@ -1,0 +1,26 @@
+/** @jest-environment jsdom */
+
+describe('form layout regression', () => {
+  test('form does not overflow vertically at large viewport sizes', () => {
+    // Simulate a large viewport
+    window.innerWidth = 1920;
+    window.innerHeight = 1080;
+
+    document.body.innerHTML = `
+      <form style="height:100vh; overflow-y:auto">
+        <div>
+          <label class="leading-normal block mb-1">Name</label>
+          <input class="leading-normal px-3 py-2.5 block w-full" />
+          <p class="leading-normal">Help text</p>
+          <p class="leading-normal text-red-600">Error message</p>
+        </div>
+      </form>
+    `;
+
+    const form = document.querySelector('form');
+    expect(form.scrollHeight).toBeLessThanOrEqual(window.innerHeight);
+    form.querySelectorAll('label,input,p').forEach(el => {
+      expect(el.scrollHeight).toBe(el.clientHeight);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- increase form input vertical padding and enforce `leading-normal` for labels, help text, and error messages
- document spacing fix in changelog and add regression test for large viewports

## Testing
- `npm run build`
- `npm test`
- `pytest tests/test_item_form.py`


------
https://chatgpt.com/codex/tasks/task_e_68b94f932128832689f58bbe7312bd91