### PR TITLE
feat: Phase D — stock-take auto-adjust + food cost report

### DIFF
--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -68,6 +68,7 @@ from .views.recipes import (
     RecipesListView,
     RecipesTableView,
     RecipeViewPartialView,
+    food_cost_report,
     recipe_create,
     recipe_create_indent,
     recipe_detail,
@@ -260,6 +261,7 @@ urlpatterns = [
     path("grns/<int:pk>/", GRNDetailView.as_view(), name="grn_detail"),
     path("recipes/", RecipesListView.as_view(), name="recipes_list"),
     path("recipes/table/", RecipesTableView.as_view(), name="recipes_table"),
+    path("recipes/food-cost-report/", food_cost_report, name="food_cost_report"),
     path("recipes/create/", recipe_create, name="recipe_create"),
     path(
         "recipes/create/partial/",

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -777,3 +777,40 @@ class RecipeDeleteView(LoginRequiredMixin, DeleteView):
         recipe.delete()
         messages.success(request, f"Recipe '{name}' deleted.", extra_tags="toast")
         return redirect(self.success_url)
+
+
+def food_cost_report(request):
+    """Report listing all active FINAL recipes with food cost metrics."""
+    status_filter = request.GET.get("status", "")
+    qs = Recipe.objects.filter(type=Recipe.Type.FINAL, is_active=True).order_by("name")
+
+    rows = []
+    for recipe in qs:
+        total_cost = recipe.get_total_cost()
+        fcp = recipe.food_cost_percentage
+        fc_status = recipe.food_cost_status
+        if status_filter and fc_status != status_filter:
+            continue
+        selling = Decimal(str(recipe.selling_price or 0))
+        gross_margin = (selling - total_cost) if selling else None
+        rows.append(
+            {
+                "recipe": recipe,
+                "total_cost": total_cost,
+                "food_cost_pct": fcp,
+                "fc_status": fc_status,
+                "gross_margin": gross_margin,
+            }
+        )
+
+    return render(
+        request,
+        "inventory/recipes/food_cost_report.html",
+        {
+            "rows": rows,
+            "status_filter": status_filter,
+            "list_url": "/recipes/",
+            "list_title": "Recipes",
+            "current_title": "Food Cost Report",
+        },
+    )

--- a/inventory/views/stock_take.py
+++ b/inventory/views/stock_take.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import logging
 from datetime import date
+from decimal import Decimal
 
 from django import forms
 from django.contrib import messages
 from django.db import transaction
+from django.db.models import F
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 
-from ..models import Department, Item, StockTake, StockTakeItem
+from ..models import Department, Item, StockTake, StockTakeItem, StockTransaction
 
 logger = logging.getLogger(__name__)
 
@@ -164,13 +166,38 @@ def stock_take_review(request, pk: int):
     if request.method == "POST":
         action = request.POST.get("action")
         if action == "complete" and st.status != "COMPLETED":
+            user_id = getattr(request.user, "username", None) or "System"
+            user_int = getattr(request.user, "pk", None)
             with transaction.atomic():
+                adjusted = 0
+                for sti in items:
+                    if sti.physical_qty is None:
+                        continue
+                    variance = Decimal(str(sti.physical_qty)) - Decimal(
+                        str(sti.system_qty)
+                    )
+                    if variance == Decimal("0"):
+                        continue
+                    Item.objects.filter(pk=sti.item_id).update(
+                        current_stock=F("current_stock") + variance
+                    )
+                    StockTransaction.objects.create(
+                        item_id=sti.item_id,
+                        quantity_change=variance,
+                        transaction_type="ADJUSTMENT",
+                        user_id=user_id,
+                        user_int_id=user_int,
+                        notes=f"Stock take #{st.pk} variance adjustment",
+                        reason_category="STOCK_TAKE",
+                    )
+                    adjusted += 1
                 st.status = "COMPLETED"
                 st.completed_at = timezone.now()
                 st.save(update_fields=["status", "completed_at"])
-            messages.success(
-                request, f"Stock take #{st.pk} completed.", extra_tags="toast"
-            )
+            msg = f"Stock take #{st.pk} completed."
+            if adjusted:
+                msg += f" {adjusted} item adjustment{'s' if adjusted != 1 else ''} applied."
+            messages.success(request, msg, extra_tags="toast")
             return redirect("stock_take_list")
         elif action == "discard":
             st.delete()

--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -89,6 +89,11 @@ NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
         "Insights & Settings",
         [
             {
+                "title": "Food Cost Report",
+                "description": "Review ingredient costs and margins across all recipes.",
+                "url_name": "food_cost_report",
+            },
+            {
                 "title": "Stock History Report",
                 "description": "Analyse trends and audit activity.",
                 "url_name": "history_reports",

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -43,6 +43,7 @@
                       {% elif link.url_name == 'purchase_orders_list' %}{% icon 'receipt-percent' 'h-4 w-4 text-blue-600' aria_label='' %}
                       {% elif link.url_name == 'recipes_list' %}{% icon 'beaker' 'h-4 w-4 text-blue-600' aria_label='' %}
                       {% elif link.url_name == 'suppliers_list' %}{% icon 'truck' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-blue-600' aria_label='' %}
                       {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-blue-600' aria_label='' %}
                       {% elif link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-blue-600' aria_label='' %}
                       {% elif link.url_name == 'ml_dashboard' %}{% icon 'sparkles' 'h-4 w-4 text-blue-600' aria_label='' %}
@@ -64,6 +65,7 @@
                       {% elif link.url_name == 'purchase_orders_list' %}{% icon 'receipt-percent' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'recipes_list' %}{% icon 'beaker' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'suppliers_list' %}{% icon 'truck' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'ml_dashboard' %}{% icon 'sparkles' 'h-4 w-4 text-gray-500' aria_label='' %}

--- a/templates/inventory/recipes/food_cost_report.html
+++ b/templates/inventory/recipes/food_cost_report.html
@@ -1,0 +1,103 @@
+{% extends "_base.html" %}
+{% load icon_tags %}
+{% block title %}Food Cost Report – Inventory Pro{% endblock %}
+{% block content %}
+<div class="w-full max-w-5xl mx-auto space-y-6 px-4 md:px-0 py-6">
+
+  <nav class="text-sm text-gray-500 flex items-center gap-1">
+    <a href="{% url 'recipes_list' %}" class="hover:text-primary hover:underline">Recipes</a>
+    <span>›</span>
+    <span class="text-bodyText">Food Cost Report</span>
+  </nav>
+
+  <div class="bg-surface border border-border rounded-2xl shadow-card overflow-hidden">
+    <div class="px-6 py-4 border-b border-border flex items-start justify-between gap-3 flex-wrap">
+      <div>
+        <h1 class="text-xl font-semibold text-bodyText">Food Cost Report</h1>
+        <p class="text-sm text-gray-500 mt-1">Active final recipes — ingredient cost vs. selling price</p>
+      </div>
+      <form method="get" class="flex items-center gap-2">
+        <label for="status-filter" class="text-sm text-gray-600">Filter:</label>
+        <select id="status-filter" name="status" onchange="this.form.submit()"
+                class="text-sm border border-border rounded-md px-2 py-1.5 bg-surface text-bodyText focus:outline-none focus:ring-2 focus:ring-primary">
+          <option value="" {% if not status_filter %}selected{% endif %}>All</option>
+          <option value="success" {% if status_filter == 'success' %}selected{% endif %}>On target</option>
+          <option value="warning" {% if status_filter == 'warning' %}selected{% endif %}>Slightly over</option>
+          <option value="danger" {% if status_filter == 'danger' %}selected{% endif %}>Over budget</option>
+          <option value="unknown" {% if status_filter == 'unknown' %}selected{% endif %}>No price set</option>
+        </select>
+      </form>
+    </div>
+
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm">
+        <thead class="bg-surfaceSubtle border-b border-border">
+          <tr>
+            <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Recipe</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Ingredient Cost</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Selling Price</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Food Cost %</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Target %</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Gross Margin</th>
+            <th scope="col" class="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wide text-gray-600">Status</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border">
+          {% for row in rows %}
+          <tr class="odd:bg-surface even:bg-surfaceSubtle text-bodyText hover:bg-surfaceSubtle">
+            <td class="px-4 py-2 font-medium">
+              <a href="{% url 'recipe_detail' row.recipe.pk %}" class="hover:text-primary hover:underline">{{ row.recipe.name }}</a>
+            </td>
+            <td class="px-4 py-2 text-right tabular-nums">
+              {% if row.total_cost %}{{ row.total_cost|floatformat:2 }}{% else %}<span class="text-gray-400">—</span>{% endif %}
+            </td>
+            <td class="px-4 py-2 text-right tabular-nums">
+              {% if row.recipe.selling_price %}{{ row.recipe.selling_price|floatformat:2 }}{% else %}<span class="text-gray-400">—</span>{% endif %}
+            </td>
+            <td class="px-4 py-2 text-right tabular-nums font-medium
+              {% if row.fc_status == 'success' %}text-success
+              {% elif row.fc_status == 'warning' %}text-warning
+              {% elif row.fc_status == 'danger' %}text-danger
+              {% else %}text-gray-400{% endif %}">
+              {% if row.food_cost_pct is not None %}{{ row.food_cost_pct|floatformat:1 }}%{% else %}<span class="text-gray-400">—</span>{% endif %}
+            </td>
+            <td class="px-4 py-2 text-right tabular-nums text-gray-500">
+              {% if row.recipe.target_food_cost_pct %}{{ row.recipe.target_food_cost_pct|floatformat:1 }}%{% else %}<span class="text-gray-400">—</span>{% endif %}
+            </td>
+            <td class="px-4 py-2 text-right tabular-nums">
+              {% if row.gross_margin is not None %}
+                <span class="{% if row.gross_margin >= 0 %}text-success{% else %}text-danger{% endif %}">
+                  {{ row.gross_margin|floatformat:2 }}
+                </span>
+              {% else %}<span class="text-gray-400">—</span>{% endif %}
+            </td>
+            <td class="px-4 py-2 text-center">
+              {% if row.fc_status == 'success' %}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-success-soft text-success">On target</span>
+              {% elif row.fc_status == 'warning' %}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700">Slightly over</span>
+              {% elif row.fc_status == 'danger' %}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-danger-soft text-danger">Over budget</span>
+              {% else %}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500">No price</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="7" class="px-4 py-8 text-center text-gray-500">
+              {% if status_filter %}No recipes match this filter.{% else %}No active final recipes found.{% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="px-6 py-3 border-t border-border bg-surfaceSubtle text-xs text-gray-500">
+      {{ rows|length }} recipe{{ rows|length|pluralize }} shown.
+      Costs are based on the most recent purchase price for each ingredient.
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary

- **D1 — Stock-take auto-adjust**: Completing a stock take now generates `ADJUSTMENT` `StockTransaction` records for every counted item with a variance, and updates `item.current_stock` atomically via `F()` expression. Uncounted items are left unchanged. A toast message reports how many adjustments were applied (e.g. "Stock take #5 completed. 3 item adjustments applied.").

- **D2 — Food cost report**: New report at `/recipes/food-cost-report/` listing all active FINAL recipes with ingredient cost, selling price, food cost %, target %, gross margin, and a colour-coded status badge (On target / Slightly over / Over budget / No price). Filterable by status. Added to the "Insights & Settings" nav group with a calculator icon.

## Files changed
| File | Change |
|---|---|
| `inventory/views/stock_take.py` | Auto-generate ADJUSTMENT transactions + update stock on completion |
| `inventory/views/recipes.py` | New `food_cost_report` view |
| `inventory/ui_urls.py` | Register `/recipes/food-cost-report/` URL |
| `inventory_app/navigation.py` | Add Food Cost Report to nav |
| `templates/inventory/recipes/food_cost_report.html` | New report template |
| `templates/components/top_nav.html` | Calculator icon for food_cost_report link |

## Test plan
- [ ] Start a stock take, count some items (mix of over/under/exact), complete it → verify `StockTransaction` ADJUSTMENT records created and `item.current_stock` updated
- [ ] Complete a stock take with some items uncounted → verify those items' stock is unchanged
- [ ] Visit `/recipes/food-cost-report/` → all active FINAL recipes listed with costs and status badges
- [ ] Use the status filter dropdown to filter by "Over budget" etc.
- [ ] Verify "Food Cost Report" appears in the "Insights & Settings" nav dropdown

https://claude.ai/code/session_016o6q2oztG1Q2j15cUVxK6K