### PR TITLE
Add plating thumbnails and combined recipe notes

### DIFF
--- a/inventory/forms/recipe_forms.py
+++ b/inventory/forms/recipe_forms.py
@@ -5,7 +5,10 @@ from django import forms
 from ..models import Item, Recipe, RecipeItem
 from .base import StyledFormMixin
 
-INPUT_CLASS = "w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+INPUT_CLASS = (
+    "w-full px-3 py-2 text-sm border border-gray-300 rounded-lg "
+    "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+)
 
 
 class RecipeForm(StyledFormMixin, forms.ModelForm):
@@ -17,19 +20,18 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
     )
     description = forms.CharField(
         required=False,
-        widget=forms.Textarea(
-            attrs={
-                "class": INPUT_CLASS,
-                "rows": 2,
-                "placeholder": "Brief recipe description...",
-            }
-        ),
+        widget=forms.HiddenInput(),
     )
     is_active = forms.BooleanField(
         required=False,
         initial=True,
         widget=forms.CheckboxInput(
-            attrs={"class": "h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"}
+            attrs={
+                "class": (
+                    "h-4 w-4 text-blue-600 focus:ring-blue-500 "
+                    "border-gray-300 rounded"
+                )
+            }
         ),
     )
     type = forms.CharField(
@@ -53,12 +55,21 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
     )
     plating_notes = forms.CharField(
         required=False,
+        widget=forms.HiddenInput(),
+    )
+    description_and_plating = forms.CharField(
+        required=False,
+        label="Description & Plating Notes",
         widget=forms.Textarea(
             attrs={
                 "class": INPUT_CLASS,
-                "rows": 2,
-                "placeholder": "Plating and presentation notes...",
+                "rows": 4,
+                "placeholder": "Capture the story and plating cues for this recipe...",
             }
+        ),
+        help_text=(
+            "Share the overview and plating details together so the team has a "
+            "single reference."
         ),
     )
 
@@ -73,6 +84,34 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
             "default_yield_unit",
             "plating_notes",
         ]
+
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        description = self.initial.get("description") or getattr(
+            self.instance, "description", ""
+        )
+        plating_notes = self.initial.get("plating_notes") or getattr(
+            self.instance, "plating_notes", ""
+        )
+        if not self.is_bound:
+            parts = [
+                str(part).strip()
+                for part in (description, plating_notes)
+                if part and str(part).strip()
+            ]
+            combined = "\n\n".join(parts) if parts else ""
+            if combined:
+                self.initial.setdefault("description_and_plating", combined)
+                self.fields["description_and_plating"].initial = combined
+
+    def clean(self):
+        cleaned_data = super().clean()
+        combined = cleaned_data.get("description_and_plating", "")
+        combined_text = str(combined).strip()
+        cleaned_data["description"] = combined_text
+        cleaned_data["plating_notes"] = combined_text
+        return cleaned_data
 
 
 class RecipeItemForm(StyledFormMixin, forms.ModelForm):

--- a/inventory/services/recipe_service.py
+++ b/inventory/services/recipe_service.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import json
 import logging
 from decimal import Decimal
+from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.db import IntegrityError, transaction
+from django.templatetags.static import static
 
 from inventory.constants import PLACEHOLDER_SELECT_COMPONENT
 
@@ -17,10 +20,47 @@ logger = logging.getLogger(__name__)
 
 TX_SALE = "SALE"
 
+PLATING_IMAGE_BASE_PATH = "img/plating"
+PLATING_IMAGE_EXTENSIONS = (".webp", ".jpg", ".jpeg", ".png", ".svg")
+PLATING_PLACEHOLDER_PATH = "img/recipe-placeholder.svg"
+
 
 # ---------------------------------------------------------------------------
 # Helper utilities
 # ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=256)
+def get_plating_image_url(recipe_id: Optional[int]) -> str:
+    """Return the best-guess plating image URL for ``recipe_id``.
+
+    The helper attempts to locate a static asset matching the recipe id using a
+    handful of common image extensions. When no dedicated thumbnail exists (or
+    ``recipe_id`` is ``None``) the shared placeholder thumbnail is returned
+    instead so the UI never renders a broken image.
+    """
+
+    placeholder_url = get_plating_placeholder_url()
+    if not recipe_id:
+        return placeholder_url
+
+    base_path = f"{PLATING_IMAGE_BASE_PATH}/{recipe_id}"
+    for extension in PLATING_IMAGE_EXTENSIONS:
+        candidate = f"{base_path}{extension}"
+        try:
+            if staticfiles_storage.exists(candidate):
+                return static(candidate)
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("Unable to resolve plating image for %s", candidate)
+            continue
+    return placeholder_url
+
+
+@lru_cache(maxsize=1)
+def get_plating_placeholder_url() -> str:
+    """Return the shared placeholder thumbnail URL."""
+
+    return static(PLATING_PLACEHOLDER_PATH)
 
 
 def _strip_or_none(val: Any) -> Optional[str]:

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -108,6 +108,7 @@ def _serialize_recipe(recipe):
     if item_count is None:
         item_count = recipe.items.count()
     qty = getattr(recipe, "default_yield_qty", None)
+    image_url = recipe_service.get_plating_image_url(getattr(recipe, "pk", None))
     return {
         "id": recipe.pk,
         "name": recipe.name,
@@ -117,6 +118,7 @@ def _serialize_recipe(recipe):
         "default_yield_qty": float(qty) if qty is not None else None,
         "default_yield_unit": recipe.default_yield_unit or "",
         "item_count": item_count,
+        "plating_image_url": image_url,
     }
 
 
@@ -132,6 +134,17 @@ def _to_decimal(value):
         return Decimal(str(value))
     except (ValueError, TypeError, ArithmeticError):  # pragma: no cover - defensive
         return Decimal("0")
+
+
+def _get_plating_urls(recipe):
+    """Return (image_url, placeholder_url) for ``recipe``."""
+
+    recipe_id = None
+    if recipe is not None:
+        recipe_id = getattr(recipe, "pk", None) or getattr(recipe, "recipe_id", None)
+    image_url = recipe_service.get_plating_image_url(recipe_id)
+    placeholder_url = recipe_service.get_plating_placeholder_url()
+    return image_url, placeholder_url
 
 
 class RecipesListView(TemplateView):
@@ -167,6 +180,8 @@ class RecipesListView(TemplateView):
             ctx["recipe_count"] = (
                 page_obj.paginator.count if page_obj and page_obj.paginator else 0
             )
+        _, placeholder = _get_plating_urls(None)
+        ctx.setdefault("plating_placeholder_url", placeholder)
         return ctx
 
     def get(self, request, *args, **kwargs):
@@ -203,13 +218,22 @@ class RecipesTableView(TemplateView):
             querystring = list_utils.build_querystring(self.request)
         except Exception:  # pragma: no cover - defensive
             querystring = ""
+        placeholder_url = recipe_service.get_plating_placeholder_url()
+        recipes = list(page_obj.object_list)
+        for recipe in recipes:
+            rid = getattr(recipe, "pk", None)
+            image_url = recipe_service.get_plating_image_url(rid)
+            setattr(recipe, "plating_image_url", image_url)
+            setattr(recipe, "plating_placeholder_url", placeholder_url)
+        page_obj.object_list = recipes
         ctx.update(
             {
                 "page_obj": page_obj,
                 "page_size": per_page,
                 "querystring": querystring,
-                "recipes": page_obj.object_list,
+                "recipes": recipes,
                 "table_url": reverse("recipes_table"),
+                "plating_placeholder_url": placeholder_url,
             }
         )
         if "recipe_count" not in ctx:
@@ -247,6 +271,7 @@ def recipe_create(request):
     else:
         form = RecipeForm()
         formset = RecipeItemFormSet(prefix="items")
+    plating_image_url, plating_placeholder_url = _get_plating_urls(None)
     return render(
         request,
         "inventory/recipes/detail.html",
@@ -258,6 +283,8 @@ def recipe_create(request):
             "list_url": reverse("recipes_list"),
             "list_title": "Recipes",
             "current_title": "New Recipe",
+            "plating_image_url": plating_image_url,
+            "plating_placeholder_url": plating_placeholder_url,
         },
     )
 
@@ -293,6 +320,8 @@ def recipe_detail(request, pk: int):
     else:
         form = RecipeForm(instance=recipe)
         formset = RecipeItemFormSet(instance=recipe, prefix="items")
+    plating_image_url, plating_placeholder_url = _get_plating_urls(recipe)
+    setattr(recipe, "plating_image_url", plating_image_url)
     return render(
         request,
         "inventory/recipes/detail.html",
@@ -304,6 +333,8 @@ def recipe_detail(request, pk: int):
             "list_url": reverse("recipes_list"),
             "list_title": "Recipes",
             "current_title": recipe.name,
+            "plating_image_url": plating_image_url,
+            "plating_placeholder_url": plating_placeholder_url,
         },
     )
 
@@ -316,10 +347,18 @@ class RecipeCreatePartialView(View):
     def get(self, request):
         form = RecipeForm()
         formset = RecipeItemFormSet(prefix="items")
+        plating_image_url, plating_placeholder_url = _get_plating_urls(None)
         return render(
             request,
             self.template_name,
-            {"form": form, "formset": formset, "recipe": None, "is_edit": False},
+            {
+                "form": form,
+                "formset": formset,
+                "recipe": None,
+                "is_edit": False,
+                "plating_image_url": plating_image_url,
+                "plating_placeholder_url": plating_placeholder_url,
+            },
         )
 
     def post(self, request):
@@ -370,10 +409,18 @@ class RecipeCreatePartialView(View):
             )
         if request.headers.get("X-Requested-With") == "XMLHttpRequest":
             return JsonResponse(_build_form_error_payload(form, formset), status=400)
+        plating_image_url, plating_placeholder_url = _get_plating_urls(None)
         return render(
             request,
             self.template_name,
-            {"form": form, "formset": formset, "recipe": None, "is_edit": False},
+            {
+                "form": form,
+                "formset": formset,
+                "recipe": None,
+                "is_edit": False,
+                "plating_image_url": plating_image_url,
+                "plating_placeholder_url": plating_placeholder_url,
+            },
             status=400,
         )
 
@@ -387,10 +434,19 @@ class RecipeEditPartialView(View):
         recipe = get_object_or_404(Recipe, pk=pk)
         form = RecipeForm(instance=recipe)
         formset = RecipeItemFormSet(instance=recipe, prefix="items")
+        plating_image_url, plating_placeholder_url = _get_plating_urls(recipe)
+        setattr(recipe, "plating_image_url", plating_image_url)
         return render(
             request,
             self.template_name,
-            {"form": form, "formset": formset, "recipe": recipe, "is_edit": True},
+            {
+                "form": form,
+                "formset": formset,
+                "recipe": recipe,
+                "is_edit": True,
+                "plating_image_url": plating_image_url,
+                "plating_placeholder_url": plating_placeholder_url,
+            },
         )
 
     def post(self, request, pk: int):
@@ -442,10 +498,19 @@ class RecipeEditPartialView(View):
             )
         if request.headers.get("X-Requested-With") == "XMLHttpRequest":
             return JsonResponse(_build_form_error_payload(form, formset), status=400)
+        plating_image_url, plating_placeholder_url = _get_plating_urls(recipe)
+        setattr(recipe, "plating_image_url", plating_image_url)
         return render(
             request,
             self.template_name,
-            {"form": form, "formset": formset, "recipe": recipe, "is_edit": True},
+            {
+                "form": form,
+                "formset": formset,
+                "recipe": recipe,
+                "is_edit": True,
+                "plating_image_url": plating_image_url,
+                "plating_placeholder_url": plating_placeholder_url,
+            },
             status=400,
         )
 
@@ -547,6 +612,8 @@ class RecipeViewPartialView(View):
 
         total_cost = total_cost.quantize(TWOPLACES) if total_cost else Decimal("0.00")
 
+        plating_image_url, plating_placeholder_url = _get_plating_urls(recipe)
+        setattr(recipe, "plating_image_url", plating_image_url)
         return render(
             request,
             self.template_name,
@@ -555,5 +622,7 @@ class RecipeViewPartialView(View):
                 "items": items,
                 "total_cost": total_cost,
                 "zero_cost": zero_cost,
+                "plating_image_url": plating_image_url,
+                "plating_placeholder_url": plating_placeholder_url,
             },
         )

--- a/static/img/recipe-placeholder.svg
+++ b/static/img/recipe-placeholder.svg
@@ -1,0 +1,7 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="160" rx="24" fill="#F4F6F8"/>
+  <path d="M48 54C48 48.4772 52.4772 44 58 44H102C107.523 44 112 48.4772 112 54V106C112 111.523 107.523 116 102 116H58C52.4772 116 48 111.523 48 106V54Z" fill="#E2E8F0"/>
+  <path d="M64 98L78 80L92 96L102 84L112 98" stroke="#94A3B8" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="72" cy="66" r="10" fill="#CBD5F5"/>
+  <path d="M60 122H100" stroke="#CBD5F5" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/templates/inventory/recipes/_form_fields.html
+++ b/templates/inventory/recipes/_form_fields.html
@@ -4,22 +4,5 @@
   {% include "components/form_field.html" with field=form.type help_text_class="text-xs text-gray-500 leading-snug" %}
   {% include "components/form_field.html" with field=form.default_yield_qty help_text_class="text-xs text-gray-500 leading-snug" %}
   {% include "components/form_field.html" with field=form.default_yield_unit help_text_class="text-xs text-gray-500 leading-snug" %}
-  <div class="md:col-span-1 md:col-start-3 flex flex-col gap-1 pt-2">
-    <label for="{{ form.is_active.id_for_label }}" class="inline-flex items-center gap-2 text-bodyText text-sm font-medium">
-      {{ form.is_active|add_class:"h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" }}
-      <span class="leading-none">Active</span>
-    </label>
-    {% if form.is_active.help_text %}
-      <p class="text-xs text-gray-500 leading-snug">{{ form.is_active.help_text }}</p>
-    {% endif %}
-    {% if form.is_active.errors %}
-      <ul class="text-xs text-danger list-disc pl-5 leading-snug">
-        {% for error in form.is_active.errors %}
-          <li>{{ error }}</li>
-        {% endfor %}
-      </ul>
-    {% endif %}
-  </div>
-  {% include "components/form_field.html" with field=form.description container_class="md:col-span-3" help_text_class="text-xs text-gray-500 leading-snug" %}
-  {% include "components/form_field.html" with field=form.plating_notes container_class="md:col-span-3" help_text_class="text-xs text-gray-500 leading-snug" %}
+  {% include "components/form_field.html" with field=form.description_and_plating container_class="md:col-span-3" help_text_class="text-xs text-gray-500 leading-snug" %}
 </div>

--- a/templates/inventory/recipes/_form_partial.html
+++ b/templates/inventory/recipes/_form_partial.html
@@ -1,12 +1,40 @@
 {% load form_tags %}
 <div class="bg-surface rounded-xl shadow border border-border overflow-hidden drawer-panel max-w-drawer-xl">
-  <div class="px-4 py-3 border-b border-border bg-surfaceSubtle flex items-center justify-between">
-    <h3 class="text-base font-semibold">{% if is_edit and recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}</h3>
-    <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
-  </div>
-  <div class="p-4">
   <form method="post" data-modal-form data-requires-line-items action="{% if is_edit and recipe %}{% url 'recipe_edit_partial' recipe.pk %}{% else %}{% url 'recipe_create_partial' %}{% endif %}">
-      {% csrf_token %}
+    {% csrf_token %}
+    <div class="px-4 py-3 border-b border-border bg-surfaceSubtle flex flex-wrap items-center gap-3">
+      <div class="flex items-center gap-3 min-w-0 flex-1">
+        <div class="h-12 w-12 overflow-hidden rounded-lg border border-border bg-surfaceSubtle">
+          <img src="{{ plating_image_url|default:plating_placeholder_url }}"
+               alt="{% if is_edit and recipe %}{{ recipe.name }} plating{% else %}Recipe plating placeholder{% endif %}"
+               class="h-full w-full object-cover"
+               loading="lazy"
+               data-role="drawer-plating-image"
+               onerror="this.onerror=null;this.src='{{ plating_placeholder_url }}';" />
+        </div>
+        <h3 class="text-base font-semibold truncate">{% if is_edit and recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}</h3>
+      </div>
+      <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
+        <div class="flex flex-col items-start gap-1 text-left sm:items-end sm:text-right" data-role="drawer-active-toggle">
+          <label for="{{ form.is_active.id_for_label }}" class="inline-flex items-center gap-2 text-sm font-medium text-bodyText">
+            {{ form.is_active|add_class:"h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" }}
+            <span class="leading-none">Active</span>
+          </label>
+          {% if form.is_active.help_text %}
+            <p class="text-xs text-gray-500 leading-snug">{{ form.is_active.help_text }}</p>
+          {% endif %}
+          {% if form.is_active.errors %}
+            <ul class="text-xs text-danger list-disc pl-5 leading-snug text-left sm:text-right">
+              {% for error in form.is_active.errors %}
+                <li>{{ error }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+        <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
+      </div>
+    </div>
+    <div class="p-4 space-y-4">
       {% include "inventory/recipes/_form_fields.html" with form=form %}
       {{ formset.management_form }}
       {% if formset.non_form_errors %}
@@ -38,7 +66,7 @@
           <div class="font-semibold">Suggested Price: <span id="recipe-suggested-price">0.00</span></div>
         </div>
       </div>
-    </form>
-  </div>
+    </div>
+  </form>
 </div>
 <script>(function(){ if(window.updateRecipeCosts) window.updateRecipeCosts(); })();</script>

--- a/templates/inventory/recipes/_recipes_table.html
+++ b/templates/inventory/recipes/_recipes_table.html
@@ -86,8 +86,20 @@
       {% for recipe in page_obj.object_list %}
         <tr class="hover:bg-surfaceSubtle focus-within:bg-surfaceSubtle" data-recipe-id="{{ recipe.recipe_id }}">
           <td class="px-4 py-2 align-top">
-            <div class="font-medium text-bodyText">{{ recipe.name }}</div>
-            <div class="text-xs text-gray-500">{{ recipe.item_count|default:0 }} ingredients</div>
+            <div class="flex items-start gap-3">
+              <div class="h-14 w-14 flex-shrink-0 overflow-hidden rounded-lg border border-border bg-surfaceSubtle">
+                <img src="{{ recipe.plating_image_url }}"
+                     alt="{{ recipe.name }} plating"
+                     class="h-full w-full object-cover"
+                     loading="lazy"
+                     data-role="recipe-thumbnail"
+                     onerror="this.onerror=null;this.src='{{ recipe.plating_placeholder_url|default:plating_placeholder_url }}';" />
+              </div>
+              <div>
+                <div class="font-medium text-bodyText">{{ recipe.name }}</div>
+                <div class="text-xs text-gray-500">{{ recipe.item_count|default:0 }} ingredients</div>
+              </div>
+            </div>
           </td>
           <td class="px-4 py-2 align-top">
             {% if recipe.type %}

--- a/templates/inventory/recipes/_view_partial.html
+++ b/templates/inventory/recipes/_view_partial.html
@@ -31,8 +31,13 @@
       </div>
       <div class="md:col-span-3">
         <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:gap-4">
-          <div class="flex h-20 w-20 items-center justify-center rounded-lg border border-dashed border-border bg-surfaceSubtle text-gray-400 sm:h-24 sm:w-24">
-            {% icon 'photo' 'w-6 h-6' %}
+          <div class="flex h-20 w-20 items-center justify-center overflow-hidden rounded-lg border border-border bg-surfaceSubtle sm:h-24 sm:w-24">
+            <img src="{{ plating_image_url|default:recipe.plating_image_url|default:plating_placeholder_url }}"
+                 alt="{{ recipe.name }} plating"
+                 class="h-full w-full object-cover"
+                 loading="lazy"
+                 data-role="recipe-view-plating-image"
+                 onerror="this.onerror=null;this.src='{{ plating_placeholder_url }}';" />
           </div>
           <div class="space-y-1 flex-1">
             <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Plating Notes</h4>

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -6,7 +6,41 @@
 {% endblock %}
 {% block form_attrs %}id="recipe-form"{% endblock %}
 {% block fields %}
-  {% include "inventory/recipes/_form_fields.html" with form=form %}
+  <div class="space-y-4">
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-2xl border border-border bg-surfaceSubtle px-4 py-3">
+      <div class="flex items-center gap-3">
+        <div class="h-16 w-16 overflow-hidden rounded-lg border border-border bg-surfaceSubtle">
+          <img src="{{ plating_image_url|default:plating_placeholder_url }}"
+               alt="{% if recipe %}{{ recipe.name }} plating{% else %}Recipe plating placeholder{% endif %}"
+               class="h-full w-full object-cover"
+               loading="lazy"
+               data-role="detail-plating-image"
+               onerror="this.onerror=null;this.src='{{ plating_placeholder_url }}';" />
+        </div>
+        <div class="text-sm text-gray-600">
+          <p class="font-medium text-bodyText">{% if recipe and recipe.type %}{{ recipe.type }}{% else %}No category yet{% endif %}</p>
+          <p>{% if recipe and recipe.default_yield_qty %}Yield: {{ recipe.default_yield_qty|floatformat:-2 }}{% if recipe.default_yield_unit %} <span class="uppercase">{{ recipe.default_yield_unit }}</span>{% endif %}{% else %}Set a default yield{% endif %}</p>
+        </div>
+      </div>
+      <div class="flex flex-col items-start gap-1 sm:items-end" data-role="detail-active-toggle">
+        <label for="{{ form.is_active.id_for_label }}" class="inline-flex items-center gap-2 text-sm font-medium text-bodyText">
+          {{ form.is_active|add_class:"h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" }}
+          <span class="leading-none">Active</span>
+        </label>
+        {% if form.is_active.help_text %}
+          <p class="text-xs text-gray-500 leading-snug text-left sm:text-right">{{ form.is_active.help_text }}</p>
+        {% endif %}
+        {% if form.is_active.errors %}
+          <ul class="text-xs text-danger list-disc pl-5 leading-snug text-left sm:text-right">
+            {% for error in form.is_active.errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    </div>
+    {% include "inventory/recipes/_form_fields.html" with form=form %}
+  </div>
   {{ formset.management_form }}
   {% if formset.non_form_errors %}
   <ul class="text-red-600 list-disc pl-5">

--- a/tests/test_recipe_drawer.py
+++ b/tests/test_recipe_drawer.py
@@ -7,6 +7,10 @@ from bs4 import BeautifulSoup
 from django.urls import reverse
 
 from inventory.models import Recipe, RecipeItem
+from inventory.services.recipe_service import (
+    get_plating_image_url,
+    get_plating_placeholder_url,
+)
 
 
 @pytest.mark.django_db
@@ -14,12 +18,11 @@ def test_recipe_create_partial_invalid_ajax_returns_json(client):
     url = reverse("recipe_create_partial")
     data = {
         "name": "",
-        "description": "",
+        "description_and_plating": "",
         "is_active": "on",
         "type": "",
         "default_yield_qty": "",
         "default_yield_unit": "",
-        "plating_notes": "",
         "items-TOTAL_FORMS": "1",
         "items-INITIAL_FORMS": "0",
         "items-MIN_NUM_FORMS": "0",
@@ -54,12 +57,11 @@ def test_recipe_create_partial_invalid_non_ajax_returns_html(client):
     url = reverse("recipe_create_partial")
     data = {
         "name": "",
-        "description": "",
+        "description_and_plating": "",
         "is_active": "on",
         "type": "",
         "default_yield_qty": "",
         "default_yield_unit": "",
-        "plating_notes": "",
         "items-TOTAL_FORMS": "1",
         "items-INITIAL_FORMS": "0",
         "items-MIN_NUM_FORMS": "0",
@@ -93,12 +95,11 @@ def test_recipe_edit_partial_invalid_ajax_returns_json(client, item_factory):
     url = reverse("recipe_edit_partial", args=[recipe.pk])
     data = {
         "name": "",
-        "description": recipe.description or "",
+        "description_and_plating": (recipe.description or recipe.plating_notes or ""),
         "is_active": "on",
         "type": recipe.type or "",
         "default_yield_qty": recipe.default_yield_qty or "",
         "default_yield_unit": recipe.default_yield_unit or "",
-        "plating_notes": recipe.plating_notes or "",
         "items-TOTAL_FORMS": "1",
         "items-INITIAL_FORMS": "1",
         "items-MIN_NUM_FORMS": "0",
@@ -140,12 +141,11 @@ def test_recipe_edit_partial_invalid_non_ajax_returns_html(client, item_factory)
     url = reverse("recipe_edit_partial", args=[recipe.pk])
     data = {
         "name": "",
-        "description": recipe.description or "",
+        "description_and_plating": (recipe.description or recipe.plating_notes or ""),
         "is_active": "on",
         "type": recipe.type or "",
         "default_yield_qty": recipe.default_yield_qty or "",
         "default_yield_unit": recipe.default_yield_unit or "",
-        "plating_notes": recipe.plating_notes or "",
         "items-TOTAL_FORMS": "1",
         "items-INITIAL_FORMS": "1",
         "items-MIN_NUM_FORMS": "0",
@@ -171,12 +171,11 @@ def test_recipe_create_partial_success_returns_close_only_payload(client, item_f
     url = reverse("recipe_create_partial")
     data = {
         "name": "Test Bread",
-        "description": "",
+        "description_and_plating": "",
         "is_active": "on",
         "type": "",
         "default_yield_qty": "1",
         "default_yield_unit": "loaf",
-        "plating_notes": "",
         "items-TOTAL_FORMS": "1",
         "items-INITIAL_FORMS": "0",
         "items-MIN_NUM_FORMS": "0",
@@ -208,6 +207,63 @@ def test_recipe_create_partial_success_returns_close_only_payload(client, item_f
 
 
 @pytest.mark.django_db
+def test_recipe_create_partial_drawer_header_has_thumbnail_and_toggle(client):
+    response = client.get(reverse("recipe_create_partial"))
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content, "html.parser")
+    thumb = soup.select_one("[data-role='drawer-plating-image']")
+    assert thumb is not None
+    assert thumb["src"] == get_plating_placeholder_url()
+    toggle = soup.select_one("[data-role='drawer-active-toggle'] input[type='checkbox']")
+    assert toggle is not None
+    notes = soup.find("textarea", {"name": "description_and_plating"})
+    assert notes is not None
+
+
+@pytest.mark.django_db
+def test_recipe_edit_partial_drawer_header_prefills_thumbnail_and_notes(client):
+    recipe = Recipe.objects.create(
+        name="House Salad",
+        description="Light and fresh",
+        plating_notes="Serve chilled",
+        is_active=False,
+    )
+    response = client.get(reverse("recipe_edit_partial", args=[recipe.pk]))
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content, "html.parser")
+    thumb = soup.select_one("[data-role='drawer-plating-image']")
+    assert thumb is not None
+    assert thumb["src"] == get_plating_image_url(recipe.pk)
+    textarea = soup.find("textarea", {"name": "description_and_plating"})
+    assert textarea is not None
+    combined_text = "\n\n".join(
+        part
+        for part in [recipe.description.strip(), recipe.plating_notes.strip()]
+        if part
+    )
+    assert textarea.text.strip() == combined_text.strip()
+    toggle = soup.select_one("[data-role='drawer-active-toggle'] input[type='checkbox']")
+    assert toggle is not None
+    assert not toggle.has_attr("checked")
+
+
+@pytest.mark.django_db
+def test_recipes_table_includes_plating_thumbnail(client):
+    recipe = Recipe.objects.create(name="Chocolate Tart", is_active=True)
+
+    response = client.get(reverse("recipes_table"))
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content, "html.parser")
+    thumb = soup.select_one("[data-role='recipe-thumbnail']")
+    assert thumb is not None
+    assert thumb["src"] == get_plating_image_url(recipe.pk)
+    assert get_plating_placeholder_url() in (thumb.get("onerror") or "")
+
+
+@pytest.mark.django_db
 def test_recipe_view_partial_renders_table_and_totals(client, item_factory):
     item = item_factory(name="Flour", initial_purchase_price=Decimal("6.00"))
     recipe = Recipe.objects.create(
@@ -227,8 +283,10 @@ def test_recipe_view_partial_renders_table_and_totals(client, item_factory):
     soup = BeautifulSoup(resp.content, "html.parser")
     header = soup.find("h3")
     assert header and recipe.name in header.text
-    plating_header = soup.select_one("#items-table thead th")
-    assert plating_header and "Plating" in plating_header.text
+    plating_thumb = soup.select_one("[data-role='recipe-view-plating-image']")
+    assert plating_thumb is not None
+    assert plating_thumb["src"] == get_plating_image_url(recipe.pk)
+    assert plating_thumb.get("onerror")
     first_row = soup.select_one("#items-table tbody tr")
     assert first_row and "Flour" in first_row.get_text()
     zero_notice = soup.select_one("#recipe-zero-cost-notice")


### PR DESCRIPTION
## Summary
- derive plating thumbnail URLs with a placeholder fallback and add a shared placeholder asset
- expose plating image URLs across recipe views so the list, detail page, and drawers render real thumbnails
- replace the separate description and plating fields with a single combined textarea and update tests to match the new layout

## Testing
- pytest
- npm test -- --watch=false
- ruff check inventory/services/recipe_service.py inventory/forms/recipe_forms.py inventory/views/recipes.py tests/test_recipe_drawer.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1ffd8ca08326ab07f356d5855d15