### PR TITLE
Fix Recipes: 8 UX/bug fixes across /recipes/ and /recipes/<pk>/

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -60,6 +60,7 @@ from .views.recipes import (
     RecipesTableView,
     RecipeViewPartialView,
     recipe_create,
+    recipe_create_indent,
     recipe_detail,
 )
 from .views.stock import POSearchView, UserSearchView, history_reports, stock_movements
@@ -240,6 +241,11 @@ urlpatterns = [
         "recipes/<int:pk>/view/partial/",
         RecipeViewPartialView.as_view(),
         name="recipe_view_partial",
+    ),
+    path(
+        "recipes/<int:pk>/create-indent/",
+        recipe_create_indent,
+        name="recipe_create_indent",
     ),
     path("recipes/<int:pk>/", recipe_detail, name="recipe_detail"),
     path("guides/workflow/", WorkflowGuideView.as_view(), name="workflow_guide"),

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -6,11 +6,12 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils import timezone
 from django.views import View
 from django.views.generic import TemplateView
 
 from ..forms.recipe_forms import RecipeForm, RecipeItemFormSet
-from ..models import Recipe, RecipeItem
+from ..models import Indent, IndentItem, Recipe, RecipeItem
 from ..services import list_utils, recipe_service
 from ..services.units_service import UnitsService
 
@@ -584,8 +585,15 @@ class RecipeViewPartialView(View):
             cost_per_base = (
                 cost_per_base.quantize(TWOPLACES) if cost_per_base else Decimal("0.00")
             )
+            # Apply loss %: effective_qty = qty / (1 - loss_pct/100)
+            effective_qty = qty
+            if qty and loss_pct and loss_pct < 100:
+                try:
+                    effective_qty = qty / (1 - loss_pct / 100)
+                except (ArithmeticError, ZeroDivisionError):
+                    effective_qty = qty
             line_cost = (
-                (cost_per_base * qty).quantize(TWOPLACES) if qty else Decimal("0.00")
+                (cost_per_base * effective_qty).quantize(TWOPLACES) if effective_qty else Decimal("0.00")
             )
             has_zero_price = bool(qty and item and cost_per_base == Decimal("0.00"))
             zero_cost = zero_cost or has_zero_price
@@ -626,3 +634,60 @@ class RecipeViewPartialView(View):
                 "plating_placeholder_url": plating_placeholder_url,
             },
         )
+
+
+def recipe_create_indent(request, pk: int):
+    """Create a DRAFT indent from a recipe's ingredient list.
+
+    POST params:
+        yield_qty  – target yield quantity (defaults to recipe.default_yield_qty)
+    """
+    if request.method != "POST":
+        return redirect("recipe_view_partial", pk=pk)
+
+    recipe = get_object_or_404(
+        Recipe.objects.prefetch_related(
+            Prefetch("items", queryset=RecipeItem.objects.select_related("item"))
+        ),
+        pk=pk,
+    )
+
+    try:
+        yield_qty = Decimal(str(request.POST.get("yield_qty") or recipe.default_yield_qty or 1))
+    except (ValueError, ArithmeticError):
+        yield_qty = _to_decimal(recipe.default_yield_qty) or Decimal("1")
+
+    base_yield = _to_decimal(recipe.default_yield_qty) or Decimal("1")
+    scale = yield_qty / base_yield if base_yield else Decimal("1")
+
+    ts = timezone.now().strftime("%Y%m%d%H%M%S%f")
+    mrn = f"MRN-{ts}"
+
+    indent = Indent.objects.create(
+        mrn=mrn,
+        notes=f"Recipe: {recipe.name}",
+        status="DRAFT",
+        date_required=None,
+    )
+
+    for row in recipe.items.all():
+        item = getattr(row, "item", None)
+        if not item:
+            continue
+        qty = _to_decimal(getattr(row, "quantity", None))
+        loss_pct = _to_decimal(getattr(row, "loss_pct", None))
+        effective_qty = qty * scale
+        if loss_pct and loss_pct < 100:
+            try:
+                effective_qty = effective_qty / (1 - loss_pct / 100)
+            except (ArithmeticError, ZeroDivisionError):
+                pass
+        effective_qty = effective_qty.quantize(TWOPLACES)
+        IndentItem.objects.create(
+            indent=indent,
+            item=item,
+            requested_qty=effective_qty,
+        )
+
+    messages.success(request, f"Indent {mrn} created from recipe", extra_tags="toast")
+    return redirect("indent_detail", pk=indent.pk)

--- a/static/js/recipe-components.js
+++ b/static/js/recipe-components.js
@@ -68,7 +68,14 @@
 
     var costElement = row.querySelector('[data-line-cost]');
     if (costElement) {
-      var lineCost = quantity * costPerBase;
+      // Apply loss %: effective_qty = qty / (1 - loss_pct/100)
+      var lossPctInput = row.querySelector('input[id$="-loss_pct"]');
+      var lossPct = lossPctInput ? toNumber(lossPctInput.value) : 0;
+      var effectiveQty = quantity;
+      if (lossPct > 0 && lossPct < 100) {
+        effectiveQty = quantity / (1 - lossPct / 100);
+      }
+      var lineCost = effectiveQty * costPerBase;
       costElement.textContent = lineCost.toFixed(2);
     }
 

--- a/templates/inventory/recipes/_view_partial.html
+++ b/templates/inventory/recipes/_view_partial.html
@@ -2,7 +2,13 @@
 <div class="bg-surface rounded-xl shadow border border-border overflow-hidden drawer-panel max-w-drawer-xl">
   <div class="px-4 py-3 border-b border-border bg-surfaceSubtle flex items-center justify-between">
     <h3 class="text-base font-semibold">{{ recipe.name }}</h3>
-    <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
+    <div class="flex items-center gap-2">
+      <button type="button"
+              class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none bg-surface text-primary border border-primary hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary"
+              data-modal-url="{% url 'recipe_edit_partial' recipe.pk %}"
+              data-modal-type="drawer">Edit Recipe</button>
+      <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
+    </div>
   </div>
   <div class="p-4 space-y-6">
     <section class="grid gap-4 md:grid-cols-3 text-sm">
@@ -48,37 +54,47 @@
     </section>
 
     <section class="space-y-3">
-      <h4 class="text-sm font-semibold">Ingredients</h4>
+      <div class="flex items-center justify-between">
+        <h4 class="text-sm font-semibold">Ingredients</h4>
+        <div class="flex items-center gap-2 text-sm">
+          <label class="text-xs text-gray-500 font-medium">Scale to yield:</label>
+          <input type="number" id="scale-qty" value="{{ recipe.default_yield_qty|floatformat:-2 }}" min="0.001" step="0.001"
+                 class="w-20 border border-border rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-primary"
+                 data-base-yield="{{ recipe.default_yield_qty|floatformat:-2 }}">
+          <button type="button" onclick="scaleRecipeView()"
+                  class="inline-flex items-center px-2 py-1 text-xs font-medium rounded border border-border bg-surface hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">
+            Recalculate
+          </button>
+        </div>
+      </div>
       <div class="table-scroll bg-surface border border-border rounded-2xl shadow-sm" data-table-container>
         <table id="items-table" class="min-w-full w-full table-auto text-label">
           <thead class="text-left text-xs font-semibold uppercase tracking-wider bg-surfaceSubtle text-gray-600">
             <tr>
-              <th scope="col">Item</th>
-              <th scope="col">Qty</th>
-              <th scope="col">Unit</th>
-              <th scope="col">Loss %</th>
-              <th scope="col">Cost</th>
-              <th scope="col" class="w-8"></th>
+              <th scope="col" class="px-3 py-2">Item</th>
+              <th scope="col" class="px-3 py-2">Qty</th>
+              <th scope="col" class="px-3 py-2">Unit</th>
+              <th scope="col" class="px-3 py-2">Loss %</th>
+              <th scope="col" class="px-3 py-2">Cost</th>
             </tr>
           </thead>
           <tbody class="bg-surface divide-y divide-border">
             {% for item in items %}
-            <tr class="form-row" data-recipe-row="true" data-category="{{ item.category }}" data-subcategory="{{ item.subcategory }}" data-cost-per-base-unit="{{ item.cost_per_base_unit_str }}" data-quantity="{{ item.quantity_str }}" data-has-item="{% if item.has_item %}1{% else %}0{% endif %}" {% if item.has_zero_price %}data-has-zero-price="1"{% endif %}>
+            <tr class="form-row {% if item.has_zero_price %}bg-amber-50{% endif %}" data-recipe-row="true" data-category="{{ item.category }}" data-subcategory="{{ item.subcategory }}" data-cost-per-base-unit="{{ item.cost_per_base_unit_str }}" data-quantity="{{ item.quantity_str }}" data-has-item="{% if item.has_item %}1{% else %}0{% endif %}" {% if item.has_zero_price %}data-has-zero-price="1"{% endif %}>
               <td class="px-3 py-2 align-top">
                 <div class="font-medium text-bodyText">{{ item.name }}</div>
                 <div class="text-xs text-gray-500">{{ item.category }}</div>
               </td>
-              <td class="px-3 py-2 align-middle">{{ item.quantity|floatformat:-2 }}</td>
+              <td class="px-3 py-2 align-middle"><span data-base-qty="{{ item.quantity_str }}">{{ item.quantity|floatformat:-2 }}</span></td>
               <td class="px-3 py-2 align-middle">{{ item.unit|default:"—" }}</td>
               <td class="px-3 py-2 align-middle">{{ item.loss_pct|floatformat:-2 }}</td>
               <td class="px-3 py-2 align-middle">
-                <div class="text-sm" data-line-cost>{{ item.line_cost_str }}</div>
+                <div class="text-sm {% if item.has_zero_price %}text-amber-600{% endif %}" data-line-cost data-base-cost="{{ item.line_cost_str }}">{{ item.line_cost_str }}</div>
               </td>
-              <td class="px-3 py-2"></td>
             </tr>
             {% empty %}
             <tr>
-              <td colspan="6" class="px-4 py-6 text-center text-gray-500">No items added yet.</td>
+              <td colspan="5" class="px-4 py-6 text-center text-gray-500">No items added yet.</td>
             </tr>
             {% endfor %}
           </tbody>
@@ -94,6 +110,24 @@
         <div>Total Cost: <span id="recipe-total-cost">{{ total_cost|floatformat:2 }}</span></div>
       </div>
     </section>
+
+    {% if recipe.pk %}
+    <section>
+      <form method="post" action="{% url 'recipe_create_indent' recipe.pk %}">
+        {% csrf_token %}
+        <div class="flex items-center gap-3">
+          <label class="text-sm text-gray-600">Yield qty:
+            <input type="number" name="yield_qty" value="{{ recipe.default_yield_qty|floatformat:-2 }}" min="0.001" step="0.001"
+                   class="ml-1 w-20 border border-border rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary">
+          </label>
+          <button type="submit"
+                  class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">
+            Request Ingredients
+          </button>
+        </div>
+      </form>
+    </section>
+    {% endif %}
   </div>
 </div>
 <script>
@@ -108,4 +142,27 @@
     window.updateRecipeCosts(rootScope);
   }
 })();
+
+function scaleRecipeView() {
+  var input = document.getElementById('scale-qty');
+  if (!input) return;
+  var baseYield = parseFloat(input.getAttribute('data-base-yield')) || 1;
+  var newYield = parseFloat(input.value) || baseYield;
+  var factor = newYield / baseYield;
+  document.querySelectorAll('[data-base-qty]').forEach(function(el) {
+    var base = parseFloat(el.getAttribute('data-base-qty')) || 0;
+    el.textContent = (base * factor).toFixed(3);
+  });
+  document.querySelectorAll('[data-line-cost][data-base-cost]').forEach(function(el) {
+    var base = parseFloat(el.getAttribute('data-base-cost')) || 0;
+    el.textContent = (base * factor).toFixed(2);
+  });
+  // Update total
+  var total = 0;
+  document.querySelectorAll('[data-line-cost][data-base-cost]').forEach(function(el) {
+    total += parseFloat(el.getAttribute('data-base-cost')) || 0;
+  });
+  var totalEl = document.getElementById('recipe-total-cost');
+  if (totalEl) totalEl.textContent = (total * factor).toFixed(2);
+}
 </script>

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -1,4 +1,5 @@
 {% extends "components/form_layout.html" %}
+{% load form_tags %}
 {% block title %}Recipe Detail – Inventory Pro{% endblock %}
 {% block heading %}{% if recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}{% endblock %}
 {% block form_summary %}

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -4,14 +4,7 @@
 {% block page_subtitle %}
   <p class="text-sm text-gray-600">Keep production formulas and BOMs in one place.</p>
 {% endblock %}
-{% block page_meta %}
-  <div id="recipes-meta-summary" class="flex flex-wrap items-center gap-2 text-xs font-medium text-gray-600">
-    <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full border border-border bg-surfaceSubtle">Total: <span class="text-bodyText">{{ recipe_count|default:0 }}</span></span>
-    {% if q %}
-      <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full border border-border bg-surfaceSubtle">Filtered by: <span class="text-bodyText">“{{ q }}”</span></span>
-    {% endif %}
-  </div>
-{% endblock %}
+{% block page_meta %}{% endblock %}
 {% block hero_extra %}
   <div class="mt-4 bg-surfaceSubtle border border-dashed border-border rounded-lg p-3 text-sm text-gray-600">
     <span class="font-medium text-bodyText">Tip:</span> Use the drawer to add a new recipe while keeping this list in view.


### PR DESCRIPTION
## Summary

- Fix 500 on /recipes/<pk>/: add {% load form_tags %} to detail.html
- Fix Loss % ignored in cost calc (view + JS)
- Add Edit Recipe button inside view drawer
- Add scaling UI in view drawer (scale-to-yield + Recalculate)
- Highlight zero-cost ingredients with amber row
- Remove duplicate Total badge from list header
- Add POST /recipes/<pk>/create-indent/ endpoint
- Add Request Ingredients button in view drawer

## Test plan

- [ ] /recipes/<pk>/ loads without 500
- [ ] View drawer: Edit button, scaling, amber highlights all work
- [ ] Request Ingredients creates DRAFT indent and redirects
- [ ] Loss % applied in live JS cost preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)