### PR TITLE
Prefetch GRN line items for list view

### DIFF
--- a/inventory/views/goods_received.py
+++ b/inventory/views/goods_received.py
@@ -32,7 +32,10 @@ class GRNListView(TemplateView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         request = self.request
-        grns = GoodsReceivedNote.objects.select_related("purchase_order", "supplier")
+        grns = (
+            GoodsReceivedNote.objects.select_related("purchase_order", "supplier")
+            .prefetch_related("grnitem_set__po_item__item")
+        )
         filters = {
             "supplier": "supplier_id",
             "start_date": "received_date__gte",


### PR DESCRIPTION
## Summary
- prefetch GRN line items and their linked PO items in the list view so the template reuse cached data when expanding line items

## Testing
- `pytest --override-ini addopts="--maxfail=3 --disable-warnings"`


------
https://chatgpt.com/codex/tasks/task_e_68d14a0421008326b49c2e8f397c07ff