### PR TITLE
Refine heading hierarchy for responsive templates

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -2,7 +2,7 @@
 {% block title %}Server Error{% endblock %}
 {% block content %}
 <div class="max-w-xl mx-auto py-10 text-center">
-  <h1 class="text-h1 md:text-h2 font-bold text-gray-900 mb-4">Something went wrong</h1>
+  <h1 class="text-xl md:text-h2 font-bold text-gray-900 mb-4">Something went wrong</h1>
   <p class="text-gray-700 mb-6">We're working to fix the issue. Please try again later.</p>
   <a href="/" class="text-blue-600 hover:underline">Return to home</a>
 </div>

--- a/templates/components/detail_layout.html
+++ b/templates/components/detail_layout.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block title %}Detail – Inventory App{% endblock %}
 {% block content %}
-  <h1 class="text-h1 md:text-h2 font-semibold mb-4">{% block heading %}{% endblock %}</h1>
+  <h1 class="text-xl md:text-h2 font-semibold mb-4">{% block heading %}{% endblock %}</h1>
   <div class="mb-4 flex justify-end gap-2">{% block actions %}{% endblock %}</div>
   {% block detail_table %}{% endblock %}
   {% block extra_tables %}{% endblock %}

--- a/templates/components/form_layout.html
+++ b/templates/components/form_layout.html
@@ -2,7 +2,7 @@
 {% block title %}Form – Inventory App{% endblock %}
 {% block content %}
 <div class="w-full max-w-4xl max-md:max-w-xl max-sm:max-w-md mx-auto max-h-screen overflow-y-auto p-8 max-sm:p-4">
-  <h1 class="text-h1 md:text-h2 font-semibold mb-4">
+  <h1 class="text-xl md:text-h2 font-semibold mb-4">
     {% block heading %}{% endblock %}
   </h1>
   {% if form %}

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -51,7 +51,7 @@
         </div>
         <a href="{% url 'root' %}" class="ml-3 text-xl font-semibold text-gray-900">Inventory Pro</a>
         {% if nav_heading %}
-        <h1 class="ml-6 text-h1 md:text-h2 font-semibold text-gray-900">{{ nav_heading }}</h1>
+        <h1 class="ml-6 text-xl md:text-h2 font-semibold text-gray-900">{{ nav_heading }}</h1>
         {% endif %}
       </div>
 

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% block title %}Stock Movements – Inventory App{% endblock %}
 {% block content %}
-  <h1 class="text-h1 md:text-h2 font-semibold mb-4">Stock Movements</h1>
+  <h1 class="text-xl md:text-h2 font-semibold mb-4">Stock Movements</h1>
   {% include "inventory/_manual_entry_section.html" %}
   {% include "inventory/_bulk_upload_section.html" %}
   {% include "inventory/_recent_transactions_section.html" %}

--- a/templates/inventory/visualizations.html
+++ b/templates/inventory/visualizations.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% block title %}Visualizations – Inventory App{% endblock %}
 {% block content %}
-  <h1 class="text-h1 md:text-h2 font-semibold mb-4">Visualizations</h1>
+  <h1 class="text-xl md:text-h2 font-semibold mb-4">Visualizations</h1>
   <form method="get" class="flex flex-col md:flex-row gap-2 mb-4">
     <div class="flex flex-col">
       <label for="metric" class="text-sm font-medium">Metric</label>


### PR DESCRIPTION
## Summary
- reduce overly prominent text-h1 classes to text-xl with md:text-h2 for better mobile-first scaling
- rebuild frontend assets to confirm new heading sizes

## Testing
- `npm run build`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b95385105c832689d6053c9d6757ed