### PR TITLE
fix: make Phase D migrations idempotent for drifted production schema

### DIFF
--- a/inventory/forms/purchase_forms.py
+++ b/inventory/forms/purchase_forms.py
@@ -175,14 +175,18 @@ class AdhocGRNForm(StyledFormMixin, forms.ModelForm):
     delivery_note_number = forms.CharField(
         required=False,
         label="Delivery Note / Invoice #",
-        widget=forms.TextInput(attrs={"class": INPUT_CLASS, "placeholder": "e.g. INV-2024-001"}),
+        widget=forms.TextInput(
+            attrs={"class": INPUT_CLASS, "placeholder": "e.g. INV-2024-001"}
+        ),
     )
 
     class Meta:
         model = GoodsReceivedNote
         fields = ["supplier", "received_date", "delivery_note_number", "notes"]
         widgets = {
-            "received_date": forms.DateInput(attrs={"type": "date", "class": INPUT_CLASS}),
+            "received_date": forms.DateInput(
+                attrs={"type": "date", "class": INPUT_CLASS}
+            ),
         }
 
     def __init__(self, *args, **kwargs):
@@ -202,14 +206,28 @@ class AdhocGRNLineForm(StyledFormMixin, forms.Form):
         min_value=Decimal("0.01"),
         decimal_places=2,
         label="Quantity",
-        widget=forms.NumberInput(attrs={"class": INPUT_CLASS, "step": "0.01", "min": "0.01", "placeholder": "0.00"}),
+        widget=forms.NumberInput(
+            attrs={
+                "class": INPUT_CLASS,
+                "step": "0.01",
+                "min": "0.01",
+                "placeholder": "0.00",
+            }
+        ),
     )
     unit_price = forms.DecimalField(
         min_value=Decimal("0"),
         decimal_places=2,
         required=False,
         label="Unit Price",
-        widget=forms.NumberInput(attrs={"class": INPUT_CLASS, "step": "0.01", "min": "0", "placeholder": "0.00"}),
+        widget=forms.NumberInput(
+            attrs={
+                "class": INPUT_CLASS,
+                "step": "0.01",
+                "min": "0",
+                "placeholder": "0.00",
+            }
+        ),
     )
     item_notes = forms.CharField(
         required=False,

--- a/inventory/forms/recipe_forms.py
+++ b/inventory/forms/recipe_forms.py
@@ -6,8 +6,6 @@ from ..models import Item, Recipe, RecipeItem
 from ..models.recipes import RECIPE_TYPES
 from .base import StyledFormMixin
 
-
-
 INPUT_CLASS = (
     "w-full px-3 py-2 text-sm border border-gray-300 rounded-lg "
     "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
@@ -81,7 +79,12 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
         required=False,
         decimal_places=2,
         widget=forms.NumberInput(
-            attrs={"class": INPUT_CLASS, "step": "0.01", "min": "0", "placeholder": "e.g. 25.00"}
+            attrs={
+                "class": INPUT_CLASS,
+                "step": "0.01",
+                "min": "0",
+                "placeholder": "e.g. 25.00",
+            }
         ),
         label="Menu Selling Price",
         help_text="Selling price excluding tax",
@@ -91,7 +94,13 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
         decimal_places=2,
         initial=30.00,
         widget=forms.NumberInput(
-            attrs={"class": INPUT_CLASS, "step": "0.1", "min": "0", "max": "100", "placeholder": "30.0"}
+            attrs={
+                "class": INPUT_CLASS,
+                "step": "0.1",
+                "min": "0",
+                "max": "100",
+                "placeholder": "30.0",
+            }
         ),
         label="Target Food Cost %",
         help_text="Target food cost as % of selling price (typically 28–32%)",

--- a/inventory/forms/stock_forms.py
+++ b/inventory/forms/stock_forms.py
@@ -289,7 +289,12 @@ class StockTransferForm(StyledFormMixin, forms.Form):
         min_value=Decimal("0.01"),
         decimal_places=2,
         widget=forms.NumberInput(
-            attrs={"class": INPUT_CLASS, "step": "0.01", "min": "0.01", "placeholder": "e.g. 5"}
+            attrs={
+                "class": INPUT_CLASS,
+                "step": "0.01",
+                "min": "0.01",
+                "placeholder": "e.g. 5",
+            }
         ),
         label="Quantity",
     )
@@ -314,6 +319,7 @@ class StockTransferForm(StyledFormMixin, forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         from ..models import Department as Dept
+
         qs = Dept.objects.all().order_by("name")
         self.fields["from_department"].queryset = qs
         self.fields["to_department"].queryset = qs

--- a/inventory/migrations/0026_purchaseorder_po_number_purchaseorderitem_line_total_and_more.py
+++ b/inventory/migrations/0026_purchaseorder_po_number_purchaseorderitem_line_total_and_more.py
@@ -5,13 +5,13 @@
 # without attempting to re-create the columns.
 
 from decimal import Decimal
+
 from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-
         ("inventory", "0024_fix_pk_sequences"),
     ]
 

--- a/inventory/migrations/0027_indent_source_recipe.py
+++ b/inventory/migrations/0027_indent_source_recipe.py
@@ -2,6 +2,11 @@
 #
 # Adds a nullable source_recipe FK to the Indent model so the list view
 # can display whether an indent was created manually or from a Recipe.
+#
+# source_recipe_id already exists in the live DB (added by the old
+# 0025_phase_d_features migration that was later deleted and renumbered).
+# This migration is state-only so Django's ORM knows about the field
+# without attempting to re-create the column.
 
 import django.db.models.deletion
 from django.db import migrations, models
@@ -17,16 +22,21 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name="indent",
-            name="source_recipe",
-            field=models.ForeignKey(
-                blank=True,
-                db_column="source_recipe_id",
-                null=True,
-                on_delete=django.db.models.deletion.SET_NULL,
-                related_name="indents",
-                to="inventory.recipe",
-            ),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="indent",
+                    name="source_recipe",
+                    field=models.ForeignKey(
+                        blank=True,
+                        db_column="source_recipe_id",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="indents",
+                        to="inventory.recipe",
+                    ),
+                ),
+            ],
+            database_operations=[],  # Column already exists in production DB
         ),
     ]

--- a/inventory/migrations/0029_phase_d_features.py
+++ b/inventory/migrations/0029_phase_d_features.py
@@ -2,19 +2,12 @@
 # 0025_phase_d_features.py (0025 was already occupied by
 # 0025_alter_stocksnapshot_options_and_more which is applied on production).
 #
-# This migration depends on 0028 and only contains operations NOT already
-# covered by 0025–0028:
-#   - Removes recipeitem unique_together (state + defensive DDL)
-#   - Adds delivery_note_number to GoodsReceivedNote
-#   - Adds direct item FK to GRNItem (ad-hoc GRN support)
-#   - Adds selling_price + target_food_cost_pct to Recipe
-#   - Adds sub_recipe FK to RecipeItem
-#   - Adds from_department + to_department to StockTransaction
-#   - Makes GoodsReceivedNote.purchase_order nullable (ad-hoc GRN)
-#   - Makes GRNItem.po_item nullable
-#   - Adds default=0 to GRNItem.quantity_ordered_on_po
-#   - Makes RecipeItem.item nullable (sub-recipe support)
-#   - Creates StockTake + StockTakeItem models
+# All DDL operations are written defensively (ADD COLUMN IF NOT EXISTS,
+# CREATE TABLE IF NOT EXISTS, etc.) because the original 0025_phase_d_features
+# was applied to the production database before it was deleted and renumbered.
+# This allows the migration to run on both:
+#   - Production DB (columns already exist → no-op)
+#   - Fresh DB (columns don't exist → creates them)
 
 import django.db.models.deletion
 from django.conf import settings
@@ -61,253 +54,458 @@ class Migration(migrations.Migration):
                 ),
             ],
         ),
-
         # ── 2. GoodsReceivedNote: add delivery_note_number ────────────────
-        migrations.AddField(
-            model_name="goodsreceivednote",
-            name="delivery_note_number",
-            field=models.CharField(
-                blank=True,
-                help_text="Delivery note or invoice number",
-                max_length=100,
-                null=True,
-            ),
-        ),
-
-        # ── 3. GRNItem: add direct item FK (ad-hoc GRNs without a PO) ────
-        migrations.AddField(
-            model_name="grnitem",
-            name="item",
-            field=models.ForeignKey(
-                blank=True,
-                db_column="direct_item_id",
-                help_text="Direct item reference (for ad-hoc GRNs without a PO)",
-                null=True,
-                on_delete=django.db.models.deletion.PROTECT,
-                related_name="grn_items",
-                to="inventory.item",
-            ),
-        ),
-
-        # ── 4. Recipe: selling_price + target_food_cost_pct ──────────────
-        migrations.AddField(
-            model_name="recipe",
-            name="selling_price",
-            field=models.DecimalField(
-                blank=True,
-                decimal_places=2,
-                help_text="Menu selling price (ex. tax)",
-                max_digits=10,
-                null=True,
-            ),
-        ),
-        migrations.AddField(
-            model_name="recipe",
-            name="target_food_cost_pct",
-            field=models.DecimalField(
-                blank=True,
-                decimal_places=2,
-                default=30.0,
-                help_text="Target food cost percentage for this item type",
-                max_digits=5,
-                null=True,
-            ),
-        ),
-
-        # ── 5. RecipeItem: sub_recipe FK ──────────────────────────────────
-        migrations.AddField(
-            model_name="recipeitem",
-            name="sub_recipe",
-            field=models.ForeignKey(
-                blank=True,
-                db_column="sub_recipe_id",
-                help_text="Sub-recipe used as an ingredient",
-                null=True,
-                on_delete=django.db.models.deletion.SET_NULL,
-                related_name="used_in",
-                to="inventory.recipe",
-            ),
-        ),
-
-        # ── 6. StockTransaction: from/to department FKs ──────────────────
-        migrations.AddField(
-            model_name="stocktransaction",
-            name="from_department",
-            field=models.ForeignKey(
-                blank=True,
-                help_text="Source department (for TRANSFER type only)",
-                null=True,
-                on_delete=django.db.models.deletion.SET_NULL,
-                related_name="transfers_out",
-                to="inventory.department",
-            ),
-        ),
-        migrations.AddField(
-            model_name="stocktransaction",
-            name="to_department",
-            field=models.ForeignKey(
-                blank=True,
-                help_text="Destination department (for TRANSFER type only)",
-                null=True,
-                on_delete=django.db.models.deletion.SET_NULL,
-                related_name="transfers_in",
-                to="inventory.department",
-            ),
-        ),
-
-        # ── 7. GoodsReceivedNote.purchase_order → nullable ────────────────
-        migrations.AlterField(
-            model_name="goodsreceivednote",
-            name="purchase_order",
-            field=models.ForeignKey(
-                blank=True,
-                db_column="po_id",
-                null=True,
-                on_delete=django.db.models.deletion.SET_NULL,
-                to="inventory.purchaseorder",
-            ),
-        ),
-
-        # ── 8. GRNItem.po_item → nullable ────────────────────────────────
-        migrations.AlterField(
-            model_name="grnitem",
-            name="po_item",
-            field=models.ForeignKey(
-                blank=True,
-                db_column="po_item_id",
-                null=True,
-                on_delete=django.db.models.deletion.SET_NULL,
-                to="inventory.purchaseorderitem",
-            ),
-        ),
-
-        # ── 9. GRNItem.quantity_ordered_on_po → default=0 ────────────────
-        migrations.AlterField(
-            model_name="grnitem",
-            name="quantity_ordered_on_po",
-            field=models.DecimalField(decimal_places=2, default=0, max_digits=10),
-        ),
-
-        # ── 10. RecipeItem.item → nullable (required for sub-recipes) ─────
-        migrations.AlterField(
-            model_name="recipeitem",
-            name="item",
-            field=models.ForeignKey(
-                blank=True,
-                db_column="item_id",
-                null=True,
-                on_delete=django.db.models.deletion.CASCADE,
-                related_name="recipe_usages",
-                to="inventory.item",
-            ),
-        ),
-
-        # ── 11. Create StockTake model ────────────────────────────────────
-        migrations.CreateModel(
-            name="StockTake",
-            fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                ("date", models.DateField()),
-                (
-                    "status",
-                    models.CharField(
-                        choices=[
-                            ("DRAFT", "Draft"),
-                            ("IN_PROGRESS", "In Progress"),
-                            ("COMPLETED", "Completed"),
-                        ],
-                        default="DRAFT",
-                        max_length=20,
-                    ),
-                ),
-                ("notes", models.TextField(blank=True)),
-                ("created_at", models.DateTimeField(auto_now_add=True)),
-                ("completed_at", models.DateTimeField(blank=True, null=True)),
-                (
-                    "created_by",
-                    models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to=settings.AUTH_USER_MODEL,
-                    ),
-                ),
-                (
-                    "department",
-                    models.ForeignKey(
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="goodsreceivednote",
+                    name="delivery_note_number",
+                    field=models.CharField(
                         blank=True,
-                        help_text="Leave blank for a full stock-take across all departments",
+                        help_text="Delivery note or invoice number",
+                        max_length=100,
+                        null=True,
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE goods_received_notes ADD COLUMN IF NOT EXISTS delivery_note_number VARCHAR(100);",
+                    reverse_sql="ALTER TABLE goods_received_notes DROP COLUMN IF EXISTS delivery_note_number;",
+                ),
+            ],
+        ),
+        # ── 3. GRNItem: add direct item FK (ad-hoc GRNs without a PO) ────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="grnitem",
+                    name="item",
+                    field=models.ForeignKey(
+                        blank=True,
+                        db_column="direct_item_id",
+                        help_text="Direct item reference (for ad-hoc GRNs without a PO)",
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="grn_items",
+                        to="inventory.item",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    ALTER TABLE grn_items ADD COLUMN IF NOT EXISTS direct_item_id BIGINT;
+                    DO $$ BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1 FROM information_schema.table_constraints
+                            WHERE constraint_type = 'FOREIGN KEY'
+                              AND table_name = 'grn_items'
+                              AND constraint_name LIKE '%direct_item_id%'
+                        ) THEN
+                            ALTER TABLE grn_items
+                                ADD CONSTRAINT grn_items_direct_item_id_items_fk
+                                FOREIGN KEY (direct_item_id) REFERENCES items(id)
+                                DEFERRABLE INITIALLY DEFERRED;
+                        END IF;
+                    END $$;
+                    """,
+                    reverse_sql="ALTER TABLE grn_items DROP COLUMN IF EXISTS direct_item_id;",
+                ),
+            ],
+        ),
+        # ── 4. Recipe: selling_price ──────────────────────────────────────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="recipe",
+                    name="selling_price",
+                    field=models.DecimalField(
+                        blank=True,
+                        decimal_places=2,
+                        help_text="Menu selling price (ex. tax)",
+                        max_digits=10,
+                        null=True,
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE recipes ADD COLUMN IF NOT EXISTS selling_price NUMERIC(10, 2);",
+                    reverse_sql="ALTER TABLE recipes DROP COLUMN IF EXISTS selling_price;",
+                ),
+            ],
+        ),
+        # ── 5. Recipe: target_food_cost_pct ──────────────────────────────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="recipe",
+                    name="target_food_cost_pct",
+                    field=models.DecimalField(
+                        blank=True,
+                        decimal_places=2,
+                        default=30.0,
+                        help_text="Target food cost percentage for this item type",
+                        max_digits=5,
+                        null=True,
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE recipes ADD COLUMN IF NOT EXISTS target_food_cost_pct NUMERIC(5, 2) DEFAULT 30.0;",
+                    reverse_sql="ALTER TABLE recipes DROP COLUMN IF EXISTS target_food_cost_pct;",
+                ),
+            ],
+        ),
+        # ── 6. RecipeItem: sub_recipe FK ──────────────────────────────────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="recipeitem",
+                    name="sub_recipe",
+                    field=models.ForeignKey(
+                        blank=True,
+                        db_column="sub_recipe_id",
+                        help_text="Sub-recipe used as an ingredient",
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="used_in",
+                        to="inventory.recipe",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    ALTER TABLE recipe_items ADD COLUMN IF NOT EXISTS sub_recipe_id BIGINT;
+                    DO $$ BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1 FROM information_schema.table_constraints
+                            WHERE constraint_type = 'FOREIGN KEY'
+                              AND table_name = 'recipe_items'
+                              AND constraint_name LIKE '%sub_recipe_id%'
+                        ) THEN
+                            ALTER TABLE recipe_items
+                                ADD CONSTRAINT recipe_items_sub_recipe_id_recipes_fk
+                                FOREIGN KEY (sub_recipe_id) REFERENCES recipes(id)
+                                DEFERRABLE INITIALLY DEFERRED;
+                        END IF;
+                    END $$;
+                    """,
+                    reverse_sql="ALTER TABLE recipe_items DROP COLUMN IF EXISTS sub_recipe_id;",
+                ),
+            ],
+        ),
+        # ── 7. StockTransaction: from_department FK ───────────────────────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="stocktransaction",
+                    name="from_department",
+                    field=models.ForeignKey(
+                        blank=True,
+                        help_text="Source department (for TRANSFER type only)",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="transfers_out",
                         to="inventory.department",
                     ),
                 ),
             ],
-            options={
-                "db_table": "stock_takes",
-                "ordering": ["-date", "-created_at"],
-                "managed": True,
-            },
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    ALTER TABLE stock_transactions ADD COLUMN IF NOT EXISTS from_department_id BIGINT;
+                    DO $$ BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1 FROM information_schema.table_constraints
+                            WHERE constraint_type = 'FOREIGN KEY'
+                              AND table_name = 'stock_transactions'
+                              AND constraint_name LIKE '%from_department_id%'
+                        ) THEN
+                            ALTER TABLE stock_transactions
+                                ADD CONSTRAINT stock_transactions_from_department_id_fk
+                                FOREIGN KEY (from_department_id) REFERENCES departments(id)
+                                DEFERRABLE INITIALLY DEFERRED;
+                        END IF;
+                    END $$;
+                    """,
+                    reverse_sql="ALTER TABLE stock_transactions DROP COLUMN IF EXISTS from_department_id;",
+                ),
+            ],
         ),
-
-        # ── 12. Create StockTakeItem model ────────────────────────────────
-        migrations.CreateModel(
-            name="StockTakeItem",
-            fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                (
-                    "system_qty",
-                    models.DecimalField(
-                        decimal_places=3,
-                        help_text="Auto-populated from current stock at time of stock-take creation",
-                        max_digits=10,
-                    ),
-                ),
-                (
-                    "physical_qty",
-                    models.DecimalField(
+        # ── 8. StockTransaction: to_department FK ─────────────────────────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name="stocktransaction",
+                    name="to_department",
+                    field=models.ForeignKey(
                         blank=True,
-                        decimal_places=3,
-                        help_text="Actual counted quantity entered by staff",
-                        max_digits=10,
+                        help_text="Destination department (for TRANSFER type only)",
                         null=True,
-                    ),
-                ),
-                ("notes", models.TextField(blank=True)),
-                (
-                    "item",
-                    models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
-                        to="inventory.item",
-                    ),
-                ),
-                (
-                    "stock_take",
-                    models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
-                        related_name="items",
-                        to="inventory.stocktake",
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="transfers_in",
+                        to="inventory.department",
                     ),
                 ),
             ],
-            options={
-                "db_table": "stock_take_items",
-                "ordering": ["item__name"],
-                "managed": True,
-            },
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    ALTER TABLE stock_transactions ADD COLUMN IF NOT EXISTS to_department_id BIGINT;
+                    DO $$ BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1 FROM information_schema.table_constraints
+                            WHERE constraint_type = 'FOREIGN KEY'
+                              AND table_name = 'stock_transactions'
+                              AND constraint_name LIKE '%to_department_id%'
+                        ) THEN
+                            ALTER TABLE stock_transactions
+                                ADD CONSTRAINT stock_transactions_to_department_id_fk
+                                FOREIGN KEY (to_department_id) REFERENCES departments(id)
+                                DEFERRABLE INITIALLY DEFERRED;
+                        END IF;
+                    END $$;
+                    """,
+                    reverse_sql="ALTER TABLE stock_transactions DROP COLUMN IF EXISTS to_department_id;",
+                ),
+            ],
+        ),
+        # ── 9. GoodsReceivedNote.purchase_order → nullable ────────────────
+        # AlterField is idempotent in PostgreSQL (DROP NOT NULL on already-nullable
+        # column is a no-op).
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="goodsreceivednote",
+                    name="purchase_order",
+                    field=models.ForeignKey(
+                        blank=True,
+                        db_column="po_id",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="inventory.purchaseorder",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE goods_received_notes ALTER COLUMN po_id DROP NOT NULL;",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+        # ── 10. GRNItem.po_item → nullable ────────────────────────────────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="grnitem",
+                    name="po_item",
+                    field=models.ForeignKey(
+                        blank=True,
+                        db_column="po_item_id",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="inventory.purchaseorderitem",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE grn_items ALTER COLUMN po_item_id DROP NOT NULL;",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+        # ── 11. GRNItem.quantity_ordered_on_po → default=0 ───────────────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="grnitem",
+                    name="quantity_ordered_on_po",
+                    field=models.DecimalField(
+                        decimal_places=2, default=0, max_digits=10
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE grn_items ALTER COLUMN quantity_ordered_on_po SET DEFAULT 0;",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+        # ── 12. RecipeItem.item → nullable (required for sub-recipes) ─────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="recipeitem",
+                    name="item",
+                    field=models.ForeignKey(
+                        blank=True,
+                        db_column="item_id",
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="recipe_usages",
+                        to="inventory.item",
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE recipe_items ALTER COLUMN item_id DROP NOT NULL;",
+                    reverse_sql=migrations.RunSQL.noop,
+                ),
+            ],
+        ),
+        # ── 13. Create StockTake model ────────────────────────────────────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="StockTake",
+                    fields=[
+                        (
+                            "id",
+                            models.BigAutoField(
+                                auto_created=True,
+                                primary_key=True,
+                                serialize=False,
+                                verbose_name="ID",
+                            ),
+                        ),
+                        ("date", models.DateField()),
+                        (
+                            "status",
+                            models.CharField(
+                                choices=[
+                                    ("DRAFT", "Draft"),
+                                    ("IN_PROGRESS", "In Progress"),
+                                    ("COMPLETED", "Completed"),
+                                ],
+                                default="DRAFT",
+                                max_length=20,
+                            ),
+                        ),
+                        ("notes", models.TextField(blank=True)),
+                        ("created_at", models.DateTimeField(auto_now_add=True)),
+                        ("completed_at", models.DateTimeField(blank=True, null=True)),
+                        (
+                            "created_by",
+                            models.ForeignKey(
+                                on_delete=django.db.models.deletion.CASCADE,
+                                to=settings.AUTH_USER_MODEL,
+                            ),
+                        ),
+                        (
+                            "department",
+                            models.ForeignKey(
+                                blank=True,
+                                help_text="Leave blank for a full stock-take across all departments",
+                                null=True,
+                                on_delete=django.db.models.deletion.SET_NULL,
+                                to="inventory.department",
+                            ),
+                        ),
+                    ],
+                    options={
+                        "db_table": "stock_takes",
+                        "ordering": ["-date", "-created_at"],
+                        "managed": True,
+                    },
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    CREATE TABLE IF NOT EXISTS stock_takes (
+                        id BIGSERIAL PRIMARY KEY,
+                        date DATE NOT NULL,
+                        status VARCHAR(20) NOT NULL DEFAULT 'DRAFT',
+                        notes TEXT NOT NULL DEFAULT '',
+                        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                        completed_at TIMESTAMPTZ,
+                        created_by_id INTEGER NOT NULL REFERENCES auth_user(id) DEFERRABLE INITIALLY DEFERRED,
+                        department_id BIGINT REFERENCES departments(id) DEFERRABLE INITIALLY DEFERRED
+                    );
+                    """,
+                    reverse_sql="DROP TABLE IF EXISTS stock_takes;",
+                ),
+            ],
+        ),
+        # ── 14. Create StockTakeItem model ────────────────────────────────
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="StockTakeItem",
+                    fields=[
+                        (
+                            "id",
+                            models.BigAutoField(
+                                auto_created=True,
+                                primary_key=True,
+                                serialize=False,
+                                verbose_name="ID",
+                            ),
+                        ),
+                        (
+                            "system_qty",
+                            models.DecimalField(
+                                decimal_places=3,
+                                help_text="Auto-populated from current stock at time of stock-take creation",
+                                max_digits=10,
+                            ),
+                        ),
+                        (
+                            "physical_qty",
+                            models.DecimalField(
+                                blank=True,
+                                decimal_places=3,
+                                help_text="Actual counted quantity entered by staff",
+                                max_digits=10,
+                                null=True,
+                            ),
+                        ),
+                        ("notes", models.TextField(blank=True)),
+                        (
+                            "item",
+                            models.ForeignKey(
+                                on_delete=django.db.models.deletion.CASCADE,
+                                to="inventory.item",
+                            ),
+                        ),
+                        (
+                            "stock_take",
+                            models.ForeignKey(
+                                on_delete=django.db.models.deletion.CASCADE,
+                                related_name="items",
+                                to="inventory.stocktake",
+                            ),
+                        ),
+                    ],
+                    options={
+                        "db_table": "stock_take_items",
+                        "ordering": ["item__name"],
+                        "managed": True,
+                    },
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="""
+                    CREATE TABLE IF NOT EXISTS stock_take_items (
+                        id BIGSERIAL PRIMARY KEY,
+                        system_qty NUMERIC(10, 3) NOT NULL,
+                        physical_qty NUMERIC(10, 3),
+                        notes TEXT NOT NULL DEFAULT '',
+                        item_id BIGINT NOT NULL REFERENCES items(id) DEFERRABLE INITIALLY DEFERRED,
+                        stock_take_id BIGINT NOT NULL REFERENCES stock_takes(id) DEFERRABLE INITIALLY DEFERRED
+                    );
+                    """,
+                    reverse_sql="DROP TABLE IF EXISTS stock_take_items;",
+                ),
+            ],
         ),
     ]

--- a/inventory/models/items.py
+++ b/inventory/models/items.py
@@ -144,14 +144,16 @@ class StockTransaction(models.Model):
     # D3: Transfer support — source/destination departments
     from_department = models.ForeignKey(
         "inventory.Department",
-        null=True, blank=True,
+        null=True,
+        blank=True,
         on_delete=models.SET_NULL,
         related_name="transfers_out",
         help_text="Source department (for TRANSFER type only)",
     )
     to_department = models.ForeignKey(
         "inventory.Department",
-        null=True, blank=True,
+        null=True,
+        blank=True,
         on_delete=models.SET_NULL,
         related_name="transfers_in",
         help_text="Destination department (for TRANSFER type only)",

--- a/inventory/models/orders.py
+++ b/inventory/models/orders.py
@@ -208,8 +208,11 @@ class GoodsReceivedNote(models.Model):
     grn_id = models.AutoField(primary_key=True)
     # D6: Made nullable to support ad-hoc GRNs without a PO
     purchase_order = models.ForeignKey(
-        PurchaseOrder, models.SET_NULL, db_column="po_id",
-        null=True, blank=True,
+        PurchaseOrder,
+        models.SET_NULL,
+        db_column="po_id",
+        null=True,
+        blank=True,
     )
     supplier = models.ForeignKey(Supplier, models.CASCADE, db_column="supplier_id")
     received_date = models.DateField()
@@ -217,8 +220,10 @@ class GoodsReceivedNote(models.Model):
     attachment = models.FileField(upload_to="grn_attachments/", blank=True, null=True)
     # D6: Delivery note / invoice number for ad-hoc GRNs
     delivery_note_number = models.CharField(
-        max_length=100, blank=True, null=True,
-        help_text="Delivery note or invoice number"
+        max_length=100,
+        blank=True,
+        null=True,
+        help_text="Delivery note or invoice number",
     )
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
@@ -238,13 +243,19 @@ class GRNItem(models.Model):
     grn = models.ForeignKey(GoodsReceivedNote, models.CASCADE, db_column="grn_id")
     # D6: Made nullable to support ad-hoc GRNs without a PO
     po_item = models.ForeignKey(
-        PurchaseOrderItem, models.SET_NULL, db_column="po_item_id",
-        null=True, blank=True,
+        PurchaseOrderItem,
+        models.SET_NULL,
+        db_column="po_item_id",
+        null=True,
+        blank=True,
     )
     # D6: Direct item FK for ad-hoc GRNs (null when linked via po_item)
     item = models.ForeignKey(
-        Item, models.PROTECT, db_column="direct_item_id",
-        null=True, blank=True,
+        Item,
+        models.PROTECT,
+        db_column="direct_item_id",
+        null=True,
+        blank=True,
         related_name="grn_items",
         help_text="Direct item reference (for ad-hoc GRNs without a PO)",
     )

--- a/inventory/models/recipes.py
+++ b/inventory/models/recipes.py
@@ -35,12 +35,19 @@ class Recipe(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
     # D2: Selling price and food cost tracking
     selling_price = models.DecimalField(
-        max_digits=10, decimal_places=2, null=True, blank=True,
-        help_text="Menu selling price (ex. tax)"
+        max_digits=10,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        help_text="Menu selling price (ex. tax)",
     )
     target_food_cost_pct = models.DecimalField(
-        max_digits=5, decimal_places=2, null=True, blank=True, default=30.00,
-        help_text="Target food cost percentage for this item type"
+        max_digits=5,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        default=30.00,
+        help_text="Target food cost percentage for this item type",
     )
 
     def __str__(self):
@@ -181,6 +188,7 @@ class RecipeItem(models.Model):
 
     def clean(self):
         from django.core.exceptions import ValidationError
+
         if not self.item and not self.sub_recipe:
             raise ValidationError("Select either an inventory item or a sub-recipe.")
         if self.item and self.sub_recipe:
@@ -194,19 +202,24 @@ class RecipeItem(models.Model):
 
     def _check_circular(self, sub, visited):
         from django.core.exceptions import ValidationError
+
         if sub.pk in visited:
             raise ValidationError(
                 f"Circular dependency detected: {sub.name} references back to this recipe."
             )
         visited.add(sub.pk)
-        for child in sub.items.filter(sub_recipe__isnull=False).select_related("sub_recipe"):
+        for child in sub.items.filter(sub_recipe__isnull=False).select_related(
+            "sub_recipe"
+        ):
             self._check_circular(child.sub_recipe, visited.copy())
 
     def get_line_cost(self):
         """Return the cost for this ingredient line."""
         if self.sub_recipe:
             sub_cost = self.sub_recipe.get_total_cost()
-            sub_yield = Decimal(str(self.sub_recipe.default_yield_qty or 1)) or Decimal("1")
+            sub_yield = Decimal(str(self.sub_recipe.default_yield_qty or 1)) or Decimal(
+                "1"
+            )
             qty = Decimal(str(self.quantity or 0))
             loss_mult = Decimal("1") + (
                 Decimal(str(self.loss_pct or 0)) / Decimal("100")

--- a/inventory/models/stock_take.py
+++ b/inventory/models/stock_take.py
@@ -1,7 +1,6 @@
 from decimal import Decimal
 
 from django.db import models
-from django.utils import timezone
 
 
 class StockTake(models.Model):
@@ -21,9 +20,7 @@ class StockTake(models.Model):
         on_delete=models.SET_NULL,
         help_text="Leave blank for a full stock-take across all departments",
     )
-    status = models.CharField(
-        max_length=20, choices=STATUS_CHOICES, default="DRAFT"
-    )
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="DRAFT")
     notes = models.TextField(blank=True)
     created_by = models.ForeignKey("auth.User", on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/inventory/services/purchase_order_kpis.py
+++ b/inventory/services/purchase_order_kpis.py
@@ -34,9 +34,7 @@ def get_po_summary_kpis() -> Dict[str, any]:
 
     # Basic counts by status
     total_pos = PurchaseOrder.objects.count()
-    pending_count = PurchaseOrder.objects.filter(
-        status__in=["SENT"]
-    ).count()
+    pending_count = PurchaseOrder.objects.filter(status__in=["SENT"]).count()
     completed_count = PurchaseOrder.objects.filter(status="RECEIVED").count()
     cancelled_count = PurchaseOrder.objects.filter(status="CANCELLED").count()
     draft_count = PurchaseOrder.objects.filter(status="DRAFT").count()

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -1,7 +1,13 @@
 from django.urls import path
 
 from .views.explore import explore, explore_export
-from .views.goods_received import GRNCreateView, GRNDetailView, GRNListView, create_adhoc_grn, grn_export
+from .views.goods_received import (
+    GRNCreateView,
+    GRNDetailView,
+    GRNListView,
+    create_adhoc_grn,
+    grn_export,
+)
 from .views.guides import WorkflowGuideView
 from .views.indents import (
     IndentCreateView,
@@ -179,7 +185,11 @@ urlpatterns = [
         name="indent_update_status",
     ),
     path("indents/<int:pk>/pdf/", indent_pdf, name="indent_pdf"),
-    path("indents/generate-from-low-stock/", generate_low_stock_indent, name="low_stock_indent"),
+    path(
+        "indents/generate-from-low-stock/",
+        generate_low_stock_indent,
+        name="low_stock_indent",
+    ),
     path("indents/consolidate/", indents_consolidate, name="indents_consolidate"),
     path(
         "indents/consolidate/preview/",

--- a/inventory/views/goods_received.py
+++ b/inventory/views/goods_received.py
@@ -360,7 +360,9 @@ class GRNDetailView(TemplateView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         grn = get_object_or_404(GoodsReceivedNote, pk=self.kwargs["pk"])
-        items = grn.grnitem_set.select_related("po_item", "po_item__item", "po_item__item__unit", "item")
+        items = grn.grnitem_set.select_related(
+            "po_item", "po_item__item", "po_item__item__unit", "item"
+        )
         if grn.purchase_order_id:
             po_row = (
                 "PO",
@@ -496,6 +498,7 @@ def grn_export(request, pk: int):
 def create_adhoc_grn(request):
     """D6: Create a GRN without a PO (ad-hoc receipt)."""
     from django.db import transaction as db_transaction
+
     from ..services import stock_service
     from ..services.goods_receiving_service import generate_grn_number
 
@@ -511,7 +514,9 @@ def create_adhoc_grn(request):
                     grn_number = generate_grn_number()
                     user_id = getattr(request.user, "username", "System") or "System"
                     for line_form in formset.forms:
-                        if not line_form.cleaned_data or line_form.cleaned_data.get("DELETE"):
+                        if not line_form.cleaned_data or line_form.cleaned_data.get(
+                            "DELETE"
+                        ):
                             continue
                         item = line_form.cleaned_data["item"]
                         qty = line_form.cleaned_data["quantity_received"]
@@ -533,7 +538,9 @@ def create_adhoc_grn(request):
                             user_id=user_id,
                             notes=f"Ad-hoc GRN {grn_number}",
                         )
-                messages.success(request, f"Ad-hoc GRN {grn.pk} created.", extra_tags="toast")
+                messages.success(
+                    request, f"Ad-hoc GRN {grn.pk} created.", extra_tags="toast"
+                )
                 return redirect("grn_detail", pk=grn.pk)
             except Exception as exc:
                 logger.error("Error creating ad-hoc GRN: %s", exc)
@@ -542,7 +549,11 @@ def create_adhoc_grn(request):
         form = AdhocGRNForm(initial={"received_date": date.today()})
         formset = AdhocGRNLineFormSet(prefix="lines")
 
-    return render(request, "inventory/grns/grn_adhoc_create.html", {
-        "form": form,
-        "formset": formset,
-    })
+    return render(
+        request,
+        "inventory/grns/grn_adhoc_create.html",
+        {
+            "form": form,
+            "formset": formset,
+        },
+    )

--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -1137,7 +1137,14 @@ def generate_low_stock_indent(request):
         )
         .filter(reorder_point__gt=0)
         .order_by("name")
-        .only("item_id", "name", "base_unit", "current_stock", "reorder_point", "minimum_order_qty")
+        .only(
+            "item_id",
+            "name",
+            "base_unit",
+            "current_stock",
+            "reorder_point",
+            "minimum_order_qty",
+        )
     )
 
     if request.method == "POST":

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -274,7 +274,9 @@ def recipe_create(request):
                 items.append(
                     {
                         "item_id": int(item_obj.pk) if item_obj else None,
-                        "sub_recipe_id": int(sub_recipe_obj.pk) if sub_recipe_obj else None,
+                        "sub_recipe_id": (
+                            int(sub_recipe_obj.pk) if sub_recipe_obj else None
+                        ),
                         "quantity": float(f.cleaned_data.get("quantity") or 0),
                         "unit": f.cleaned_data.get("unit"),
                         "loss_pct": float(f.cleaned_data.get("loss_pct") or 0),
@@ -325,7 +327,9 @@ def recipe_detail(request, pk: int):
                 items.append(
                     {
                         "item_id": int(item_obj.pk) if item_obj else None,
-                        "sub_recipe_id": int(sub_recipe_obj.pk) if sub_recipe_obj else None,
+                        "sub_recipe_id": (
+                            int(sub_recipe_obj.pk) if sub_recipe_obj else None
+                        ),
                         "quantity": float(f.cleaned_data.get("quantity") or 0),
                         "unit": f.cleaned_data.get("unit"),
                         "loss_pct": float(f.cleaned_data.get("loss_pct") or 0),
@@ -621,12 +625,22 @@ class RecipeViewPartialView(View):
             if sub_recipe_obj and not item:
                 try:
                     sub_cost = sub_recipe_obj.get_total_cost()
-                    sub_yield = _to_decimal(getattr(sub_recipe_obj, "default_yield_qty", None)) or Decimal("1")
-                    cost_per_base = (sub_cost / sub_yield).quantize(TWOPLACES) if sub_yield else Decimal("0.00")
+                    sub_yield = _to_decimal(
+                        getattr(sub_recipe_obj, "default_yield_qty", None)
+                    ) or Decimal("1")
+                    cost_per_base = (
+                        (sub_cost / sub_yield).quantize(TWOPLACES)
+                        if sub_yield
+                        else Decimal("0.00")
+                    )
                 except Exception:
                     cost_per_base = Decimal("0.00")
                 loss_mult = Decimal("1") + (loss_pct / Decimal("100"))
-                line_cost = (cost_per_base * qty * loss_mult).quantize(TWOPLACES) if qty else Decimal("0.00")
+                line_cost = (
+                    (cost_per_base * qty * loss_mult).quantize(TWOPLACES)
+                    if qty
+                    else Decimal("0.00")
+                )
                 total_cost += line_cost
                 items.append(
                     {

--- a/inventory/views/stock.py
+++ b/inventory/views/stock.py
@@ -246,6 +246,7 @@ def stock_movements(request):
                 cd = transfer_form.cleaned_data
                 try:
                     from ..models import StockTransaction
+
                     StockTransaction.objects.create(
                         item=cd["item"],
                         quantity_change=cd["quantity"],
@@ -386,9 +387,7 @@ def stock_movements(request):
     query_string = params.urlencode()
 
     total_transactions = qs.count()
-    pending_orders = PurchaseOrder.objects.filter(
-        status__in=["SENT"]
-    ).count()
+    pending_orders = PurchaseOrder.objects.filter(status__in=["SENT"]).count()
 
     tabs = [
         {

--- a/inventory/views/stock_take.py
+++ b/inventory/views/stock_take.py
@@ -1,4 +1,5 @@
 """D4: Physical stock-take workflow views."""
+
 from __future__ import annotations
 
 import logging
@@ -37,18 +38,26 @@ class StockTakeStartForm(forms.Form):
     )
     notes = forms.CharField(
         required=False,
-        widget=forms.Textarea(attrs={"class": INPUT_CLASS, "rows": 2, "placeholder": "Optional notes"}),
+        widget=forms.Textarea(
+            attrs={"class": INPUT_CLASS, "rows": 2, "placeholder": "Optional notes"}
+        ),
     )
 
 
 def stock_take_list(request):
-    stock_takes = StockTake.objects.select_related("department", "created_by").order_by("-date", "-created_at")
-    return render(request, "inventory/stock_take_list.html", {
-        "stock_takes": stock_takes,
-        "list_url": "/",
-        "list_title": "Dashboard",
-        "current_title": "Stock Takes",
-    })
+    stock_takes = StockTake.objects.select_related("department", "created_by").order_by(
+        "-date", "-created_at"
+    )
+    return render(
+        request,
+        "inventory/stock_take_list.html",
+        {
+            "stock_takes": stock_takes,
+            "list_url": "/",
+            "list_title": "Dashboard",
+            "current_title": "Stock Takes",
+        },
+    )
 
 
 def create_stock_take(request):
@@ -67,30 +76,40 @@ def create_stock_take(request):
                 items_qs = Item.objects.filter(is_active=True).order_by("name")
                 if dept:
                     items_qs = items_qs.filter(departments=dept)
-                StockTakeItem.objects.bulk_create([
-                    StockTakeItem(
-                        stock_take=st,
-                        item=item,
-                        system_qty=item.current_stock or 0,
-                    )
-                    for item in items_qs
-                ])
-            messages.success(request, f"Stock take #{st.pk} started.", extra_tags="toast")
+                StockTakeItem.objects.bulk_create(
+                    [
+                        StockTakeItem(
+                            stock_take=st,
+                            item=item,
+                            system_qty=item.current_stock or 0,
+                        )
+                        for item in items_qs
+                    ]
+                )
+            messages.success(
+                request, f"Stock take #{st.pk} started.", extra_tags="toast"
+            )
             return redirect("stock_take_count", pk=st.pk)
     else:
         form = StockTakeStartForm()
-    return render(request, "inventory/stock_take_start.html", {
-        "form": form,
-        "list_url": "/stock-takes/",
-        "list_title": "Stock Takes",
-        "current_title": "New Stock Take",
-    })
+    return render(
+        request,
+        "inventory/stock_take_start.html",
+        {
+            "form": form,
+            "list_url": "/stock-takes/",
+            "list_title": "Stock Takes",
+            "current_title": "New Stock Take",
+        },
+    )
 
 
 def stock_take_count(request, pk: int):
     st = get_object_or_404(StockTake, pk=pk)
     if st.status == "COMPLETED":
-        messages.info(request, "This stock take is already completed.", extra_tags="toast")
+        messages.info(
+            request, "This stock take is already completed.", extra_tags="toast"
+        )
         return redirect("stock_take_review", pk=pk)
 
     items = list(st.items.select_related("item").order_by("item__name"))
@@ -113,13 +132,17 @@ def stock_take_count(request, pk: int):
         messages.success(request, "Counts saved.", extra_tags="toast")
         return redirect("stock_take_review", pk=pk)
 
-    return render(request, "inventory/stock_take_count.html", {
-        "stock_take": st,
-        "items": items,
-        "list_url": "/stock-takes/",
-        "list_title": "Stock Takes",
-        "current_title": f"Count — Stock Take #{st.pk}",
-    })
+    return render(
+        request,
+        "inventory/stock_take_count.html",
+        {
+            "stock_take": st,
+            "items": items,
+            "list_url": "/stock-takes/",
+            "list_title": "Stock Takes",
+            "current_title": f"Count — Stock Take #{st.pk}",
+        },
+    )
 
 
 def stock_take_review(request, pk: int):
@@ -133,7 +156,9 @@ def stock_take_review(request, pk: int):
                 st.status = "COMPLETED"
                 st.completed_at = timezone.now()
                 st.save(update_fields=["status", "completed_at"])
-            messages.success(request, f"Stock take #{st.pk} completed.", extra_tags="toast")
+            messages.success(
+                request, f"Stock take #{st.pk} completed.", extra_tags="toast"
+            )
             return redirect("stock_take_list")
         elif action == "discard":
             st.delete()
@@ -143,17 +168,20 @@ def stock_take_review(request, pk: int):
     counted = [i for i in items if i.physical_qty is not None]
     uncounted = len(items) - len(counted)
     total_variance = sum(
-        (float(i.physical_qty or 0) - float(i.system_qty or 0))
-        for i in counted
+        (float(i.physical_qty or 0) - float(i.system_qty or 0)) for i in counted
     )
 
-    return render(request, "inventory/stock_take_review.html", {
-        "stock_take": st,
-        "items": items,
-        "counted_count": len(counted),
-        "uncounted_count": uncounted,
-        "total_variance": total_variance,
-        "list_url": "/stock-takes/",
-        "list_title": "Stock Takes",
-        "current_title": f"Review — Stock Take #{st.pk}",
-    })
+    return render(
+        request,
+        "inventory/stock_take_review.html",
+        {
+            "stock_take": st,
+            "items": items,
+            "counted_count": len(counted),
+            "uncounted_count": uncounted,
+            "total_variance": total_variance,
+            "list_url": "/stock-takes/",
+            "list_title": "Stock Takes",
+            "current_title": f"Review — Stock Take #{st.pk}",
+        },
+    )

--- a/inventory/views/suppliers.py
+++ b/inventory/views/suppliers.py
@@ -138,9 +138,7 @@ def _annotate_open_po_count(qs):
     return qs.annotate(
         open_po_count=Count(
             "purchaseorder",
-            filter=Q(
-                purchaseorder__status__in=["DRAFT", "SENT"]
-            ),
+            filter=Q(purchaseorder__status__in=["DRAFT", "SENT"]),
         )
     )
 

--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -225,7 +225,10 @@ def primary_navigation(request):
                     }
                 )
                 notifications.append(
-                    {"text": f"Generate indent for {low} low-stock {noun}", "url": "/indents/generate-from-low-stock/"}
+                    {
+                        "text": f"Generate indent for {low} low-stock {noun}",
+                        "url": "/indents/generate-from-low-stock/",
+                    }
                 )
             ctx["notification_count"] = low + pending
             ctx["notifications"] = notifications


### PR DESCRIPTION
## Summary

- **Root cause of `build_failed`:** Migration `0027_indent_source_recipe` was failing with `DuplicateColumn: column "source_recipe_id" of relation "indents" already exists`. The production DB already has Phase D schema (added by the original `0025_phase_d_features` migration that ran before it was deleted and renumbered), so every new Phase D migration was hitting column-already-exists errors.

- **0027 fix:** Wrapped the `AddField` in `SeparateDatabaseAndState` with empty `database_operations` — state-only, since the column already exists.

- **0029 fix:** Rewrote all 14 operations to be fully defensive:
  - `AddField` → `ALTER TABLE ... ADD COLUMN IF NOT EXISTS ...`
  - `CreateModel` (StockTake, StockTakeItem) → `CREATE TABLE IF NOT EXISTS ...`
  - `AlterField` (nullable/default changes) → idempotent `ALTER COLUMN DROP NOT NULL` / `SET DEFAULT`
  - Works on both production (no-op) and fresh DBs (creates schema)

## Test plan

- [ ] Merge PR and confirm Render deploy succeeds (no `DuplicateColumn` errors)
- [ ] Verify `/stock-takes/` returns 200
- [ ] Verify `/grns/create/adhoc/` returns 200
- [ ] Verify `/indents/generate-from-low-stock/` returns 200
- [ ] Verify Stock Takes appears in navigation under "Fulfill & Track"
- [ ] Verify PO detail heading shows `PO-0008` not `Purchase Order 8`
- [ ] Verify Indent create department dropdown has no blank/malformed options

https://claude.ai/code/session_016o6q2oztG1Q2j15cUVxK6K