### PR TITLE
Ensure recipe cost grouping and form layout improvements

### DIFF
--- a/static/js/recipe-components.js
+++ b/static/js/recipe-components.js
@@ -716,7 +716,7 @@
           return;
         }
         var deleteField = row.querySelector('input[id$="-DELETE"]');
-        if (deleteField && (deleteField.checked || deleteField.value === 'on')) {
+        if (deleteField && deleteField.checked) {
           return;
         }
 

--- a/templates/inventory/recipes/_form_fields.html
+++ b/templates/inventory/recipes/_form_fields.html
@@ -1,5 +1,11 @@
 <div class="grid grid-cols-2 gap-4 max-sm:grid-cols-1 mb-4">
-  {% for field in form %}
-    {% include "components/form_field.html" with field=field %}
-  {% endfor %}
+  {% include "components/form_field.html" with field=form.name %}
+  {% include "components/form_field.html" with field=form.type %}
+  {% include "components/form_field.html" with field=form.description %}
+  {% include "components/form_field.html" with field=form.is_active %}
+</div>
+<div class="grid grid-cols-2 gap-4 max-sm:grid-cols-1">
+  {% include "components/form_field.html" with field=form.default_yield_qty %}
+  {% include "components/form_field.html" with field=form.default_yield_unit %}
+  {% include "components/form_field.html" with field=form.plating_notes container_class="sm:col-span-2" %}
 </div>


### PR DESCRIPTION
## Summary
- ensure `updateRecipeCosts` only skips rows whose delete checkbox is checked so the first populated line contributes to headings and totals
- render recipe form fields explicitly in a compact two-tier grid with primary fields up top and yield/plating fields tucked below

## Testing
- pytest tests/test_recipe_service.py
- npm test -- --watch=false
- Manual recipe drawer sanity check (new + edit flows)


------
https://chatgpt.com/codex/tasks/task_e_68cbcf1343d88326a8bc0506e2114059