### PR TITLE
Fix history reports: date + type filter race condition

### DIFF
--- a/templates/inventory/history_reports.html
+++ b/templates/inventory/history_reports.html
@@ -65,6 +65,7 @@
         input.setAttribute('hx-indicator', '#htmx-spinner');
         form.appendChild(input);
       });
+      htmx.process(form);
       flatpickr('#date-range', {
         mode: 'range',
         dateFormat: 'Y-m-d',
@@ -81,11 +82,7 @@
 
 {% block data_container %}
   <div class="bg-surface border border-border rounded-2xl shadow-card overflow-hidden">
-    <div id="history_table"
-         hx-get="{% url 'history_reports' %}"
-         hx-trigger="load"
-         hx-include="#filters"
-         hx-indicator="#htmx-spinner">
+    <div id="history_table">
     {% include "inventory/_history_tabs.html" %}
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Remove redundant `hx-trigger="load"` from `#history_table` — was overwriting filtered results with unfiltered ones on page load
- Add `htmx.process(form)` after flatpickr appends hidden `start_date`/`end_date` inputs so HTMX registers them

## Test plan

- [ ] Navigate to History Reports
- [ ] Change Type filter → table updates immediately with correct results
- [ ] Change date range via flatpickr → table updates correctly
- [ ] No stale overwrite after both filters are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)