### PR TITLE
Improve item filters and accessibility

### DIFF
--- a/inventory/services/category_filters.py
+++ b/inventory/services/category_filters.py
@@ -14,7 +14,7 @@ def resolve_category_filters(request) -> Dict[str, Any]:
 
     category = (request.GET.get("category") or "").strip()
     subcategory = (request.GET.get("subcategory") or "").strip()
-    department = (request.GET.get("department") or "").strip()
+    department = [v for v in request.GET.getlist("department") if v.strip()]
     base_unit = (request.GET.get("base_unit") or "").strip()
     supplier = (request.GET.get("supplier") or "").strip()
 
@@ -29,9 +29,7 @@ def resolve_category_filters(request) -> Dict[str, Any]:
     subcategories = [sc[1] for sc in subcats]
 
     departments = list(
-        Department.objects.all()
-        .values_list("department_id", "name")
-        .order_by("name")
+        Department.objects.all().values_list("department_id", "name").order_by("name")
     )
 
     base_units = list(
@@ -57,7 +55,7 @@ def resolve_category_filters(request) -> Dict[str, Any]:
         "base_units": base_units,
         "units": [],
         "suppliers": suppliers,
-    "departments": [(str(did), name) for did, name in departments],
+        "departments": [(str(did), name) for did, name in departments],
     }
 
 
@@ -113,7 +111,7 @@ def build_filters(request) -> List[Dict[str, Any]]:
         {
             "name": "department",
             "label": "Department",
-            "value": resolved["department"],
+            "value": ",".join(resolved["department"]),
             "options": department_options,
         },
     ]

--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -85,7 +85,8 @@ def _filter_and_sort_items(request, qs=None):
             resolved_ids = id_ints  # best-effort fallback
         if resolved_ids:
             qs = qs.filter(departments__department_id__in=resolved_ids).distinct()
-            params["department"] = ",".join(dep_vals)
+    if dep_vals:
+        params["department"] = dep_vals
     # Apply stock status filter if present
     stock_status = (request.GET.get("stock_status") or "").strip().lower()
     if stock_status == "low":

--- a/templates/components/header_filter_control.html
+++ b/templates/components/header_filter_control.html
@@ -1,0 +1,1 @@
+hx-get="{% url 'items_table' %}" hx-target="#items-list" hx-include="#filters" hx-indicator="#items-loading"

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -9,7 +9,7 @@
     <thead class="text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
       <tr>
         <th scope="col" class="sticky z-10 w-8 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md">
-          <input type="checkbox" data-select-all aria-label="Select all" />
+          <input id="select-all" type="checkbox" data-select-all aria-label="Select all" />
         </th>
         <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="name" data-sort="col1" aria-sort="none">
           <a data-sort-link data-sort-key="name" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">
@@ -42,29 +42,27 @@
       <tr class="bg-gray-50 border-b border-gray-200">
         <th class="px-4 py-2"></th>
         <th class="px-4 py-2">
+          <label for="filter-q" class="sr-only">Search</label>
           <input
+            id="filter-q"
             type="text"
             name="q"
             value="{{ q }}"
             placeholder="Search"
             autocomplete="off"
             class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
-            hx-get="{% url 'items_table' %}"
-            hx-target="#items-list"
+            {% include "components/header_filter_control.html" %}
             hx-trigger="keyup changed delay:300ms"
-            hx-include="#filters"
-            hx-indicator="#items-loading"
           />
         </th>
         <th class="px-4 py-2">
+          <label for="filter-category" class="sr-only">Category</label>
           <select
+            id="filter-category"
             name="category"
             class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
-            hx-get="{% url 'items_table' %}"
-            hx-target="#items-list"
+            {% include "components/header_filter_control.html" %}
             hx-trigger="change"
-            hx-include="#filters"
-            hx-indicator="#items-loading"
             autocomplete="off"
           >
             <option value="">All Categories</option>
@@ -74,14 +72,13 @@
           </select>
         </th>
         <th class="px-4 py-2">
+          <label for="filter-base-unit" class="sr-only">Unit</label>
           <select
+            id="filter-base-unit"
             name="base_unit"
             class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
-            hx-get="{% url 'items_table' %}"
-            hx-target="#items-list"
+            {% include "components/header_filter_control.html" %}
             hx-trigger="change"
-            hx-include="#filters"
-            hx-indicator="#items-loading"
             autocomplete="off"
           >
             <option value="">All Units</option>
@@ -92,14 +89,13 @@
         </th>
         <th class="px-4 py-2"></th>
         <th class="px-4 py-2">
+          <label for="filter-stock-status" class="sr-only">Stock Status</label>
           <select
+            id="filter-stock-status"
             name="stock_status"
             class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
-            hx-get="{% url 'items_table' %}"
-            hx-target="#items-list"
+            {% include "components/header_filter_control.html" %}
             hx-trigger="change"
-            hx-include="#filters"
-            hx-indicator="#items-loading"
             autocomplete="off"
           >
             <option value="">All Statuses</option>
@@ -109,31 +105,30 @@
           </select>
         </th>
         <th class="px-4 py-2">
+          <label for="filter-department" class="sr-only">Departments</label>
           <select
+            id="filter-department"
             name="department"
-            class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
-            hx-get="{% url 'items_table' %}"
-            hx-target="#items-list"
+            multiple
+            class="w-full h-20 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+            {% include "components/header_filter_control.html" %}
             hx-trigger="change"
-            hx-include="#filters"
-            hx-indicator="#items-loading"
             autocomplete="off"
           >
             <option value="">All Departments</option>
             {% for val, label in departments %}
-              <option value="{{ val }}"{% if val == department %} selected{% endif %}>{{ label }}</option>
+              <option value="{{ val }}"{% if val in department %} selected{% endif %}>{{ label }}</option>
             {% endfor %}
           </select>
         </th>
         <th class="px-4 py-2">
+          <label for="filter-active" class="sr-only">Status</label>
           <select
+            id="filter-active"
             name="active"
             class="w-full h-8 px-2 text-xs border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
-            hx-get="{% url 'items_table' %}"
-            hx-target="#items-list"
+            {% include "components/header_filter_control.html" %}
             hx-trigger="change"
-            hx-include="#filters"
-            hx-indicator="#items-loading"
             autocomplete="off"
           >
             <option value="">All</option>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -145,45 +145,6 @@
         scroller.addEventListener('scroll', onScroll, { passive: true });
         onScroll();
       });
-
-      // Dynamic subcategory filter: update options when category changes
-      const filtersForm = document.getElementById('filters');
-      if (filtersForm) {
-        const catSel = filtersForm.querySelector('select[name="category"]');
-        const catHidden = filtersForm.querySelector('input[type="hidden"][name="category"]');
-        const categoryInput = catHidden || catSel; // whichever exists
-        const subSel = filtersForm.querySelector('select[name="subcategory"]');
-        if (categoryInput && subSel) {
-          const onCategoryChange = async () => {
-            const cat = categoryInput.value;
-            subSel.innerHTML = '<option value="">All Subcategories</option>';
-            if (!cat) { subSel.dispatchEvent(new Event('change', { bubbles: true })); return; }
-            try {
-              const res = await fetch(`/items/subcategories/?category=${encodeURIComponent(cat)}`);
-              const data = await res.json();
-              if (data && Array.isArray(data.subcategories)) {
-                data.subcategories.forEach(s => {
-                  const opt = document.createElement('option');
-                  // Handle tuple-like [value, label] or plain string
-                  if (Array.isArray(s) && s.length >= 2) {
-                    opt.value = s[0]; opt.textContent = s[1];
-                  } else {
-                    opt.value = s; opt.textContent = s;
-                  }
-                  subSel.appendChild(opt);
-                });
-              }
-            } catch (e) { /* noop */ }
-            // trigger table refresh via HTMX
-            subSel.dispatchEvent(new Event('change', { bubbles: true }));
-            // If subcategory is predictive on other pages, re-init. Here it's native.
-            if (window.initPredictiveDropdowns) {
-              window.initPredictiveDropdowns(filtersForm);
-            }
-          };
-          categoryInput.addEventListener('change', onCategoryChange);
-        }
-      }
     });
     </script>
     <!-- Hidden templates for inline editing selects -->

--- a/tests/frontend/form_layout.test.js
+++ b/tests/frontend/form_layout.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 
-describe('form layout regression', () => {
-  test('form does not overflow vertically at large viewport sizes', () => {
+describe("form layout regression", () => {
+  test("form does not overflow vertically at large viewport sizes", () => {
     // Simulate a large viewport
     window.innerWidth = 1920;
     window.innerHeight = 1080;
@@ -17,10 +17,27 @@ describe('form layout regression', () => {
       </form>
     `;
 
-    const form = document.querySelector('form');
+    const form = document.querySelector("form");
     expect(form.scrollHeight).toBeLessThanOrEqual(window.innerHeight);
-    form.querySelectorAll('label,input,p').forEach(el => {
+    form.querySelectorAll("label,input,p").forEach((el) => {
       expect(el.scrollHeight).toBe(el.clientHeight);
     });
   });
+});
+
+test("items_list template has no subcategory script", () => {
+  const fs = require("fs");
+  const path = require("path");
+  const tpl = fs.readFileSync(
+    path.join(
+      __dirname,
+      "..",
+      "..",
+      "templates",
+      "inventory",
+      "items_list.html",
+    ),
+    "utf8",
+  );
+  expect(tpl.includes("items/subcategories")).toBe(false);
 });

--- a/tests/test_items_filters.py
+++ b/tests/test_items_filters.py
@@ -2,6 +2,7 @@ import pytest
 from django.test import RequestFactory
 
 from inventory.models import Item, Supplier, Unit
+from inventory.models.departments import Department
 from inventory.services import category_filters
 from inventory.views.items.list import _filter_and_sort_items
 
@@ -54,3 +55,37 @@ def test_category_filters_include_supplier_and_units():
     assert any(opt["value"] == "kg" for opt in base_filter["options"])
     supplier_filter = next(f for f in filters if f["name"] == "supplier")
     assert any(opt["label"] == "Acme" for opt in supplier_filter["options"])
+
+
+@pytest.mark.django_db
+def test_filter_by_multiple_departments():
+    rf = RequestFactory()
+    unit = Unit.objects.create(purchase_unit="kg", base_unit="kg", conversion_factor=1)
+    dept1 = Department.objects.create(name="Kitchen")
+    dept2 = Department.objects.create(name="Bar")
+    item1 = Item.objects.create(
+        name="Sugar",
+        unit=unit,
+        reorder_point=1,
+        notes="n",
+        is_active=True,
+    )
+    item1.departments.add(dept1)
+    item2 = Item.objects.create(
+        name="Salt",
+        unit=unit,
+        reorder_point=1,
+        notes="n",
+        is_active=True,
+    )
+    item2.departments.add(dept2)
+    request = rf.get(
+        "/items/",
+        {"department": [str(dept1.department_id), str(dept2.department_id)]},
+    )
+    qs, params = _filter_and_sort_items(request)
+    assert set(qs) == {item1, item2}
+    assert set(params["department"]) == {
+        str(dept1.department_id),
+        str(dept2.department_id),
+    }

--- a/tests/test_items_table_accessibility.py
+++ b/tests/test_items_table_accessibility.py
@@ -15,3 +15,18 @@ def test_column_menu_has_accessibility_attrs():
     assert 'title="Show/Hide Columns"' in btn
     assert 'aria-controls="columns-menu"' in btn
     assert 'aria-label="Show/Hide Columns"' in btn
+
+
+def test_filter_controls_have_labels_and_ids():
+    content = Path("templates/inventory/_items_table.html").read_text()
+    expected = {
+        "filter-q": "Search",
+        "filter-category": "Category",
+        "filter-base-unit": "Unit",
+        "filter-stock-status": "Stock Status",
+        "filter-department": "Departments",
+        "filter-active": "Status",
+    }
+    for fid, label in expected.items():
+        assert f'id="{fid}"' in content
+        assert f'<label for="{fid}" class="sr-only">{label}</label>' in content

--- a/tests/test_items_table_header.py
+++ b/tests/test_items_table_header.py
@@ -29,3 +29,11 @@ def test_items_table_header_top_zero_and_structure():
     for i, th in enumerate(ths[1:-1], start=1):
         assert f'data-sort="col{i}"' in th
         assert 'aria-sort="none"' in th
+
+
+def test_header_filter_control_partial_exists():
+    partial = Path("templates/components/header_filter_control.html").read_text()
+    for attr in ["hx-get", "hx-target", "hx-include", "hx-indicator"]:
+        assert attr in partial
+    tpl = Path("templates/inventory/_items_table.html").read_text()
+    assert "components/header_filter_control.html" in tpl


### PR DESCRIPTION
## Summary
- add accessible labels and IDs for item list filters
- support multi-select department filtering and abstract HTMX attributes into a partial
- remove unused subcategory fetch script and update tests

## Testing
- `pre-commit run --files inventory/services/category_filters.py inventory/views/items/list.py templates/inventory/_items_table.html templates/inventory/items_list.html templates/components/header_filter_control.html tests/frontend/form_layout.test.js tests/test_items_filters.py tests/test_items_table_accessibility.py tests/test_items_table_header.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1709f05d88326a28745bd8a62e350