### PR TITLE
feat: inline table filters for inventory items

### DIFF
--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -2,7 +2,7 @@ import logging
 
 from django.contrib import messages
 from django.db import DatabaseError, IntegrityError
-from django.db.models import BooleanField, Case, F, Value, When, Q
+from django.db.models import BooleanField, Case, F, Q, Value, When
 from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -267,7 +267,10 @@ class ItemsTableView(TemplateView):
             querystring = list_utils.build_querystring(self.request)
         except Exception:  # pragma: no cover - defensive
             querystring = ""
-        ctx.update({"page_obj": page_obj, "page_size": per_page, "querystring": querystring})
+        ctx.update(
+            {"page_obj": page_obj, "page_size": per_page, "querystring": querystring}
+        )
+        ctx.update(category_filters.resolve_category_filters(self.request))
         return ctx
 
 

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,44 +1,149 @@
 {% load icon_tags category_tags %}
 <!-- prettier-ignore -->
-<table
-  class="min-w-full w-full table-fixed bg-white border border-gray-200 rounded-lg table-sticky"
-  id="items-table"
-  data-sortable
->
-  <thead class="text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
-    <tr>
-      <th scope="col" class="sticky z-10 w-8 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md">
-        <input type="checkbox" data-select-all aria-label="Select all" />
-      </th>
-  <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="name" data-sort="col1" aria-sort="none">
-        <a data-sort-link data-sort-key="name" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">
-          Name
-          {% if sort == 'name' %}
-            <span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>
-          {% else %}
-            <span class="text-xs text-gray-400">⇅</span>
-          {% endif %}
-        </a>
-      </th>
-  <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="category" data-sort="col2" aria-sort="none">
-        <a data-sort-link data-sort-key="category__category" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=category__category&direction={% if sort == 'category__category' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=category__category&direction={% if sort == 'category__category' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Category {% if sort == 'category__category' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
-      </th>
-  <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="unit" data-sort="col3" aria-sort="none">
-        <a data-sort-link data-sort-key="unit__base_unit" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=unit__base_unit&direction={% if sort == 'unit__base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=unit__base_unit&direction={% if sort == 'unit__base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Unit {% if sort == 'unit__base_unit' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
-      </th>
-  <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="stock" data-sort="col4" aria-sort="none">
-        <a data-sort-link data-sort-key="current_stock" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Stock {% if sort == 'current_stock' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
-      </th>
-  <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="stock_status" data-sort="col5" aria-sort="none">Stock Status</th>
-  <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="departments" data-sort="col6" aria-sort="none">Departments</th>
-  <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="status" data-sort="col7" aria-sort="none">
-        <a data-sort-link data-sort-key="is_active" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Status {% if sort == 'is_active' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
-      </th>
-      <th scope="col" class="sticky z-10 w-30 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md">
-        Actions
-      </th>
-    </tr>
-  </thead>
+<form id="filters" method="get">
+  <table
+    class="min-w-full w-full table-fixed bg-white border border-gray-200 rounded-lg table-sticky"
+    id="items-table"
+    data-sortable
+  >
+    <thead class="text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+      <tr>
+        <th scope="col" class="sticky z-10 w-8 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md">
+          <input type="checkbox" data-select-all aria-label="Select all" />
+        </th>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="name" data-sort="col1" aria-sort="none">
+          <a data-sort-link data-sort-key="name" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">
+            Name
+            {% if sort == 'name' %}
+              <span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>
+            {% else %}
+              <span class="text-xs text-gray-400">⇅</span>
+            {% endif %}
+          </a>
+        </th>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="category" data-sort="col2" aria-sort="none">
+          <a data-sort-link data-sort-key="category__category" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=category__category&direction={% if sort == 'category__category' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=category__category&direction={% if sort == 'category__category' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Category {% if sort == 'category__category' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
+        </th>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="unit" data-sort="col3" aria-sort="none">
+          <a data-sort-link data-sort-key="unit__base_unit" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=unit__base_unit&direction={% if sort == 'unit__base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=unit__base_unit&direction={% if sort == 'unit__base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Unit {% if sort == 'unit__base_unit' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
+        </th>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="stock" data-sort="col4" aria-sort="none">
+          <a data-sort-link data-sort-key="current_stock" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Stock {% if sort == 'current_stock' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
+        </th>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="stock_status" data-sort="col5" aria-sort="none">Stock Status</th>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="departments" data-sort="col6" aria-sort="none">Departments</th>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="status" data-sort="col7" aria-sort="none">
+          <a data-sort-link data-sort-key="is_active" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Status {% if sort == 'is_active' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
+        </th>
+        <th scope="col" class="sticky z-10 w-30 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md">
+          Actions
+        </th>
+      </tr>
+      <tr class="bg-gray-50 border-b border-gray-200">
+        <th class="px-4 py-2"></th>
+        <th class="px-4 py-2">
+          <input
+            type="text"
+            name="q"
+            value="{{ q }}"
+            placeholder="Search"
+            autocomplete="off"
+            class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            hx-get="{% url 'items_table' %}"
+            hx-target="#items-list"
+            hx-trigger="keyup changed delay:300ms"
+            hx-include="#filters"
+            hx-indicator="#items-loading"
+          />
+        </th>
+        <th class="px-4 py-2">
+          <select
+            name="category"
+            class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            hx-get="{% url 'items_table' %}"
+            hx-target="#items-list"
+            hx-trigger="change"
+            hx-include="#filters"
+            hx-indicator="#items-loading"
+            autocomplete="off"
+          >
+            <option value="">All Categories</option>
+            {% for c in categories %}
+              <option value="{{ c }}"{% if c == category %} selected{% endif %}>{{ c }}</option>
+            {% endfor %}
+          </select>
+        </th>
+        <th class="px-4 py-2">
+          <select
+            name="base_unit"
+            class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            hx-get="{% url 'items_table' %}"
+            hx-target="#items-list"
+            hx-trigger="change"
+            hx-include="#filters"
+            hx-indicator="#items-loading"
+            autocomplete="off"
+          >
+            <option value="">All Units</option>
+            {% for u in base_units %}
+              <option value="{{ u }}"{% if u == base_unit %} selected{% endif %}>{{ u }}</option>
+            {% endfor %}
+          </select>
+        </th>
+        <th class="px-4 py-2"></th>
+        <th class="px-4 py-2">
+          <select
+            name="stock_status"
+            class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            hx-get="{% url 'items_table' %}"
+            hx-target="#items-list"
+            hx-trigger="change"
+            hx-include="#filters"
+            hx-indicator="#items-loading"
+            autocomplete="off"
+          >
+            <option value="">All Statuses</option>
+            <option value="low"{% if stock_status == 'low' %} selected{% endif %}>Low</option>
+            <option value="out"{% if stock_status == 'out' %} selected{% endif %}>Out</option>
+            <option value="normal"{% if stock_status == 'normal' %} selected{% endif %}>In Stock</option>
+          </select>
+        </th>
+        <th class="px-4 py-2">
+          <select
+            name="department"
+            class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            hx-get="{% url 'items_table' %}"
+            hx-target="#items-list"
+            hx-trigger="change"
+            hx-include="#filters"
+            hx-indicator="#items-loading"
+            autocomplete="off"
+          >
+            <option value="">All Departments</option>
+            {% for val, label in departments %}
+              <option value="{{ val }}"{% if val == department %} selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+          </select>
+        </th>
+        <th class="px-4 py-2">
+          <select
+            name="active"
+            class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            hx-get="{% url 'items_table' %}"
+            hx-target="#items-list"
+            hx-trigger="change"
+            hx-include="#filters"
+            hx-indicator="#items-loading"
+            autocomplete="off"
+          >
+            <option value="">All</option>
+            <option value="true"{% if active == 'true' or active == '1' %} selected{% endif %}>Active</option>
+            <option value="false"{% if active == 'false' or active == '0' %} selected{% endif %}>Inactive</option>
+          </select>
+        </th>
+        <th class="px-4 py-2"></th>
+      </tr>
+    </thead>
   <tbody class="bg-white divide-y divide-border">
     {% for item in page_obj.object_list %}
     <tr
@@ -169,4 +274,8 @@
     </tr>
     {% endfor %}
   </tbody>
-</table>
+  </table>
+  {% if page_size %}<input type="hidden" name="page_size" value="{{ page_size|default:25 }}">{% endif %}
+  {% if sort %}<input type="hidden" name="sort" value="{{ sort|default:'name' }}">{% endif %}
+  {% if direction %}<input type="hidden" name="direction" value="{{ direction|default:'asc' }}">{% endif %}
+</form>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -71,13 +71,6 @@
             </div>
           </div>
         </div>
-        <!-- Filter bar -->
-        <div id="items-filter-bar" class="px-4 pb-2 pt-2 border-b border-gray-100 bg-white">
-          {% url 'items_table' as items_table_url %}
-          <div class="filters-line flex flex-wrap md:flex-nowrap gap-2 md:gap-3 w-full">
-            {% include "components/filter_bar.html" with q=request.GET.q filters=filters hx_get=items_table_url hx_target='#items-list' hx_indicator='#items-loading' search_placeholder='e.g., Tomato, Rice' page_size=page_size sort=sort direction=direction predictive_names=predictive_filter_names only %}
-          </div>
-        </div>
       </div>
       <div class="table-scroll group pt-2 md:pt-3">
         <div id="items-list">

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -120,9 +120,10 @@ def test_items_toolbar_structure(client):
     soup = BeautifulSoup(resp.content, "html.parser")
     toolbar = soup.find(id="items-toolbar")
     assert toolbar is not None
-    # Ensure search/filter form is present on the left
-    filters_form = toolbar.find("form", id="filters")
+    # Filter form should exist but not inside the toolbar
+    filters_form = soup.find("form", id="filters")
     assert filters_form is not None
+    assert toolbar.find("form", id="filters") is None
     # Ensure action buttons are present on the right
     add_btn = toolbar.find(
         "button",
@@ -172,19 +173,19 @@ def test_item_create_partial_departments_multiselect_container(client):
 def test_filters_persist_after_table_refresh(client):
     """Filters should remain visible after HTMX table updates."""
     _create_item()
-    # Initial page load contains the filter bar
+    # Initial page load contains the filter form
     resp = client.get(reverse("items_list"))
     assert resp.status_code == 200
     initial_html = resp.content.decode()
-    assert 'id="items-filter-bar"' in initial_html
+    assert 'id="filters"' in initial_html
 
     # Simulate an HTMX request to refresh the table
     table_resp = client.get(reverse("items_table"), HTTP_HX_REQUEST="true")
     assert table_resp.status_code == 200
     table_html = table_resp.content.decode()
 
-    # The table partial should not contain the filter bar
-    assert "items-filter-bar" not in table_html
+    # The table partial should still contain the filter form
+    assert 'id="filters"' in table_html
 
 
 @pytest.mark.django_db

--- a/tests/test_items_table_header.py
+++ b/tests/test_items_table_header.py
@@ -21,7 +21,9 @@ def test_items_table_header_top_zero_and_structure():
 
     assert 'data-col="rop"' not in tpl
 
-    ths = re.findall(r"<th[^>]*>.*?</th>", header, re.DOTALL)
+    # Only inspect the first header row for column metadata
+    first_row = re.search(r"<tr>.*?</tr>", header, re.DOTALL).group(0)
+    ths = re.findall(r"<th[^>]*>.*?</th>", first_row, re.DOTALL)
     assert "data-sort" not in ths[0]
     assert "data-sort" not in ths[-1]
     for i, th in enumerate(ths[1:-1], start=1):


### PR DESCRIPTION
## Summary
- enable inline filtering by adding inputs to items table header and wrapping table in #filters form
- drop separate filter bar and keep export action referencing shared form
- support header filters during HTMX refresh and adjust tests

## Testing
- `pre-commit run --files inventory/views/items/list.py templates/inventory/_items_table.html templates/inventory/items_list.html tests/test_items_list.py`
- `pre-commit run --files tests/test_items_table_header.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1573016b483268b99bc795c95b573