### PR TITLE
Expose table filter binding

### DIFF
--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -782,6 +782,9 @@
         window.__tableSortInFlight = false;
         // Re-enable links marked busy
         document.querySelectorAll('a[data-sort-link][data-sort-busy="1"]').forEach(a=>{ delete a.dataset.sortBusy; });
+        if (window.tableFilters && window.tableFilters.bind) {
+          window.tableFilters.bind(ev.target);
+        }
         document.removeEventListener('htmx:afterSwap', handler);
       }
     });
@@ -898,8 +901,12 @@
     if (getQueryTerm()) highlightTable(document);
   });
   document.addEventListener('htmx:afterSwap', (e) => {
-    if (e && e.target && e.target.id === 'items-list' && getQueryTerm())
-      highlightTable(e.target);
+    if (e && e.target && e.target.id === 'items-list') {
+      if (getQueryTerm()) highlightTable(e.target);
+      if (window.tableFilters && window.tableFilters.bind) {
+        window.tableFilters.bind(e.target);
+      }
+    }
   });
 
   function getCsrfToken() {

--- a/static/js/table-filters.js
+++ b/static/js/table-filters.js
@@ -15,6 +15,7 @@
       }
     });
   }
-  document.addEventListener('DOMContentLoaded', ()=>bind(document));
-  document.body.addEventListener('htmx:afterSwap', (e)=>bind(e.target));
+  window.tableFilters = { bind };
+  document.addEventListener('DOMContentLoaded', () => bind(document));
+  document.body.addEventListener('htmx:afterSwap', (e) => bind(e.target));
 })();

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -138,6 +138,9 @@
       if (listEl) {
         listEl.addEventListener('htmx:afterSwap', (e) => {
           announceCount();
+          if (window.tableFilters && window.tableFilters.bind) {
+            window.tableFilters.bind(e.target);
+          }
         });
       }
 


### PR DESCRIPTION
## Summary
- expose table filter `bind` method via `window.tableFilters`
- refresh table filter bindings after HTMX swaps in items table and list

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3261927388326aae50ae3e91e4e9a