### PR TITLE
Fix Consolidation Preview: 10 UX/functionality improvements

### DIFF
--- a/inventory/services/indent_consolidation_service.py
+++ b/inventory/services/indent_consolidation_service.py
@@ -34,14 +34,26 @@ def _pending_qty(ii: IndentItem) -> Decimal:
     return pending if pending > 0 else Decimal("0")
 
 
-def consolidate_approved_indents(indent_ids: Iterable[int]) -> ConsolidationResult:
+def consolidate_approved_indents(
+    indent_ids: Iterable[int],
+    qty_overrides: Dict[int, Decimal] | None = None,
+    excluded_item_ids: set | None = None,
+) -> ConsolidationResult:
     """Group approved indent items by preferred supplier and create POs.
+
+    Args:
+        indent_ids: Indent PKs to consolidate (empty = all approved).
+        qty_overrides: Optional mapping of item_id -> override qty. Overrides
+            the aggregated pending qty for that item across all indents.
+        excluded_item_ids: Optional set of item PKs to skip entirely.
 
     Constraints: no schema changes, so we do not create explicit linkage rows.
     We annotate `IndentItem.notes` with simple references for traceability.
     """
 
     indent_ids = list(indent_ids or [])
+    qty_overrides = qty_overrides or {}
+    excluded_item_ids = excluded_item_ids or set()
     if not indent_ids:
         return ConsolidationResult(created_po_ids=[], skipped_items=0, total_items=0)
 
@@ -73,6 +85,10 @@ def consolidate_approved_indents(indent_ids: Iterable[int]) -> ConsolidationResu
             continue
         total += 1
         itm: Item = ii.item  # type: ignore
+        # Skip excluded items (Fix 4 — per-item exclusion checkboxes)
+        if itm.pk in excluded_item_ids:
+            skipped += 1
+            continue
         supplier_id = getattr(itm, "preferred_supplier_id", None)
         if not supplier_id:
             skipped += 1
@@ -82,6 +98,13 @@ def consolidate_approved_indents(indent_ids: Iterable[int]) -> ConsolidationResu
             {"qty": Decimal("0"), "price": Decimal(str(itm.last_purchase_price or 0))},
         )
         entry["qty"] += pending
+
+    # Apply qty overrides (Fix 3 — editable qty inputs replace aggregated pending)
+    for item_id, override_qty in qty_overrides.items():
+        for sup_map in supplier_items.values():
+            if item_id in sup_map:
+                sup_map[item_id]["qty"] = Decimal(str(override_qty))
+                break
 
     created_po_ids: List[int] = []
     order_date = timezone.now().date()

--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -865,7 +865,7 @@ def consolidate_indents(request):
         base_filter["indent_id__in"] = ids
     # Gather approved indent items with pending quantities and a preferred supplier
     qs = IndentItemModel.objects.select_related(
-        "item", "indent", "item__preferred_supplier"
+        "item", "indent", "item__preferred_supplier", "item__unit"
     ).filter(**base_filter)
     groups: dict[int, dict] = {}
     total_items = 0
@@ -887,8 +887,19 @@ def consolidate_indents(request):
                 )
             except Exception:
                 g["supplier"] = None
-        entry = g["items"].setdefault(item.pk, {"item": item, "qty": 0})
+        # Build unit display from the related unit FK
+        try:
+            unit_display = str(item.unit) if item.unit_id else ""
+        except Exception:
+            unit_display = ""
+        entry = g["items"].setdefault(
+            item.pk,
+            {"item": item, "qty": 0, "unit_display": unit_display, "mrn_lines": []},
+        )
         entry["qty"] += pending
+        # Track which MRN contributed and how much (Fix 5)
+        mrn_label = getattr(ii.indent, "mrn", None) or f"Indent {ii.indent_id}"
+        entry["mrn_lines"].append({"mrn": mrn_label, "qty": pending})
         total_items += 1
     # Transform to template-friendly structure
     grouped = []
@@ -908,8 +919,41 @@ def consolidate_indents(request):
     grouped.sort(key=lambda g: (getattr(g["supplier"], "name", "") or "").lower())
 
     if request.method == "POST":
-        # Perform consolidation for the same scope
-        result = indent_consolidation_service.consolidate_approved_indents(ids)
+        # Read per-item qty overrides and exclusions from POST data (Fixes 3+4)
+        from decimal import Decimal as _Decimal
+
+        qty_overrides: dict[int, _Decimal] = {}
+        excluded_item_ids: set[int] = set()
+        # Collect all known item IDs from the consolidated groups to check exclusions
+        all_item_ids: set[int] = set()
+        for grp in grouped:
+            for row in grp["items"]:
+                iid = row["item"].pk
+                all_item_ids.add(iid)
+                # Checkbox: present in POST means included, absent means excluded
+                if f"include_item_{iid}" not in request.POST:
+                    excluded_item_ids.add(iid)
+                # Qty override
+                raw = request.POST.get(f"qty_override_{iid}", "")
+                if raw:
+                    try:
+                        val = _Decimal(str(raw))
+                        if val > 0:
+                            qty_overrides[iid] = val
+                    except Exception:
+                        pass
+        # If no specific IDs were requested, resolve all currently-approved indent IDs
+        consolidate_ids = ids
+        if not consolidate_ids:
+            from ..models import Indent as _Indent
+            consolidate_ids = list(
+                _Indent.objects.filter(status="APPROVED").values_list("indent_id", flat=True)
+            )
+        result = indent_consolidation_service.consolidate_approved_indents(
+            consolidate_ids,
+            qty_overrides=qty_overrides,
+            excluded_item_ids=excluded_item_ids,
+        )
         if result.created_po_ids:
             messages.success(
                 request,
@@ -922,6 +966,8 @@ def consolidate_indents(request):
         )
         return redirect("indents_list")
 
+    total_supplier_count = len(grouped)
+    total_item_count = sum(grp["total_lines"] for grp in grouped)
     return render(
         request,
         "inventory/indents_consolidate_preview.html",
@@ -929,6 +975,8 @@ def consolidate_indents(request):
             "groups": grouped,
             "total_groups": len(grouped),
             "total_items": total_items,
+            "total_supplier_count": total_supplier_count,
+            "total_item_count": total_item_count,
             "ids_csv": ",".join(str(x) for x in ids) if ids else "",
         },
     )

--- a/templates/inventory/indents_consolidate_preview.html
+++ b/templates/inventory/indents_consolidate_preview.html
@@ -1,52 +1,175 @@
 {% extends "components/create_manage_layout.html" %}
-{% block page_title %}Consolidate Indents – Inventory Pro{% endblock %}
-{% block page_heading %}Consolidate Indents{% endblock %}
+{% block page_title %}Consolidation Preview – Inventory Pro{% endblock %}
+{% block page_heading %}Consolidation Preview{% endblock %}
+{% block page_subtitle %}
+  <p class="text-sm text-gray-600">Review and confirm the Purchase Orders that will be created.</p>
+{% endblock %}
 
 {% block content %}
-<div class="bg-surface rounded-xl shadow border border-border overflow-hidden">
-  <div class="px-4 py-3 border-b border-border flex items-center justify-between">
-    <h2 class="text-lg font-semibold text-bodyText">Approved Items Grouped by Supplier</h2>
-    <a href="{% url 'indents_list' %}" class="text-sm text-gray-600 hover:text-gray-800">Back to Indents</a>
-  </div>
-  <div class="p-4">
-    {% if total_groups == 0 %}
-      <p class="text-sm text-gray-600">No eligible items found for consolidation.</p>
-    {% else %}
-      <form method="post">
-        {% csrf_token %}
-        {% if ids_csv %}<input type="hidden" name="ids" value="{{ ids_csv }}">{% endif %}
-        <div class="space-y-6">
-          {% for group in groups %}
-            <div class="border border-border rounded-lg">
-              <div class="px-3 py-2 bg-surfaceSubtle border-b border-border flex items-center justify-between">
-                <div class="font-medium">Supplier: {{ group.supplier.name|default:"(Unknown Supplier)" }}</div>
-                <div class="text-xs text-gray-500">{{ group.total_lines }} item{{ group.total_lines|pluralize }}</div>
+<div style="display:flex;flex-direction:column;min-height:calc(100vh - 120px)">
+  <div class="bg-surface rounded-xl shadow border border-border overflow-hidden flex-1">
+    <div class="px-4 py-3 border-b border-border flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-bodyText">Approved Items Grouped by Supplier</h2>
+      <a href="{% url 'indents_list' %}" class="text-sm text-gray-600 hover:text-gray-800">Back to Indents</a>
+    </div>
+    <div class="p-4">
+      {% if total_groups == 0 %}
+        {# Fix 9: Empty state #}
+        <div class="text-center py-16 text-gray-400">
+          <svg class="mx-auto mb-3 w-12 h-12 text-gray-300" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z"/></svg>
+          <p class="text-lg font-medium text-gray-500">Nothing to consolidate yet</p>
+          <p class="text-sm mt-1">Approve some indents first, then return here to create Purchase Orders.</p>
+          <a href="{% url 'indents_list' %}" class="inline-flex items-center mt-4 px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">Go to Indents</a>
+        </div>
+      {% else %}
+        <form method="post" id="consolidate-form">
+          {% csrf_token %}
+          {% if ids_csv %}<input type="hidden" name="ids" value="{{ ids_csv }}">{% endif %}
+          <div class="space-y-6">
+            {% for group in groups %}
+              <div class="border border-border rounded-lg overflow-hidden">
+                {# Fix 8: Supplier header — darker bg + bold + left accent border #}
+                <div class="px-3 py-2 border-b border-border flex items-center justify-between" style="background-color:#E5E7EB;border-left:3px solid #2563EB">
+                  <div class="font-semibold text-gray-800">{{ group.supplier.name|default:"(Unknown Supplier)" }}</div>
+                  <div class="flex items-center gap-3">
+                    {# Select-all / deselect-all per group (Fix 4) #}
+                    <button type="button" class="text-xs text-blue-600 hover:underline" data-select-all="group-{{ forloop.counter }}">Select all</button>
+                    <span class="text-gray-300">|</span>
+                    <button type="button" class="text-xs text-blue-600 hover:underline" data-deselect-all="group-{{ forloop.counter }}">Deselect all</button>
+                    <span class="text-xs text-gray-500 ml-2">{{ group.total_lines }} item{{ group.total_lines|pluralize }}</span>
+                  </div>
+                </div>
+                <table class="min-w-full">
+                  <thead class="text-left text-xs font-semibold text-gray-600 uppercase tracking-wider bg-surfaceSubtle">
+                    <tr>
+                      <th class="px-3 py-2 w-8">{# checkbox #}</th>
+                      <th class="px-3 py-2">Item</th>
+                      <th class="px-3 py-2 text-right">Pending Qty</th>
+                    </tr>
+                  </thead>
+                  <tbody class="divide-y divide-gray-100">
+                    {% for row in group.items %}
+                    <tr class="odd:bg-surface even:bg-surfaceSubtle" data-group-id="group-{{ forloop.parentloop.counter }}">
+                      {# Fix 4: Per-item exclusion checkbox #}
+                      <td class="px-3 py-2">
+                        <input type="checkbox"
+                               name="include_item_{{ row.item.pk }}"
+                               id="include_item_{{ row.item.pk }}"
+                               class="group-checkbox group-{{ forloop.parentloop.counter }}"
+                               checked
+                               aria-label="Include {{ row.item.name }}">
+                      </td>
+                      <td class="px-3 py-2">
+                        <label for="include_item_{{ row.item.pk }}" class="font-medium cursor-pointer">{{ row.item.name }}</label>
+                        {# Fix 5: Source MRN traceability #}
+                        {% if row.mrn_lines %}
+                        <div class="text-xs text-gray-400 mt-0.5">
+                          From:
+                          {% for src in row.mrn_lines %}{{ src.mrn }} (<span class="tabular-nums">{{ src.qty|floatformat:2 }}</span>){% if not forloop.last %}, {% endif %}{% endfor %}
+                        </div>
+                        {% endif %}
+                      </td>
+                      {# Fix 3: Editable qty override + Fix 2: Unit display #}
+                      <td class="px-3 py-2 text-right">
+                        <div class="inline-flex items-center gap-1.5 justify-end">
+                          <input type="number"
+                                 name="qty_override_{{ row.item.pk }}"
+                                 value="{{ row.qty|floatformat:2 }}"
+                                 min="0.01" step="0.01"
+                                 class="w-24 border border-border rounded px-2 py-1 text-sm tabular-nums text-right bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
+                                 aria-label="Quantity for {{ row.item.name }}">
+                          {% if row.unit_display %}
+                          <span class="text-gray-500 text-sm whitespace-nowrap">{{ row.unit_display }}</span>
+                          {% endif %}
+                        </div>
+                      </td>
+                    </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
               </div>
-              <table class="min-w-full">
-                <thead class="text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
-                  <tr>
-                    <th class="px-3 py-2">Item</th>
-                    <th class="px-3 py-2">Pending Qty</th>
-                  </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-100">
-                  {% for row in group.items %}
-                  <tr class="odd:bg-surface even:bg-surfaceSubtle">
-                    <td class="px-3 py-2">{{ row.item.name }}</td>
-                    <td class="px-3 py-2 tabular-nums">{{ row.qty|floatformat:2 }}</td>
-                  </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
-            </div>
-          {% endfor %}
-        </div>
-        <div class="mt-4 flex items-center justify-end gap-2">
-          <a href="{% url 'indents_list' %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Cancel</a>
-          <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">Create Purchase Orders</button>
-        </div>
-      </form>
-    {% endif %}
+            {% endfor %}
+          </div>
+
+          {# Fix 11: Buttons pushed to bottom via margin-top:auto #}
+          <div class="mt-6 flex items-center justify-end gap-3" style="margin-top:auto">
+            {# Fix 7: Cancel as outlined button #}
+            <a href="{% url 'indents_list' %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Cancel</a>
+            {# Fix 1: Button triggers confirmation modal instead of direct submit #}
+            <button type="button" id="open-confirm-modal" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">Create Purchase Orders</button>
+          </div>
+        </form>
+      {% endif %}
+    </div>
   </div>
 </div>
+
+{# Fix 1: Confirmation modal #}
+{% if total_groups > 0 %}
+<div id="confirm-modal" role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title"
+     style="display:none;position:fixed;inset:0;z-index:50;background:rgba(0,0,0,0.4);align-items:center;justify-content:center">
+  <div style="background:#fff;border-radius:12px;padding:28px 32px;max-width:460px;width:100%;margin:0 16px;box-shadow:0 20px 60px rgba(0,0,0,0.2)">
+    <h2 id="confirm-modal-title" style="font-size:1.125rem;font-weight:700;margin:0 0 12px">Confirm Purchase Order Creation</h2>
+    <p id="confirm-modal-body" style="color:#374151;margin:0 0 24px;line-height:1.6">
+      You are about to create <strong id="confirm-po-count">{{ total_supplier_count }}</strong> Purchase Order{{ total_supplier_count|pluralize }}
+      covering <strong id="confirm-item-count">{{ total_item_count }}</strong> item{{ total_item_count|pluralize }}
+      across <strong>{{ total_supplier_count }}</strong> supplier{{ total_supplier_count|pluralize }}.
+      This action cannot be undone.
+    </p>
+    <div style="display:flex;justify-content:flex-end;gap:12px">
+      <button type="button" id="cancel-confirm-modal"
+              style="padding:8px 18px;border-radius:6px;border:1px solid #D1D5DB;background:#fff;font-size:.875rem;font-weight:500;cursor:pointer">
+        Cancel
+      </button>
+      <button type="button" id="confirm-submit"
+              style="padding:8px 18px;border-radius:6px;border:none;background:#1D4ED8;color:#fff;font-size:.875rem;font-weight:500;cursor:pointer">
+        Confirm &amp; Create
+      </button>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  var modal = document.getElementById('confirm-modal');
+  var openBtn = document.getElementById('open-confirm-modal');
+  var cancelBtn = document.getElementById('cancel-confirm-modal');
+  var confirmBtn = document.getElementById('confirm-submit');
+  var form = document.getElementById('consolidate-form');
+
+  openBtn.addEventListener('click', function () {
+    // Update counts based on currently checked items
+    var checked = document.querySelectorAll('.group-checkbox:checked').length;
+    document.getElementById('confirm-item-count').textContent = checked;
+    modal.style.display = 'flex';
+    confirmBtn.focus();
+  });
+  cancelBtn.addEventListener('click', function () { modal.style.display = 'none'; });
+  modal.addEventListener('click', function (e) {
+    if (e.target === modal) modal.style.display = 'none';
+  });
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') modal.style.display = 'none';
+  });
+  confirmBtn.addEventListener('click', function () {
+    modal.style.display = 'none';
+    form.submit();
+  });
+
+  // Select-all / deselect-all per group (Fix 4)
+  document.querySelectorAll('[data-select-all]').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var grp = btn.getAttribute('data-select-all');
+      document.querySelectorAll('.' + grp).forEach(function (cb) { cb.checked = true; });
+    });
+  });
+  document.querySelectorAll('[data-deselect-all]').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var grp = btn.getAttribute('data-deselect-all');
+      document.querySelectorAll('.' + grp).forEach(function (cb) { cb.checked = false; });
+    });
+  });
+})();
+</script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

- **Fix 1** — Confirmation modal before creating POs: shows PO count, item count, supplier count; Cancel / Confirm & Create buttons
- **Fix 2** — Unit of measure displayed next to every quantity (gray, smaller text)
- **Fix 3** — Pending Qty column is now editable; overrides are used as the actual PO line quantities
- **Fix 4** — Per-item inclusion checkboxes (all checked by default); Select all / Deselect all per supplier group
- **Fix 5** — Source MRN traceability shown under each item name (From: MRN-014 (1.00), MRN-012 (11.00))
- **Fix 6** — Consolidation Planner was already only in Plan & Request nav; no change needed
- **Fix 7** — Cancel changed from plain link to outlined button, visually paired with Create POs
- **Fix 8** — Supplier header uses gray-200 bg + blue left border accent for clear contrast
- **Fix 9** — Empty state with SVG icon, helpful message, Go to Indents link when no approved items exist
- **Fix 10** — Page heading changed to Consolidation Preview with action-oriented subtitle
- **Fix 11** — Button row uses flex + margin-top:auto to avoid dead space below content

Also fixes pre-existing bug: POST with no ?ids= param now falls back to all approved indents.

## Files changed

| File | Changes |
|------|---------|
| templates/inventory/indents_consolidate_preview.html | Full rewrite with all 10 fixes |
| inventory/views/indents.py | GET: unit_display + MRN breakdown; POST: reads overrides/exclusions; fallback indent IDs |
| inventory/services/indent_consolidation_service.py | Accepts qty_overrides and excluded_item_ids params |

## Test plan

- [ ] Navigate to /indents/consolidate/preview/ with approved indents — items show with units and MRN sources
- [ ] Adjust a qty → PO created with the overridden quantity
- [ ] Uncheck an item → that item is skipped, others still consolidate
- [ ] Click Create Purchase Orders → confirmation modal appears before any POST
- [ ] Click Confirm & Create in modal → POs created, redirect to PO list
- [ ] Click Cancel in modal → modal closes, no form submitted
- [ ] Navigate with no approved indents → empty state shows with Go to Indents link
- [ ] Cancel button is styled as outlined button

Generated with Claude Code