### PR TITLE
Improve recipe partial handling and focus preservation

### DIFF
--- a/inventory/forms/recipe_forms.py
+++ b/inventory/forms/recipe_forms.py
@@ -77,7 +77,7 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
 
 class RecipeItemForm(StyledFormMixin, forms.ModelForm):
     """Form for Recipe Items - simplified from RecipeComponent."""
-    
+
     item = forms.ModelChoiceField(
         queryset=Item.objects.filter(is_active=True),
         widget=forms.Select(
@@ -138,10 +138,27 @@ class RecipeItemForm(StyledFormMixin, forms.ModelForm):
         model = RecipeItem
         fields = [
             "item",
-            "quantity", 
+            "quantity",
             "unit",
             "loss_pct",
         ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        instance = getattr(self, "instance", None)
+        has_instance = getattr(instance, "pk", None) is not None
+        unit_value = ""
+        if has_instance:
+            unit_value = instance.unit or ""
+            if unit_value:
+                self.initial.setdefault("unit", unit_value)
+                self.initial.setdefault("unit_display", unit_value)
+        # Keep the form fields in sync with the initial data so the template
+        # renders the stored unit immediately while the JS metadata loads.
+        self.fields["unit"].initial = self.initial.get("unit", unit_value)
+        self.fields["unit_display"].initial = self.initial.get(
+            "unit_display", unit_value
+        )
 
 
 RecipeItemFormSet = forms.inlineformset_factory(

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -96,6 +96,27 @@ def _build_form_error_payload(form, formset):
     }
 
 
+def _serialize_recipe(recipe):
+    """Return a lightweight payload describing a recipe."""
+
+    if recipe is None:
+        return {}
+    item_count = getattr(recipe, "item_count", None)
+    if item_count is None:
+        item_count = recipe.items.count()
+    qty = getattr(recipe, "default_yield_qty", None)
+    return {
+        "id": recipe.pk,
+        "name": recipe.name,
+        "url": reverse("recipe_detail", kwargs={"pk": recipe.pk}),
+        "is_active": recipe.is_active,
+        "type": recipe.type or "",
+        "default_yield_qty": float(qty) if qty is not None else None,
+        "default_yield_unit": recipe.default_yield_unit or "",
+        "item_count": item_count,
+    }
+
+
 class RecipesListView(TemplateView):
     """Display all recipes with search and card grid.
 
@@ -369,13 +390,25 @@ class RecipeCreatePartialView(View):
                 )
             ok, msg, rid = recipe_service.create_recipe(data, items)
             if ok and rid:
+                recipe = Recipe.objects.filter(pk=rid).first()
+                recipe_payload = _serialize_recipe(recipe)
                 return JsonResponse(
                     {
                         "ok": True,
                         "id": rid,
                         "message": "Recipe created",
-                        "redirect": reverse("recipe_detail", kwargs={"pk": rid}),
                         "toast": True,
+                        "toast_message": "Recipe created",
+                        "toast_type": "success",
+                        "close_only": True,
+                        "recipe": recipe_payload,
+                        "htmx": {
+                            "event": "recipes:refresh",
+                            "detail": {
+                                "recipe": recipe_payload,
+                                "action": "created",
+                            },
+                        },
                     }
                 )
             return JsonResponse({"ok": False, "message": msg or "Error creating recipe"}, status=400)
@@ -429,13 +462,25 @@ class RecipeEditPartialView(View):
                 )
             ok, msg = recipe_service.update_recipe(recipe.pk, data, items)
             if ok:
+                recipe.refresh_from_db()
+                recipe_payload = _serialize_recipe(recipe)
                 return JsonResponse(
                     {
                         "ok": True,
                         "id": recipe.pk,
                         "message": "Recipe updated",
-                        "redirect": reverse("recipe_detail", kwargs={"pk": recipe.pk}),
                         "toast": True,
+                        "toast_message": "Recipe updated",
+                        "toast_type": "success",
+                        "close_only": True,
+                        "recipe": recipe_payload,
+                        "htmx": {
+                            "event": "recipes:refresh",
+                            "detail": {
+                                "recipe": recipe_payload,
+                                "action": "updated",
+                            },
+                        },
                     }
                 )
             return JsonResponse({"ok": False, "message": msg or "Error updating recipe"}, status=400)

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -146,6 +146,35 @@
     return entry.html;
   }
 
+  function triggerHtmxEvents(config, fallbackDetail) {
+    if (!config) return;
+    const entries = Array.isArray(config)
+      ? config
+      : Array.isArray(config.events)
+        ? config.events
+        : [config];
+    entries.forEach((entry) => {
+      if (!entry) return;
+      const name = entry.event || entry.name;
+      if (!name) return;
+      const target = entry.target
+        ? document.querySelector(entry.target)
+        : document.body;
+      if (!target) return;
+      let detail;
+      if (entry.detail !== undefined) detail = entry.detail;
+      else if (fallbackDetail !== undefined) detail = fallbackDetail;
+      else detail = null;
+      if (window.htmx && typeof window.htmx.trigger === "function") {
+        window.htmx.trigger(target, name, detail);
+      } else {
+        target.dispatchEvent(
+          new CustomEvent(name, { detail, bubbles: true }),
+        );
+      }
+    });
+  }
+
   // Prefetch helper
   function prefetch(url) {
     if (!url) return;
@@ -189,6 +218,9 @@
     root.classList.add("hidden");
     root.removeAttribute("aria-labelledby");
     content.innerHTML = "";
+    try {
+      root.dispatchEvent(new CustomEvent("modal:close", { bubbles: true }));
+    } catch (_) {}
     if (lastFocused && typeof lastFocused.focus === "function") {
       lastFocused.focus();
       lastFocused = null;
@@ -579,10 +611,46 @@
             if (shouldToast && window.notifications)
               window.notifications.showToast(toastMsg, toastType);
             closeModal();
-            // Success navigation: prefer explicit redirect if provided; otherwise reload
+            try {
+              document.body.dispatchEvent(
+                new CustomEvent('modal:success', { detail: data, bubbles: true }),
+              );
+            } catch (_) {}
+            // Success navigation: prefer explicit redirect if provided; otherwise
+            // defer to flags returned by the server response.
             if (data && data.redirect) {
               try { window.location.href = data.redirect; return; } catch(_) {}
             }
+            const reloadInstruction = data ? data.reload : undefined;
+            const closeOnly = Boolean(data && data.close_only);
+            const fallbackDetail = (data && data.recipe) || data;
+            if (reloadInstruction && typeof reloadInstruction === 'object') {
+              const reloadUrl = reloadInstruction.url;
+              const reloadTarget = reloadInstruction.target;
+              if (reloadUrl && reloadTarget && window.htmx && window.htmx.ajax) {
+                window.htmx.ajax('GET', reloadUrl, { target: reloadTarget });
+                return;
+              }
+              if (reloadUrl) {
+                window.location.href = reloadUrl;
+                return;
+              }
+            }
+            if (typeof reloadInstruction === 'string') {
+              window.location.href = reloadInstruction;
+              return;
+            }
+            if (reloadInstruction === true) {
+              window.location.reload();
+              return;
+            }
+            if (closeOnly || reloadInstruction === false) {
+              triggerHtmxEvents(data && data.htmx, fallbackDetail);
+              triggerHtmxEvents(data && data.events, fallbackDetail);
+              triggerHtmxEvents(data && data.trigger, fallbackDetail);
+              return;
+            }
+            // Legacy fallback for endpoints that have not been updated yet.
             window.location.reload();
           } else {
             // Show inline error inside the modal form for better visibility

--- a/static/js/recipe-components.js
+++ b/static/js/recipe-components.js
@@ -108,6 +108,7 @@
     
     existingRows.forEach(function(row) {
       bindRowEvents(row);
+      try { bootstrapExistingRow(row); } catch (err) { console.warn('bootstrapExistingRow failed', err); }
     });
     try { debugFormsetState(table, 'after-init-existing-binds'); } catch(e) {}
     
@@ -511,10 +512,40 @@
       });
     }
   }
-  
-  function handleItemChange(itemSelect, val) {
+
+  function bootstrapExistingRow(row) {
+    if (!row || row.dataset.recipeBootstrapped === '1') {
+      return;
+    }
+    var itemSelect = row.querySelector('select[id$="-item"]');
+    if (!itemSelect || !itemSelect.value) {
+      return;
+    }
+    row.dataset.recipeBootstrapped = '1';
+
+    if (!row.dataset.costPerBaseUnit) {
+      var attrCost = row.getAttribute('data-cost-per-base-unit');
+      if (attrCost) {
+        row.dataset.costPerBaseUnit = attrCost;
+      }
+    }
+
+    if (row.dataset.recipeMetaReady === '1' || row.dataset.costPerBaseUnit) {
+      try { updateRowCost(itemSelect, null); } catch (_) {}
+      return;
+    }
+
+    if (itemSelect.dataset.recipeFetching === '1') {
+      return;
+    }
+
+    handleItemChange(itemSelect, itemSelect.value, { bootstrap: true });
+  }
+
+  function handleItemChange(itemSelect, val, options) {
+    options = options || {};
     console.log('🔄 Handling item change for:', itemSelect.id, 'value:', val);
-    
+
     // Find unit fields for this row - the formset uses patterns like id_items-0-item, id_items-0-unit, etc.
     var baseId = itemSelect.id.replace('-item', '');
     var unitHidden = document.getElementById(baseId + '-unit');
@@ -538,7 +569,15 @@
         return { id: inp.id, name: inp.name, type: inp.type };
       }));
     }
-    
+
+    if (options.bootstrap && row && row.dataset.recipeMetaReady === '1') {
+      try { updateRowCost(itemSelect, null); } catch (_) {}
+      if (window.updateRecipeCosts) {
+        window.updateRecipeCosts();
+      }
+      return;
+    }
+
     // If no item selected, clear unit fields
     if (!val) {
       if (unitHidden) {
@@ -549,11 +588,12 @@
         unitDisplay.value = '';
         console.log('✅ Cleared unit display field');
       }
-      var clearRow = itemSelect.closest('tr');
-      if (clearRow) {
-        clearRow.dataset.category = '';
-        clearRow.dataset.subcategory = '';
-        clearRow.dataset.itemName = '';
+      if (row) {
+        row.dataset.category = '';
+        row.dataset.subcategory = '';
+        row.dataset.itemName = '';
+        delete row.dataset.costPerBaseUnit;
+        delete row.dataset.recipeMetaReady;
       }
       updateRowCost(itemSelect, null);
       if (window.updateRecipeCosts) {
@@ -561,11 +601,17 @@
       }
       return;
     }
-    
+
+    if (itemSelect.dataset.recipeFetching === '1') {
+      console.log('⏳ Skipping duplicate fetch for', itemSelect.id);
+      return;
+    }
+
     // Fetch item metadata using the item's primary key
     console.log('🌐 Fetching item meta for ID:', val);
+    itemSelect.dataset.recipeFetching = '1';
     fetch('/items/meta/' + val + '/')
-      .then(function(r) { 
+      .then(function(r) {
         console.log('📡 Item meta fetch status:', r.status);
         if (!r.ok) {
           throw new Error('Failed to fetch item meta: ' + r.status);
@@ -586,12 +632,12 @@
           }
           // Cache cost per base unit on the row for quick recompute
           try {
-            var r = itemSelect.closest('tr');
-            if (r) {
-              r.dataset.costPerBaseUnit = String(data.cost_per_base_unit || 0);
-              r.dataset.category = (data.category || '').trim();
-              r.dataset.subcategory = (data.subcategory || '').trim();
-              r.dataset.itemName = (data.name || '').trim();
+            if (row) {
+              row.dataset.costPerBaseUnit = String(data.cost_per_base_unit || 0);
+              row.dataset.category = (data.category || '').trim();
+              row.dataset.subcategory = (data.subcategory || '').trim();
+              row.dataset.itemName = (data.name || '').trim();
+              row.dataset.recipeMetaReady = '1';
             }
           } catch (_) {}
 
@@ -607,6 +653,9 @@
       })
       .catch(function(err) {
         console.error('❌ Failed to fetch item meta:', err);
+      })
+      .finally(function() {
+        delete itemSelect.dataset.recipeFetching;
       });
   }
   
@@ -695,6 +744,29 @@
       var tbody = table.querySelector('tbody');
       if (!tbody) {
         return;
+      }
+
+      var activeElement = document.activeElement;
+      var shouldRestoreFocus = Boolean(activeElement && table.contains(activeElement));
+      var selectionStart = null;
+      var selectionEnd = null;
+      var selectionDirection = null;
+      var hasSelection = false;
+      if (shouldRestoreFocus) {
+        try {
+          var start = activeElement.selectionStart;
+          var end = activeElement.selectionEnd;
+          if (typeof start === 'number' && typeof end === 'number') {
+            selectionStart = start;
+            selectionEnd = end;
+            selectionDirection = activeElement.selectionDirection || null;
+            hasSelection = true;
+          }
+        } catch (_) {
+          selectionStart = null;
+          selectionEnd = null;
+          selectionDirection = null;
+        }
       }
 
       var hiddenTemplate = table.querySelector('#items-empty-row');
@@ -842,6 +914,26 @@
         suggestedEl.textContent = Number.isFinite(suggested)
           ? suggested.toFixed(2)
           : totalCost.toFixed(2);
+      }
+
+      if (shouldRestoreFocus && activeElement) {
+        var isConnected = typeof activeElement.isConnected === 'boolean'
+          ? activeElement.isConnected
+          : document.contains(activeElement);
+        if (isConnected) {
+          if (document.activeElement !== activeElement) {
+            try { activeElement.focus({ preventScroll: true }); } catch (_) {}
+          }
+          if (hasSelection && typeof activeElement.setSelectionRange === 'function') {
+            try {
+              if (selectionDirection) {
+                activeElement.setSelectionRange(selectionStart, selectionEnd, selectionDirection);
+              } else {
+                activeElement.setSelectionRange(selectionStart, selectionEnd);
+              }
+            } catch (_) {}
+          }
+        }
       }
 
       table.dataset.recipeGroupingApplied = groups.length ? '1' : '0';

--- a/static/js/recipe-components.test.js
+++ b/static/js/recipe-components.test.js
@@ -1,0 +1,50 @@
+/** @jest-environment jsdom */
+
+describe('recipe cost helpers', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div>
+        <div id="cost-by-category"></div>
+        <div id="recipe-total-cost">0.00</div>
+        <div id="recipe-suggested-price">0.00</div>
+        <input id="recipe-margin" type="number" value="0" />
+        <table id="items-table">
+          <tbody>
+            <tr class="form-row" data-form-index="0" data-category="Produce">
+              <td><input id="id_items-0-quantity" type="number" value="2.00" /></td>
+              <td><div data-line-cost>10.00</div></td>
+            </tr>
+            <tr class="form-row hidden" id="items-empty-row"></tr>
+          </tbody>
+        </table>
+      </div>`;
+
+    jest.isolateModules(() => {
+      require('./recipe-components.js');
+    });
+  });
+
+  test('updateRecipeCosts keeps focus and recalculates totals', () => {
+    const quantityInput = document.getElementById('id_items-0-quantity');
+    const lineCost = document.querySelector('[data-line-cost]');
+    const total = document.getElementById('recipe-total-cost');
+    const summary = document.getElementById('cost-by-category');
+
+    quantityInput.focus();
+    expect(document.activeElement).toBe(quantityInput);
+
+    lineCost.textContent = '12.34';
+    window.updateRecipeCosts();
+
+    expect(document.activeElement).toBe(quantityInput);
+    expect(total.textContent).toBe('12.34');
+    expect(summary.textContent).toContain('Produce');
+    expect(summary.textContent).toContain('12.34');
+
+    lineCost.textContent = '15.50';
+    window.updateRecipeCosts();
+
+    expect(document.activeElement).toBe(quantityInput);
+    expect(total.textContent).toBe('15.50');
+  });
+});

--- a/tests/test_recipe_drawer.py
+++ b/tests/test_recipe_drawer.py
@@ -157,3 +157,45 @@ def test_recipe_edit_partial_invalid_non_ajax_returns_html(client, item_factory)
     assert response.status_code == 400
     assert response["Content-Type"].startswith("text/html")
     assert b"<form" in response.content
+
+
+@pytest.mark.django_db
+def test_recipe_create_partial_success_returns_close_only_payload(client, item_factory):
+    item = item_factory(name="Flour")
+    url = reverse("recipe_create_partial")
+    data = {
+        "name": "Test Bread",
+        "description": "",
+        "is_active": "on",
+        "type": "",
+        "default_yield_qty": "1",
+        "default_yield_unit": "loaf",
+        "plating_notes": "",
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "0",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-item": str(item.pk),
+        "items-0-quantity": "2.5",
+        "items-0-unit": "kg",
+        "items-0-unit_display": "kg",
+        "items-0-loss_pct": "0",
+        "items-0-DELETE": "",
+    }
+
+    response = client.post(
+        url,
+        data,
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert "redirect" not in payload
+    assert payload.get("close_only") is True
+    assert payload.get("reload") not in (True, "true")
+    assert payload["recipe"]["name"] == "Test Bread"
+    assert Recipe.objects.filter(name="Test Bread").exists()
+    assert payload.get("htmx", {}).get("event") == "recipes:refresh"
+    assert payload.get("htmx", {}).get("detail", {}).get("action") == "created"


### PR DESCRIPTION
## Summary
- ensure recipe item rows bootstrap metadata, cache cost data, and keep quantity inputs focused during cost recomputations
- surface stored units immediately in the recipe item form and update partial view JSON responses to request drawer-only closes with HTMX refresh payloads
- extend modal success handling to honor reload flags and add Django + Jest tests covering the new drawer behavior

## Testing
- pytest tests/test_recipe_drawer.py
- npm test -- recipe-components

------
https://chatgpt.com/codex/tasks/task_e_68cc389ae9b48326afac17541a9db434