### PR TITLE
Fix login page: 11 UX/UI issues resolved

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -41,11 +41,12 @@ def root_view(request):
         }
         return render(request, "core/dashboard.html", context)
 
-    form = AuthenticationForm(request, data=request.POST or None)
-    if request.method == "POST" and form.is_valid():
-        login(request, form.get_user())
-        return redirect("root")
-    return render(request, "core/dashboard.html", {"form": form})
+    return redirect("/accounts/login/")
+
+
+def password_reset_info_view(request):
+    """Inform users to contact admin to reset their password."""
+    return render(request, "registration/password_reset_info.html")
 
 
 def health_check(request):

--- a/inventory_app/settings/base.py
+++ b/inventory_app/settings/base.py
@@ -204,7 +204,8 @@ Q_CLUSTER = {
 }
 
 # Login URL
-LOGIN_URL = "/login/"
+LOGIN_URL = "/accounts/login/"
+LOGIN_REDIRECT_URL = "/"
 
 # Expanded URLs exempt from login requirement
 LOGIN_EXEMPT_URLS = [
@@ -212,6 +213,7 @@ LOGIN_EXEMPT_URLS = [
     r"^login/$",
     r"^accounts/login/$",
     r"^accounts/logout/$",
+    r"^accounts/password-reset-info/$",
     r"^healthz$",
     r"^static/.*$",
     r"^api/.*$",  # Exempt API endpoints

--- a/inventory_app/urls.py
+++ b/inventory_app/urls.py
@@ -22,7 +22,7 @@ from django.templatetags.static import static
 from django.urls import include, path
 from django.views.generic.base import RedirectView
 
-from core.views import dashboard_kpis, health_check, root_view
+from core.views import dashboard_kpis, health_check, password_reset_info_view, root_view
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -36,13 +36,14 @@ urlpatterns = [
     ),
     path(
         "login/",
-        RedirectView.as_view(pattern_name="root", permanent=False),
+        RedirectView.as_view(url="/accounts/login/", permanent=False),
         name="login",
     ),
     path("", root_view, name="root"),
     path("kpis/", dashboard_kpis, name="dashboard-kpis"),
     path("healthz", health_check, name="health-check"),
     path("accounts/", include("django.contrib.auth.urls")),
+    path("accounts/password-reset-info/", password_reset_info_view, name="password-reset-info"),
     path("", include("core.urls")),
     path("api/", include("inventory.urls")),  # DRF API
     path("", include("inventory.ui_urls")),  # HTML UI routes

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,157 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login – Inventory Pro</title>
+  <link rel="icon" href="{% static 'img/favicon.svg' %}" type="image/svg+xml">
+  <link href="{% static 'css/app.css' %}" rel="stylesheet">
+  <style>
+    .login-hero {
+      min-height: 100vh;
+      background: linear-gradient(135deg, #2563EB 0%, #1D4ED8 100%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 48px 16px 48px;
+    }
+    .login-btn {
+      width: 100%;
+      padding: 10px 16px;
+      background-color: #1D4ED8;
+      color: #fff;
+      font-weight: 600;
+      font-size: 0.875rem;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: background-color 0.15s;
+    }
+    .login-btn:hover { background-color: #1E40AF; }
+    .login-btn:focus { outline: 2px solid #93C5FD; outline-offset: 2px; }
+    .error-alert {
+      background-color: #FEE2E2;
+      color: #991B1B;
+      border-radius: 6px;
+      padding: 10px 14px;
+      font-size: 0.875rem;
+      font-weight: 500;
+      margin-bottom: 16px;
+    }
+  </style>
+</head>
+<body>
+  <div class="login-hero">
+
+    <!-- Logo -->
+    <div style="margin-bottom:16px">
+      <img src="{% static 'img/favicon.svg' %}" alt="Inventory Pro logo" width="48" height="48">
+    </div>
+
+    <!-- Headline -->
+    <h1 style="color:#fff;font-size:1.5rem;font-weight:700;text-align:center;margin:0 0 6px">
+      Welcome to Inventory Pro
+    </h1>
+    <p style="color:rgba(255,255,255,0.8);font-size:0.875rem;text-align:center;margin:0 0 32px">
+      Manage stock effortlessly
+    </p>
+
+    <!-- Login Card -->
+    <div style="width:100%;max-width:400px;background:#fff;border-radius:12px;box-shadow:0 10px 40px rgba(0,0,0,0.15);padding:32px">
+
+      <!-- Error alert (wrong credentials) -->
+      {% if form.errors %}
+      <div class="error-alert" role="alert">
+        Incorrect username or password. Please try again.
+      </div>
+      {% endif %}
+
+      <form method="post" novalidate>
+        {% csrf_token %}
+
+        <!-- Username -->
+        <div style="margin-bottom:16px">
+          <label for="id_username" style="display:block;font-size:0.875rem;font-weight:500;color:#374151;margin-bottom:4px">
+            Username
+          </label>
+          <input
+            type="text"
+            name="username"
+            id="id_username"
+            required
+            autocomplete="username"
+            class="block w-full px-3 py-2.5 border border-gray-300 rounded-md bg-white text-gray-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
+          >
+        </div>
+
+        <!-- Password with show/hide toggle -->
+        <div style="margin-bottom:24px">
+          <label for="id_password" style="display:block;font-size:0.875rem;font-weight:500;color:#374151;margin-bottom:4px">
+            Password
+          </label>
+          <div style="position:relative">
+            <input
+              type="password"
+              name="password"
+              id="id_password"
+              required
+              autocomplete="current-password"
+              class="block w-full px-3 py-2.5 border border-gray-300 rounded-md bg-white text-gray-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
+              style="padding-right:40px"
+            >
+            <button
+              type="button"
+              id="togglePassword"
+              aria-label="Toggle password visibility"
+              style="position:absolute;right:10px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;color:#9CA3AF;padding:0;display:flex;align-items:center"
+            >
+              <!-- Eye open -->
+              <svg id="eyeOpen" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/>
+              </svg>
+              <!-- Eye closed (slash) -->
+              <svg id="eyeClosed" xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" style="display:none">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.542-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.542 7a10.025 10.025 0 01-4.132 4.411m0 0L21 21"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Submit -->
+        <button type="submit" class="login-btn">Login</button>
+      </form>
+
+      <!-- Forgot password -->
+      <p style="text-align:center;margin-top:16px;font-size:0.875rem">
+        <a href="{% url 'password-reset-info' %}" style="color:#1D4ED8;text-decoration:none" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">
+          Forgot your password?
+        </a>
+      </p>
+
+    </div>
+  </div>
+
+  <script>
+    (function () {
+      var btn = document.getElementById('togglePassword');
+      var pwd = document.getElementById('id_password');
+      var eyeOpen = document.getElementById('eyeOpen');
+      var eyeClosed = document.getElementById('eyeClosed');
+      btn.addEventListener('click', function () {
+        if (pwd.type === 'password') {
+          pwd.type = 'text';
+          eyeOpen.style.display = 'none';
+          eyeClosed.style.display = 'block';
+        } else {
+          pwd.type = 'password';
+          eyeOpen.style.display = 'block';
+          eyeClosed.style.display = 'none';
+        }
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/templates/registration/password_reset_info.html
+++ b/templates/registration/password_reset_info.html
@@ -1,0 +1,53 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Forgot Password – Inventory Pro</title>
+  <link rel="icon" href="{% static 'img/favicon.svg' %}" type="image/svg+xml">
+  <link href="{% static 'css/app.css' %}" rel="stylesheet">
+  <style>
+    .login-hero {
+      min-height: 100vh;
+      background: linear-gradient(135deg, #2563EB 0%, #1D4ED8 100%);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 48px 16px;
+    }
+  </style>
+</head>
+<body>
+  <div class="login-hero">
+    <div style="margin-bottom:16px">
+      <img src="{% static 'img/favicon.svg' %}" alt="Inventory Pro logo" width="48" height="48">
+    </div>
+
+    <div style="width:100%;max-width:400px;background:#fff;border-radius:12px;box-shadow:0 10px 40px rgba(0,0,0,0.15);padding:32px;text-align:center">
+      <!-- Lock icon -->
+      <div style="margin-bottom:16px">
+        <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="none" viewBox="0 0 24 24" stroke="#2563EB" stroke-width="1.5" style="margin:0 auto">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z"/>
+        </svg>
+      </div>
+
+      <h2 style="font-size:1.125rem;font-weight:700;color:#111827;margin:0 0 8px">Forgot your password?</h2>
+      <p style="font-size:0.875rem;color:#6B7280;margin:0 0 24px;line-height:1.5">
+        Password resets are managed by your system administrator.<br>
+        Please contact them to have your password reset.
+      </p>
+
+      <a
+        href="/accounts/login/"
+        style="display:inline-block;padding:10px 24px;background-color:#1D4ED8;color:#fff;font-weight:600;font-size:0.875rem;border-radius:6px;text-decoration:none;transition:background-color 0.15s"
+        onmouseover="this.style.backgroundColor='#1E40AF'"
+        onmouseout="this.style.backgroundColor='#1D4ED8'"
+      >
+        Back to Login
+      </a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Bug 1:** Created `registration/login.html` — Django's built-in login view at `/accounts/login/` now renders (was 500)
- **Bug 2:** Red error alert shown on failed login (`{% if form.errors %}`)
- **Bug 3:** No nav bar — standalone page, does not extend `_base.html`
- **Bug 4:** Full-viewport blue hero (`min-height: 100vh; display: flex; align-items: center`)
- **Bug 5:** Card has `padding: 32px`; body has `padding: 48px 16px` — no clipping
- **Bug 6:** Login button `#1D4ED8` (darker than hero `#2563EB`)
- **Bug 7:** App logo (`favicon.svg`, 48px) centred above headline
- **Bug 8:** `padding-top: 48px` gives headline breathing room
- **Bug 9:** Password show/hide toggle (inline SVG eye icons, JS toggles `input.type`)
- **Bug 10:** "Forgot your password?" link → `/accounts/password-reset-info/` info page
- **Bug 11:** `required` on both username and password inputs

Also adds `password_reset_info.html` (same visual style, contact-admin message) and wires up `LOGIN_URL`, `LOGIN_REDIRECT_URL`, and exempt URL list.

## Test plan

- [ ] `GET /accounts/login/` — full-viewport blue hero, logo, no nav
- [ ] Login with wrong credentials → red error banner
- [ ] Login with empty fields → browser blocks (HTML5 required)
- [ ] Login with correct credentials → redirects to `/`
- [ ] `GET /` unauthenticated → redirects to `/accounts/login/`
- [ ] Password eye icon toggles visibility
- [ ] "Forgot your password?" loads info page
- [ ] Login button visibly darker than hero background

🤖 Generated with [Claude Code](https://claude.com/claude-code)