### PR TITLE
feat: keep-alive background thread to prevent Render sleep

### DIFF
--- a/inventory/apps.py
+++ b/inventory/apps.py
@@ -1,6 +1,32 @@
+import os
+import threading
+import time
+
+import requests
 from django.apps import AppConfig
+
+
+def _keep_alive():
+    """Ping the app every 5 minutes so Render never lets it sleep."""
+    url = os.environ.get("KEEP_ALIVE_URL", "https://inventory-app-kguo.onrender.com/")
+    while True:
+        time.sleep(300)  # wait first so startup completes before first ping
+        try:
+            resp = requests.get(url, timeout=10)
+            print(f"[keep-alive] {resp.status_code} {url}")
+        except Exception as exc:
+            print(f"[keep-alive] error: {exc}")
 
 
 class InventoryConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "inventory"
+
+    def ready(self):
+        # Only start the keep-alive thread in the main web process,
+        # not during manage.py commands (migrate, collectstatic, etc.)
+        if os.environ.get("RUN_MAIN") != "true" and not os.environ.get(
+            "DISABLE_KEEP_ALIVE"
+        ):
+            t = threading.Thread(target=_keep_alive, daemon=True, name="keep-alive")
+            t.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ fpdf2==2.8.4                  # PDF generation for GRNs / indents
 pydantic==2.11.7              # Data validation / view models
 statsmodels==0.14.4           # Forecasting (Holt-Winters) — 0.14.5 incompatible with Python 3.13.4
 django-q2==1.8.0              # Background task queue
+requests==2.32.3              # HTTP client (keep-alive self-ping)
 
 # NOTE: Removed (previously present):
 #   supabase (no runtime usage; docs only)


### PR DESCRIPTION
## Summary

Adds a daemon background thread that pings the app every 5 minutes so Render's free tier never hits the 15-minute idle timer and puts the app to sleep.

- **How it works**: `InventoryConfig.ready()` spawns a `threading.Thread(daemon=True)` that loops forever, sleeping 300 s then calling `requests.get(url)`. Because it's a daemon thread, it dies automatically when gunicorn shuts down — no zombie processes.
- **First ping is delayed**: The thread sleeps *first* (5 min) so the app fully starts before attempting the ping.
- **Configurable URL**: Defaults to `https://inventory-app-kguo.onrender.com/` but can be overridden with the `KEEP_ALIVE_URL` env var.
- **Opt-out**: Set `DISABLE_KEEP_ALIVE=true` to skip thread creation (useful in CI or one-off management commands where `RUN_MAIN` is also absent).
- **`requests` pinned**: Added `requests==2.32.3` to `requirements.txt` as an explicit dependency.

## Files changed
| File | Change |
|---|---|
| `inventory/apps.py` | `_keep_alive()` function + `InventoryConfig.ready()` override |
| `requirements.txt` | Pin `requests==2.32.3` |

## Test plan
- [ ] Deploy to Render and wait 20+ minutes — app should remain responsive without a cold-start delay
- [ ] Check Render logs for `[keep-alive] 200 https://inventory-app-kguo.onrender.com/` every ~5 minutes
- [ ] Set `DISABLE_KEEP_ALIVE=true` → confirm no keep-alive log lines appear

https://claude.ai/code/session_016o6q2oztG1Q2j15cUVxK6K