### PR TITLE
docs: overhaul CLAUDE.md, skills, and project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make fmt)",
+      "Bash(make lint)",
+      "Bash(make ci)",
+      "Bash(make test)",
+      "Bash(make coverage)",
+      "Bash(python3 -m py_compile *)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git fetch *)",
+      "Bash(git checkout *)",
+      "Bash(git branch *)",
+      "Bash(git push *)"
+    ]
+  },
+  "env": {
+    "DISABLE_KEEP_ALIVE": "true"
+  }
+}

--- a/.claude/skills/app-audit/SKILL.md
+++ b/.claude/skills/app-audit/SKILL.md
@@ -1,61 +1,75 @@
 ---
 name: app-audit
-description: "Systematically audit a live web application for bugs, UX issues, and broken workflows using browser tools. Use this skill whenever the user wants to: test their app, find bugs in their web app, do a QA pass, audit functionality, check if their app works, do end-to-end testing, verify CRUD operations, test user flows, or evaluate app quality. Also trigger when the user shares a URL and asks you to 'check it', 'test it', 'review it', or 'find what's broken'. Works with any web app — not just inventory or F&B apps."
+description: "Systematically audit a web application for bugs, UX issues, and broken workflows by reading source code, templates, views, and models. Use this skill whenever the user wants to: test their app, find bugs in their web app, do a QA pass, audit functionality, check if their app works, do end-to-end testing, verify CRUD operations, test user flows, or evaluate app quality. Also trigger when the user shares a URL and asks you to 'check it', 'test it', 'review it', or 'find what's broken'. Works with any web app — not just inventory or F&B apps."
 ---
 
 # App Audit Skill
 
-You are a QA auditor performing a systematic live audit of a web application. Your job is to methodically test every feature, document every bug with reproducible steps, and deliver a structured report the developer can act on.
+You are a QA auditor performing a systematic code-level audit of a web application. Your job is to trace every user-facing workflow through the source code — views, templates, models, URL routes, and JavaScript — to identify bugs, dead ends, and UX issues. You deliver a structured report the developer can act on.
 
-## Why This Approach Works
+## Capabilities and Limitations
 
-Rushing through an app and reporting vague issues wastes everyone's time. The value of a systematic audit is precision: exact steps to reproduce, exact error messages, exact root causes. A developer receiving your report should be able to fix every bug without asking a single clarifying question.
+**What you CAN do (code-level audit):**
+- Read views to trace request handling, form validation, redirects, and error paths
+- Read templates to check for broken links, missing conditionals, wrong field names
+- Read models to verify field constraints, computed properties, status transitions
+- Read URL configs to find orphaned routes, naming mismatches, missing views
+- Read JavaScript to check event handlers, AJAX calls, drawer/modal behaviour
+- Read navigation config to spot missing or duplicated links
+- Cross-reference: verify template variables exist in the view context, model fields match form fields, URL names match `{% url %}` tags
+
+**What you CANNOT do (no browser access):**
+- You cannot load pages in a browser, see rendered output, or check CSS styling
+- You cannot execute JavaScript or test client-side interactivity
+- You cannot check network requests, console errors, or response times
+- You cannot test authentication flows or session behaviour live
+
+Be upfront about this. If an issue can only be confirmed via live testing, note it as "Needs live verification" in the report.
 
 ## Before You Start
 
 Ask the user these questions (skip any they've already answered):
 
-1. **URL and credentials** — Where is the app and how do I log in?
-2. **App type** — What domain is this? (e.g., restaurant inventory, e-commerce, SaaS dashboard). This shapes what "correct behaviour" looks like.
-3. **Audit depth** — Quick smoke test (15 min), standard audit (1 hr), or deep dive (2+ hrs)?
-4. **Priority areas** — Any specific flows or pages they're worried about?
+1. **App type** — What domain is this? (e.g., restaurant inventory, e-commerce, SaaS dashboard). This shapes what "correct behaviour" looks like.
+2. **Audit depth** — Quick scan (key workflows only) or deep dive (every view and template)?
+3. **Priority areas** — Any specific flows or pages they're worried about?
+4. **Previous work** — Check the Completed Work Log in CLAUDE.md to know what's already been fixed.
 
 ## Audit Methodology
 
 Work through the app in this exact order. Complete each phase before moving to the next.
 
-### Phase 1 — Page-by-Page UI Scan
-Visit every page accessible from the navigation. For each page:
-- Does it load without errors?
-- Are there any visible template artifacts, debug text, or broken layouts?
-- Do all buttons, links, and interactive elements respond to clicks?
-- Do forms open correctly (drawers, modals, or full pages)?
-- Is the page responsive (if applicable)?
+### Phase 1 — Route and Navigation Scan
+- Read `ui_urls.py` (and any other URL configs) to build a complete map of all routes
+- Read `navigation.py` to check what's exposed in the nav vs what exists
+- Flag: orphaned URLs (no nav link, no internal reference), broken URL names, nav items pointing to non-existent views
 
-Record findings as you go. Don't try to fix anything yet.
+### Phase 2 — View-by-View Trace
+For each view (prioritise user-facing views over API/partial views):
+- Does the view handle both GET and POST correctly?
+- Are form errors returned to the user (not silently swallowed)?
+- Does it pass all required context variables to the template?
+- Are permissions/login checks in place?
+- Are database writes wrapped in `transaction.atomic()` where needed?
 
-### Phase 2 — CRUD Audit
-For each entity/module in the app (e.g., Items, Orders, Users):
-- **Create** — Fill the form, submit, verify it appears in the list
-- **Read** — Open the detail view, verify all data is displayed correctly
-- **Update** — Edit a record, save, verify changes persist
-- **Delete** — Delete a record, verify it's removed (check for confirmation dialogs)
+### Phase 3 — Template Audit
+For each template:
+- Do `{% url %}` tags reference valid URL names?
+- Do template variables (`{{ var }}`) match what the view passes in context?
+- Are conditionals correct (e.g., status-based button visibility)?
+- Are there hardcoded values that should be dynamic?
+- Do drawer/partial templates avoid `{# django comments #}` (leak as visible text)?
 
-Test with both valid and invalid data. Try empty required fields, extremely long text, special characters, zero/negative numbers.
+### Phase 4 — Model and Data Integrity
+- Are there fields with NOT NULL constraints that views might forget to set?
+- Do computed fields (properties) handle None/zero values safely?
+- Are status transitions enforced (or can invalid transitions happen)?
+- Do `save()` overrides and `clean()` methods cover edge cases?
 
-### Phase 3 — Process Flow Audit
-Map the end-to-end workflows the app supports. For each flow:
-- Walk through every step from start to finish
-- Verify each step's output becomes the next step's input
-- Check status transitions happen correctly
-- Look for dead ends (steps that can't proceed forward)
-- Look for bypasses (steps that can be skipped when they shouldn't be)
-
-### Phase 4 — Cross-Cutting Concerns
-- **Error handling** — What happens when things go wrong? Are error messages helpful?
-- **Data consistency** — Do counts, totals, and status badges match reality?
-- **Navigation** — Can the user get back to where they were? Do breadcrumbs work?
-- **Search/Filter** — Do search and filter controls actually narrow results correctly?
+### Phase 5 — Cross-Cutting Concerns
+- **Error handling** — Do views catch exceptions and show user-friendly messages?
+- **Consistency** — Do counts, totals, and badges match the data they represent?
+- **Search/Filter** — Do filter parameters map to actual model fields?
 
 ## Bug Documentation Format
 
@@ -64,41 +78,35 @@ Every bug must include ALL of these fields:
 ```
 ID: [MODULE]-[NUMBER] (e.g., PO-01, RECIPE-03)
 Title: [One-line description]
-Priority: P0 (app crashes/data loss), P1 (feature broken), P2 (UX issue/cosmetic)
-Page: [URL or page name]
-Steps to reproduce:
-  1. [Exact step]
-  2. [Exact step]
-  3. [Exact step]
-Actual result: [What happened — include exact error text if any]
-Expected result: [What should have happened]
-Root cause (if identifiable): [Why it's happening]
-Fix suggestion: [How to fix it — include file paths and code patterns if you can identify them]
+Priority: P0 (data loss/crash), P1 (feature broken), P2 (UX issue/cosmetic)
+File(s): [file path(s) and line number(s)]
+Evidence: [The specific code that causes the issue — quote the relevant lines]
+Actual behaviour: [What the code does]
+Expected behaviour: [What it should do]
+Fix suggestion: [Specific code change]
+Needs live verification: [Yes/No — can this be confirmed from code alone?]
 ```
 
-The priority levels matter because they determine fix order:
-- **P0 Critical** — App crashes, data loss, security issue, or a feature that is completely non-functional and blocks other features downstream
-- **P1 High** — Feature is broken but has a workaround, or a workflow can be bypassed in a way that corrupts data integrity
+Priority levels:
+- **P0 Critical** — Data loss, crash, security issue, or completely non-functional feature blocking downstream workflows
+- **P1 High** — Feature broken with workaround, or a workflow bypass that corrupts data integrity
 - **P2 Medium** — UX confusion, cosmetic issues, missing validation, unclear error messages
 
 ## Delivering the Report
 
 Structure your final report as:
 
-1. **Executive Summary** — How many bugs, how many per priority, overall app health assessment
-2. **What Works** — List everything that functions correctly (this is important — it tells the developer what NOT to touch)
-3. **Bug Table** — All bugs in a sortable table: ID | Title | Priority | Module | Impact
+1. **Executive Summary** — Bug count by priority, overall code health assessment
+2. **What Works** — List everything that is correctly implemented (tells the developer what NOT to touch)
+3. **Bug Table** — All bugs: ID | Title | Priority | File | Needs Live Verification
 4. **Detailed Bug Reports** — Full details for each bug following the format above
-5. **Missing Features** — Things the app should have for its domain but doesn't (separate from bugs)
+5. **Potential Issues (Needs Live Testing)** — Things that look suspicious but can only be confirmed in a browser
 6. **Verification Checklist** — A checkbox list the developer can use after fixing
 
-Save the report as a markdown file in the outputs folder.
+## Tips
 
-## Tips From Experience
-
-- **Test the happy path first, then break it.** Confirm the intended flow works before trying edge cases. If the happy path is already broken, document that as P0 and move on — edge case testing is pointless on a broken flow.
-- **Watch the browser console.** JS errors often explain why buttons don't respond or drawers don't open.
-- **Check network requests.** A 500 response with a JSON error body tells you more than "it didn't work."
-- **Screenshot everything.** If you have screenshot capability, capture the exact state when a bug occurs.
-- **Don't assume.** If a button says "Edit" but opens a read-only view, that's a bug — even if the developer might have intended it as a "View" button. Document what the UI promises vs what it delivers.
-- **Track what you haven't tested.** At the end of each phase, list anything you skipped or couldn't test and why.
+- **Read the Completed Work Log first.** CLAUDE.md tracks what's already been fixed. Don't re-report resolved issues.
+- **Trace the full request cycle.** For any suspicious view, follow: URL → view function → template → back to view (POST). Most bugs live at the seams between these layers.
+- **Check formset handling carefully.** Django formsets are a common source of subtle bugs — missing management forms, wrong prefix, items not saved.
+- **Look at what's NOT there.** Missing `login_required`, missing `transaction.atomic()`, missing error handling — absences are bugs too.
+- **Group by module.** Report bugs grouped by module (Indents, POs, Recipes, etc.) for easier developer triage.

--- a/.claude/skills/production-readiness-checker/SKILL.md
+++ b/.claude/skills/production-readiness-checker/SKILL.md
@@ -18,7 +18,7 @@ Before evaluating, establish:
 1. **What does this app do?** (domain, core workflow)
 2. **Who uses it?** (internal team of 5? public SaaS? restaurant kitchen staff?)
 3. **What's the scale?** (10 users/day? 10,000?)
-4. **What's already been done?** (any prior audits, bug fixes, phases completed?)
+4. **What's already been done?** Check the **Completed Work Log** section in CLAUDE.md — it tracks all phases completed so far. Don't re-evaluate fixed issues.
 5. **What's the deployment target?** (already hosted? needs CI/CD? compliance requirements?)
 
 The answers shape every recommendation. A 5-person internal tool doesn't need GDPR compliance flows. A public SaaS doesn't need kitchen station assignments.

--- a/.claude/skills/production-readiness-checker/references/domain-checklists.md
+++ b/.claude/skills/production-readiness-checker/references/domain-checklists.md
@@ -2,24 +2,26 @@
 
 When evaluating production readiness, use the relevant domain checklist below to identify missing features. These are based on industry standards — not every app needs every item, but missing critical ones should be flagged.
 
+Items marked with [DONE] are already implemented in Inventory Pro (see CLAUDE.md Completed Work Log for details).
+
 ## Restaurant / F&B Inventory
 
 ### Critical (app is incomplete without these)
-- Sub-recipes / semi-processed items (a recipe using another recipe as an ingredient)
-- Food Cost % (total ingredient cost / selling price × 100) — the #1 metric
-- Physical stock-take workflow (count vs system, variance tracking)
-- Full procurement pipeline: Indent → PO → GRN → Stock update
+- [DONE] Sub-recipes / semi-processed items (a recipe using another recipe as an ingredient)
+- [DONE] Food Cost % (total ingredient cost / selling price x 100) — the #1 metric
+- [DONE] Physical stock-take workflow (count vs system, variance tracking, auto-adjust)
+- [DONE] Full procurement pipeline: Indent → PO → GRN → Stock update
 
 ### High (users will notice within first week)
-- Stock transfers between departments (Kitchen ↔ Bar ↔ Pastry)
-- Low-stock alerts with auto-reorder action
-- Ad-hoc receiving (goods without a PO — emergency purchases)
+- [DONE] Stock transfers between departments (Kitchen ↔ Bar ↔ Pastry)
+- [DONE] Low-stock alerts with auto-reorder action
+- [DONE] Ad-hoc receiving (goods without a PO — emergency purchases)
 - Allergen tracking on items, auto-display on recipes
-- Wastage reason codes (Spoiled / Over-prep / Dropped / Expired)
+- [DONE] Wastage reason codes (Spoiled / Over-prep / Dropped / Expired)
 
 ### Medium (will be requested eventually)
 - Batch/lot tracking with expiry dates
-- Consumption tracking — auto-deduct stock when a recipe is produced
+- [DONE] Consumption tracking — auto-deduct stock when a recipe is produced
 - Food cost trend reports over time
 - Recipe profitability ranking
 - Prep instructions and station assignment on recipes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,17 +2,16 @@
 
 ## Project Overview
 
-Inventory Pro is a Django-based F&B (Food & Beverage) inventory management app for restaurant and café operations. It covers the full procurement-to-stock pipeline: Indents → Purchase Orders → GRN (Goods Received Notes) → Stock Movements, plus Recipe costing, Reporting, and ML-based demand planning.
+Inventory Pro is a Django-based F&B (Food & Beverage) inventory management app for restaurant and cafe operations. It covers the full procurement-to-stock pipeline: Indents → Purchase Orders → GRN (Goods Received Notes) → Stock Movements, plus Recipe costing, Food Cost reporting, and ML-based demand planning.
 
 **Live URL:** https://inventory-app-kguo.onrender.com/
-**Login:** admin / admin123!
-**Hosting:** Render.com free tier (cold starts ~50-60s)
+**Hosting:** Render.com free tier — a background keep-alive thread pings the app every 5 min to prevent idle sleep (see `inventory/apps.py`). Set `DISABLE_KEEP_ALIVE=true` to suppress.
 
 ## Tech Stack
 
-- **Backend:** Django (Python)
+- **Backend:** Django 5.2 (Python)
 - **Frontend:** Django templates + HTMX for AJAX interactions + Alpine.js for some reactivity
-- **CSS:** Bootstrap 5
+- **CSS:** Tailwind CSS (utility classes: `px-4 py-2 rounded-lg bg-surface text-bodyText`, etc.)
 - **Charts:** Plotly (Receipts Over Time, Stock Activity Heatmap), Chart.js (some dashboard widgets)
 - **Database:** PostgreSQL (hosted on Render)
 - **No separate frontend build step** — all JS/CSS is served via Django static files
@@ -36,6 +35,9 @@ if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
 ### Django Formsets
 PO line items and recipe ingredients use Django formsets with management fields (`items-TOTAL_FORMS`, `items-0-item`, etc.). Always include the management form in templates.
 
+### Navigation
+Navigation is driven from `inventory_app/navigation.py` — groups and links are defined there, not hardcoded in templates. To add a nav item, add an entry to `NAVIGATION_GROUPS` and register the icon in `templates/components/top_nav.html`.
+
 ## Key Models & Relationships
 
 ```
@@ -45,11 +47,16 @@ PurchaseOrder → PurchaseOrderItem (line_total = quantity_ordered × unit_price
   ↓
 GRN (GoodsReceivedNote) → GRNItem
   ↓ (auto-creates on confirm)
-StockMovement (types: RECEIVING, ADJUSTMENT, WASTAGE, TRANSFER)
+StockTransaction (types: RECEIVING, ADJUSTMENT, WASTAGE, TRANSFER, SALE, ISSUE)
+  - reason_category: STOCK_TAKE, MANUAL, etc.
 
 Recipe → RecipeItem → Item (raw ingredient) OR Recipe (sub-recipe)
   - selling_price, food_cost_percentage (computed property)
   - Recursive costing for sub-recipes
+
+StockTake → StockTakeItem (system_qty vs physical_qty)
+  - On completion: auto-generates ADJUSTMENT StockTransactions for variances
+  - Updates Item.current_stock atomically via F() expressions
 
 Department — used for indent assignment and stock transfers
 Supplier — linked to POs and GRNs
@@ -62,17 +69,21 @@ Item — has current_stock, reorder_point, moq, unit, category, department, ABC 
 `SUBMITTED → APPROVED → PROCESSING → COMPLETED`
 (Also: `CANCELLED` from any active state)
 - Only SUBMITTED and APPROVED can be edited
-- Drawer buttons must be status-conditional (Phase B fix)
+- Drawer buttons are status-conditional
 
-### PO Statuses (simplified in Phase C)
+### PO Statuses
 `DRAFT → SENT (to Supplier) → RECEIVED`
-- Previously was 5 statuses (Draft → Submitted → Approved → Processing → Completed)
-- Migration `simplify_po_statuses` consolidated old values
+- Migration `simplify_po_statuses` consolidated old 5-status flow
 
 ### GRN
 `DRAFT → RECEIVED`
-- On confirmation, auto-fulfills connected indents (Phase C fix)
-- Supports ad-hoc GRNs without a PO (Phase D)
+- On confirmation, auto-fulfills connected indents
+- Supports ad-hoc GRNs without a PO
+
+### Stock Take
+`DRAFT → IN_PROGRESS → COMPLETED`
+- On completion, generates ADJUSTMENT transactions for all counted items with variance
+- Uncounted items are left unchanged
 
 ## Important Conventions
 
@@ -82,24 +93,29 @@ The `line_total` column has a NOT NULL constraint. It must always be computed as
 ### Template Comments
 Use HTML comments (`<!-- -->`) not Django template comments (`{# #}`) for any comment that might appear in an included partial — Django comments can leak as visible text if the partial is loaded outside a template context.
 
-### Stock Movement Types
+### StockTransaction Types
 - **RECEIVING** — goods arriving from supplier (via GRN or direct receive)
-- **ADJUSTMENT** — correcting a counting error only
+- **ADJUSTMENT** — correcting stock levels (manual correction or stock-take variance)
 - **WASTAGE** — food thrown away (spoiled, expired, dropped, over-prepped)
 - **TRANSFER** — between departments (Kitchen ↔ Bar ↔ Pastry etc.)
+- **SALE** — auto-deducted when a recipe sale is recorded
+- **ISSUE** — stock issued to a department
 
 ### Recipe Sub-recipes
 RecipeItem can reference either an `item` (raw ingredient) OR a `sub_recipe` (another Recipe). Validation prevents circular dependencies. Cost calculation is recursive with a visited-set guard.
 
+### Decimal Arithmetic in Templates
+Django templates cannot do arithmetic with Decimal values. If you need a computed value in a template (e.g. `remaining = ordered - received`), add a `@property` on the model and reference it as `{{ obj.remaining }}`.
+
 ## URL Naming Conventions
 
-URLs follow the pattern: `<module>-<action>` e.g.:
-- `indent-list`, `indent-detail`, `indent-create`, `indent-update`
-- `po-list`, `po-create-partial`, `grn-create`, `grn-create-adhoc`
-- `stock-take-list`, `stock-take-create`, `stock-take-count`, `stock-take-review`
-- `consolidation-preview`, `low-stock-indent`
+URLs use underscores: `<module>_<action>` e.g.:
+- `indent_list`, `indent_detail`, `indent_create`, `indent_update`
+- `po_list`, `po_create_partial`, `grn_create`, `grn_create_adhoc`
+- `stock_take_list`, `stock_take_start`, `stock_take_count`, `stock_take_review`
+- `food_cost_report`, `history_reports`, `recipes_list`
 
-Partial views (for drawers) typically have `-partial` suffix in the URL name.
+Partial views (for drawers) typically have `_partial` suffix in the URL name.
 
 ## Development Workflow
 
@@ -110,7 +126,7 @@ Partial views (for drawers) typically have `-partial` suffix in the URL name.
 3. Run `make ci` (formats with Black, lints with Ruff, runs pytest)
 4. Commit and push: `git push -u origin feature/<slug>`
 5. Claude opens a PR targeting `feature/django-refactor` with a clear description
-6. User tests in the live preview: https://inventory-app-kguo.onrender.com/
+6. User tests in the live preview
 7. User confirms → Claude merges the PR
 
 ### Tooling (via Makefile)
@@ -142,13 +158,38 @@ All `make` commands invoke the environment-appropriate Python automatically.
 - Target branch: `feature/django-refactor`
 
 ### Task Planning
-Tasks are discussed and planned collaboratively at the start of each session. There is no fixed phased roadmap — the user directs priorities.
+Tasks are discussed and planned collaboratively at the start of each session. The user directs priorities.
 
 ## Common Gotchas
 
-1. **Render cold starts:** The free tier sleeps after 15 min inactivity. First request takes 50-60s. Use sequential waits if automating.
+1. **Render keep-alive:** A background thread in `inventory/apps.py` pings the app every 5 min. If you see the app still sleeping, check `DISABLE_KEEP_ALIVE` isn't set and verify the thread is running in Render logs (`[keep-alive] 200`).
 2. **form.submit() in drawers:** Never use native `form.submit()` — it causes full-page navigation to the partial endpoint. Always use `fetch()` or HTMX.
 3. **line_total on PO items:** Forgetting to compute this before save causes `NOT NULL constraint violation`. Always set `line_total = quantity_ordered * unit_price`.
 4. **Status-conditional buttons:** Indent and PO drawer/detail pages must show different action buttons based on current status. Never show all buttons statically.
 5. **Decimal precision:** Use `Decimal` (not `float`) for all monetary and quantity calculations. Import from `decimal`.
 6. **Circular sub-recipes:** The `_check_circular()` method on RecipeItem prevents A→B→A loops. Always call `clean()` before saving recipe items.
+7. **Template arithmetic:** Don't attempt Decimal math in Django templates. Add a `@property` on the model instead.
+
+## Completed Work Log
+
+Track what's been built so future sessions have context. Newest first.
+
+### Phase D — Domain Gaps (March 2025)
+- **Stock-take auto-adjust**: Completing a stock take generates ADJUSTMENT StockTransactions for all items with variance and updates `Item.current_stock` atomically. `reason_category="STOCK_TAKE"` tags these transactions.
+- **Food cost report**: `/recipes/food-cost-report/` — lists all active FINAL recipes with ingredient cost, selling price, food cost %, target %, gross margin, and status badges. Filterable by status. Added to "Insights & Settings" nav.
+- **Keep-alive thread**: Background daemon thread in `InventoryConfig.ready()` pings the app URL every 5 min to prevent Render idle sleep.
+
+### Phase C — UX Confusion (March 2025)
+- Replaced hardcoded user list in indent filter with live DB query
+- Added "Remaining" column on PO receive form (model `@property` pattern for template arithmetic)
+- Added uncounted-items warning + confirmation guard on stock-take review page
+- Confirmed nav was already clean (no table/card sub-URLs, workflow guide already present)
+
+### Phase B — Known Bugs (March 2025)
+- Status-conditional buttons on indent and PO drawers
+- Various P1/P2 bug fixes from audit
+
+### Phase A — Core Workflow (March 2025)
+- Fixed PO creation (removed invalid `po_number` kwarg)
+- Fixed `line_total` NOT NULL constraint (model `save()` safety net + view computation)
+- Fixed consolidation planner → PO creation pipeline


### PR DESCRIPTION
## Summary

Comprehensive update to project configuration for better cross-session context and accuracy.

### CLAUDE.md fixes
- **Tech stack**: Bootstrap 5 → Tailwind CSS (matches actual templates)
- **Model name**: StockMovement → StockTransaction (matches actual code)
- **URL naming**: hyphens → underscores (matches actual url names)
- **Credentials removed** from checked-in file
- **Cold-start note** updated to reflect keep-alive thread
- **Added**: Navigation architecture note, Decimal-in-templates gotcha
- **Added**: Completed Work Log section (Phases A–D) — gives future sessions full context on what's been built

### New: `.claude/settings.json`
- Project-level permissions for `make`, `git`, and `py_compile` commands
- `DISABLE_KEEP_ALIVE=true` for dev/CI environments

### Skill updates
- **app-audit**: Rewritten for code-level auditing (no browser tools). Explicit capabilities/limitations section. References Completed Work Log.
- **production-readiness-checker**: References Completed Work Log so it doesn't re-evaluate fixed issues.
- **domain-checklists**: Marks implemented F&B features as [DONE] (sub-recipes, food cost %, stock-take, transfers, etc.)

## Test plan
- [ ] New session reads CLAUDE.md and has correct context about tech stack, models, completed work
- [ ] Skills trigger correctly and reference completed work
- [ ] Settings permissions allow make/git commands without prompting

https://claude.ai/code/session_016o6q2oztG1Q2j15cUVxK6K