### PR TITLE
fix: add sub_recipe_id to recipe_items_new (correct RecipeItem table)

### DIFF
--- a/inventory/migrations/0033_fix_recipe_items_new_columns.py
+++ b/inventory/migrations/0033_fix_recipe_items_new_columns.py
@@ -1,0 +1,34 @@
+# Migration 0033: Add missing columns to recipe_items_new (the actual RecipeItem table)
+#
+# Root cause of the food cost report 500 error:
+#
+#   RecipeItem.Meta.db_table = "recipe_items_new"
+#
+# Migration 0029 was state-only (database_operations=[]) so no DDL ran.
+# Migrations 0030 and 0032 added sub_recipe_id to "recipe_items" (the old
+# deprecated RecipeComponent table), not to "recipe_items_new".
+#
+# This migration adds the missing columns to the correct table.
+# All operations use IF NOT EXISTS / idempotent DDL — safe to run in any state.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0032_ensure_recipe_item_sub_recipe_column"),
+    ]
+
+    operations = [
+        # Add sub_recipe_id to the correct table
+        migrations.RunSQL(
+            sql="ALTER TABLE recipe_items_new ADD COLUMN IF NOT EXISTS sub_recipe_id INTEGER;",
+            reverse_sql="ALTER TABLE recipe_items_new DROP COLUMN IF EXISTS sub_recipe_id;",
+        ),
+        # Make item_id nullable (required for sub-recipe rows where item is NULL)
+        migrations.RunSQL(
+            sql="ALTER TABLE recipe_items_new ALTER COLUMN item_id DROP NOT NULL;",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]


### PR DESCRIPTION
## Root Cause

`RecipeItem.Meta.db_table = "recipe_items_new"` — this is the actual table Django queries for all recipe ingredient operations.

Previous fix attempts (migrations 0030 and 0032) added `sub_recipe_id` to `"recipe_items"` — the old deprecated `RecipeComponent` table. Migration 0029 was state-only (`database_operations=[]`) so no DDL ever ran on the correct table.

Result: every query touching existing `RecipeItem` rows failed with a missing column error → 500 on food cost report, recipe detail, API, admin list.

## Fix

Migration 0033 adds `sub_recipe_id` to `recipe_items_new` (with `IF NOT EXISTS`) and drops the `NOT NULL` on `item_id` (required for sub-recipe rows). Both operations are idempotent.

## Test plan

- [ ] After deploy: `/recipes/food-cost-report/` returns 200 with data
- [ ] Recipe detail pages load
- [ ] `/admin/inventory/recipeitem/` list loads

https://claude.ai/code/session_016o6q2oztG1Q2j15cUVxK6K