### PR TITLE
Return JSON errors for recipe drawer forms

### DIFF
--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -29,6 +29,73 @@ def _filtered_recipes_queryset(request):
     return qs, params
 
 
+def _get_field_label(form_like, field_name):
+    field = getattr(form_like, "fields", {}).get(field_name)
+    if field and getattr(field, "label", None):
+        return str(field.label)
+    return field_name.replace("_", " ").capitalize()
+
+
+def _build_form_error_payload(form, formset):
+    """Collect validation errors into a friendly JSON payload."""
+
+    form_non_field_errors = [str(error) for error in form.non_field_errors()]
+    formset_non_form_errors = [str(error) for error in formset.non_form_errors()]
+
+    form_errors = {}
+    first_form_field_error = None
+    for field_name, errors in form.errors.items():
+        error_texts = [str(error) for error in errors]
+        if not error_texts:
+            continue
+        form_errors[field_name] = error_texts
+        if first_form_field_error is None:
+            label = _get_field_label(form, field_name)
+            first_form_field_error = f"{label}: {error_texts[0]}"
+
+    formset_errors = []
+    first_formset_field_error = None
+    forms = list(formset.forms)
+    total_forms = len(forms)
+    for index, form_instance in enumerate(forms):
+        child_errors = {}
+        for field_name, errors in form_instance.errors.items():
+            error_texts = [str(error) for error in errors]
+            if not error_texts:
+                continue
+            child_errors[field_name] = error_texts
+            if first_formset_field_error is None:
+                label = _get_field_label(form_instance, field_name)
+                prefix = f"Row {index + 1} - " if total_forms > 1 else ""
+                first_formset_field_error = f"{prefix}{label}: {error_texts[0]}"
+        if child_errors:
+            formset_errors.append({"index": index, "errors": child_errors})
+
+    message_parts = []
+    message_parts.extend(form_non_field_errors)
+    message_parts.extend(formset_non_form_errors)
+    if first_form_field_error:
+        message_parts.append(first_form_field_error)
+    if first_formset_field_error:
+        message_parts.append(first_formset_field_error)
+
+    if not message_parts:
+        message_parts.append("Please correct the highlighted errors and try again.")
+
+    message = " ".join(part.strip() for part in message_parts if part)
+
+    return {
+        "ok": False,
+        "message": message,
+        "errors": {
+            "form": form_errors,
+            "form_non_field": form_non_field_errors,
+            "formset_non_form": formset_non_form_errors,
+            "formset": formset_errors,
+        },
+    }
+
+
 class RecipesListView(TemplateView):
     """Display all recipes with search and card grid.
 
@@ -312,6 +379,8 @@ class RecipeCreatePartialView(View):
                     }
                 )
             return JsonResponse({"ok": False, "message": msg or "Error creating recipe"}, status=400)
+        if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            return JsonResponse(_build_form_error_payload(form, formset), status=400)
         return render(
             request,
             self.template_name,
@@ -370,6 +439,8 @@ class RecipeEditPartialView(View):
                     }
                 )
             return JsonResponse({"ok": False, "message": msg or "Error updating recipe"}, status=400)
+        if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            return JsonResponse(_build_form_error_payload(form, formset), status=400)
         return render(
             request,
             self.template_name,

--- a/tests/test_recipe_drawer.py
+++ b/tests/test_recipe_drawer.py
@@ -1,0 +1,159 @@
+"""Tests for the recipe drawer create/edit partial views."""
+
+import pytest
+from django.urls import reverse
+
+from inventory.models import Recipe, RecipeItem
+
+
+@pytest.mark.django_db
+def test_recipe_create_partial_invalid_ajax_returns_json(client):
+    url = reverse("recipe_create_partial")
+    data = {
+        "name": "",
+        "description": "",
+        "is_active": "on",
+        "type": "",
+        "default_yield_qty": "",
+        "default_yield_unit": "",
+        "plating_notes": "",
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "0",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-item": "",
+        "items-0-quantity": "",
+        "items-0-unit": "",
+        "items-0-loss_pct": "",
+        "items-0-DELETE": "",
+    }
+
+    response = client.post(
+        url,
+        data,
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["message"]
+    assert "<" not in payload["message"]
+    assert payload["errors"]["form"]["name"][0] == "This field is required."
+    assert payload["errors"]["formset"][0]["errors"]["item"][0] == "This field is required."
+
+
+@pytest.mark.django_db
+def test_recipe_create_partial_invalid_non_ajax_returns_html(client):
+    url = reverse("recipe_create_partial")
+    data = {
+        "name": "",
+        "description": "",
+        "is_active": "on",
+        "type": "",
+        "default_yield_qty": "",
+        "default_yield_unit": "",
+        "plating_notes": "",
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "0",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-item": "",
+        "items-0-quantity": "",
+        "items-0-unit": "",
+        "items-0-loss_pct": "",
+        "items-0-DELETE": "",
+    }
+
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert response["Content-Type"].startswith("text/html")
+    assert b"<form" in response.content
+
+
+@pytest.mark.django_db
+def test_recipe_edit_partial_invalid_ajax_returns_json(client, item_factory):
+    item = item_factory(name="Flour")
+    recipe = Recipe.objects.create(name="Bread", is_active=True)
+    recipe_item = RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=1,
+        unit="kg",
+        loss_pct=0,
+    )
+
+    url = reverse("recipe_edit_partial", args=[recipe.pk])
+    data = {
+        "name": "",
+        "description": recipe.description or "",
+        "is_active": "on",
+        "type": recipe.type or "",
+        "default_yield_qty": recipe.default_yield_qty or "",
+        "default_yield_unit": recipe.default_yield_unit or "",
+        "plating_notes": recipe.plating_notes or "",
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "1",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-id": str(recipe_item.pk),
+        "items-0-item": str(item.pk),
+        "items-0-quantity": "1",
+        "items-0-unit": recipe_item.unit or "",
+        "items-0-loss_pct": "0",
+        "items-0-DELETE": "",
+    }
+
+    response = client.post(
+        url,
+        data,
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["message"].startswith("Name:")
+    assert "<" not in payload["message"]
+    assert payload["errors"]["form"]["name"][0] == "This field is required."
+
+
+@pytest.mark.django_db
+def test_recipe_edit_partial_invalid_non_ajax_returns_html(client, item_factory):
+    item = item_factory(name="Flour")
+    recipe = Recipe.objects.create(name="Bread", is_active=True)
+    recipe_item = RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=1,
+        unit="kg",
+        loss_pct=0,
+    )
+
+    url = reverse("recipe_edit_partial", args=[recipe.pk])
+    data = {
+        "name": "",
+        "description": recipe.description or "",
+        "is_active": "on",
+        "type": recipe.type or "",
+        "default_yield_qty": recipe.default_yield_qty or "",
+        "default_yield_unit": recipe.default_yield_unit or "",
+        "plating_notes": recipe.plating_notes or "",
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "1",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-id": str(recipe_item.pk),
+        "items-0-item": str(item.pk),
+        "items-0-quantity": "1",
+        "items-0-unit": recipe_item.unit or "",
+        "items-0-loss_pct": "0",
+        "items-0-DELETE": "",
+    }
+
+    response = client.post(url, data)
+
+    assert response.status_code == 400
+    assert response["Content-Type"].startswith("text/html")
+    assert b"<form" in response.content


### PR DESCRIPTION
## Summary
- add a shared helper that flattens recipe form and formset validation errors into a friendly JSON payload
- return that payload from the recipe drawer create/edit POST handlers when the request comes from the modal fetch, while keeping HTML for regular page posts
- cover both the AJAX and non-AJAX flows with new tests to ensure the modal shows a clean message and pages still render normally

## Testing
- pytest tests/test_recipe_drawer.py

------
https://chatgpt.com/codex/tasks/task_e_68cc1bdea8008326b6da468a3d143da9