### PR TITLE
Fix 10 process flow audit bugs (P0-P2)

### DIFF
--- a/inventory/forms/purchase_forms.py
+++ b/inventory/forms/purchase_forms.py
@@ -113,8 +113,8 @@ class PurchaseOrderItemForm(StyledFormMixin, forms.ModelForm):
             if quantity < item.minimum_order_qty:
                 raise forms.ValidationError(
                     (
-                        f"Quantity ({quantity}) is below minimum order quantity "
-                        f"({item.minimum_order_qty}) for this item"
+                        f"Quantity ({quantity}) for '{item.name}' is below its "
+                        f"minimum order quantity ({item.minimum_order_qty})."
                     )
                 )
 

--- a/inventory/forms/recipe_forms.py
+++ b/inventory/forms/recipe_forms.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from django import forms
 
 from ..models import Item, Recipe, RecipeItem
+from ..models.recipes import RECIPE_TYPES
 from .base import StyledFormMixin
 
 INPUT_CLASS = (
@@ -34,11 +35,11 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
             }
         ),
     )
-    type = forms.CharField(
+    type = forms.ChoiceField(
         required=False,
-        max_length=50,
-        widget=forms.TextInput(attrs={"class": INPUT_CLASS}),
-        help_text="e.g., Main Course, Appetizer, Dessert",
+        choices=RECIPE_TYPES,
+        widget=forms.Select(attrs={"class": INPUT_CLASS}),
+        help_text="Category of this recipe",
     )
     default_yield_qty = forms.DecimalField(
         required=False,

--- a/inventory/models/orders.py
+++ b/inventory/models/orders.py
@@ -88,6 +88,7 @@ class PurchaseOrder(models.Model):
     """Orders items from a supplier based on approved indents."""
 
     po_id = models.AutoField(primary_key=True)
+    po_number = models.TextField(default="")
     supplier = models.ForeignKey(Supplier, models.CASCADE, db_column="supplier_id")
     order_date = models.DateField()
     expected_delivery_date = models.DateField(blank=True, null=True)
@@ -98,8 +99,15 @@ class PurchaseOrder(models.Model):
     )
     notes = models.TextField(blank=True, null=True, default="")
 
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        if not self.po_number:
+            self.po_number = f"PO-{self.po_id:04d}"
+            super().save(update_fields=["po_number"])
+
     def __str__(self) -> str:  # pragma: no cover - simple representation
-        return f"PO {self.pk} to {self.supplier}"
+        label = self.po_number or f"PO {self.pk}"
+        return f"{label} to {self.supplier}"
 
     class Meta:
         managed = True

--- a/inventory/models/recipes.py
+++ b/inventory/models/recipes.py
@@ -4,13 +4,26 @@ from django.db import models
 
 from .fields import CoerceFloatField
 
+RECIPE_TYPES = [
+    ("", "Select type..."),
+    ("MAIN", "Main Course"),
+    ("APPETIZER", "Appetizer / Starter"),
+    ("DESSERT", "Dessert"),
+    ("BEVERAGE", "Beverage"),
+    ("PREP", "Prep / Base Recipe"),
+    ("SAUCE", "Sauce / Dressing"),
+    ("SIDE", "Side Dish"),
+    ("BATCH", "Batch Production"),
+    ("OTHER", "Other"),
+]
+
 
 class Recipe(models.Model):
     recipe_id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255, unique=True, null=False, blank=False)
     description = models.TextField(blank=True, null=True)
     is_active = models.BooleanField(default=False, null=False)
-    type = models.CharField(max_length=50, blank=True, null=True)
+    type = models.CharField(max_length=50, blank=True, null=True, choices=RECIPE_TYPES)
     default_yield_qty = CoerceFloatField(default=Decimal("0"), blank=True, null=True)
     default_yield_unit = models.CharField(max_length=50, blank=True, null=True)
     plating_notes = models.TextField(blank=True, null=True, default="")

--- a/inventory/services/purchase_order_service.py
+++ b/inventory/services/purchase_order_service.py
@@ -71,7 +71,7 @@ def get_po_by_id(po_id: int) -> Optional[Dict[str, Any]]:
         return None
     header = {
         "po_id": po.po_id,
-        "po_number": generate_po_number() if po.po_id is None else f"PO-{po.po_id:04d}",
+        "po_number": po.po_number or f"PO-{po.po_id:04d}",
         "supplier_id": po.supplier_id,
         "supplier_name": po.supplier.name,
         "order_date": po.order_date,

--- a/inventory/views/purchase_orders.py
+++ b/inventory/views/purchase_orders.py
@@ -479,14 +479,14 @@ class PurchaseOrderCreatePartialView(View):
                         }
                     )
             try:
-                po = purchase_order_service.create_po(po_data, items_data)
+                po_id = purchase_order_service.create_po(po_data, items_data)
                 return JsonResponse(
                     {
                         "ok": True,
-                        "id": getattr(po, "pk", None),
+                        "id": po_id,
                         "message": "Purchase order created",
                         "redirect": reverse(
-                            "purchase_order_detail", kwargs={"pk": po.pk}
+                            "purchase_order_detail", kwargs={"pk": po_id}
                         ),
                     }
                 )

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -25,12 +25,26 @@ def _filtered_recipes_queryset(request):
         request,
         qs,
         search_fields=["name", "description"],
-        filter_fields={"active": "is_active"},
+        filter_fields={"active": "is_active", "type": "type"},
         allowed_sorts=["name", "type", "default_yield_unit", "is_active"],
         default_sort="name",
     )
     params.setdefault("q", "")
     params["recipe_count"] = qs.count()
+
+    # Build filter options for the template filter_bar
+    from inventory.models.recipes import RECIPE_TYPES
+
+    type_value = request.GET.get("type", "")
+    params["filters"] = [
+        {
+            "name": "type",
+            "label": "Type",
+            "value": type_value,
+            "options": [{"value": "", "label": "All Types"}]
+            + [{"value": v, "label": l} for v, l in RECIPE_TYPES if v],
+        },
+    ]
     return qs, params
 
 

--- a/inventory/views/settings.py
+++ b/inventory/views/settings.py
@@ -137,12 +137,19 @@ def settings_view(request):
         elif action == "add_department":
             name = request.POST.get("name", "").strip()
             if name:
-                try:
-                    Department.objects.get_or_create(name=name)
-                    messages.success(request, f"Department '{name}' added.")
-                except Exception as exc:
-                    logger.error("Failed to add department: %s", exc)
-                    messages.error(request, "Failed to add department.")
+                existing = Department.objects.filter(name__iexact=name).first()
+                if existing:
+                    messages.warning(
+                        request,
+                        f"A department with a similar name already exists: '{existing.name}'.",
+                    )
+                else:
+                    try:
+                        Department.objects.create(name=name)
+                        messages.success(request, f"Department '{name}' added.")
+                    except Exception as exc:
+                        logger.error("Failed to add department: %s", exc)
+                        messages.error(request, "Failed to add department.")
             else:
                 messages.error(request, "Department name is required.")
 
@@ -150,14 +157,25 @@ def settings_view(request):
             department_id = request.POST.get("department_id")
             name = request.POST.get("name", "").strip()
             if name:
-                try:
-                    Department.objects.filter(department_id=department_id).update(
-                        name=name
+                dup = (
+                    Department.objects.filter(name__iexact=name)
+                    .exclude(department_id=department_id)
+                    .first()
+                )
+                if dup:
+                    messages.warning(
+                        request,
+                        f"A department with a similar name already exists: '{dup.name}'.",
                     )
-                    messages.success(request, f"Department '{name}' updated.")
-                except Exception as exc:
-                    logger.error("Failed to edit department: %s", exc)
-                    messages.error(request, "Failed to update department.")
+                else:
+                    try:
+                        Department.objects.filter(department_id=department_id).update(
+                            name=name
+                        )
+                        messages.success(request, f"Department '{name}' updated.")
+                    except Exception as exc:
+                        logger.error("Failed to edit department: %s", exc)
+                        messages.error(request, "Failed to update department.")
             else:
                 messages.error(request, "Department name is required.")
 

--- a/templates/components/_confirm_modal.html
+++ b/templates/components/_confirm_modal.html
@@ -1,8 +1,4 @@
 {% load static %}
-{# Reusable delete-confirmation modal.
-   Trigger: confirmDelete(deleteUrl, itemName, entityType)
-   The modal submits a POST form to deleteUrl with a CSRF token.
-#}
 <div id="confirmModal"
      class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
      style="display:none!important"

--- a/templates/inventory/grns/create.html
+++ b/templates/inventory/grns/create.html
@@ -44,6 +44,22 @@
           <a href="{% url 'purchase_orders_list' %}" class="mt-2 inline-block text-sm text-primary hover:underline">View all purchase orders →</a>
         </div>
       {% endif %}
+
+      {# Ad-hoc receipt without PO #}
+      <div class="mt-6 p-4 border border-dashed border-border rounded-xl bg-surfaceSubtle">
+        <div class="flex items-start gap-3">
+          {% icon 'inbox-arrow-down' 'w-5 h-5 text-gray-400 mt-0.5 flex-shrink-0' %}
+          <div>
+            <h3 class="text-sm font-semibold text-bodyText">No Purchase Order?</h3>
+            <p class="text-xs text-gray-500 mt-0.5">Record an ad-hoc receipt for emergency or walk-in purchases directly as a stock adjustment.</p>
+            <a href="{% url 'stock_movements' %}?type=RECEIVING"
+               class="inline-flex items-center gap-1 mt-2 text-sm font-medium text-primary hover:underline">
+              {% icon 'arrow-right' 'w-4 h-4' %}
+              Record Ad-hoc Receipt
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
 
     {% else %}

--- a/templates/inventory/visualizations.html
+++ b/templates/inventory/visualizations.html
@@ -81,7 +81,7 @@
         marker: { size: 6, color: color }
       }], {
         title: label + ' Over Time',
-        xaxis: { title: 'Date', type: 'date' },
+        xaxis: { title: 'Date', type: 'date', tickformat: '%b %d, %Y', dtick: 86400000 },
         yaxis: { title: 'Quantity', rangemode: 'tozero' },
         paper_bgcolor: 'transparent',
         plot_bgcolor:  'transparent',
@@ -98,7 +98,7 @@
         showscale: true
       }], {
         title: 'Stock Activity Heatmap',
-        xaxis: { title: 'Date', type: 'date' },
+        xaxis: { title: 'Date', type: 'date', tickformat: '%b %d, %Y', dtick: 86400000 },
         paper_bgcolor: 'transparent',
         plot_bgcolor:  'transparent',
         margin: { t: 40, r: 80, b: 50, l: 100 },


### PR DESCRIPTION
## Summary

Fixes all 10 bugs found during the live process flow audit.

### P0 — Critical
- **FLOW-01/02**: PO creation completely broken — `po_number` field missing from Django model (exists in DB). Added field, auto-generate on save, fixed `create_po()` return value handling
- **FLOW-17**: Django template comment visible as text on Recipes & Settings pages — multi-line `{# #}` comment (Django only supports single-line). Removed.

### P1 — High
- **FLOW-03**: PO drawer form 500 error causing full-page navigation — view called `.pk` on an `int` return value
- **FLOW-07**: Recipe Type changed from free-text to dropdown with 9 predefined choices + filter on list page
- **FLOW-15**: Visualization charts show millisecond x-axis — added explicit Plotly `tickformat` and `dtick`

### P2 — Medium
- **FLOW-05**: Added "Receive Without PO" option on GRN create page
- **FLOW-06**: MOQ validation error now includes item name
- **FLOW-18**: Case-insensitive department name uniqueness check on add/edit

## Test plan
- [ ] Consolidation → Create Purchase Orders → Confirm: POs created
- [ ] New PO drawer → Save → PO created, drawer closes
- [ ] Quick PO button opens drawer
- [ ] No template comment text on Recipes/Settings pages
- [ ] Recipe form shows Type as dropdown
- [ ] Visualization charts show date labels (not milliseconds)
- [ ] GRN create page shows "Receive Without PO" option
- [ ] MOQ error includes item name
- [ ] Duplicate department name (case-insensitive) shows warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)