### PR TITLE
feat: separate images from text in lists

### DIFF
--- a/templates/components/image_uploader.html
+++ b/templates/components/image_uploader.html
@@ -1,9 +1,13 @@
-<form method="post" enctype="multipart/form-data" class="mb-4 flex flex-col gap-2">
+<form method="post" enctype="multipart/form-data" class="mb-4">
   {% csrf_token %}
-  <label for="id_thumbnail" class="font-semibold">Thumbnail</label>
-  {% if image_url %}
-    <img src="{{ image_url }}" alt="Current thumbnail" class="h-24 w-24 object-cover rounded" />
-  {% endif %}
-  <input type="file" name="thumbnail" id="id_thumbnail" accept="image/*" class="block" />
-  <button type="submit" class="inline-flex items-center px-4 py-2 text-label font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">Upload</button>
+  <div class="flex items-start gap-4 overflow-hidden">
+    {% if image_url %}
+      <img src="{{ image_url }}" alt="Current thumbnail" class="w-24 max-w-full h-auto object-contain rounded flex-shrink-0" />
+    {% endif %}
+    <div class="flex flex-col gap-2">
+      <label for="id_thumbnail" class="font-semibold">Thumbnail</label>
+      <input type="file" name="thumbnail" id="id_thumbnail" accept="image/*" class="block" />
+      <button type="submit" class="inline-flex items-center px-4 py-2 text-label font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary">Upload</button>
+    </div>
+  </div>
 </form>

--- a/templates/inventory/recipes/_recipe_card.html
+++ b/templates/inventory/recipes/_recipe_card.html
@@ -1,9 +1,11 @@
 <a href="{% url 'recipe_detail' recipe.recipe_id %}" class="block bg-white rounded-lg shadow hover:shadow-xl transition-transform transform hover:-translate-y-1">
-  {% if recipe.image %}
-  <img src="{{ recipe.image }}" alt="{{ recipe.name }}" class="w-full h-40 object-cover rounded-t-lg" />
-  {% endif %}
-  <div class="p-4">
-    <h3 class="text-lg font-semibold mb-2">{{ recipe.name }}</h3>
-    <p class="text-sm text-gray-600">{{ recipe.component_count }} ingredients</p>
+  <div class="flex items-start gap-4 overflow-hidden p-4">
+    {% if recipe.image %}
+      <img src="{{ recipe.image }}" alt="{{ recipe.name }}" class="w-24 max-w-full h-auto object-contain rounded flex-shrink-0" />
+    {% endif %}
+    <div class="flex-1 overflow-hidden">
+      <h3 class="text-lg font-semibold mb-2 truncate">{{ recipe.name }}</h3>
+      <p class="text-sm text-gray-600 truncate">{{ recipe.component_count }} ingredients</p>
+    </div>
   </div>
 </a>

--- a/tests/test_recipe_list_layout.py
+++ b/tests/test_recipe_list_layout.py
@@ -1,0 +1,24 @@
+import pytest
+from bs4 import BeautifulSoup
+from django.urls import reverse
+
+from inventory.models import Recipe
+
+
+@pytest.mark.django_db
+def test_recipe_card_handles_long_text_without_overlap(client):
+    long_name = "Long Recipe " * 20
+    recipe = Recipe.objects.create(name=long_name)
+    resp = client.get(reverse("recipes_list"))
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.content, "html.parser")
+    card = soup.find("a", href=reverse("recipe_detail", args=[recipe.pk]))
+    wrapper = card.find("div", class_="flex")
+    assert wrapper is not None
+    classes = wrapper.get("class", [])
+    assert "overflow-hidden" in classes
+    assert "gap-4" in classes
+    img = wrapper.find("img")
+    img_classes = img.get("class", [])
+    for expected in ["max-w-full", "h-auto", "object-contain"]:
+        assert expected in img_classes


### PR DESCRIPTION
## Summary
- wrap uploader and recipe card media and text in overflow-hidden flex containers with spacing
- prevent thumbnail distortion with `max-w-full h-auto object-contain`
- add regression test for long recipe titles next to images

## Testing
- `pytest tests/test_recipe_list_layout.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9512776dc83268f7a57bda87aed99