### PR TITLE
Fix: unit display on consolidation page (purchase_unit not str(unit))

### DIFF
--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -889,7 +889,7 @@ def consolidate_indents(request):
                 g["supplier"] = None
         # Build unit display from the related unit FK
         try:
-            unit_display = str(item.unit) if item.unit_id else ""
+            unit_display = (item.unit.purchase_unit or str(item.unit)) if item.unit_id else ""
         except Exception:
             unit_display = ""
         entry = g["items"].setdefault(


### PR DESCRIPTION
## Summary

Unit.__str__ returns "KG (KG)" (purchase_unit + base_unit), but the consolidation preview only needs the purchase unit label. Quantities were rendering as "8.00 KG (KG)" instead of "8.00 KG".

**Fix:** Use  directly instead of .

## Test plan
- [ ] Navigate to /indents/consolidate/preview/ with approved indents
- [ ] Verify quantities show as "12.00 KG" not "12.00 KG (KG)"

Generated with [Claude Code](https://claude.com/claude-code)