### PR TITLE
Align recipe drawer layout with spec

### DIFF
--- a/inventory/forms/recipe_forms.py
+++ b/inventory/forms/recipe_forms.py
@@ -62,8 +62,9 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
         label="Description & Plating Notes",
         widget=forms.Textarea(
             attrs={
-                "class": INPUT_CLASS,
-                "rows": 4,
+                "class": INPUT_CLASS + " resize-y",
+                "rows": 2,
+                "style": "min-height: 2.75rem;",
                 "placeholder": "Capture the story and plating cues for this recipe...",
             }
         ),

--- a/static/js/recipe-components.js
+++ b/static/js/recipe-components.js
@@ -125,11 +125,16 @@
         if (!data || !data.ok) {
           return;
         }
+        var baseUnitValue = data.base_unit;
+        if (!baseUnitValue || !String(baseUnitValue).trim()) {
+          baseUnitValue = data.unit;
+        }
+        var resolvedUnit = baseUnitValue ? String(baseUnitValue).trim() : '';
         if (unitHidden) {
-          unitHidden.value = data.base_unit || '';
+          unitHidden.value = resolvedUnit;
         }
         if (unitDisplay) {
-          unitDisplay.value = data.base_unit || '';
+          unitDisplay.value = resolvedUnit;
         }
         row.dataset.category = (data.category || '').trim();
         row.dataset.subcategory = (data.subcategory || '').trim();

--- a/templates/inventory/recipes/_components_form_table.html
+++ b/templates/inventory/recipes/_components_form_table.html
@@ -1,10 +1,7 @@
 {% extends "components/responsive_table.html" %}
-{% load icon_tags %}
-
 {% block caption %}<caption>Recipe Items</caption>{% endblock %}
 
 {% block headers %}
-  <th scope="col" class="w-16">Plating</th>
   <th scope="col">Item</th>
   <th scope="col">Qty</th>
   <th scope="col">Unit</th>
@@ -16,11 +13,6 @@
 {% block rows %}
   {% for cform in formset.forms %}
   <tr class="form-row" data-form-index="{{ forloop.counter0 }}" data-recipe-row="true" data-has-item="0" data-quantity="0" data-cost-per-base-unit="0">
-    <td class="px-3 py-2 align-middle">
-      <div class="flex h-12 w-12 items-center justify-center rounded-lg border border-dashed border-border bg-surfaceSubtle text-gray-400">
-        {% icon 'photo' 'w-5 h-5' %}
-      </div>
-    </td>
     <td class="px-3 py-2">
       {% include "components/form_field_table.html" with field=cform.item %}
     </td>
@@ -41,11 +33,6 @@
   {% endfor %}
   {# empty form template row #}
   <tr class="form-row hidden" id="items-empty-row" data-recipe-row="true" data-has-item="0" data-quantity="0" data-cost-per-base-unit="0">
-    <td class="px-3 py-2 align-middle">
-      <div class="flex h-12 w-12 items-center justify-center rounded-lg border border-dashed border-border bg-surfaceSubtle text-gray-400">
-        {% icon 'photo' 'w-5 h-5' %}
-      </div>
-    </td>
     <td class="px-3 py-2">
       {% include "components/form_field_table.html" with field=formset.empty_form.item %}
     </td>

--- a/templates/inventory/recipes/_form_partial.html
+++ b/templates/inventory/recipes/_form_partial.html
@@ -2,36 +2,38 @@
 <div class="bg-surface rounded-xl shadow border border-border overflow-hidden drawer-panel max-w-drawer-xl">
   <form method="post" data-modal-form data-requires-line-items action="{% if is_edit and recipe %}{% url 'recipe_edit_partial' recipe.pk %}{% else %}{% url 'recipe_create_partial' %}{% endif %}">
     {% csrf_token %}
-    <div class="px-4 py-3 border-b border-border bg-surfaceSubtle flex flex-wrap items-center gap-3">
-      <div class="flex items-center gap-3 min-w-0 flex-1">
-        <div class="h-12 w-12 overflow-hidden rounded-lg border border-border bg-surfaceSubtle">
-          <img src="{{ plating_image_url|default:plating_placeholder_url }}"
-               alt="{% if is_edit and recipe %}{{ recipe.name }} plating{% else %}Recipe plating placeholder{% endif %}"
-               class="h-full w-full object-cover"
-               loading="lazy"
-               data-role="drawer-plating-image"
-               onerror="this.onerror=null;this.src='{{ plating_placeholder_url }}';" />
+    <div class="px-4 py-3 border-b border-border bg-surfaceSubtle">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex items-center gap-3 min-w-0 sm:flex-1">
+          <div class="h-12 w-12 overflow-hidden rounded-lg border border-border bg-surfaceSubtle">
+            <img src="{{ plating_image_url|default:plating_placeholder_url }}"
+                 alt="{% if is_edit and recipe %}{{ recipe.name }} plating{% else %}Recipe plating placeholder{% endif %}"
+                 class="h-full w-full object-cover"
+                 loading="lazy"
+                 data-role="drawer-plating-image"
+                 onerror="this.onerror=null;this.src='{{ plating_placeholder_url }}';" />
+          </div>
+          <h3 class="text-base font-semibold truncate">{% if is_edit and recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}</h3>
         </div>
-        <h3 class="text-base font-semibold truncate">{% if is_edit and recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}</h3>
-      </div>
-      <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
-        <div class="flex flex-col items-start gap-1 text-left sm:items-end sm:text-right" data-role="drawer-active-toggle">
-          <label for="{{ form.is_active.id_for_label }}" class="inline-flex items-center gap-2 text-sm font-medium text-bodyText">
-            {{ form.is_active|add_class:"h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" }}
-            <span class="leading-none">Active</span>
-          </label>
-          {% if form.is_active.help_text %}
-            <p class="text-xs text-gray-500 leading-snug">{{ form.is_active.help_text }}</p>
-          {% endif %}
-          {% if form.is_active.errors %}
-            <ul class="text-xs text-danger list-disc pl-5 leading-snug text-left sm:text-right">
-              {% for error in form.is_active.errors %}
-                <li>{{ error }}</li>
-              {% endfor %}
-            </ul>
-          {% endif %}
+        <div class="flex items-start gap-3 sm:items-center sm:gap-4">
+          <div class="flex flex-col items-start gap-1 text-left sm:items-end sm:text-right" data-role="drawer-active-toggle">
+            <label for="{{ form.is_active.id_for_label }}" class="inline-flex items-center gap-2 text-sm font-medium text-bodyText">
+              {{ form.is_active|add_class:"h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" }}
+              <span class="leading-none">Active</span>
+            </label>
+            {% if form.is_active.help_text %}
+              <p class="text-xs text-gray-500 leading-snug">{{ form.is_active.help_text }}</p>
+            {% endif %}
+            {% if form.is_active.errors %}
+              <ul class="text-xs text-danger list-disc pl-5 leading-snug text-left sm:text-right">
+                {% for error in form.is_active.errors %}
+                  <li>{{ error }}</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
+          <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
         </div>
-        <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
       </div>
     </div>
     <div class="p-4 space-y-4">


### PR DESCRIPTION
## Summary
- remove the plating image column from the recipe items table and keep the responsive layout tidy
- shrink the combined description/plating textarea so it matches nearby inputs and clean up the header so the Active toggle sits with the close button
- fall back to the API `unit` value when no `base_unit` is provided so unit labels and costs populate for every selected item

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd3f108e3c83269eacf918c774318c