### PR TITLE
feat: replace freeform recipe types with binary FINAL/SUB TextChoices

### DIFF
--- a/inventory/forms/recipe_forms.py
+++ b/inventory/forms/recipe_forms.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 from django import forms
 
 from ..models import Item, Recipe, RecipeItem
-from ..models.recipes import RECIPE_TYPES
 from .base import StyledFormMixin
 
 INPUT_CLASS = (
@@ -35,10 +34,10 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
         ),
     )
     type = forms.ChoiceField(
-        required=False,
-        choices=RECIPE_TYPES,
+        choices=Recipe.Type.choices,
+        initial=Recipe.Type.FINAL,
         widget=forms.Select(attrs={"class": INPUT_CLASS}),
-        help_text="Category of this recipe",
+        help_text="Final recipes are on the menu; Sub-recipes are components used inside other recipes.",
     )
     default_yield_qty = forms.DecimalField(
         required=False,
@@ -164,7 +163,7 @@ class RecipeItemForm(StyledFormMixin, forms.ModelForm):
     )
     # D1: sub-recipe selector
     sub_recipe = forms.ModelChoiceField(
-        queryset=Recipe.objects.filter(is_active=True),
+        queryset=Recipe.objects.filter(is_active=True, type=Recipe.Type.SUB),
         required=False,
         widget=forms.Select(
             attrs={

--- a/inventory/migrations/0031_recipe_type_binary.py
+++ b/inventory/migrations/0031_recipe_type_binary.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+# Old values that map to SUB-recipe semantics
+_SUB_VALUES = {"PREP", "SAUCE", "BATCH", "OTHER"}
+
+
+def _map_to_binary(apps, schema_editor):
+    """Migrate freeform type labels to FINAL / SUB."""
+    Recipe = apps.get_model("inventory", "Recipe")
+    for recipe in Recipe.objects.all():
+        recipe.type = "SUB" if recipe.type in _SUB_VALUES else "FINAL"
+        recipe.save(update_fields=["type"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("inventory", "0030_phase_d_apply_schema"),
+    ]
+
+    operations = [
+        migrations.RunPython(_map_to_binary, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="recipe",
+            name="type",
+            field=models.CharField(
+                blank=False,
+                choices=[("FINAL", "Final Recipe"), ("SUB", "Sub-Recipe")],
+                default="FINAL",
+                max_length=10,
+                null=False,
+            ),
+        ),
+    ]

--- a/inventory/models/recipes.py
+++ b/inventory/models/recipes.py
@@ -4,26 +4,23 @@ from django.db import models
 
 from .fields import CoerceFloatField
 
-RECIPE_TYPES = [
-    ("", "Select type..."),
-    ("MAIN", "Main Course"),
-    ("APPETIZER", "Appetizer / Starter"),
-    ("DESSERT", "Dessert"),
-    ("BEVERAGE", "Beverage"),
-    ("PREP", "Prep / Base Recipe"),
-    ("SAUCE", "Sauce / Dressing"),
-    ("SIDE", "Side Dish"),
-    ("BATCH", "Batch Production"),
-    ("OTHER", "Other"),
-]
-
 
 class Recipe(models.Model):
+    class Type(models.TextChoices):
+        FINAL = "FINAL", "Final Recipe"
+        SUB = "SUB", "Sub-Recipe"
+
     recipe_id = models.AutoField(primary_key=True)
     name = models.CharField(max_length=255, unique=True, null=False, blank=False)
     description = models.TextField(blank=True, null=True)
     is_active = models.BooleanField(default=False, null=False)
-    type = models.CharField(max_length=50, blank=True, null=True, choices=RECIPE_TYPES)
+    type = models.CharField(
+        max_length=10,
+        choices=Type.choices,
+        default=Type.FINAL,
+        null=False,
+        blank=False,
+    )
     default_yield_qty = CoerceFloatField(default=Decimal("0"), blank=True, null=True)
     default_yield_unit = models.CharField(max_length=50, blank=True, null=True)
     plating_notes = models.TextField(blank=True, null=True, default="")

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -33,8 +33,6 @@ def _filtered_recipes_queryset(request):
     params["recipe_count"] = qs.count()
 
     # Build filter options for the template filter_bar
-    from inventory.models.recipes import RECIPE_TYPES
-
     type_value = request.GET.get("type", "")
     params["filters"] = [
         {
@@ -42,7 +40,7 @@ def _filtered_recipes_queryset(request):
             "label": "Type",
             "value": type_value,
             "options": [{"value": "", "label": "All Types"}]
-            + [{"value": v, "label": label} for v, label in RECIPE_TYPES if v],
+            + [{"value": v, "label": label} for v, label in Recipe.Type.choices],
         },
     ]
     return qs, params

--- a/templates/inventory/recipes/_recipes_table.html
+++ b/templates/inventory/recipes/_recipes_table.html
@@ -104,10 +104,10 @@
             </div>
           </td>
           <td class="px-4 py-2 align-top">
-            {% if recipe.type %}
-              {{ recipe.type }}
+            {% if recipe.type == "SUB" %}
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-700">Sub-Recipe</span>
             {% else %}
-              <span class="text-gray-400">—</span>
+              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">Final Recipe</span>
             {% endif %}
           </td>
           <td class="px-4 py-2 align-top">

--- a/templates/inventory/recipes/_view_partial.html
+++ b/templates/inventory/recipes/_view_partial.html
@@ -18,7 +18,7 @@
       </div>
       <div class="space-y-1">
         <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Type</h4>
-        <p class="text-bodyText leading-snug">{{ recipe.type|default:"—" }}</p>
+        <p class="text-bodyText leading-snug">{{ recipe.get_type_display }}</p>
       </div>
       <div class="space-y-1">
         <h4 class="text-xs font-semibold uppercase tracking-wide text-gray-500">Default Yield</h4>

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -19,7 +19,7 @@
                onerror="this.onerror=null;this.src='{{ plating_placeholder_url }}';" />
         </div>
         <div class="text-sm text-gray-600">
-          <p class="font-medium text-bodyText">{% if recipe and recipe.type %}{{ recipe.type }}{% else %}No category yet{% endif %}</p>
+          <p class="font-medium text-bodyText">{% if recipe %}{{ recipe.get_type_display }}{% else %}Final Recipe{% endif %}</p>
           <p>{% if recipe and recipe.default_yield_qty %}Yield: {{ recipe.default_yield_qty|floatformat:-2 }}{% if recipe.default_yield_unit %} <span class="uppercase">{{ recipe.default_yield_unit }}</span>{% endif %}{% else %}Set a default yield{% endif %}</p>
         </div>
       </div>

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -148,7 +148,7 @@ def test_recipe_metadata_fields():
         "name": "Salad",
         "description": "Fresh",
         "is_active": True,
-        "type": "FOOD",
+        "type": "FINAL",
         "default_yield_qty": 4,
         "default_yield_unit": "plate",
         "tags": "vegan,healthy",
@@ -165,6 +165,6 @@ def test_recipe_metadata_fields():
     assert ok and rid
 
     recipe = Recipe.objects.get(pk=rid)
-    assert recipe.type == "FOOD"
+    assert recipe.type == "FINAL"
     assert recipe.default_yield_unit == "plate"
     assert recipe.tags == ["vegan", "healthy"]


### PR DESCRIPTION
## Summary

- Replace the 9-label `RECIPE_TYPES` list with a `Recipe.Type` TextChoices enum (`FINAL` / `SUB`) nested on the model
- Migration 0031 maps old values: `PREP/SAUCE/BATCH/OTHER → SUB`, everything else → `FINAL`, then alters the column to `NOT NULL max_length=10`
- Recipe form type field is now a clean 2-option select (no blank "Select type…" entry)
- Sub-recipe ingredient selector restricted to `type=SUB` recipes only
- Recipe list table shows coloured badges: blue "Final Recipe", purple "Sub-Recipe"
- `detail.html` and `_view_partial.html` use `get_type_display`
- Fix stale test assertion `"FOOD"` → `"FINAL"`

## Test plan

- [ ] Run `python manage.py migrate` — migration applies cleanly
- [ ] Create a new recipe — type dropdown shows only "Final Recipe" / "Sub-Recipe"
- [ ] Create a Sub-Recipe type recipe, then open another recipe's ingredient form — sub-recipe selector only lists SUB type recipes
- [ ] Recipe list table shows correct colour-coded type badges
- [ ] Type filter dropdown on recipe list shows "All Types / Final Recipe / Sub-Recipe"
- [ ] View drawer and detail page show human-readable type label

https://claude.ai/code/session_016o6q2oztG1Q2j15cUVxK6K