### PR TITLE
style: tune fluid typography scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Render deployment uses two Gunicorn workers by default to limit concurrent connections
 - Example environment files document direct Supabase hosts and optional pooler parameters
 - Simplified purchase order progress bar to set width directly with inline style, removing custom CSS variable
+- Reduced fluid typography range and heading scale for more balanced text across viewports
 
 - Replaced `.page-title`, `.page-subtitle`, and `.nav-icon` component classes with inline Tailwind utilities.
 - Replaced `.badge` and `.alert` component classes with inline Tailwind utility sets.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -103,10 +103,10 @@ module.exports = {
   plugins: [
     require("tailwindcss-fluid-type")({
       settings: {
-        fontSizeMin: 1,
-        fontSizeMax: 1.25,
-        ratioMin: 1.2,
-        ratioMax: 1.333,
+        fontSizeMin: 0.875,
+        fontSizeMax: 1.125,
+        ratioMin: 1.15,
+        ratioMax: 1.2,
         screenMin: 20,
         screenMax: 96,
         unit: "rem",
@@ -119,9 +119,9 @@ module.exports = {
         base: [0, 1.6],
         lg: [1, 1.6],
         xl: [2, 1.4],
-        h1: [5, 1.2],
-        h2: [4, 1.3],
-        h3: [3, 1.4],
+        h1: [3, 1.25],
+        h2: [2, 1.25],
+        h3: [1, 1.3],
         label: [-1, 1.6],
         body: [0, 1.6],
         caption: [-2, 1.6],


### PR DESCRIPTION
## Summary
- narrow fluid type min/max sizes and ratios for steadier scaling
- shrink heading steps so large displays stay under 3 rem
- document refined typography settings in changelog

## Testing
- `npm run build`
- `pre-commit run --files tailwind.config.js CHANGELOG.md`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b95238d3088326aaf9b887948e8516