### PR TITLE
Fix Consolidation Preview: 11 UX/functionality improvements + production PO creation crash

### DIFF
--- a/inventory/services/purchase_order_service.py
+++ b/inventory/services/purchase_order_service.py
@@ -38,6 +38,7 @@ def create_po(po_data: Dict[str, Any], items_data: List[Dict[str, Any]]) -> int:
         with transaction.atomic():
             supplier = Supplier.objects.get(pk=po_data["supplier_id"])
             po = PurchaseOrder.objects.create(
+                po_number=po_data.get("po_number") or generate_po_number(),
                 supplier=supplier,
                 order_date=po_data["order_date"],
                 expected_delivery_date=po_data.get("expected_delivery_date"),


### PR DESCRIPTION
## Summary

- **Production crash fix** — `create_po()` was not calling `generate_po_number()`, causing `null value in column "po_number"` NOT NULL violation in Postgres on every Confirm & Create click
- **Confirmation modal** before creating POs (title, item count, supplier count, Cancel + Confirm & Create buttons)
- **Unit of measure** shown on every quantity (e.g. `12.00 KG`)
- **Editable qty inputs** — override pending qty per item before confirming
- **Per-item exclusion checkboxes** — uncheck to skip; Select all / Deselect all per supplier group
- **Source MRN traceability** — each item shows which indents contributed (e.g. `From: MRN-014 (1.00), MRN-012 (11.00)`)
- **Nav fix** — removed duplicate Consolidation Planner from Fulfill & Track dropdown
- **Cancel button** styled as outlined button (visually paired with Confirm)
- **Supplier header** contrast increased (gray-200 bg + left blue border accent)
- **Empty state** when no approved indents exist
- **Page heading** changed to "Consolidation Preview" with action-oriented subtitle

## Test plan

- [ ] Click Confirm & Create — PO created successfully in production (no more 500 error)
- [ ] Navigate with approved indents — items show with units and MRN breakdown
- [ ] Adjust a qty input — PO created with the new qty
- [ ] Uncheck an item — that item is skipped when POs are created
- [ ] Click Cancel — returns to indents list
- [ ] Navigate with no approved indents — empty state shown

Generated with Claude Code