### PR TITLE
Add paginated recipes table view and cost grouping

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -54,6 +54,7 @@ from .views.recipes import (
     RecipeCreatePartialView,
     RecipeEditPartialView,
     RecipesListView,
+    RecipesTableView,
     recipe_create,
     recipe_detail,
 )
@@ -208,6 +209,7 @@ urlpatterns = [
     path("grns/<int:pk>/export/", grn_export, name="grn_export"),
     path("grns/<int:pk>/", GRNDetailView.as_view(), name="grn_detail"),
     path("recipes/", RecipesListView.as_view(), name="recipes_list"),
+    path("recipes/table/", RecipesTableView.as_view(), name="recipes_table"),
     path("recipes/create/", recipe_create, name="recipe_create"),
     path(
         "recipes/create/partial/",

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -9,7 +9,24 @@ from django.views.generic import TemplateView
 
 from ..forms.recipe_forms import RecipeItemFormSet, RecipeForm
 from ..models import Recipe
-from ..services import recipe_service
+from ..services import list_utils, recipe_service
+
+
+def _filtered_recipes_queryset(request):
+    """Return the recipe queryset filtered, searched and sorted for tables/cards."""
+
+    qs = Recipe.objects.annotate(item_count=Count("items"))
+    qs, params = list_utils.apply_filters_sort(
+        request,
+        qs,
+        search_fields=["name", "description"],
+        filter_fields={"active": "is_active"},
+        allowed_sorts=["name", "type", "default_yield_unit", "is_active"],
+        default_sort="name",
+    )
+    params.setdefault("q", "")
+    params["recipe_count"] = qs.count()
+    return qs, params
 
 
 class RecipesListView(TemplateView):
@@ -23,14 +40,8 @@ class RecipesListView(TemplateView):
 
     def _get_recipes(self):
         """Return recipes annotated with item counts and optional images."""
-        q = (self.request.GET.get("q") or "").strip()
-        qs = (
-            Recipe.objects.all()
-            .annotate(item_count=Count("items"))
-            .order_by("name")
-        )
-        if q:
-            qs = qs.filter(name__icontains=q)
+
+        qs, params = _filtered_recipes_queryset(self.request)
 
         recipes = []
         for r in qs:
@@ -45,27 +56,54 @@ class RecipesListView(TemplateView):
                     "name": r.name,
                     "image": image,
                     "item_count": r.item_count,
+                    "component_count": r.item_count,
+                    "category": getattr(r, "type", "") or "",
+                    "default_yield_unit": getattr(r, "default_yield_unit", "") or "",
+                    "is_active": r.is_active,
                 }
             )
-        return recipes, q
+        return recipes, params
+
+    def _render_table_partial(self):
+        """Render the recipes table once so the list page has initial HTML."""
+
+        table_view = RecipesTableView()
+        table_view.setup(self.request, *self.args, **self.kwargs)
+        table_context = table_view.get_context_data()
+        table_html = render_to_string(
+            table_view.get_template_names()[0],
+            table_context,
+            request=self.request,
+        )
+        return table_html, table_context
 
     def get(self, request, *args, **kwargs):
-        recipes, q = self._get_recipes()
+        recipes, params = self._get_recipes()
         if request.headers.get("HX-Request"):
             return render(request, self.grid_template, {"recipes": recipes})
 
+        table_html, table_ctx = self._render_table_partial()
         grid_html = render_to_string(
             self.grid_template, {"recipes": recipes}, request=request
         )
         ctx = {
             "recipes_grid": grid_html,
-            "q": q,
-            "recipe_count": len(recipes),
+            "recipes_table": table_html,
+            "recipe_count": params.get("recipe_count", len(recipes)),
             "form": RecipeForm(),
             "list_url": reverse("root"),
             "list_title": "Dashboard",
             "current_title": "Recipes",
         }
+        ctx.update(params)
+        ctx.update(
+            {
+                "page_size": table_ctx.get("page_size"),
+                "sort": table_ctx.get("sort"),
+                "direction": table_ctx.get("direction"),
+                "querystring": table_ctx.get("querystring"),
+            }
+        )
         return render(request, self.template_name, ctx)
 
     def post(self, request, *args, **kwargs):
@@ -75,20 +113,64 @@ class RecipesListView(TemplateView):
             messages.success(request, "Recipe created", extra_tags="toast")
             return redirect("recipe_detail", pk=recipe.pk)
 
-        recipes, q = self._get_recipes()
+        recipes, params = self._get_recipes()
+        table_html, table_ctx = self._render_table_partial()
         grid_html = render_to_string(
             self.grid_template, {"recipes": recipes}, request=request
         )
         ctx = {
             "recipes_grid": grid_html,
-            "q": q,
-            "recipe_count": len(recipes),
+            "recipes_table": table_html,
+            "recipe_count": params.get("recipe_count", len(recipes)),
             "form": form,
             "list_url": reverse("root"),
             "list_title": "Dashboard",
             "current_title": "Recipes",
         }
+        ctx.update(params)
+        ctx.update(
+            {
+                "page_size": table_ctx.get("page_size"),
+                "sort": table_ctx.get("sort"),
+                "direction": table_ctx.get("direction"),
+                "querystring": table_ctx.get("querystring"),
+            }
+        )
         return render(request, self.template_name, ctx)
+
+
+class RecipesTableView(TemplateView):
+    """Render the paginated table view of recipes for HTMX swaps."""
+
+    template_name = "inventory/recipes/_recipes_table.html"
+
+    def _get_queryset(self):
+        qs, params = _filtered_recipes_queryset(self.request)
+        self._filter_params = params
+        return qs
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        qs = self._get_queryset()
+        page_obj, per_page = list_utils.paginate(self.request, qs)
+        params = getattr(self, "_filter_params", {})
+        ctx.update(params)
+        try:
+            querystring = list_utils.build_querystring(self.request)
+        except Exception:  # pragma: no cover - defensive
+            querystring = ""
+        ctx.update(
+            {
+                "page_obj": page_obj,
+                "page_size": per_page,
+                "querystring": querystring,
+                "recipes": page_obj.object_list,
+                "table_url": reverse("recipes_table"),
+            }
+        )
+        if "recipe_count" not in ctx:
+            ctx["recipe_count"] = qs.count()
+        return ctx
 
 
 def recipe_create(request):

--- a/static/js/recipe-components.js
+++ b/static/js/recipe-components.js
@@ -258,7 +258,14 @@
 
     // Clone the empty row
     var newRow = emptyRow.cloneNode(true);
-    
+    try {
+      newRow.dataset.category = (newRow.dataset.category || '').trim();
+      newRow.dataset.subcategory = (newRow.dataset.subcategory || '').trim();
+      newRow.dataset.itemName = (newRow.dataset.itemName || '').trim();
+    } catch (err) {
+      console.warn('Dataset init failed for new row:', err);
+    }
+
     // Replace the prefix in all form elements
     var inputs = newRow.querySelectorAll('input, select, textarea');
     inputs.forEach(function(input) {
@@ -299,7 +306,7 @@
     try { newRow.setAttribute('data-form-index', String(index)); } catch (e) {}
     newRow.classList.remove('hidden');
     tbody.appendChild(newRow);
-    
+
     console.log('🔧 Initializing new row...');
     
     // Use setTimeout to ensure DOM is updated before initializing dropdowns
@@ -364,9 +371,12 @@
         bindRowEvents(newRow);
         // Run a dedupe pass across the table to ensure no duplicate _text inputs exist
         try { dedupePredictiveInputs(table); } catch (e) { console.warn('Dedupe failed:', e); }
+        if (window.updateRecipeCosts) {
+          window.updateRecipeCosts();
+        }
       }, 200);
     }, 10);
-    
+
     // Release lock in next tick to allow another add
     setTimeout(function(){ delete totalForms.dataset.addLock; }, 0);
     console.log('✅ Row added and scheduled for initialization! New count:', totalForms.value);
@@ -494,6 +504,9 @@
         e.preventDefault();
         console.log('🗑️ Remove button clicked');
         row.remove();
+        if (window.updateRecipeCosts) {
+          window.updateRecipeCosts();
+        }
         // Note: In a real formset, you'd need to handle the DELETE field properly
       });
     }
@@ -536,7 +549,16 @@
         unitDisplay.value = '';
         console.log('✅ Cleared unit display field');
       }
+      var clearRow = itemSelect.closest('tr');
+      if (clearRow) {
+        clearRow.dataset.category = '';
+        clearRow.dataset.subcategory = '';
+        clearRow.dataset.itemName = '';
+      }
       updateRowCost(itemSelect, null);
+      if (window.updateRecipeCosts) {
+        window.updateRecipeCosts();
+      }
       return;
     }
     
@@ -563,10 +585,21 @@
             console.log('✅ Set unit display (BASE) to:', data.base_unit);
           }
           // Cache cost per base unit on the row for quick recompute
-          try { var r = itemSelect.closest('tr'); if (r) r.dataset.costPerBaseUnit = String(data.cost_per_base_unit || 0); } catch (_) {}
+          try {
+            var r = itemSelect.closest('tr');
+            if (r) {
+              r.dataset.costPerBaseUnit = String(data.cost_per_base_unit || 0);
+              r.dataset.category = (data.category || '').trim();
+              r.dataset.subcategory = (data.subcategory || '').trim();
+              r.dataset.itemName = (data.name || '').trim();
+            }
+          } catch (_) {}
 
           // Update cost
           updateRowCost(itemSelect, data);
+          if (window.updateRecipeCosts) {
+            window.updateRecipeCosts();
+          }
           try { var table = itemSelect.closest('table'); if (table) debugFormsetState(table, 'after-item-change'); } catch(e) {}
         } else {
           console.error('❌ Invalid item data received:', data);
@@ -597,9 +630,8 @@
         costPerBase = parseFloat(rowCached.dataset.costPerBaseUnit);
       }
     }
-    if (!costPerBase || isNaN(costPerBase)) {
-      console.log('⚠️ No cost data available');
-      return;
+    if (costPerBase === null || typeof costPerBase === 'undefined' || isNaN(costPerBase)) {
+      costPerBase = 0;
     }
 
     // Find the cost display element for this row
@@ -623,6 +655,200 @@
       }
     }
   }
+
+  function slugifyCategoryLabel(label) {
+    return String(label || 'uncategorized')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'uncategorized';
+  }
+
+  function parseLineCost(el) {
+    if (!el) {
+      return 0;
+    }
+    var text = String(el.textContent || '').replace(/[^0-9.-]/g, '');
+    var value = parseFloat(text);
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  function clampMarginValue(raw) {
+    if (!Number.isFinite(raw)) {
+      return 0;
+    }
+    if (raw < 0) {
+      return 0;
+    }
+    if (raw > 95) {
+      return 95;
+    }
+    return raw;
+  }
+
+  window.updateRecipeCosts = function(root) {
+    try {
+      var scope = root || document;
+      var table = scope.querySelector('#items-table');
+      if (!table) {
+        return;
+      }
+      var tbody = table.querySelector('tbody');
+      if (!tbody) {
+        return;
+      }
+
+      var hiddenTemplate = table.querySelector('#items-empty-row');
+      if (hiddenTemplate && hiddenTemplate.parentNode === tbody) {
+        tbody.removeChild(hiddenTemplate);
+      }
+
+      Array.from(tbody.querySelectorAll('tr[data-category-heading]')).forEach(function(row) {
+        row.remove();
+      });
+
+      var visibleRows = Array.from(tbody.querySelectorAll('tr.form-row'));
+      var groups = [];
+      var groupMap = Object.create(null);
+      var totalCost = 0;
+
+      visibleRows.forEach(function(row, index) {
+        if (row.classList.contains('hidden')) {
+          return;
+        }
+        var deleteField = row.querySelector('input[id$="-DELETE"]');
+        if (deleteField && (deleteField.checked || deleteField.value === 'on')) {
+          return;
+        }
+
+        var category = (row.dataset.category || '').trim();
+        if (!category) {
+          category = 'Uncategorized';
+        }
+        var key = category.toLowerCase() || 'uncategorized';
+        var group = groupMap[key];
+        if (!group) {
+          group = { key: key, label: category, rows: [], total: 0 };
+          groupMap[key] = group;
+          groups.push(group);
+        }
+
+        var lineCost = parseLineCost(row.querySelector('[data-line-cost]'));
+        totalCost += lineCost;
+        group.total += lineCost;
+        group.rows.push({ row: row, index: index });
+      });
+
+      groups.sort(function(a, b) {
+        if (a.label === b.label) {
+          return 0;
+        }
+        if (a.label === 'Uncategorized') {
+          return 1;
+        }
+        if (b.label === 'Uncategorized') {
+          return -1;
+        }
+        return a.label.localeCompare(b.label);
+      });
+
+      var fragment = document.createDocumentFragment();
+      groups.forEach(function(group, idx) {
+        var headingId = 'recipe-category-' + slugifyCategoryLabel(group.label) + '-' + idx;
+        var headingRow = document.createElement('tr');
+        headingRow.setAttribute('data-category-heading', '1');
+        headingRow.setAttribute('data-category-key', group.key);
+        headingRow.setAttribute('role', 'row');
+        var headingCell = document.createElement('th');
+        headingCell.setAttribute('scope', 'colgroup');
+        headingCell.setAttribute('colspan', '6');
+        headingCell.id = headingId;
+        headingCell.className = 'px-4 py-2 text-xs font-semibold uppercase tracking-wide text-gray-600 bg-surfaceSubtle';
+        headingCell.textContent = group.label;
+        headingRow.appendChild(headingCell);
+        fragment.appendChild(headingRow);
+        group.headingId = headingId;
+        group.rows.forEach(function(entry) {
+          entry.row.setAttribute('aria-labelledby', headingId);
+          fragment.appendChild(entry.row);
+        });
+      });
+
+      if (fragment.childNodes.length) {
+        tbody.appendChild(fragment);
+      }
+
+      if (hiddenTemplate) {
+        tbody.appendChild(hiddenTemplate);
+      }
+
+      var costContainer = scope.querySelector('#cost-by-category');
+      if (costContainer) {
+        while (costContainer.firstChild) {
+          costContainer.removeChild(costContainer.firstChild);
+        }
+        if (!groups.length) {
+          var emptyMessage = document.createElement('p');
+          emptyMessage.className = 'text-sm text-gray-500';
+          emptyMessage.textContent = 'Add items to see category totals.';
+          costContainer.appendChild(emptyMessage);
+        } else {
+          groups.forEach(function(group) {
+            var item = document.createElement('div');
+            item.className = 'flex items-center justify-between gap-2';
+            item.setAttribute('role', 'group');
+            if (group.headingId) {
+              item.setAttribute('aria-labelledby', group.headingId);
+            }
+            var label = document.createElement('span');
+            label.className = 'text-gray-600';
+            label.textContent = group.label;
+            var value = document.createElement('span');
+            value.className = 'font-medium text-bodyText';
+            value.textContent = group.total.toFixed(2);
+            item.appendChild(label);
+            item.appendChild(value);
+            costContainer.appendChild(item);
+          });
+        }
+      }
+
+      var totalCostEl = scope.querySelector('#recipe-total-cost');
+      if (totalCostEl) {
+        totalCostEl.textContent = totalCost.toFixed(2);
+      }
+
+      var marginInput = scope.querySelector('#recipe-margin');
+      if (marginInput && !marginInput.dataset.recipeMarginBound) {
+        var marginHandler = function() {
+          window.updateRecipeCosts(scope);
+        };
+        marginInput.addEventListener('input', marginHandler);
+        marginInput.addEventListener('change', marginHandler);
+        marginInput.dataset.recipeMarginBound = '1';
+      }
+
+      var suggestedEl = scope.querySelector('#recipe-suggested-price');
+      var marginValue = marginInput ? parseFloat(marginInput.value || '0') : 0;
+      var clampedMargin = clampMarginValue(marginValue);
+      if (marginInput && marginValue !== clampedMargin) {
+        marginInput.value = clampedMargin;
+      }
+      var marginDecimal = clampedMargin / 100;
+      var suggested = totalCost;
+      if (marginDecimal > 0 && marginDecimal < 0.999) {
+        suggested = totalCost / (1 - marginDecimal);
+      }
+      if (suggestedEl) {
+        suggestedEl.textContent = Number.isFinite(suggested)
+          ? suggested.toFixed(2)
+          : totalCost.toFixed(2);
+      }
+
+      table.dataset.recipeGroupingApplied = groups.length ? '1' : '0';
+    } catch (err) {
+      console.error('updateRecipeCosts failed:', err);
+    }
+  };
   
   // Expose globally with the correct name for modal.js
   window.initRecipeComponentsTable = initRecipeComponentsTable;

--- a/templates/inventory/recipes/_components_form_table.html
+++ b/templates/inventory/recipes/_components_form_table.html
@@ -13,7 +13,7 @@
 
 {% block rows %}
   {% for cform in formset.forms %}
-  <tr class="form-row" data-form-index="{{ forloop.counter0 }}">
+  <tr class="form-row" data-form-index="{{ forloop.counter0 }}" data-recipe-row="true">
     <td>
       {% include "components/form_field_table.html" with field=cform.item %}
     </td>
@@ -33,7 +33,7 @@
   </tr>
   {% endfor %}
   {# empty form template row #}
-  <tr class="form-row hidden" id="items-empty-row">
+  <tr class="form-row hidden" id="items-empty-row" data-recipe-row="true">
     <td>
       {% include "components/form_field_table.html" with field=formset.empty_form.item %}
     </td>
@@ -60,6 +60,9 @@
   var tableId = '{{ table_id|default:"items-table" }}';
   // Use the closest drawer/modal container as root scope for JS
   var tableEl = document.getElementById(tableId);
+  if (tableEl) {
+    tableEl.dataset.recipeGrouping = '1';
+  }
   var rootScope = tableEl ? (tableEl.closest('.drawer-panel') || tableEl.closest('[data-modal-root]') || document) : document;
   console.log('🎯 Table footer script running for table:', tableId);
   
@@ -89,6 +92,9 @@
     if (window.initRecipeComponentsTable) {
       console.log('✅ Found initRecipeComponentsTable function');
       window.initRecipeComponentsTable(rootScope, tableId);
+      if (window.updateRecipeCosts) {
+        window.updateRecipeCosts();
+      }
     } else {
       console.log('❌ initRecipeComponentsTable not available, trying manual setup');
       
@@ -107,6 +113,9 @@
           }
         });
         console.log('✅ Manual event listener attached');
+      }
+      if (window.updateRecipeCosts) {
+        window.updateRecipeCosts();
       }
     }
   };

--- a/templates/inventory/recipes/_recipe_card.html
+++ b/templates/inventory/recipes/_recipe_card.html
@@ -1,11 +1,23 @@
-<a href="{% url 'recipe_detail' recipe.recipe_id %}" class="block bg-surface rounded-lg shadow hover:shadow-xl transition-transform transform hover:-translate-y-1">
-  <div class="flex items-start gap-4 overflow-hidden p-4">
-    {% if recipe.image %}
-      <img src="{{ recipe.image }}" alt="{{ recipe.name }}" class="w-24 max-w-full h-auto object-contain rounded flex-shrink-0" />
-    {% endif %}
-    <div class="flex-1 overflow-hidden">
-      <h3 class="text-lg font-semibold mb-2 truncate">{{ recipe.name }}</h3>
-      <p class="text-sm text-gray-600 truncate">{{ recipe.component_count }} ingredients</p>
+<div class="bg-surface rounded-lg shadow hover:shadow-xl transition-transform transform hover:-translate-y-1">
+  <a href="{% url 'recipe_detail' recipe.recipe_id %}" class="block">
+    <div class="flex items-start gap-4 overflow-hidden p-4">
+      {% if recipe.image %}
+        <img src="{{ recipe.image }}" alt="{{ recipe.name }}" class="w-24 max-w-full h-auto object-contain rounded flex-shrink-0"/>
+      {% endif %}
+      <div class="flex-1 overflow-hidden">
+        <h3 class="text-lg font-semibold mb-2 truncate">{{ recipe.name }}</h3>
+        <p class="text-sm text-gray-600 truncate">{{ recipe.component_count|default:recipe.item_count|default:0 }} ingredients</p>
+      </div>
     </div>
+  </a>
+  <div class="px-4 pb-4 flex items-center justify-end border-t border-border bg-surfaceSubtle/40">
+    <button type="button"
+            class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary"
+            data-modal-url="{% url 'recipe_edit_partial' recipe.recipe_id %}"
+            data-modal-type="drawer"
+            data-modal-prefetch="hover"
+            aria-label="Edit {{ recipe.name }}">
+      Edit
+    </button>
   </div>
-</a>
+</div>

--- a/templates/inventory/recipes/_recipes_table.html
+++ b/templates/inventory/recipes/_recipes_table.html
@@ -1,0 +1,143 @@
+{% load icon_tags %}
+<div id="recipes-meta-summary" class="flex flex-wrap items-center gap-2 text-xs font-medium text-gray-600" hx-swap-oob="outerHTML">
+  <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full border border-border bg-surfaceSubtle">Total:
+    <span class="text-bodyText">{{ recipe_count|default:0 }}</span>
+  </span>
+  {% if q %}
+    <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full border border-border bg-surfaceSubtle">Filtered by:
+      <span class="text-bodyText">“{{ q }}”</span>
+    </span>
+  {% endif %}
+</div>
+<div class="table-scroll group bg-surface border border-border rounded-2xl shadow-card" data-table-container data-optimistic-sort="true" data-table-key="recipes-table">
+  <div class="sr-only" aria-live="polite" data-table-announcer></div>
+  <table id="recipes-table" class="min-w-full w-full table-auto text-label">
+    <caption class="sr-only">Recipes</caption>
+    <thead class="text-left text-xs font-semibold uppercase tracking-wider bg-surfaceSubtle text-gray-600">
+      <tr>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-surfaceSubtle border-b border-border group-data-[shadow=true]:shadow-md" data-col="name" aria-sort="{% if sort == 'name' %}{{ 'ascending' if direction == 'asc' else 'descending' }}{% else %}none{% endif %}">
+          <a data-sort-link data-sort-key="name"
+             href="{{ table_url }}?{% if querystring %}{{ querystring }}&{% endif %}sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-get="{{ table_url }}?{% if querystring %}{{ querystring }}&{% endif %}sort=name&direction={% if sort == 'name' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#recipes-table-container"
+             hx-indicator="#recipes-table-loading"
+             hx-include="#filters"
+             class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">
+            Name
+            {% if sort == 'name' %}
+              <span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>
+            {% else %}
+              <span class="text-xs text-gray-400">⇅</span>
+            {% endif %}
+          </a>
+        </th>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-surfaceSubtle border-b border-border group-data-[shadow=true]:shadow-md" data-col="category" aria-sort="{% if sort == 'type' %}{{ 'ascending' if direction == 'asc' else 'descending' }}{% else %}none{% endif %}">
+          <a data-sort-link data-sort-key="type"
+             href="{{ table_url }}?{% if querystring %}{{ querystring }}&{% endif %}sort=type&direction={% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-get="{{ table_url }}?{% if querystring %}{{ querystring }}&{% endif %}sort=type&direction={% if sort == 'type' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#recipes-table-container"
+             hx-indicator="#recipes-table-loading"
+             hx-include="#filters"
+             class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">
+            Category
+            {% if sort == 'type' %}
+              <span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>
+            {% else %}
+              <span class="text-xs text-gray-400">⇅</span>
+            {% endif %}
+          </a>
+        </th>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-surfaceSubtle border-b border-border group-data-[shadow=true]:shadow-md" data-col="yield" aria-sort="{% if sort == 'default_yield_unit' %}{{ 'ascending' if direction == 'asc' else 'descending' }}{% else %}none{% endif %}">
+          <a data-sort-link data-sort-key="default_yield_unit"
+             href="{{ table_url }}?{% if querystring %}{{ querystring }}&{% endif %}sort=default_yield_unit&direction={% if sort == 'default_yield_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-get="{{ table_url }}?{% if querystring %}{{ querystring }}&{% endif %}sort=default_yield_unit&direction={% if sort == 'default_yield_unit' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#recipes-table-container"
+             hx-indicator="#recipes-table-loading"
+             hx-include="#filters"
+             class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">
+            Yield Unit
+            {% if sort == 'default_yield_unit' %}
+              <span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>
+            {% else %}
+              <span class="text-xs text-gray-400">⇅</span>
+            {% endif %}
+          </a>
+        </th>
+        <th scope="col" class="sticky z-10 px-4 py-2.5 bg-surfaceSubtle border-b border-border group-data-[shadow=true]:shadow-md" data-col="active" aria-sort="{% if sort == 'is_active' %}{{ 'ascending' if direction == 'asc' else 'descending' }}{% else %}none{% endif %}">
+          <a data-sort-link data-sort-key="is_active"
+             href="{{ table_url }}?{% if querystring %}{{ querystring }}&{% endif %}sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-get="{{ table_url }}?{% if querystring %}{{ querystring }}&{% endif %}sort=is_active&direction={% if sort == 'is_active' and direction == 'asc' %}desc{% else %}asc{% endif %}"
+             hx-target="#recipes-table-container"
+             hx-indicator="#recipes-table-loading"
+             hx-include="#filters"
+             class="flex items-center gap-1 focus:outline-none focus:ring-2 focus:ring-primary">
+            Active
+            {% if sort == 'is_active' %}
+              <span class="text-xs">{% if direction == 'asc' %}▲{% else %}▼{% endif %}</span>
+            {% else %}
+              <span class="text-xs text-gray-400">⇅</span>
+            {% endif %}
+          </a>
+        </th>
+        <th scope="col" class="sticky z-10 w-32 px-4 py-2.5 bg-surfaceSubtle border-b border-border group-data-[shadow=true]:shadow-md">Actions</th>
+      </tr>
+    </thead>
+    <tbody class="bg-surface divide-y divide-border">
+      {% for recipe in page_obj.object_list %}
+        <tr class="hover:bg-surfaceSubtle focus-within:bg-surfaceSubtle" data-recipe-id="{{ recipe.recipe_id }}">
+          <td class="px-4 py-2 align-top">
+            <div class="font-medium text-bodyText">{{ recipe.name }}</div>
+            <div class="text-xs text-gray-500">{{ recipe.item_count|default:0 }} ingredients</div>
+          </td>
+          <td class="px-4 py-2 align-top">
+            {% if recipe.type %}
+              {{ recipe.type }}
+            {% else %}
+              <span class="text-gray-400">—</span>
+            {% endif %}
+          </td>
+          <td class="px-4 py-2 align-top">
+            {% if recipe.default_yield_unit %}
+              {{ recipe.default_yield_unit }}
+            {% else %}
+              <span class="text-gray-400">—</span>
+            {% endif %}
+          </td>
+          <td class="px-4 py-2 align-top">
+            {% if recipe.is_active %}
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-success-soft text-success">Active</span>
+            {% else %}
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-danger-soft text-danger">Inactive</span>
+            {% endif %}
+          </td>
+          <td class="px-4 py-2 align-top">
+            <div class="flex items-center gap-2">
+              <button type="button"
+                      class="inline-flex items-center justify-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary"
+                      data-modal-url="{% url 'recipe_edit_partial' recipe.recipe_id %}"
+                      data-modal-type="drawer"
+                      data-modal-prefetch="hover"
+                      aria-label="Edit {{ recipe.name }}">
+                {% icon 'pencil-square' 'w-4 h-4' %}
+              </button>
+              <a href="{% url 'recipe_detail' recipe.recipe_id %}"
+                 class="inline-flex items-center justify-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary"
+                 aria-label="Open {{ recipe.name }} details">
+                {% icon 'arrow-top-right-on-square' 'w-4 h-4' %}
+              </a>
+            </div>
+          </td>
+        </tr>
+      {% empty %}
+        <tr>
+          <td colspan="5" class="px-4 py-6 text-center text-gray-500">No recipes found.</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% if page_obj %}
+  <div class="mt-4">
+    {% include "components/pagination.html" with page_obj=page_obj base_url=table_url extra_query=querystring hx_target="#recipes-table-container" hx_include="#filters" hx_indicator="#recipes-table-loading" %}
+  </div>
+{% endif %}

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -5,7 +5,7 @@
   <p class="text-sm text-gray-600">Keep production formulas and BOMs in one place.</p>
 {% endblock %}
 {% block page_meta %}
-  <div class="flex flex-wrap items-center gap-2 text-xs font-medium text-gray-600">
+  <div id="recipes-meta-summary" class="flex flex-wrap items-center gap-2 text-xs font-medium text-gray-600">
     <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full border border-border bg-surfaceSubtle">Total: <span class="text-bodyText">{{ recipe_count|default:0 }}</span></span>
     {% if q %}
       <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full border border-border bg-surfaceSubtle">Filtered by: <span class="text-bodyText">“{{ q }}”</span></span>
@@ -27,18 +27,25 @@
 {% endblock %}
 
 {% block filters %}
-  {% url 'recipes_list' as recipes_list_url %}
-  {% include "components/filter_bar.html" with search_placeholder="Search recipes..." hx_get=recipes_list_url hx_target="#recipes_grid" q=q %}
+  {% url 'recipes_table' as recipes_table_url %}
+  {% include "components/filter_bar.html" with search_placeholder="Search recipes..." hx_get=recipes_table_url hx_target="#recipes-table-container" hx_indicator="#recipes-table-loading" q=q %}
 {% endblock %}
 
 {% block extra_top %}{% endblock %}
 
+{% block table_id %}recipes-table-wrapper{% endblock %}
+
 {% block data_container %}
-  <div id="recipes_grid"
-       hx-get="{% url 'recipes_list' %}"
-       hx-trigger="load"
-       hx-include="#filters"
-       hx-indicator="#htmx-spinner">
-    {{ recipes_grid|safe }}
+  <div class="bg-surface border border-border rounded-2xl shadow-card overflow-hidden">
+    <div class="pt-2 md:pt-3">
+      <div id="recipes-table-container">
+        {{ recipes_table|default_if_none:''|safe }}
+      </div>
+    </div>
+    <div id="recipes-table-loading" class="hidden p-4" aria-hidden="true">
+      <div class="h-11 w-full rounded-lg mb-2 bg-surfaceSubtle animate-pulse"></div>
+      <div class="h-11 w-full rounded-lg mb-2 bg-surfaceSubtle animate-pulse"></div>
+      <div class="h-11 w-full rounded-lg mb-2 bg-surfaceSubtle animate-pulse"></div>
+    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a shared filtered queryset helper and `RecipesTableView` endpoint so recipes can be rendered through the HTMX table flow
- replace the recipes grid loader with the new `_recipes_table.html` partial and drawer-friendly edit triggers on the list and cards
- extend the recipe components JavaScript to cache item categories, regroup visible rows with accessible headings, and recalculate totals/margins per group

## Testing
- pytest tests/test_recipe_service.py
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cbbdeb7a0c8326b84fb769a4059ad8