### PR TITLE
feat: configurable quantity decimal places setting

### DIFF
--- a/inventory/migrations/0036_siteconfig_quantity_decimal_places.py
+++ b/inventory/migrations/0036_siteconfig_quantity_decimal_places.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("inventory", "0035_remove_currency_symbol"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="siteconfig",
+            name="quantity_decimal_places",
+            field=models.IntegerField(
+                choices=[(0, "0"), (1, "1"), (2, "2"), (3, "3"), (4, "4")],
+                default=2,
+                help_text="Number of decimal places shown for stock quantities and conversion factors.",
+            ),
+        ),
+    ]

--- a/inventory/models/site_config.py
+++ b/inventory/models/site_config.py
@@ -23,6 +23,11 @@ class SiteConfig(models.Model):
         default=30,
         help_text="Default target food cost % used in recipe costing.",
     )
+    quantity_decimal_places = models.IntegerField(
+        default=2,
+        choices=[(0, "0"), (1, "1"), (2, "2"), (3, "3"), (4, "4")],
+        help_text="Number of decimal places shown for stock quantities and conversion factors.",
+    )
 
     class Meta:
         managed = True

--- a/inventory/views/settings.py
+++ b/inventory/views/settings.py
@@ -35,6 +35,7 @@ def settings_view(request):
             cfg = SiteConfig.get()
             business_name = request.POST.get("business_name", "").strip()
             food_cost_target = request.POST.get("default_food_cost_target", "").strip()
+            qty_dp = request.POST.get("quantity_decimal_places", "").strip()
             if business_name:
                 cfg.business_name = business_name
             if food_cost_target:
@@ -45,6 +46,8 @@ def settings_view(request):
                 except Exception:
                     messages.error(request, "Invalid food cost target value.")
                     return HttpResponseRedirect(reverse("settings") + "?tab=config")
+            if qty_dp in ("0", "1", "2", "3", "4"):
+                cfg.quantity_decimal_places = int(qty_dp)
             cfg.save()
             messages.success(request, "App configuration saved.", extra_tags="toast")
             return HttpResponseRedirect(reverse("settings") + "?tab=config")

--- a/templates/inventory/_ml_dashboard_table.html
+++ b/templates/inventory/_ml_dashboard_table.html
@@ -48,7 +48,7 @@
           {# Forecast qty #}
           <td class="px-4 py-3">
             {% if row.has_data %}
-              {{ row.forecast|floatformat:2 }}
+              {{ row.forecast|floatformat:site_config.quantity_decimal_places }}
               {% if row.item.unit %}
                 <span class="text-gray-400 text-xs">{{ row.item.unit.unit_name }}</span>
               {% endif %}
@@ -62,7 +62,7 @@
 
           {# Current stock #}
           <td class="px-4 py-3 text-gray-700">
-            {{ row.item.current_stock|floatformat:2 }}
+            {{ row.item.current_stock|floatformat:site_config.quantity_decimal_places }}
             {% if row.item.unit %}
               <span class="text-gray-400 text-xs">{{ row.item.unit.unit_name }}</span>
             {% endif %}

--- a/templates/inventory/explore.html
+++ b/templates/inventory/explore.html
@@ -121,9 +121,9 @@
           <td class="px-4 py-2 text-gray-600">{{ item.unit.base_unit|default:'—' }}</td>
           <td class="px-4 py-2 text-right tabular-nums font-medium
             {% if item.current_stock <= 0 %}text-red-700{% elif item.current_stock < item.reorder_point %}text-amber-700{% else %}text-green-700{% endif %}">
-            {{ item.current_stock|floatformat:2 }}
+            {{ item.current_stock|floatformat:site_config.quantity_decimal_places }}
           </td>
-          <td class="px-4 py-2 text-right tabular-nums text-gray-600">{{ item.reorder_point|floatformat:2 }}</td>
+          <td class="px-4 py-2 text-right tabular-nums text-gray-600">{{ item.reorder_point|floatformat:site_config.quantity_decimal_places }}</td>
           <td class="px-4 py-2">
             {% if item.current_stock <= 0 %}
               <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium text-red-700 bg-red-100">Out of Stock</span>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -38,7 +38,7 @@
       <h3 class="text-sm font-medium text-gray-500 mb-2">Top Fastest Movers (7d)</h3>
       <ul class="text-sm text-bodyText space-y-1">
         {% for name, qty in stats.fastest_movers %}
-          <li>{{ name }} - {{ qty|floatformat:2 }}</li>
+          <li>{{ name }} - {{ qty|floatformat:site_config.quantity_decimal_places }}</li>
         {% endfor %}
       </ul>
     </div>

--- a/templates/inventory/settings.html
+++ b/templates/inventory/settings.html
@@ -85,6 +85,20 @@
           <p class="mt-1 text-xs text-gray-400">Default target for new recipes. Drag the slider or type a value (0–100).</p>
         </div>
 
+        <!-- Quantity Decimal Places -->
+        <div class="max-w-xs">
+          <label class="block text-sm font-medium text-gray-700 mb-1" for="cfg-qty-dp">Quantity Decimal Places</label>
+          <select id="cfg-qty-dp" name="quantity_decimal_places"
+                  class="w-full h-10 px-3 border border-form-border rounded-lg bg-form-bg text-sm focus:outline-none focus:ring-2 focus:ring-primary">
+            <option value="0" {% if site_config.quantity_decimal_places == 0 %}selected{% endif %}>0 — whole numbers (e.g. 125)</option>
+            <option value="1" {% if site_config.quantity_decimal_places == 1 %}selected{% endif %}>1 decimal place (e.g. 125.5)</option>
+            <option value="2" {% if site_config.quantity_decimal_places == 2 %}selected{% endif %}>2 decimal places (e.g. 125.50)</option>
+            <option value="3" {% if site_config.quantity_decimal_places == 3 %}selected{% endif %}>3 decimal places (e.g. 125.500)</option>
+            <option value="4" {% if site_config.quantity_decimal_places == 4 %}selected{% endif %}>4 decimal places (e.g. 125.5000)</option>
+          </select>
+          <p class="mt-1 text-xs text-gray-400">Controls how stock quantities are displayed throughout the app (e.g. items list, forecasts).</p>
+        </div>
+
         <div class="pt-2 border-t border-border flex justify-end">
           <button type="submit"
                   class="h-9 px-6 text-sm font-medium rounded-lg bg-primary text-white hover:bg-primaryHover focus:outline-none focus:ring-2 focus:ring-primary transition-colors">
@@ -162,11 +176,11 @@
             <tr class="hover:bg-surfaceSubtle transition-colors" data-row>
               <td class="px-4 py-2.5 font-medium" id="unit-pu-{{ unit.unit_id }}">{{ unit.purchase_unit }}</td>
               <td class="px-4 py-2.5 text-gray-600" id="unit-bu-{{ unit.unit_id }}">{{ unit.base_unit }}</td>
-              <td class="px-4 py-2.5 text-right tabular-nums text-gray-600">{{ unit.conversion_factor|floatformat:"-4" }}</td>
+              <td class="px-4 py-2.5 text-right tabular-nums text-gray-600">{{ unit.conversion_factor|floatformat:"-6" }}</td>
               <td class="px-4 py-2.5 text-right whitespace-nowrap">
                 <button type="button"
                         class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-md border border-border bg-surface hover:bg-surfaceSubtle text-bodyText transition-colors mr-1"
-                        onclick="openEditUnit({{ unit.unit_id }}, '{{ unit.purchase_unit|escapejs }}', '{{ unit.base_unit|escapejs }}', '{{ unit.conversion_factor }}')">Edit</button>
+                        onclick="openEditUnit({{ unit.unit_id }}, '{{ unit.purchase_unit|escapejs }}', '{{ unit.base_unit|escapejs }}', '{{ unit.conversion_factor|floatformat:"-6" }}')">Edit</button>
                 <button type="button"
                         class="inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-md border border-red-200 bg-red-50 hover:bg-red-100 text-red-700 transition-colors"
                         onclick="confirmSettingsDelete('delete_unit', 'unit_id', {{ unit.unit_id }}, '{{ unit.purchase_unit|escapejs }}')">Delete</button>


### PR DESCRIPTION
## Summary
- Adds a **Quantity Decimal Places** setting (0-4, default 2) to SiteConfig, selectable from Settings -> Configuration tab
- Fixes the unit edit modal showing raw 6-decimal strings like 2000.000000 - now displays clean values like 2000
- Stock quantity displays in Items list, Explore, and ML Demand Planning table now respect the configured decimal places

## Changes
- SiteConfig model: new quantity_decimal_places IntegerField + migration 0036
- Settings view: saves quantity_decimal_places in the save_app_config handler
- settings.html: new select dropdown in Configuration tab; unit table and edit modal use floatformat:-6 for conversion factors
- explore.html, _ml_dashboard_table.html, items_list.html: qty displays use site_config.quantity_decimal_places

## Test plan
- [ ] Go to Settings -> Configuration, change Quantity Decimal Places and save - verify it persists
- [ ] Check Items list and Explore page - stock quantities reflect the chosen precision
- [ ] Open a unit Edit dialog - conversion factor shows clean number (no trailing zeros like 2000.000000)
- [ ] ML Demand Planning table - forecast and current stock columns use the configured dp