### PR TITLE
Fix Item Catalogue: 8 UX/functionality improvements

### DIFF
--- a/inventory/forms/item_forms.py
+++ b/inventory/forms/item_forms.py
@@ -70,7 +70,6 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
             "minimum_order_qty",
             "lead_time_days",
             "reorder_point",
-            "current_stock",
             "notes",
             "is_active",
         ]
@@ -106,14 +105,6 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
                     "step": "0.01",
                     "min": "0",
                     "placeholder": "10.00",
-                }
-            ),
-            "current_stock": forms.NumberInput(
-                attrs={
-                    "class": INPUT_CLASS,
-                    "step": "0.01",
-                    "min": "0",
-                    "placeholder": "0.00",
                 }
             ),
             "is_active": forms.CheckboxInput(
@@ -159,7 +150,6 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
                 "minimum_order_qty",
                 "lead_time_days",
                 "reorder_point",
-                "current_stock",
             ]:
                 if f in self.fields:
                     # Using empty string ensures the input renders blank

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -60,6 +60,7 @@ from .views.recipes import (
     RecipesTableView,
     RecipeViewPartialView,
     recipe_create,
+    recipe_create_indent,
     recipe_detail,
 )
 from .views.stock import POSearchView, UserSearchView, history_reports, stock_movements
@@ -240,6 +241,11 @@ urlpatterns = [
         "recipes/<int:pk>/view/partial/",
         RecipeViewPartialView.as_view(),
         name="recipe_view_partial",
+    ),
+    path(
+        "recipes/<int:pk>/create-indent/",
+        recipe_create_indent,
+        name="recipe_create_indent",
     ),
     path("recipes/<int:pk>/", recipe_detail, name="recipe_detail"),
     path("guides/workflow/", WorkflowGuideView.as_view(), name="workflow_guide"),

--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -3,7 +3,8 @@ import logging
 from django.contrib import messages
 from django.core.cache import cache
 from django.db import DatabaseError, IntegrityError
-from django.db.models import BooleanField, Case, F, Prefetch, Q, Value, When
+from django.db.models import BooleanField, Case, DecimalField, ExpressionWrapper, F, Prefetch, Q, Sum, Value, When
+from django.db.models.functions import Coalesce
 from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -313,20 +314,43 @@ class ItemsListView(TemplateView):
         ctx.update(params)
         ctx.update(category_ctx)
         ctx.update(table_ctx)
+        # Filter-aware KPI stats computed from the filtered queryset
+        kpi_qs, _ = _basic_item_filters(request)
         stats = {}
-        # Cache expensive KPI computations to avoid recomputing per request
         try:
-            stats["total_active"] = cache.get_or_set(
-                "kpi:items:total_active", kpis.total_active_items, 120
-            )
+            active_qs = kpi_qs.filter(is_active=True)
+            stats["total_active"] = active_qs.count()
         except Exception:  # pragma: no cover - defensive
+            active_qs = kpi_qs.none()
             stats["total_active"] = 0
         try:
-            stats["low_stock_percentage"] = cache.get_or_set(
-                "kpi:items:low_stock_pct", kpis.low_stock_percentage, 120
-            )
+            total_active = stats.get("total_active", 0)
+            if total_active:
+                low_stock_count = active_qs.filter(
+                    current_stock__isnull=False,
+                    reorder_point__isnull=False,
+                    current_stock__lte=F("reorder_point"),
+                ).count()
+                stats["low_stock_percentage"] = low_stock_count / total_active * 100
+            else:
+                stats["low_stock_percentage"] = 0
         except Exception:  # pragma: no cover - defensive
             stats["low_stock_percentage"] = 0
+        try:
+            stats["stock_value_on_hand"] = active_qs.aggregate(
+                total=Coalesce(
+                    Sum(
+                        ExpressionWrapper(
+                            F("current_stock") * F("last_purchase_price"),
+                            output_field=DecimalField(),
+                        )
+                    ),
+                    0,
+                    output_field=DecimalField(),
+                )
+            )["total"] or 0
+        except Exception:  # pragma: no cover - defensive
+            stats["stock_value_on_hand"] = 0
         try:
             stats["avg_days_since_last_purchase"] = cache.get_or_set(
                 "kpi:items:avg_days_since_last_purchase",
@@ -335,12 +359,6 @@ class ItemsListView(TemplateView):
             )
         except Exception:  # pragma: no cover - defensive
             stats["avg_days_since_last_purchase"] = 0
-        try:
-            stats["stock_value_on_hand"] = cache.get_or_set(
-                "kpi:items:stock_value_on_hand", kpis.stock_value_on_hand, 120
-            )
-        except Exception:  # pragma: no cover - defensive
-            stats["stock_value_on_hand"] = 0
         try:
             stats["fastest_movers"] = cache.get_or_set(
                 "kpi:items:fastest_movers_7d",

--- a/inventory/views/items/stock.py
+++ b/inventory/views/items/stock.py
@@ -103,6 +103,10 @@ class ItemsBulkUpdateView(View):
                     it.departments.add(dept)
                 return JsonResponse({"ok": True, "updated": items.count()})
 
+            if action == "delete":
+                deleted_count, _ = Item.objects.filter(pk__in=ids).delete()
+                return JsonResponse({"ok": True, "deleted": deleted_count})
+
             return JsonResponse({"ok": False, "message": "Unknown action"}, status=400)
         except Exception as e:  # pragma: no cover - defensive
             logger.exception("Bulk update failed: %s", e)

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -6,11 +6,12 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils import timezone
 from django.views import View
 from django.views.generic import TemplateView
 
 from ..forms.recipe_forms import RecipeForm, RecipeItemFormSet
-from ..models import Recipe, RecipeItem
+from ..models import Indent, IndentItem, Recipe, RecipeItem
 from ..services import list_utils, recipe_service
 from ..services.units_service import UnitsService
 
@@ -584,8 +585,15 @@ class RecipeViewPartialView(View):
             cost_per_base = (
                 cost_per_base.quantize(TWOPLACES) if cost_per_base else Decimal("0.00")
             )
+            # Apply loss %: effective_qty = qty / (1 - loss_pct/100)
+            effective_qty = qty
+            if qty and loss_pct and loss_pct < 100:
+                try:
+                    effective_qty = qty / (1 - loss_pct / 100)
+                except (ArithmeticError, ZeroDivisionError):
+                    effective_qty = qty
             line_cost = (
-                (cost_per_base * qty).quantize(TWOPLACES) if qty else Decimal("0.00")
+                (cost_per_base * effective_qty).quantize(TWOPLACES) if effective_qty else Decimal("0.00")
             )
             has_zero_price = bool(qty and item and cost_per_base == Decimal("0.00"))
             zero_cost = zero_cost or has_zero_price
@@ -626,3 +634,60 @@ class RecipeViewPartialView(View):
                 "plating_placeholder_url": plating_placeholder_url,
             },
         )
+
+
+def recipe_create_indent(request, pk: int):
+    """Create a DRAFT indent from a recipe's ingredient list.
+
+    POST params:
+        yield_qty  – target yield quantity (defaults to recipe.default_yield_qty)
+    """
+    if request.method != "POST":
+        return redirect("recipe_view_partial", pk=pk)
+
+    recipe = get_object_or_404(
+        Recipe.objects.prefetch_related(
+            Prefetch("items", queryset=RecipeItem.objects.select_related("item"))
+        ),
+        pk=pk,
+    )
+
+    try:
+        yield_qty = Decimal(str(request.POST.get("yield_qty") or recipe.default_yield_qty or 1))
+    except (ValueError, ArithmeticError):
+        yield_qty = _to_decimal(recipe.default_yield_qty) or Decimal("1")
+
+    base_yield = _to_decimal(recipe.default_yield_qty) or Decimal("1")
+    scale = yield_qty / base_yield if base_yield else Decimal("1")
+
+    ts = timezone.now().strftime("%Y%m%d%H%M%S%f")
+    mrn = f"MRN-{ts}"
+
+    indent = Indent.objects.create(
+        mrn=mrn,
+        notes=f"Recipe: {recipe.name}",
+        status="DRAFT",
+        date_required=None,
+    )
+
+    for row in recipe.items.all():
+        item = getattr(row, "item", None)
+        if not item:
+            continue
+        qty = _to_decimal(getattr(row, "quantity", None))
+        loss_pct = _to_decimal(getattr(row, "loss_pct", None))
+        effective_qty = qty * scale
+        if loss_pct and loss_pct < 100:
+            try:
+                effective_qty = effective_qty / (1 - loss_pct / 100)
+            except (ArithmeticError, ZeroDivisionError):
+                pass
+        effective_qty = effective_qty.quantize(TWOPLACES)
+        IndentItem.objects.create(
+            indent=indent,
+            item=item,
+            requested_qty=effective_qty,
+        )
+
+    messages.success(request, f"Indent {mrn} created from recipe", extra_tags="toast")
+    return redirect("indent_detail", pk=indent.pk)

--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -283,9 +283,11 @@
   function deleteItem(row) {
     const itemId = row?.dataset.itemId;
     if (!itemId) return;
+    const nameEl = row.querySelector('[id^="item-title-"]');
+    const itemName = nameEl ? nameEl.textContent.trim() : "this item";
     if (
       !confirm(
-        "Are you sure you want to delete this item? This action cannot be undone.",
+        `Delete "${itemName}"?\n\nThis will permanently remove the item. Any linked Recipes or Purchase Orders may be affected.\n\nThis action cannot be undone.`,
       )
     )
       return;
@@ -1016,6 +1018,9 @@
         : '<input id=\"bulk-dept-select\" placeholder=\"Dept ID\">';
       const html = `
           <div class=\"card\" style=\"max-width:480px\">\n          <div class=\"card-header\"><strong>Assign Department</strong></div>\n          <div class=\"card-body\">\n            <label class=\"block text-sm font-medium text-gray-700 mb-1\">Department</label>\n            ${selectHtml}\n            <div class=\"mt-3 flex\" style=\"gap:.5rem; justify-content:flex-end\">\n              <button type=\"button\" class=\"inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-white text-gray-700 border border-border hover:bg-secondaryHover focus:ring-2 focus:ring-primary\" data-modal-close>Cancel</button>\n              <button type=\"button\" class=\"inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary\" data-action=\"confirm-bulk\" data-action-type=\"assign_dept\">Assign</button>\n            </div>\n          </div>\n        </div>`;
+      if (window.modal) window.modal.open(html);
+    } else if (action === "delete") {
+      const html = `<div class="card" style="max-width:420px"><div class="card-header"><strong>Delete ${ids.length} item(s)?</strong></div><div class="card-body"><p class="mb-3" style="color:#991b1b">This will permanently delete the selected items. Any linked Recipes or Purchase Orders may be affected. This cannot be undone.</p><div class="flex" style="gap:.5rem;justify-content:flex-end"><button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle" data-modal-close>Cancel</button><button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-red-600 text-white hover:bg-red-700" data-action="confirm-bulk" data-action-type="delete">Delete</button></div></div></div>`;
       if (window.modal) window.modal.open(html);
     }
   });

--- a/static/js/recipe-components.js
+++ b/static/js/recipe-components.js
@@ -68,7 +68,14 @@
 
     var costElement = row.querySelector('[data-line-cost]');
     if (costElement) {
-      var lineCost = quantity * costPerBase;
+      // Apply loss %: effective_qty = qty / (1 - loss_pct/100)
+      var lossPctInput = row.querySelector('input[id$="-loss_pct"]');
+      var lossPct = lossPctInput ? toNumber(lossPctInput.value) : 0;
+      var effectiveQty = quantity;
+      if (lossPct > 0 && lossPct < 100) {
+        effectiveQty = quantity / (1 - lossPct / 100);
+      }
+      var lineCost = effectiveQty * costPerBase;
       costElement.textContent = lineCost.toFixed(2);
     }
 

--- a/templates/inventory/_item_detail_partial.html
+++ b/templates/inventory/_item_detail_partial.html
@@ -11,7 +11,6 @@
       <section class="bg-surface rounded-md border border-border p-4">
         <h3 class="text-sm font-semibold text-bodyText mb-3">Basic Information</h3>
         <dl class="grid grid-cols-1 gap-2 text-sm">
-          <div><dt class="text-gray-500">Item ID</dt><dd class="text-bodyText">{{ item.item_id }}</dd></div>
           <div><dt class="text-gray-500">Category</dt><dd class="text-bodyText">{{ item.category|default:"Not set" }}</dd></div>
           <div><dt class="text-gray-500">Sub Category</dt><dd class="text-bodyText">{{ item.sub_category|default:"Not set" }}</dd></div>
           <div><dt class="text-gray-500">Base Unit</dt><dd class="text-bodyText">{{ item.base_unit|default:"Not set" }}</dd></div>
@@ -22,18 +21,18 @@
       <section class="bg-surface rounded-md border border-border p-4">
         <h3 class="text-sm font-semibold text-bodyText mb-3">Stock Information</h3>
         <dl class="grid grid-cols-1 gap-2 text-sm">
-          <div><dt class="text-gray-500">Current Stock</dt><dd class="text-bodyText">{{ item.current_stock|default:"Not set" }}</dd></div>
-          <div><dt class="text-gray-500">Reorder Point</dt><dd class="text-bodyText">{{ item.reorder_point|default:"Not set" }}</dd></div>
-          <div><dt class="text-gray-500">Initial Purchase Price</dt><dd class="text-bodyText">{{ item.initial_purchase_price|default:"Not set" }}</dd></div>
-          <div><dt class="text-gray-500">Last Purchase Price</dt><dd class="text-bodyText">{{ item.last_purchase_price|default:"Not set" }}</dd></div>
+          <div><dt class="text-gray-500">Current Stock</dt><dd class="text-bodyText">{% if item.current_stock is not None %}{{ item.current_stock }}{% else %}Not set{% endif %}</dd></div>
+          <div><dt class="text-gray-500">Reorder Point</dt><dd class="text-bodyText">{% if item.reorder_point is not None %}{{ item.reorder_point }}{% else %}Not set{% endif %}</dd></div>
+          <div><dt class="text-gray-500">Initial Purchase Price</dt><dd class="text-bodyText">{% if item.initial_purchase_price is not None %}{{ item.initial_purchase_price }}{% else %}Not set{% endif %}</dd></div>
+          <div><dt class="text-gray-500">Last Purchase Price</dt><dd class="text-bodyText">{% if item.last_purchase_price is not None %}{{ item.last_purchase_price }}{% else %}Not set{% endif %}</dd></div>
         </dl>
       </section>
       <section class="bg-surface rounded-md border border-border p-4">
         <h3 class="text-sm font-semibold text-bodyText mb-3">Additional Details</h3>
         <dl class="grid grid-cols-1 gap-2 text-sm">
           <div><dt class="text-gray-500">Preferred Supplier</dt><dd class="text-bodyText">{{ item.preferred_supplier|default:"Not set" }}</dd></div>
-          <div><dt class="text-gray-500">Minimum Order Qty</dt><dd class="text-bodyText">{{ item.minimum_order_qty|default:"Not set" }}</dd></div>
-          <div><dt class="text-gray-500">Lead Time (Days)</dt><dd class="text-bodyText">{{ item.lead_time_days|default:"Not set" }}</dd></div>
+          <div><dt class="text-gray-500">Minimum Order Qty</dt><dd class="text-bodyText">{% if item.minimum_order_qty is not None %}{{ item.minimum_order_qty }}{% else %}Not set{% endif %}</dd></div>
+          <div><dt class="text-gray-500">Lead Time (Days)</dt><dd class="text-bodyText">{% if item.lead_time_days is not None %}{{ item.lead_time_days }}{% else %}Not set{% endif %}</dd></div>
           <div><dt class="text-gray-500">Notes</dt><dd class="text-bodyText">{{ item.notes|default:"None" }}</dd></div>
           <div><dt class="text-gray-500">Active</dt><dd class="text-bodyText">{% if item.is_active %}Yes{% else %}No{% endif %}</dd></div>
           <div><dt class="text-gray-500">Last Updated</dt><dd class="text-bodyText">{{ item.updated_at|date:"Y-m-d H:i" }}</dd></div>
@@ -52,6 +51,11 @@
         <li class="text-gray-500">No recent activity.</li>
         {% endfor %}
       </ul>
+    </div>
+    <div class="flex flex-wrap gap-2 pt-2 border-t border-border">
+      <a href="/stock-movements/?item={{ item.item_id }}" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-surface border border-border hover:bg-surfaceSubtle text-bodyText transition">Stock Movements</a>
+      <a href="{% url 'item_edit' item.item_id %}?partial=1" data-modal-url="{% url 'item_edit' item.item_id %}?partial=1" data-modal-type="drawer" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-surface border border-border hover:bg-surfaceSubtle text-bodyText transition">Edit Item →</a>
+      <a href="{% url 'indent_create' %}?item={{ item.item_id }}" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md bg-surface border border-border hover:bg-surfaceSubtle text-bodyText transition">Raise Indent</a>
     </div>
   </div>
 </div>

--- a/templates/inventory/_item_form_partial.html
+++ b/templates/inventory/_item_form_partial.html
@@ -28,9 +28,11 @@
               {% include "forms/feedback.html" %}
             </div>
             <div class="space-y-1">
-              <label for="{{ form.current_stock.id_for_label }}" class="block text-sm font-medium text-bodyText mb-1">Current Stock</label>
-              {{ form.current_stock }}
-              {% include "forms/feedback.html" %}
+              <label class="block text-sm font-medium text-bodyText mb-1">Current Stock</label>
+              <div class="flex items-center gap-3 h-9">
+                <span class="text-bodyText font-medium">{% if item.current_stock is not None %}{{ item.current_stock|floatformat:2 }}{% else %}—{% endif %}</span>
+                <a href="/stock-movements/?item={{ item.item_id }}" class="text-xs text-accent hover:underline">Adjust Stock →</a>
+              </div>
             </div>
             <div class="space-y-1">
               <label for="{{ form.reorder_point.id_for_label }}" class="block text-sm font-medium text-bodyText mb-1">Reorder Point</label>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -58,7 +58,7 @@
   <tbody class="bg-surface divide-y divide-border">
     {% for item in page_obj.object_list %}
     <tr
-      class="item-row odd:bg-surfaceSubtle odd:bg-gray-50 hover:bg-surfaceSubtle"
+      class="item-row odd:bg-surfaceSubtle odd:bg-gray-50 hover:bg-surfaceSubtle{% if item.current_stock is not None and item.current_stock < 0 %} !bg-red-50{% endif %}"
       data-item-id="{{ item.item_id }}"
       data-unit-id="{{ item.unit_id }}"
       data-category-id="{{ item.category_id }}"
@@ -93,7 +93,10 @@
   <td data-col="unit" class="px-4 py-2 whitespace-normal break-words">{{ item.unit.purchase_unit|default:"—" }}</td>
       <td data-col="stock" class="px-4 py-2 whitespace-normal break-words">
         {% if item.current_stock is not None %}
-          {{ item.current_stock|floatformat:0 }}
+          <span class="{% if item.current_stock < 0 %}text-danger font-medium{% endif %}">{{ item.current_stock|floatformat:0 }}</span>
+          {% if item.current_stock < 0 %}
+            <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-danger-soft text-danger ml-1">⚠ Negative</span>
+          {% endif %}
         {% else %}
           <span class="text-gray-400">—</span>
         {% endif %}
@@ -113,11 +116,18 @@
         {% endif %}
       </td>
       <td data-col="departments" class="px-4 py-2 whitespace-normal break-words">
-        {% if item.departments.all %} {% for dept in item.departments.all %}
-        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">{{ dept.name }}</span>
-        {% endfor %} {% else %}
-        <span class="text-gray-400">—</span>
+        {% with all_depts=item.departments.all %}
+        {% if all_depts %}
+          {% for dept in all_depts|slice:":2" %}
+          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">{{ dept.name }}</span>
+          {% endfor %}
+          {% if all_depts|length > 2 %}
+          <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-surfaceSubtle text-bodyText">+{{ all_depts|length|add:"-2" }} more</span>
+          {% endif %}
+        {% else %}
+          <span class="text-gray-400">—</span>
         {% endif %}
+        {% endwith %}
       </td>
       <td data-col="status" class="px-4 py-2 whitespace-normal break-words">
         {% if item.is_active %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -70,6 +70,7 @@
                   <div class="flex items-center gap-2">
                     <button type="button" data-bulk-action="deactivate" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Deactivate</button>
                     <button type="button" data-bulk-action="assign" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Assign Dept</button>
+                    <button type="button" data-bulk-action="delete" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-red-50 text-red-700 border border-red-200 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500">Delete Selected</button>
                   </div>
                 </div>
             <div class="relative" data-col-menu-container>
@@ -112,7 +113,7 @@
         <div class="flex items-center gap-2">
           <button type="button" data-bulk-action="deactivate" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Deactivate</button>
           <button type="button" data-bulk-action="assign" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Assign Dept</button>
-          
+          <button type="button" data-bulk-action="delete" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-red-50 text-red-700 border border-red-200 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500">Delete Selected</button>
         </div>
       </div>
       

--- a/templates/inventory/recipes/_view_partial.html
+++ b/templates/inventory/recipes/_view_partial.html
@@ -2,7 +2,13 @@
 <div class="bg-surface rounded-xl shadow border border-border overflow-hidden drawer-panel max-w-drawer-xl">
   <div class="px-4 py-3 border-b border-border bg-surfaceSubtle flex items-center justify-between">
     <h3 class="text-base font-semibold">{{ recipe.name }}</h3>
-    <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
+    <div class="flex items-center gap-2">
+      <button type="button"
+              class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none bg-surface text-primary border border-primary hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary"
+              data-modal-url="{% url 'recipe_edit_partial' recipe.pk %}"
+              data-modal-type="drawer">Edit Recipe</button>
+      <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
+    </div>
   </div>
   <div class="p-4 space-y-6">
     <section class="grid gap-4 md:grid-cols-3 text-sm">
@@ -48,37 +54,47 @@
     </section>
 
     <section class="space-y-3">
-      <h4 class="text-sm font-semibold">Ingredients</h4>
+      <div class="flex items-center justify-between">
+        <h4 class="text-sm font-semibold">Ingredients</h4>
+        <div class="flex items-center gap-2 text-sm">
+          <label class="text-xs text-gray-500 font-medium">Scale to yield:</label>
+          <input type="number" id="scale-qty" value="{{ recipe.default_yield_qty|floatformat:-2 }}" min="0.001" step="0.001"
+                 class="w-20 border border-border rounded px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-primary"
+                 data-base-yield="{{ recipe.default_yield_qty|floatformat:-2 }}">
+          <button type="button" onclick="scaleRecipeView()"
+                  class="inline-flex items-center px-2 py-1 text-xs font-medium rounded border border-border bg-surface hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">
+            Recalculate
+          </button>
+        </div>
+      </div>
       <div class="table-scroll bg-surface border border-border rounded-2xl shadow-sm" data-table-container>
         <table id="items-table" class="min-w-full w-full table-auto text-label">
           <thead class="text-left text-xs font-semibold uppercase tracking-wider bg-surfaceSubtle text-gray-600">
             <tr>
-              <th scope="col">Item</th>
-              <th scope="col">Qty</th>
-              <th scope="col">Unit</th>
-              <th scope="col">Loss %</th>
-              <th scope="col">Cost</th>
-              <th scope="col" class="w-8"></th>
+              <th scope="col" class="px-3 py-2">Item</th>
+              <th scope="col" class="px-3 py-2">Qty</th>
+              <th scope="col" class="px-3 py-2">Unit</th>
+              <th scope="col" class="px-3 py-2">Loss %</th>
+              <th scope="col" class="px-3 py-2">Cost</th>
             </tr>
           </thead>
           <tbody class="bg-surface divide-y divide-border">
             {% for item in items %}
-            <tr class="form-row" data-recipe-row="true" data-category="{{ item.category }}" data-subcategory="{{ item.subcategory }}" data-cost-per-base-unit="{{ item.cost_per_base_unit_str }}" data-quantity="{{ item.quantity_str }}" data-has-item="{% if item.has_item %}1{% else %}0{% endif %}" {% if item.has_zero_price %}data-has-zero-price="1"{% endif %}>
+            <tr class="form-row {% if item.has_zero_price %}bg-amber-50{% endif %}" data-recipe-row="true" data-category="{{ item.category }}" data-subcategory="{{ item.subcategory }}" data-cost-per-base-unit="{{ item.cost_per_base_unit_str }}" data-quantity="{{ item.quantity_str }}" data-has-item="{% if item.has_item %}1{% else %}0{% endif %}" {% if item.has_zero_price %}data-has-zero-price="1"{% endif %}>
               <td class="px-3 py-2 align-top">
                 <div class="font-medium text-bodyText">{{ item.name }}</div>
                 <div class="text-xs text-gray-500">{{ item.category }}</div>
               </td>
-              <td class="px-3 py-2 align-middle">{{ item.quantity|floatformat:-2 }}</td>
+              <td class="px-3 py-2 align-middle"><span data-base-qty="{{ item.quantity_str }}">{{ item.quantity|floatformat:-2 }}</span></td>
               <td class="px-3 py-2 align-middle">{{ item.unit|default:"—" }}</td>
               <td class="px-3 py-2 align-middle">{{ item.loss_pct|floatformat:-2 }}</td>
               <td class="px-3 py-2 align-middle">
-                <div class="text-sm" data-line-cost>{{ item.line_cost_str }}</div>
+                <div class="text-sm {% if item.has_zero_price %}text-amber-600{% endif %}" data-line-cost data-base-cost="{{ item.line_cost_str }}">{{ item.line_cost_str }}</div>
               </td>
-              <td class="px-3 py-2"></td>
             </tr>
             {% empty %}
             <tr>
-              <td colspan="6" class="px-4 py-6 text-center text-gray-500">No items added yet.</td>
+              <td colspan="5" class="px-4 py-6 text-center text-gray-500">No items added yet.</td>
             </tr>
             {% endfor %}
           </tbody>
@@ -94,6 +110,24 @@
         <div>Total Cost: <span id="recipe-total-cost">{{ total_cost|floatformat:2 }}</span></div>
       </div>
     </section>
+
+    {% if recipe.pk %}
+    <section>
+      <form method="post" action="{% url 'recipe_create_indent' recipe.pk %}">
+        {% csrf_token %}
+        <div class="flex items-center gap-3">
+          <label class="text-sm text-gray-600">Yield qty:
+            <input type="number" name="yield_qty" value="{{ recipe.default_yield_qty|floatformat:-2 }}" min="0.001" step="0.001"
+                   class="ml-1 w-20 border border-border rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary">
+          </label>
+          <button type="submit"
+                  class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary">
+            Request Ingredients
+          </button>
+        </div>
+      </form>
+    </section>
+    {% endif %}
   </div>
 </div>
 <script>
@@ -108,4 +142,27 @@
     window.updateRecipeCosts(rootScope);
   }
 })();
+
+function scaleRecipeView() {
+  var input = document.getElementById('scale-qty');
+  if (!input) return;
+  var baseYield = parseFloat(input.getAttribute('data-base-yield')) || 1;
+  var newYield = parseFloat(input.value) || baseYield;
+  var factor = newYield / baseYield;
+  document.querySelectorAll('[data-base-qty]').forEach(function(el) {
+    var base = parseFloat(el.getAttribute('data-base-qty')) || 0;
+    el.textContent = (base * factor).toFixed(3);
+  });
+  document.querySelectorAll('[data-line-cost][data-base-cost]').forEach(function(el) {
+    var base = parseFloat(el.getAttribute('data-base-cost')) || 0;
+    el.textContent = (base * factor).toFixed(2);
+  });
+  // Update total
+  var total = 0;
+  document.querySelectorAll('[data-line-cost][data-base-cost]').forEach(function(el) {
+    total += parseFloat(el.getAttribute('data-base-cost')) || 0;
+  });
+  var totalEl = document.getElementById('recipe-total-cost');
+  if (totalEl) totalEl.textContent = (total * factor).toFixed(2);
+}
 </script>

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -1,4 +1,5 @@
 {% extends "components/form_layout.html" %}
+{% load form_tags %}
 {% block title %}Recipe Detail – Inventory Pro{% endblock %}
 {% block heading %}{% if recipe %}Edit {{ recipe.name }}{% else %}New Recipe{% endif %}{% endblock %}
 {% block form_summary %}

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -4,14 +4,7 @@
 {% block page_subtitle %}
   <p class="text-sm text-gray-600">Keep production formulas and BOMs in one place.</p>
 {% endblock %}
-{% block page_meta %}
-  <div id="recipes-meta-summary" class="flex flex-wrap items-center gap-2 text-xs font-medium text-gray-600">
-    <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full border border-border bg-surfaceSubtle">Total: <span class="text-bodyText">{{ recipe_count|default:0 }}</span></span>
-    {% if q %}
-      <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full border border-border bg-surfaceSubtle">Filtered by: <span class="text-bodyText">“{{ q }}”</span></span>
-    {% endif %}
-  </div>
-{% endblock %}
+{% block page_meta %}{% endblock %}
 {% block hero_extra %}
   <div class="mt-4 bg-surfaceSubtle border border-dashed border-border rounded-lg p-3 text-sm text-gray-600">
     <span class="font-medium text-bodyText">Tip:</span> Use the drawer to add a new recipe while keeping this list in view.


### PR DESCRIPTION
## Summary
- Remove current_stock from Item Edit Form (read-only + Adjust Stock link)
- Fix View Drawer Not set for zero values; remove Item ID row; add cross-links
- Negative stock row highlight + badge
- Filter-aware KPI cards (total_active, low_stock_pct, stock_value from filtered qs)
- Enhanced single-item delete confirmation with item name + Recipes/POs warning
- Bulk Delete Selected (modal + ItemsBulkUpdateView handler)
- Department cell capped at 2 chips + N more badge

## Test plan
- [ ] /items/ loads, KPI cards filter-aware
- [ ] Edit item: current_stock read-only
- [ ] View item with zero stock/price: shows 0 not Not set
- [ ] Negative stock: red row + badge
- [ ] Bulk delete works
- [ ] Single delete shows item name
- [ ] 3+ departments shows 2 + N more