### PR TITLE
feat: reorganize navigation for restaurant workflow

### DIFF
--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -21,102 +21,92 @@ logger = logging.getLogger(__name__)
 # sections in the future.
 NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
     (
-        "Plan & Request",
+        "Insights",
         [
             {
-                "title": "Item Catalog",
-                "description": "Maintain products, variants, and stock policies.",
-                "url_name": "items_list",
+                "title": "Overview",
+                "description": "Daily numbers, charts, and alerts.",
+                "url_name": "visualizations",
             },
             {
-                "title": "Recipes & BOMs",
-                "description": "Build formulations and production yields.",
-                "url_name": "recipes_list",
+                "title": "Food Cost",
+                "description": "Recipe costs, margins, and selling prices.",
+                "url_name": "food_cost_report",
             },
             {
-                "title": "Indent Requests",
-                "description": "Capture and prioritise internal demand.",
+                "title": "History",
+                "description": "Past stock activity and audit trail.",
+                "url_name": "history_reports",
+            },
+            {
+                "title": "Reorder Suggestions",
+                "description": "What to order based on usage patterns.",
+                "url_name": "ml_dashboard",
+            },
+        ],
+    ),
+    (
+        "Procurement",
+        [
+            {
+                "title": "Indents",
+                "description": "Raise requests for items you need.",
                 "url_name": "indents_list",
             },
             {
-                "title": "Consolidation Planner",
-                "description": "Bundle approved indents into supplier orders.",
+                "title": "Order Planner",
+                "description": "Combine indents into purchase orders.",
                 "url_name": "indents_consolidate_preview",
             },
-        ],
-    ),
-    (
-        "Buy & Receive",
-        [
             {
                 "title": "Purchase Orders",
-                "description": "Plan sourcing and track order progress.",
+                "description": "Orders sent to suppliers.",
                 "url_name": "purchase_orders_list",
             },
             {
-                "title": "Goods Received Notes",
-                "description": "Verify deliveries and attach supporting docs.",
+                "title": "Receiving",
+                "description": "Check in deliveries from suppliers.",
                 "url_name": "grn_list",
-            },
-            {
-                "title": "Supplier Directory",
-                "description": "Manage vendor contacts and statuses.",
-                "url_name": "suppliers_list",
             },
         ],
     ),
     (
-        "Fulfill & Track",
+        "Stock",
         [
             {
-                "title": "Stock Movements",
-                "description": "Review adjustments and inter-store transfers.",
-                "url_name": "stock_movements",
-            },
-            {
-                "title": "Inventory Explorer",
-                "description": "Search items, batches, and availability.",
+                "title": "Stock Levels",
+                "description": "What you have on hand right now.",
                 "url_name": "explore",
             },
             {
-                "title": "Stock Takes",
-                "description": "Run physical counts and reconcile variances.",
+                "title": "Movements",
+                "description": "Transfers, wastage, and adjustments.",
+                "url_name": "stock_movements",
+            },
+            {
+                "title": "Stock Count",
+                "description": "Physical count and fix differences.",
                 "url_name": "stock_take_list",
             },
         ],
     ),
     (
-        "Insights & Settings",
+        "Master Data",
         [
             {
-                "title": "Food Cost Report",
-                "description": "Review ingredient costs and margins across all recipes.",
-                "url_name": "food_cost_report",
+                "title": "Items",
+                "description": "Your products and stock settings.",
+                "url_name": "items_list",
             },
             {
-                "title": "Stock History Report",
-                "description": "Analyse trends and audit activity.",
-                "url_name": "history_reports",
+                "title": "Recipes",
+                "description": "Ingredients, portions, and costings.",
+                "url_name": "recipes_list",
             },
             {
-                "title": "Visual Dashboards",
-                "description": "Track KPIs and live performance.",
-                "url_name": "visualizations",
-            },
-            {
-                "title": "ML Planner",
-                "description": "View ABC classification and demand forecasts.",
-                "url_name": "ml_dashboard",
-            },
-            {
-                "title": "Workflow Handbook",
-                "description": "Follow the end-to-end Inventory Pro process.",
-                "url_name": "workflow_guide",
-            },
-            {
-                "title": "Settings",
-                "description": "Manage reference data: units, categories, departments.",
-                "url_name": "settings",
+                "title": "Suppliers",
+                "description": "Who you buy from.",
+                "url_name": "suppliers_list",
             },
         ],
     ),

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -21,10 +21,10 @@
           <button type="button" data-nav-trigger aria-haspopup="true" aria-expanded="false"
                   class="nav-link flex items-center gap-1 {% if is_active %}nav-link--active text-label{% else %}nav-link--inactive text-label{% endif %}">
             <span class="flex items-center gap-1">
-              {% if 'Plan' in group.category %}{% icon 'clipboard-document-list' 'h-4 w-4 text-gray-500' aria_label='' %}
-              {% elif 'Buy' in group.category %}{% icon 'truck' 'h-4 w-4 text-gray-500' aria_label='' %}
-              {% elif 'Fulfill' in group.category %}{% icon 'arrows-right-left' 'h-4 w-4 text-gray-500' aria_label='' %}
-              {% elif 'Insights' in group.category %}{% icon 'chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
+              {% if 'Insights' in group.category %}{% icon 'chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
+              {% elif 'Procurement' in group.category %}{% icon 'shopping-cart' 'h-4 w-4 text-gray-500' aria_label='' %}
+              {% elif 'Stock' in group.category %}{% icon 'cube' 'h-4 w-4 text-gray-500' aria_label='' %}
+              {% elif 'Master' in group.category %}{% icon 'circle-stack' 'h-4 w-4 text-gray-500' aria_label='' %}
               {% else %}{% icon 'ellipsis-horizontal' 'h-4 w-4 text-gray-500' aria_label='' %}{% endif %}
               <span>{{ group.category|safe }}</span>
             </span>
@@ -36,18 +36,20 @@
                 <li role="none">
                   {% if request.resolver_match.url_name == link.url_name %}
                     <a role="menuitem" href="{{ link.url }}" class="flex items-start gap-2 px-4 py-2 text-sm font-semibold text-blue-700 bg-blue-50" data-nav-link>
-                      {% if link.url_name == 'items_list' %}{% icon 'cube' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'stock_movements' %}{% icon 'arrows-right-left' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'indents_list' %}{% icon 'clipboard-document-list' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'grn_list' %}{% icon 'inbox-arrow-down' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'purchase_orders_list' %}{% icon 'receipt-percent' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'recipes_list' %}{% icon 'beaker' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'suppliers_list' %}{% icon 'truck' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% if link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-blue-600' aria_label='' %}
                       {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-blue-600' aria_label='' %}
                       {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-blue-600' aria_label='' %}
                       {% elif link.url_name == 'ml_dashboard' %}{% icon 'sparkles' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% elif link.url_name == 'indents_list' %}{% icon 'clipboard-document-list' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% elif link.url_name == 'indents_consolidate_preview' %}{% icon 'queue-list' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% elif link.url_name == 'purchase_orders_list' %}{% icon 'receipt-percent' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% elif link.url_name == 'grn_list' %}{% icon 'inbox-arrow-down' 'h-4 w-4 text-blue-600' aria_label='' %}
                       {% elif link.url_name == 'explore' %}{% icon 'magnifying-glass-plus' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% elif link.url_name == 'stock_movements' %}{% icon 'arrows-right-left' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% elif link.url_name == 'stock_take_list' %}{% icon 'clipboard-document-check' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% elif link.url_name == 'items_list' %}{% icon 'cube' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% elif link.url_name == 'recipes_list' %}{% icon 'beaker' 'h-4 w-4 text-blue-600' aria_label='' %}
+                      {% elif link.url_name == 'suppliers_list' %}{% icon 'truck' 'h-4 w-4 text-blue-600' aria_label='' %}
                       {% else %}{% icon 'square-2-stack' 'h-4 w-4 text-blue-600' aria_label='' %}{% endif %}
                       <span class="flex flex-col text-left">
                         <span class="truncate">{{ link.title|safe }}</span>
@@ -58,18 +60,20 @@
                     </a>
                   {% else %}
                     <a role="menuitem" href="{{ link.url }}" class="flex items-start gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" data-nav-link>
-                      {% if link.url_name == 'items_list' %}{% icon 'cube' 'h-4 w-4 text-gray-500' aria_label='' %}
-                      {% elif link.url_name == 'stock_movements' %}{% icon 'arrows-right-left' 'h-4 w-4 text-gray-500' aria_label='' %}
-                      {% elif link.url_name == 'indents_list' %}{% icon 'clipboard-document-list' 'h-4 w-4 text-gray-500' aria_label='' %}
-                      {% elif link.url_name == 'grn_list' %}{% icon 'inbox-arrow-down' 'h-4 w-4 text-gray-500' aria_label='' %}
-                      {% elif link.url_name == 'purchase_orders_list' %}{% icon 'receipt-percent' 'h-4 w-4 text-gray-500' aria_label='' %}
-                      {% elif link.url_name == 'recipes_list' %}{% icon 'beaker' 'h-4 w-4 text-gray-500' aria_label='' %}
-                      {% elif link.url_name == 'suppliers_list' %}{% icon 'truck' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% if link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
-                      {% elif link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'ml_dashboard' %}{% icon 'sparkles' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'indents_list' %}{% icon 'clipboard-document-list' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'indents_consolidate_preview' %}{% icon 'queue-list' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'purchase_orders_list' %}{% icon 'receipt-percent' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'grn_list' %}{% icon 'inbox-arrow-down' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'explore' %}{% icon 'magnifying-glass-plus' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'stock_movements' %}{% icon 'arrows-right-left' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'stock_take_list' %}{% icon 'clipboard-document-check' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'items_list' %}{% icon 'cube' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'recipes_list' %}{% icon 'beaker' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'suppliers_list' %}{% icon 'truck' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% else %}{% icon 'square-2-stack' 'h-4 w-4 text-gray-500' aria_label='' %}{% endif %}
                       <span class="flex flex-col text-left">
                         <span class="truncate">{{ link.title|safe }}</span>
@@ -152,10 +156,12 @@
           </button>
           <div x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
             <div class="py-1" role="menu">
-              <a href="/admin/" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Admin</a>
               <a href="{% url 'interactive-dashboard' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Dashboard</a>
               <a href="{% url 'settings' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Settings</a>
-              <a href="{% url 'logout' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Sign out</a>
+              <a href="{% url 'workflow_guide' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Help &amp; Guide</a>
+              <div class="border-t border-gray-100 my-1"></div>
+              <a href="/admin/" class="block px-4 py-2 text-sm text-gray-500 hover:bg-gray-100" role="menuitem">Admin Panel</a>
+              <a href="{% url 'logout' %}" class="block px-4 py-2 text-sm text-red-600 hover:bg-red-50" role="menuitem">Sign out</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Restructures the 4 navigation groups to match how restaurant staff actually work, with plain language labels.

**New structure (left to right by frequency of use):**

| Group | Items |
|---|---|
| **Insights** | Overview, Food Cost, History, Reorder Suggestions |
| **Procurement** | Indents, Order Planner, Purchase Orders, Receiving |
| **Stock** | Stock Levels, Movements, Stock Count |
| **Master Data** | Items, Recipes, Suppliers |

**Other changes:**
- Settings and Workflow Guide removed from main nav, now in user avatar menu
- User menu reorganized with divider: Dashboard, Settings, Help & Guide | Admin Panel, Sign out
- Added missing icons for Stock Count and Order Planner nav items
- All descriptions rewritten in plain, non-technical language

## Test plan
- [ ] Verify all 4 nav dropdowns render with correct items and icons
- [ ] Click every nav link to confirm URLs resolve correctly
- [ ] Check user avatar menu shows Settings, Help & Guide, Admin Panel, Sign out
- [ ] Test mobile hamburger menu shows the new groups
- [ ] Verify active page highlighting works in each group