### PR TITLE
feat: move filters into item table header

### DIFF
--- a/inventory/services/category_filters.py
+++ b/inventory/services/category_filters.py
@@ -12,11 +12,20 @@ def resolve_category_filters(request) -> Dict[str, Any]:
     """Return selected filter values and available options."""
     from ..models import Department, Supplier, Unit
 
-    category = (request.GET.get("category") or "").strip()
-    subcategory = (request.GET.get("subcategory") or "").strip()
-    department = [v for v in request.GET.getlist("department") if v.strip()]
-    base_unit = (request.GET.get("base_unit") or "").strip()
-    supplier = (request.GET.get("supplier") or "").strip()
+    def _values_for(name: str) -> List[str]:
+        vals: List[str] = []
+        for v in request.GET.getlist(name):
+            if v is None:
+                continue
+            parts = [p.strip() for p in str(v).split(",")]
+            vals.extend([p for p in parts if p])
+        return vals
+
+    category = _values_for("category")
+    subcategory = _values_for("subcategory")
+    department = _values_for("department")
+    base_unit = _values_for("base_unit")
+    supplier = _values_for("supplier")
 
     try:
         categories_map = CategoriesService.get_category_choices_grouped()
@@ -25,7 +34,9 @@ def resolve_category_filters(request) -> Dict[str, Any]:
         categories_map = {}
 
     categories = list(categories_map.keys())
-    subcats = categories_map.get(category, [])
+    subcats: List[tuple] = []
+    for c in category:
+        subcats.extend(categories_map.get(c, []))
     subcategories = [sc[1] for sc in subcats]
 
     departments = list(
@@ -87,25 +98,25 @@ def build_filters(request) -> List[Dict[str, Any]]:
         {
             "name": "category",
             "label": "Category",
-            "value": resolved["category"],
+            "value": ",".join(resolved["category"]),
             "options": category_options,
         },
         {
             "name": "subcategory",
             "label": "Subcategory",
-            "value": resolved["subcategory"],
+            "value": ",".join(resolved["subcategory"]),
             "options": subcategory_options,
         },
         {
             "name": "base_unit",
             "label": "Unit",
-            "value": resolved["base_unit"],
+            "value": ",".join(resolved["base_unit"]),
             "options": base_unit_options,
         },
         {
             "name": "supplier",
             "label": "Supplier",
-            "value": resolved["supplier"],
+            "value": ",".join(resolved["supplier"]),
             "options": supplier_options,
         },
         {

--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -385,6 +385,12 @@ class ItemsTableView(TemplateView):
             {"page_obj": page_obj, "page_size": per_page, "querystring": querystring}
         )
         ctx.update(category_filters.resolve_category_filters(self.request))
+        ctx["predictive_filter_names"] = [
+            "category",
+            "base_unit",
+            "supplier",
+            "department",
+        ]
         return ctx
 
 

--- a/static/js/table-filters.js
+++ b/static/js/table-filters.js
@@ -1,0 +1,20 @@
+(function(){
+  function debounce(fn, delay){
+    let t; return function(){clearTimeout(t); t=setTimeout(fn, delay);};
+  }
+  function bind(root){
+    const form = root.getElementById ? root : document.getElementById('filters');
+    if(!form) return;
+    const inputs = form.querySelectorAll('[data-inline-filter]');
+    inputs.forEach(el=>{
+      if(el._ifBound) return; el._ifBound=true;
+      if(el.tagName === 'INPUT'){
+        el.addEventListener('input', debounce(()=>{ window.htmx && window.htmx.trigger(form,'submit');},300));
+      }else{
+        el.addEventListener('change', ()=>{ window.htmx && window.htmx.trigger(form,'submit');});
+      }
+    });
+  }
+  document.addEventListener('DOMContentLoaded', ()=>bind(document));
+  document.body.addEventListener('htmx:afterSwap', (e)=>bind(e.target));
+})();

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -1,6 +1,6 @@
 {% load icon_tags category_tags %}
 <!-- prettier-ignore -->
-<form id="filters" method="get">
+<form id="filters" method="get" hx-get="{% url 'items_table' %}" hx-target="#items-list" hx-push-url="true" hx-indicator="#items-loading">
   <table
     class="min-w-full w-full table-fixed bg-white border border-gray-200 rounded-lg table-sticky"
     id="items-table"
@@ -11,66 +11,104 @@
           <input id="select-all" type="checkbox" data-select-all aria-label="Select all" />
         </th>
         <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="name" data-sort="col1" aria-sort="none">
-          <div class="flex items-center gap-1">
-            <a data-sort-link data-sort-key="name" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">
-              Name
-              {% if sort == 'name' %}
-                <span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>
-              {% else %}
-                <span class="text-xs text-gray-400">⇅</span>
-              {% endif %}
-            </a>
-            <button type="button" class="ml-1 text-gray-500 hover:text-gray-700 focus:outline-none" aria-label="Filter Name" data-filter-btn data-field="name" data-param="q">
-              {% icon 'funnel' 'w-4 h-4' %}
-            </button>
-          </div>
+          <a data-sort-link data-sort-key="name" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">
+            Name
+            {% if sort == 'name' %}
+              <span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>
+            {% else %}
+              <span class="text-xs text-gray-400">⇅</span>
+            {% endif %}
+          </a>
         </th>
         <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="category" data-sort="col2" aria-sort="none">
-          <div class="flex items-center gap-1">
-            <a data-sort-link data-sort-key="category__category" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=category__category&direction={% if sort == 'category__category' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=category__category&direction={% if sort == 'category__category' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Category {% if sort == 'category__category' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
-            <button type="button" class="ml-1 text-gray-500 hover:text-gray-700 focus:outline-none" aria-label="Filter Category" data-filter-btn data-field="category" data-param="category">
-              {% icon 'funnel' 'w-4 h-4' %}
-            </button>
-          </div>
+          <a data-sort-link data-sort-key="category__category" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=category__category&direction={% if sort == 'category__category' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=category__category&direction={% if sort == 'category__category' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Category {% if sort == 'category__category' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
         </th>
         <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="unit" data-sort="col3" aria-sort="none">
-          <div class="flex items-center gap-1">
-            <a data-sort-link data-sort-key="unit__base_unit" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=unit__base_unit&direction={% if sort == 'unit__base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=unit__base_unit&direction={% if sort == 'unit__base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Unit {% if sort == 'unit__base_unit' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
-            <button type="button" class="ml-1 text-gray-500 hover:text-gray-700 focus:outline-none" aria-label="Filter Unit" data-filter-btn data-field="unit" data-param="base_unit">
-              {% icon 'funnel' 'w-4 h-4' %}
-            </button>
-          </div>
+          <a data-sort-link data-sort-key="unit__base_unit" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=unit__base_unit&direction={% if sort == 'unit__base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=unit__base_unit&direction={% if sort == 'unit__base_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Unit {% if sort == 'unit__base_unit' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
         </th>
         <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="stock" data-sort="col4" aria-sort="none">
           <a data-sort-link data-sort-key="current_stock" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=current_stock&direction={% if sort == 'current_stock' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Stock {% if sort == 'current_stock' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
         </th>
         <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="stock_status" data-sort="col5" aria-sort="none">
-          <div class="flex items-center gap-1">
-            <span>Stock Status</span>
-            <button type="button" class="ml-1 text-gray-500 hover:text-gray-700 focus:outline-none" aria-label="Filter Stock Status" data-filter-btn data-field="stock_status" data-param="stock_status">
-              {% icon 'funnel' 'w-4 h-4' %}
-            </button>
-          </div>
+          <span>Stock Status</span>
         </th>
         <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="departments" data-sort="col6" aria-sort="none">
-          <div class="flex items-center gap-1">
-            <span>Departments</span>
-            <button type="button" class="ml-1 text-gray-500 hover:text-gray-700 focus:outline-none" aria-label="Filter Departments" data-filter-btn data-field="department" data-param="department">
-              {% icon 'funnel' 'w-4 h-4' %}
-            </button>
-          </div>
+          <span>Departments</span>
         </th>
         <th scope="col" class="sticky z-10 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md" data-col="status" data-sort="col7" aria-sort="none">
-          <div class="flex items-center gap-1">
-            <a data-sort-link data-sort-key="is_active" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Status {% if sort == 'is_active' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
-            <button type="button" class="ml-1 text-gray-500 hover:text-gray-700 focus:outline-none" aria-label="Filter Status" data-filter-btn data-field="active" data-param="active">
-              {% icon 'funnel' 'w-4 h-4' %}
-            </button>
-          </div>
+          <a data-sort-link data-sort-key="is_active" href="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-get="{% url 'items_table' %}?{{ querystring|default:'' }}&sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}" hx-target="#items-list" hx-indicator="#items-loading" class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">Status {% if sort == 'is_active' %}<span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>{% else %}<span class="text-xs text-gray-400">⇅</span>{% endif %}</a>
         </th>
         <th scope="col" class="sticky z-10 w-30 px-4 py-2.5 bg-gray-50 border-b border-gray-200 group-data-[shadow=true]:shadow-md">
           Actions
         </th>
+      </tr>
+      <tr class="bg-gray-50">
+        <th></th>
+        <th class="px-4 py-2">
+          <label for="filter-q" class="sr-only">Filter Name</label>
+          <input id="filter-q" name="q" type="text" value="{{ q }}" placeholder="Search name" class="w-full h-8 px-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary" data-inline-filter />
+        </th>
+        <th class="px-4 py-2">
+          <label for="filter-category" class="sr-only">Filter Category</label>
+          <select id="filter-category" name="category" multiple class="w-full h-8 px-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary{% if predictive_filter_names and 'category' in predictive_filter_names %} predictive{% endif %}" data-inline-filter>
+            <option value="">All Categories</option>
+            {% for c in categories %}
+              <option value="{{ c }}"{% if c in category %} selected{% endif %}>{{ c }}</option>
+            {% endfor %}
+          </select>
+          <label for="filter-subcategory" class="sr-only">Filter Subcategory</label>
+          <select id="filter-subcategory" name="subcategory" multiple class="mt-1 w-full h-8 px-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary{% if predictive_filter_names and 'subcategory' in predictive_filter_names %} predictive{% endif %}" data-inline-filter>
+            <option value="">All Subcategories</option>
+            {% for sc in subcategories %}
+              <option value="{{ sc }}"{% if sc in subcategory %} selected{% endif %}>{{ sc }}</option>
+            {% endfor %}
+          </select>
+        </th>
+        <th class="px-4 py-2">
+          <label for="filter-unit" class="sr-only">Filter Unit</label>
+          <select id="filter-unit" name="base_unit" multiple class="w-full h-8 px-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary{% if predictive_filter_names and 'base_unit' in predictive_filter_names %} predictive{% endif %}" data-inline-filter>
+            <option value="">All Units</option>
+            {% for u in base_units %}
+              <option value="{{ u }}"{% if u in base_unit %} selected{% endif %}>{{ u }}</option>
+            {% endfor %}
+          </select>
+        </th>
+        <th class="px-4 py-2">
+          <label for="filter-supplier" class="sr-only">Filter Supplier</label>
+          <select id="filter-supplier" name="supplier" multiple class="w-full h-8 px-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary{% if predictive_filter_names and 'supplier' in predictive_filter_names %} predictive{% endif %}" data-inline-filter>
+            <option value="">All Suppliers</option>
+            {% for sid, name in suppliers %}
+              <option value="{{ sid }}"{% if sid|stringformat:'s' in supplier %} selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+          </select>
+        </th>
+        <th class="px-4 py-2">
+          <label for="filter-stock-status" class="sr-only">Filter Stock Status</label>
+          <select id="filter-stock-status" name="stock_status" class="w-full h-8 px-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary" data-inline-filter>
+            <option value="">All Stock Statuses</option>
+            <option value="low"{% if stock_status == 'low' %} selected{% endif %}>Low Stock</option>
+            <option value="out"{% if stock_status == 'out' %} selected{% endif %}>Out of Stock</option>
+            <option value="normal"{% if stock_status == 'normal' %} selected{% endif %}>In Stock</option>
+          </select>
+        </th>
+        <th class="px-4 py-2">
+          <label for="filter-department" class="sr-only">Filter Departments</label>
+          <select id="filter-department" name="department" multiple class="w-full h-8 px-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary{% if predictive_filter_names and 'department' in predictive_filter_names %} predictive{% endif %}" data-inline-filter>
+            <option value="">All Departments</option>
+            {% for did, name in departments %}
+              <option value="{{ did }}"{% if did in department %} selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+          </select>
+        </th>
+        <th class="px-4 py-2">
+          <label for="filter-active" class="sr-only">Filter Status</label>
+          <select id="filter-active" name="active" class="w-full h-8 px-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary" data-inline-filter>
+            <option value="">All Statuses</option>
+            <option value="true"{% if active == 'true' %} selected{% endif %}>Active</option>
+            <option value="false"{% if active == 'false' %} selected{% endif %}>Inactive</option>
+          </select>
+        </th>
+        <th></th>
       </tr>
     </thead>
   <tbody class="bg-white divide-y divide-border">

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -43,9 +43,6 @@
 
 {% block data_container %}
     {% url 'items_table' as items_table_url %}
-    <div class="mb-4">
-      {% include "components/responsive_filter_controls.html" with filters=filters predictive_names=predictive_filter_names hx_get=items_table_url hx_target="#items-list" hx_indicator="#items-loading" %}
-    </div>
     <div class="bg-white rounded-xl shadow border border-gray-200 overflow-hidden">
       <div id="items-toolbar">
         <!-- Actions bar -->
@@ -107,7 +104,7 @@
 
 {% block page_scripts %}
     <script src="{% static 'js/predictive-dropdown.js' %}?v={{ STATIC_VERSION }}" defer></script>
-    <script src="{% static 'js/column-filters.js' %}?v={{ STATIC_VERSION }}" defer></script>
+    <script src="{% static 'js/table-filters.js' %}?v={{ STATIC_VERSION }}" defer></script>
     <script>
     document.addEventListener('DOMContentLoaded', () => {
       const listEl = document.getElementById('items-list');

--- a/tests/frontend/form_layout.test.js
+++ b/tests/frontend/form_layout.test.js
@@ -25,7 +25,7 @@ describe("form layout regression", () => {
   });
 });
 
-test("items_list template includes column filter script", () => {
+test("items_list template includes table filter script", () => {
   const fs = require("fs");
   const path = require("path");
   const tpl = fs.readFileSync(
@@ -39,10 +39,10 @@ test("items_list template includes column filter script", () => {
     ),
     "utf8",
   );
-  expect(tpl.includes("column-filters.js")).toBe(true);
+  expect(tpl.includes("table-filters.js")).toBe(true);
 });
 
-test("items_table renders column filter buttons", () => {
+test("items_table renders inline filter controls", () => {
   const fs = require("fs");
   const path = require("path");
   const tpl = fs.readFileSync(
@@ -56,5 +56,5 @@ test("items_table renders column filter buttons", () => {
     ),
     "utf8",
   );
-  expect(tpl.includes('data-filter-btn')).toBe(true);
+  expect(tpl.includes('data-inline-filter')).toBe(true);
 });

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -177,7 +177,6 @@ def test_filters_persist_after_table_refresh(client):
     assert resp.status_code == 200
     initial_html = resp.content.decode()
     assert 'id="filters"' in initial_html
-    assert 'id="mobile-filters-form"' in initial_html
 
     table_resp = client.get(reverse("items_table"), HTTP_HX_REQUEST="true")
     assert table_resp.status_code == 200
@@ -192,13 +191,10 @@ def test_mobile_filter_drawer_attributes(client):
     resp = client.get(reverse("items_list"))
     assert resp.status_code == 200
     soup = BeautifulSoup(resp.content, "html.parser")
-    toggle = soup.find("button", {"data-mobile-filters-toggle": True})
-    assert toggle is not None
-    assert "md:hidden" in toggle.get("class", [])
-    drawer = soup.find("div", id="mobile-filters-drawer")
-    assert drawer is not None
-    assert drawer.get("role") == "dialog"
-    assert drawer.get("aria-modal") == "true"
+    form = soup.find("form", id="filters")
+    assert form is not None
+    assert form.find("input", {"id": "filter-q"}) is not None
+    assert form.find("select", {"id": "filter-category"}) is not None
 
 
 @pytest.mark.django_db

--- a/tests/test_items_table_accessibility.py
+++ b/tests/test_items_table_accessibility.py
@@ -19,12 +19,14 @@ def test_column_menu_has_accessibility_attrs():
 
 def test_filter_controls_have_labels_and_ids():
     content = Path("templates/inventory/_items_table.html").read_text()
-    for label in [
-        "Filter Name",
-        "Filter Category",
-        "Filter Unit",
-        "Filter Stock Status",
-        "Filter Departments",
-        "Filter Status",
-    ]:
-        assert f'aria-label="{label}"' in content
+    pairs = [
+        ("filter-q", "Filter Name"),
+        ("filter-category", "Filter Category"),
+        ("filter-unit", "Filter Unit"),
+        ("filter-stock-status", "Filter Stock Status"),
+        ("filter-department", "Filter Departments"),
+        ("filter-active", "Filter Status"),
+    ]
+    for fid, label in pairs:
+        assert f'id="{fid}"' in content
+        assert f'<label for="{fid}" class="sr-only">{label}</label>' in content

--- a/tests/test_items_table_header.py
+++ b/tests/test_items_table_header.py
@@ -28,5 +28,5 @@ def test_items_table_header_top_zero_and_structure():
         assert f'data-sort="col{i}"' in th
         assert 'aria-sort="none"' in th
 
-    for field in ["name", "category", "unit", "stock_status", "department", "active"]:
-        assert f'data-field="{field}"' in header
+    for name_attr in ["q", "category", "base_unit", "stock_status", "department", "active"]:
+        assert f'name="{name_attr}"' in header


### PR DESCRIPTION
## Summary
- inline filters added directly into items table header
- allow multi-select filtering for categories, units, suppliers, and departments
- trigger HTMX requests when inline filters change

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c31dfd0c408326a3e30849782ab954