### PR TITLE
Restore predictive filter bar with cached column options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `build` npm script for dedicated Tailwind CSS builds.
 - `build-css` npm script alias that proxies to `npm run build` for backwards compatibility.
 - Semantic Tailwind color tokens (`success`, `warning`, etc.) for consistent theming.
+- Predictive filter bar with keyboard-friendly dropdowns and HTMX integration.
+- Column filters now rebind after HTMX swaps and respect client-side caching.
 
 ### Deprecated
 
@@ -54,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example environment files document direct Supabase hosts and optional pooler parameters
 - Simplified purchase order progress bar to set width directly with inline style, removing custom CSS variable
 - Reduced fluid typography range and heading scale for more balanced text across viewports
+- Distinct-value lookups now query dedicated tables with short-term caching for faster column filtering.
 
 - Replaced `.page-title`, `.page-subtitle`, and `.nav-icon` component classes with inline Tailwind utilities.
 - Replaced `.badge` and `.alert` component classes with inline Tailwind utility sets.

--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -3,6 +3,7 @@ import logging
 from django.contrib import messages
 from django.db import DatabaseError, IntegrityError
 from django.db.models import BooleanField, Case, F, Q, Value, When
+from django.core.cache import cache
 from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -13,7 +14,7 @@ from inventory.services.item_service import get_unit_display_name
 
 from ...forms.bulk_forms import BulkUploadForm
 from ...forms.item_forms import ItemForm
-from ...models import Item, Supplier
+from ...models import Item, Supplier, Category, Unit
 from ...models.departments import Department
 from ...services import category_filters, kpis, list_utils
 from ...services.categories_service import CategoriesService
@@ -146,6 +147,13 @@ def _filter_and_sort_items(request, qs=None):
 def distinct_values(request, field):
     """Return distinct values for a given column respecting current filters."""
     qs, _ = _basic_item_filters(request)
+    CACHE_TTL = 30
+    cache_key = f"distinct:{field}:{request.GET.urlencode()}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        resp = JsonResponse(cached, safe=False)
+        resp["Cache-Control"] = f"max-age={CACHE_TTL}"
+        return resp
     try:
         limit = int(request.GET.get("limit", 50))
     except (TypeError, ValueError):
@@ -159,10 +167,7 @@ def distinct_values(request, field):
     offset = (page - 1) * limit
     field_map = {
         "name": "name",
-        "category": "category__category",
-        "unit": "unit__base_unit",
         "active": "is_active",
-        "department": "departments__department_id",
     }
     if field == "stock_status":
         data = []
@@ -173,24 +178,46 @@ def distinct_values(request, field):
         if qs.filter(current_stock__gte=F("reorder_point")).exists():
             data.append({"value": "normal", "label": "In Stock"})
         return JsonResponse(data, safe=False)
-    lookup = field_map.get(field)
-    if not lookup:
-        return JsonResponse([], safe=False)
     if field == "department":
         vals = (
-            qs.values("departments__department_id", "departments__name")
-            .order_by("departments__name")
+            Department.objects.filter(items__in=qs)
+            .order_by("name")
+            .values_list("department_id", "name")
             .distinct()
         )[offset : offset + limit]
         data = [
-            {
-                "value": str(v["departments__department_id"]),
-                "label": v["departments__name"],
-            }
+            {"value": str(pk), "label": name}
+            for pk, name in vals
+            if pk
+        ]
+    elif field == "category":
+        vals = (
+            Category.objects.filter(item__in=qs)
+            .order_by("category")
+            .values_list("category", flat=True)
+            .distinct()
+        )[offset : offset + limit]
+        data = [
+            {"value": str(v), "label": str(v)}
             for v in vals
-            if v["departments__department_id"]
+            if v not in [None, ""]
+        ]
+    elif field == "unit":
+        vals = (
+            Unit.objects.filter(item__in=qs)
+            .order_by("base_unit")
+            .values_list("base_unit", flat=True)
+            .distinct()
+        )[offset : offset + limit]
+        data = [
+            {"value": str(v), "label": str(v)}
+            for v in vals
+            if v not in [None, ""]
         ]
     else:
+        lookup = field_map.get(field)
+        if not lookup:
+            return JsonResponse([], safe=False)
         vals = (
             qs.order_by(lookup)
             .values_list(lookup, flat=True)
@@ -201,7 +228,10 @@ def distinct_values(request, field):
             for v in vals
             if v not in [None, ""]
         ]
-    return JsonResponse(data, safe=False)
+    cache.set(cache_key, data, CACHE_TTL)
+    resp = JsonResponse(data, safe=False)
+    resp["Cache-Control"] = f"max-age={CACHE_TTL}"
+    return resp
 
 
 class ItemsListView(TemplateView):

--- a/static/js/column-filters.js
+++ b/static/js/column-filters.js
@@ -1,6 +1,7 @@
 (function () {
   const cache = new Map();
   const LIMIT = 50;
+  const CLIENT_TTL = 30000; // 30s fallback TTL
 
   function createDropdown() {
     const tpl = document.getElementById('column-filter-dropdown-template');
@@ -24,8 +25,15 @@
     p.set('limit', LIMIT);
     p.set('page', page);
     return fetch(`/items/distinct/${field}/?${p.toString()}`)
-      .then((r) => (r.ok ? r.json() : []))
-      .catch(() => []);
+      .then(async (r) => {
+        if (!r.ok) return { data: [], ttl: 0 };
+        const data = await r.json();
+        const cc = r.headers.get('Cache-Control') || '';
+        const m = cc.match(/max-age=(\d+)/);
+        const ttl = m ? parseInt(m[1], 10) * 1000 : 0;
+        return { data, ttl };
+      })
+      .catch(() => ({ data: [], ttl: 0 }));
   }
 
   function populateOptions(drop, options, param, params, append = false) {
@@ -46,18 +54,27 @@
   function syncForm(params) {
     const form = document.getElementById('filters');
     if (!form) return;
+    // Remove hidden inputs that are no longer present and have no visible counterpart
     form.querySelectorAll('input[type="hidden"]').forEach((el) => {
-      if (!params.has(el.name)) el.remove();
+      if (!params.has(el.name) && !form.querySelector(`[name="${el.name}"]:not([type="hidden"])`)) {
+        el.remove();
+      }
     });
     params.forEach((val, key) => {
-      let input = form.querySelector(`input[name="${key}"]`);
-      if (!input) {
-        input = document.createElement('input');
-        input.type = 'hidden';
-        input.name = key;
-        form.appendChild(input);
+      const field = form.querySelector(`[name="${key}"]:not([type="hidden"])`);
+      if (field) {
+        field.value = val;
+        field.dispatchEvent(new Event('input'));
+      } else {
+        let input = form.querySelector(`input[name="${key}"]`);
+        if (!input) {
+          input = document.createElement('input');
+          input.type = 'hidden';
+          input.name = key;
+          form.appendChild(input);
+        }
+        input.value = val;
       }
-      input.value = val;
     });
   }
 
@@ -84,9 +101,11 @@
     closeDropdown(drop);
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const buttons = document.querySelectorAll('[data-filter-btn]');
-    buttons.forEach((btn) => {
+  function initColumnFilters(root) {
+    const scope = root || document;
+    scope.querySelectorAll('[data-filter-btn]').forEach((btn) => {
+      if (btn._cfBound) return;
+      btn._cfBound = true;
       btn.addEventListener('click', async () => {
         if (btn._dropdown && !btn._dropdown.classList.contains('hidden')) {
           closeDropdown(btn._dropdown);
@@ -95,58 +114,77 @@
         let drop = btn._dropdown;
         if (!drop) {
           drop = createDropdown();
+          if (!drop) return;
           btn._dropdown = drop;
           document.body.appendChild(drop);
-          drop._page = 1;
           const field = btn.dataset.field;
           const params = new URLSearchParams(window.location.search);
-          if (field !== 'name') {
-            let entry = cache.get(field);
-            if (!entry) {
-              const data = await fetchOptions(field, params, 1);
-              entry = { options: data.slice(), page: 1, done: data.length < LIMIT };
-              cache.set(field, entry);
-            }
-            populateOptions(drop, entry.options, btn.dataset.param, params);
-            const showMore = drop.querySelector('[data-show-more]');
-            if (!entry.done) showMore.classList.remove('hidden');
-            const loadMore = async () => {
-              if (entry.done) return;
-              const data = await fetchOptions(field, new URLSearchParams(window.location.search), entry.page + 1);
-              entry.page += 1;
-              entry.options = entry.options.concat(data);
-              entry.done = data.length < LIMIT;
-              cache.set(field, entry);
-              populateOptions(drop, data, btn.dataset.param, new URLSearchParams(window.location.search), true);
-              if (entry.done) showMore.classList.add('hidden');
+          const key = `${field}|${params.toString()}`;
+          let entry = cache.get(key);
+          const now = Date.now();
+          if (!entry || entry.expires < now) {
+            const { data, ttl } = await fetchOptions(field, params, 1);
+            entry = {
+              options: data.slice(),
+              page: 1,
+              done: data.length < LIMIT,
+              expires: now + (ttl || CLIENT_TTL),
             };
-            showMore.addEventListener('click', loadMore);
-            const container = drop.querySelector('[data-filter-options]');
-            container.addEventListener('scroll', () => {
-              if (container.scrollTop + container.clientHeight >= container.scrollHeight - 5) {
-                loadMore();
-              }
-            });
-          } else {
-            const search = drop.querySelector('[data-filter-search]');
-            search.value = params.get(btn.dataset.param) || '';
+            cache.set(key, entry);
           }
+          populateOptions(drop, entry.options, btn.dataset.param, params);
+          const showMore = drop.querySelector('[data-show-more]');
+          if (!entry.done) showMore.classList.remove('hidden');
+          const loadMore = async () => {
+            if (entry.done) return;
+            const { data, ttl } = await fetchOptions(
+              field,
+              new URLSearchParams(window.location.search),
+              entry.page + 1,
+            );
+            entry.page += 1;
+            entry.options = entry.options.concat(data);
+            entry.done = data.length < LIMIT;
+            entry.expires = Date.now() + (ttl || CLIENT_TTL);
+            cache.set(key, entry);
+            populateOptions(
+              drop,
+              data,
+              btn.dataset.param,
+              new URLSearchParams(window.location.search),
+              true,
+            );
+            if (entry.done) showMore.classList.add('hidden');
+          };
+          showMore.addEventListener('click', loadMore);
+          const container = drop.querySelector('[data-filter-options]');
+          container.addEventListener('scroll', () => {
+            if (container.scrollTop + container.clientHeight >= container.scrollHeight - 5) {
+              loadMore();
+            }
+          });
           drop.querySelector('[data-select-all]').addEventListener('click', () => {
-            drop.querySelectorAll('input[type="checkbox"]').forEach((c) => (c.checked = true));
+            drop
+              .querySelectorAll('input[type="checkbox"]')
+              .forEach((c) => (c.checked = true));
           });
           drop.querySelector('[data-clear]').addEventListener('click', () => {
-            drop.querySelectorAll('input[type="checkbox"]').forEach((c) => (c.checked = false));
+            drop
+              .querySelectorAll('input[type="checkbox"]')
+              .forEach((c) => (c.checked = false));
             const search = drop.querySelector('[data-filter-search]');
             if (search) search.value = '';
           });
-          drop.querySelector('[data-apply]').addEventListener('click', () => applyFilter(drop, btn));
+          drop.querySelector('[data-apply]').addEventListener('click', () =>
+            applyFilter(drop, btn),
+          );
           drop._outsideHandler = (ev) => {
             if (!drop.contains(ev.target) && ev.target !== btn) closeDropdown(drop);
           };
         } else {
           const params = new URLSearchParams(window.location.search);
-          const field = btn.dataset.field;
-          const entry = cache.get(field);
+          const key = `${btn.dataset.field}|${params.toString()}`;
+          const entry = cache.get(key);
           if (entry) {
             populateOptions(drop, entry.options, btn.dataset.param, params);
             const showMore = drop.querySelector('[data-show-more]');
@@ -161,5 +199,8 @@
         if (search) search.focus();
       });
     });
-  });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => initColumnFilters());
+  document.body.addEventListener('htmx:afterSwap', (e) => initColumnFilters(e.target));
 })();

--- a/static/js/column-filters.test.js
+++ b/static/js/column-filters.test.js
@@ -28,6 +28,7 @@ describe("column-filters dropdown", () => {
     fetch.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve([{ value: "a", label: "A" }]),
+      headers: { get: () => null },
     });
     const btn = document.querySelector("[data-filter-btn]");
     btn.click();
@@ -43,11 +44,21 @@ describe("column-filters dropdown", () => {
     fetch.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve([{ value: "a", label: "A" }]),
+      headers: { get: () => null },
     });
     const btn = document.querySelector("[data-filter-btn]");
     btn.click();
     await flushPromises();
     const showMore = document.querySelector("[data-show-more]");
     expect(showMore.classList.contains("hidden")).toBe(true);
+  });
+  test("rebinds after htmx swap", async () => {
+    const container = document.createElement("div");
+    container.innerHTML = '<button data-filter-btn data-field="unit" data-param="base_unit"></button>';
+    document.body.appendChild(container);
+    document.body.dispatchEvent(new Event("htmx:afterSwap", { bubbles: true }));
+    await flushPromises();
+    const btn = container.querySelector("[data-filter-btn]");
+    expect(btn._cfBound).toBe(true);
   });
 });

--- a/static/js/predictive-dropdown.js
+++ b/static/js/predictive-dropdown.js
@@ -197,6 +197,11 @@
   originalSelect.style.whiteSpace = "nowrap";
   originalSelect.style.border = "0";
     originalSelect.tabIndex = -1; // keep out of tab order
+
+  originalSelect.addEventListener("input", () => {
+    const match = options.find((o) => o.value === originalSelect.value);
+    textInput.value = match ? match.text : "";
+  });
   }
 
   window.initPredictiveDropdowns = function (root) {

--- a/static/js/predictive-dropdown.test.js
+++ b/static/js/predictive-dropdown.test.js
@@ -1,0 +1,37 @@
+/** @jest-environment jsdom */
+
+describe('predictive dropdown', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <select id="category" class="predictive">
+        <option value="">--</option>
+        <option value="a">Alpha</option>
+        <option value="b">Beta</option>
+      </select>`;
+    jest.isolateModules(() => {
+      require('./predictive-dropdown.js');
+    });
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  test('selects option via keyboard', () => {
+    const select = document.getElementById('category');
+    const input = document.getElementById('category_text');
+    const handler = jest.fn();
+    select.addEventListener('change', handler);
+    input.focus();
+    input.dispatchEvent(new Event('focus'));
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(select.value).toBe('a');
+    expect(handler).toHaveBeenCalled();
+  });
+
+  test('upgrades selects after htmx swap', () => {
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = `<select id="dept" class="predictive"><option value="">--</option><option value="1">One</option></select>`;
+    document.body.appendChild(wrapper);
+    wrapper.dispatchEvent(new Event('htmx:afterSwap', { bubbles: true }));
+    expect(wrapper.querySelector('#dept_text')).not.toBeNull();
+  });
+});

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -41,7 +41,11 @@
 </div>
 {% endblock %}
 
-    {% block data_container %}
+{% block data_container %}
+    {% url 'items_table' as items_table_url %}
+    <div class="mb-4">
+      {% include "components/filter_bar.html" with filters=filters predictive_names=predictive_filter_names hx_get=items_table_url hx_target="#items-list" hx_indicator="#items-loading" %}
+    </div>
     <div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden">
       <div id="items-toolbar">
         <!-- Actions bar -->
@@ -103,6 +107,7 @@
 {% endblock %}
 
 {% block page_scripts %}
+    <script src="{% static 'js/predictive-dropdown.js' %}?v={{ STATIC_VERSION }}" defer></script>
     <script src="{% static 'js/column-filters.js' %}?v={{ STATIC_VERSION }}" defer></script>
     <script>
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Rebind column filter controls after HTMX swaps and cache option lookups with TTL-aware client cache
- Use dedicated tables and short-term server caching for distinct filter values
- Restore predictive filter bar with shared form and new Jest tests

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2c035eed08326949ea6fd10adecf6