### PR TITLE
refactor: Phase 2 — standardize table headers, form inputs, and nav tokens

### DIFF
--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -6,7 +6,7 @@
   <!-- Left side: Logo and main nav -->
   <div class="flex items-center min-w-0 flex-1">
         <!-- App logo links to home (title removed) -->
-        <a href="{% url 'root' %}" aria-label="Home" class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-primary">
+        <a href="{% url 'root' %}" aria-label="Home" class="h-8 w-8 bg-primary rounded-lg flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-primary">
           {% icon 'squares-2x2' 'h-5 w-5 text-white' variant='solid' size=20 aria_label='' %}
         </a>
 
@@ -35,31 +35,31 @@
               {% for link in group.links %}
                 <li role="none">
                   {% if request.resolver_match.url_name == link.url_name %}
-                    <a role="menuitem" href="{{ link.url }}" class="flex items-start gap-2 px-4 py-2 text-sm font-semibold text-blue-700 bg-blue-50" data-nav-link>
-                      {% if link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'ml_dashboard' %}{% icon 'sparkles' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'indents_list' %}{% icon 'clipboard-document-list' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'indents_consolidate_preview' %}{% icon 'queue-list' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'purchase_orders_list' %}{% icon 'receipt-percent' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'grn_list' %}{% icon 'inbox-arrow-down' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'explore' %}{% icon 'magnifying-glass-plus' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'stock_movements' %}{% icon 'arrows-right-left' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'stock_take_list' %}{% icon 'clipboard-document-check' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'items_list' %}{% icon 'cube' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'recipes_list' %}{% icon 'beaker' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% elif link.url_name == 'suppliers_list' %}{% icon 'truck' 'h-4 w-4 text-blue-600' aria_label='' %}
-                      {% else %}{% icon 'square-2-stack' 'h-4 w-4 text-blue-600' aria_label='' %}{% endif %}
+                    <a role="menuitem" href="{{ link.url }}" class="flex items-start gap-2 px-4 py-2 text-sm font-semibold text-primary bg-primary/10" data-nav-link>
+                      {% if link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'ml_dashboard' %}{% icon 'sparkles' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'indents_list' %}{% icon 'clipboard-document-list' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'indents_consolidate_preview' %}{% icon 'queue-list' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'purchase_orders_list' %}{% icon 'receipt-percent' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'grn_list' %}{% icon 'inbox-arrow-down' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'explore' %}{% icon 'magnifying-glass-plus' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'stock_movements' %}{% icon 'arrows-right-left' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'stock_take_list' %}{% icon 'clipboard-document-check' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'items_list' %}{% icon 'cube' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'recipes_list' %}{% icon 'beaker' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'suppliers_list' %}{% icon 'truck' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% else %}{% icon 'square-2-stack' 'h-4 w-4 text-primary' aria_label='' %}{% endif %}
                       <span class="flex flex-col text-left">
                         <span class="truncate">{{ link.title|safe }}</span>
                         {% if link.description %}
-                          <span class="text-xs font-normal text-blue-900/70 leading-tight">{{ link.description }}</span>
+                          <span class="text-xs font-normal text-primary/70 leading-tight">{{ link.description }}</span>
                         {% endif %}
                       </span>
                     </a>
                   {% else %}
-                    <a role="menuitem" href="{{ link.url }}" class="flex items-start gap-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" data-nav-link>
+                    <a role="menuitem" href="{{ link.url }}" class="flex items-start gap-2 px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" data-nav-link>
                       {% if link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
@@ -99,7 +99,7 @@
         </div>
 
   {% if nav_heading %}
-  <h1 class="ml-6 text-xl md:text-h2 font-semibold text-gray-900">{{ nav_heading }}</h1>
+  <h1 class="ml-6 text-xl md:text-h2 font-semibold text-bodyText">{{ nav_heading }}</h1>
   {% endif %}
       </div>
 
@@ -108,11 +108,11 @@
         {% if user.is_authenticated %}
         <!-- Global Search (dropdown) -->
         <div class="relative" x-data="{open:false}" @keydown.escape.window="open=false">
-          <button @click="open=!open; if(open){ $nextTick(()=> $refs.globalSearch && $refs.globalSearch.focus()) }" class="flex items-center gap-2 h-10 px-3 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary" aria-haspopup="true" :aria-expanded="open.toString()" aria-controls="global-search-panel">
+          <button @click="open=!open; if(open){ $nextTick(()=> $refs.globalSearch && $refs.globalSearch.focus()) }" class="flex items-center gap-2 h-10 px-3 text-sm text-bodyText border border-border rounded-lg hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" aria-haspopup="true" :aria-expanded="open.toString()" aria-controls="global-search-panel">
             {% icon 'magnifying-glass' 'h-5 w-5 text-gray-500' aria_label='' %}
             <span class="hidden md:inline">Search</span>
           </button>
-          <div id="global-search-panel" x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-80 md:w-96 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50 p-3">
+          <div id="global-search-panel" x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-80 md:w-96 rounded-md shadow-lg bg-surface ring-1 ring-black ring-opacity-5 z-50 p-3">
             <form action="{% url 'items_list' %}" method="get" role="search" class="relative">
               <label for="global-search-input" class="sr-only">search across items, suppliers, orders, and recipes</label>
               <span class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none text-gray-400">
@@ -120,22 +120,22 @@
               </span>
               <input id="global-search-input" x-ref="globalSearch" type="text" name="q" autocomplete="off"
                      placeholder="Global search: items, suppliers, orders, recipes…"
-                     class="block w-full h-10 pl-10 pr-3 text-sm md:text-base bg-white appearance-none border border-gray-300 rounded-lg text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                     class="block w-full h-10 pl-10 pr-3 text-sm md:text-base bg-form-bg appearance-none border border-form-border rounded-lg text-bodyText placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
             </form>
           </div>
         </div>
 
         <!-- Notifications -->
         <div class="relative" x-data="{open:false}" @keydown.escape.window="open=false">
-          <button @click="open=!open" class="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 relative focus:outline-none focus:ring-2 focus:ring-primary" aria-haspopup="true" :aria-expanded="open.toString()" aria-label="View notifications">
+          <button @click="open=!open" class="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-surfaceSubtle relative focus:outline-none focus:ring-2 focus:ring-primary" aria-haspopup="true" :aria-expanded="open.toString()" aria-label="View notifications">
             {% icon 'bell' 'h-6 w-6' aria_label='' %}
-            {% if notification_count %}<span class="absolute -top-1 -right-1 h-4 w-4 bg-red-500 text-white text-caption rounded-full flex items-center justify-center">{{ notification_count }}</span>{% endif %}
+            {% if notification_count %}<span class="absolute -top-1 -right-1 h-4 w-4 bg-danger text-white text-caption rounded-full flex items-center justify-center">{{ notification_count }}</span>{% endif %}
           </button>
-          <div x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-72 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
+          <div x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-72 rounded-md shadow-lg bg-surface ring-1 ring-black ring-opacity-5 z-50">
             <div class="py-2">
-              <div class="px-4 py-2 text-sm text-gray-700 font-medium border-b border-border">Notifications</div>
+              <div class="px-4 py-2 text-sm text-bodyText font-medium border-b border-border">Notifications</div>
               {% for notif in notifications %}
-                <a href="{{ notif.url }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">{{ notif.text }}</a>
+                <a href="{{ notif.url }}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle">{{ notif.text }}</a>
               {% empty %}
                 <div class="px-4 py-2 text-sm text-gray-500">No new notifications</div>
               {% endfor %}
@@ -147,21 +147,21 @@
         <!-- User Menu -->
         {% if user.is_authenticated %}
         <div class="relative" x-data="{open:false}" @keydown.escape.window="open=false">
-          <button @click="open=!open" class="flex items-center space-x-3 text-label rounded-lg p-2 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary" aria-haspopup="true" :aria-expanded="open.toString()">
-            <div class="h-8 w-8 bg-blue-100 rounded-full flex items-center justify-center">
-              <span class="text-blue-600 font-medium">{% if user.first_name %}{{ user.first_name.0|upper }}{% elif user.username %}{{ user.username.0|upper }}{% else %}?{% endif %}</span>
+          <button @click="open=!open" class="flex items-center space-x-3 text-label rounded-lg p-2 hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" aria-haspopup="true" :aria-expanded="open.toString()">
+            <div class="h-8 w-8 bg-primary/10 rounded-full flex items-center justify-center">
+              <span class="text-primary font-medium">{% if user.first_name %}{{ user.first_name.0|upper }}{% elif user.username %}{{ user.username.0|upper }}{% else %}?{% endif %}</span>
             </div>
-            <span class="hidden lg:block text-gray-700 font-medium truncate max-w-[10ch]">{{ user.first_name|default:user.username }}</span>
+            <span class="hidden lg:block text-bodyText font-medium truncate max-w-[10ch]">{{ user.first_name|default:user.username }}</span>
             {% icon 'chevron-down' 'h-4 w-4 text-gray-400' variant='solid' size=20 aria_label='' %}
           </button>
-          <div x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50">
+          <div x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-surface ring-1 ring-black ring-opacity-5 z-50">
             <div class="py-1" role="menu">
-              <a href="{% url 'interactive-dashboard' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Dashboard</a>
-              <a href="{% url 'settings' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Settings</a>
-              <a href="{% url 'workflow_guide' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">Help &amp; Guide</a>
-              <div class="border-t border-gray-100 my-1"></div>
-              <a href="/admin/" class="block px-4 py-2 text-sm text-gray-500 hover:bg-gray-100" role="menuitem">Admin Panel</a>
-              <a href="{% url 'logout' %}" class="block px-4 py-2 text-sm text-red-600 hover:bg-red-50" role="menuitem">Sign out</a>
+              <a href="{% url 'interactive-dashboard' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Dashboard</a>
+              <a href="{% url 'settings' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Settings</a>
+              <a href="{% url 'workflow_guide' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Help &amp; Guide</a>
+              <div class="border-t border-border my-1"></div>
+              <a href="/admin/" class="block px-4 py-2 text-sm text-gray-500 hover:bg-surfaceSubtle" role="menuitem">Admin Panel</a>
+              <a href="{% url 'logout' %}" class="block px-4 py-2 text-sm text-danger hover:bg-danger-soft" role="menuitem">Sign out</a>
             </div>
           </div>
         </div>
@@ -170,19 +170,19 @@
         {% if user.is_authenticated %}
         <!-- Mobile menu button -->
         <div x-data="{open:false}" class="relative md:hidden">
-          <button @click="open=!open" :aria-expanded="open.toString()" class="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-primary" aria-label="Open mobile menu">
+          <button @click="open=!open" :aria-expanded="open.toString()" class="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" aria-label="Open mobile menu">
             {% icon 'bars-3' 'h-6 w-6' aria_label='' %}
           </button>
           <!-- Mobile slide-out/dropdown -->
-          <div x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-64 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-50 p-2">
+          <div x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-64 rounded-md shadow-lg bg-surface ring-1 ring-black ring-opacity-5 z-50 p-2">
             {% for group in navigation_groups %}
               <div class="py-1">
                 <div class="px-3 py-1 text-xs font-semibold text-gray-500">{{ group.category|safe }}</div>
                 {% for link in group.links %}
                   {% if request.resolver_match.url_name == link.url_name %}
-                    <a href="{{ link.url }}" class="block px-3 py-2 rounded-md text-sm text-blue-700 bg-blue-50">{{ link.title|safe }}</a>
+                    <a href="{{ link.url }}" class="block px-3 py-2 rounded-md text-sm text-primary bg-primary/10 font-medium">{{ link.title|safe }}</a>
                   {% else %}
-                    <a href="{{ link.url }}" class="block px-3 py-2 rounded-md text-sm text-gray-700 hover:bg-gray-100">{{ link.title|safe }}</a>
+                    <a href="{{ link.url }}" class="block px-3 py-2 rounded-md text-sm text-bodyText hover:bg-surfaceSubtle">{{ link.title|safe }}</a>
                   {% endif %}
                 {% endfor %}
               </div>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -58,7 +58,7 @@
   <tbody class="bg-surface divide-y divide-border">
     {% for item in page_obj.object_list %}
     <tr
-      class="item-row odd:bg-surfaceSubtle odd:bg-gray-50 hover:bg-surfaceSubtle{% if item.current_stock is not None and item.current_stock < 0 %} !bg-danger-soft{% endif %}"
+      class="item-row odd:bg-surfaceSubtle hover:bg-surfaceSubtle{% if item.current_stock is not None and item.current_stock < 0 %} !bg-danger-soft{% endif %}"
       data-item-id="{{ item.item_id }}"
       data-unit-id="{{ item.unit_id }}"
       data-category-id="{{ item.category_id }}"

--- a/templates/inventory/_ml_dashboard_table.html
+++ b/templates/inventory/_ml_dashboard_table.html
@@ -1,7 +1,7 @@
 {% if table_data %}
 <div class="overflow-x-auto rounded-xl border border-border shadow-sm">
   <table class="w-full text-sm text-left table-sticky">
-    <thead class="bg-gray-50 text-gray-600 text-xs uppercase tracking-wide">
+    <thead class="bg-surfaceSubtle text-gray-600 text-xs font-semibold uppercase tracking-wider">
       <tr>
         <th scope="col" class="px-4 py-3">Item</th>
         <th scope="col" class="px-4 py-3">Category</th>
@@ -19,7 +19,7 @@
         {% elif row.days_cover is not None and row.days_cover < 7 %}
           <tr class="bg-warning-soft hover:bg-warning-soft transition">
         {% else %}
-          <tr class="hover:bg-gray-50 transition">
+          <tr class="hover:bg-surfaceSubtle transition">
         {% endif %}
 
           {# Item name + link #}

--- a/templates/inventory/change_password.html
+++ b/templates/inventory/change_password.html
@@ -19,7 +19,7 @@
                  id="{{ field.id_for_label }}"
                  name="{{ field.html_name }}"
                  autocomplete="{% if field.html_name == 'old_password' %}current-password{% else %}new-password{% endif %}"
-                 class="block w-full px-3 py-2 border {% if field.errors %}border-danger{% else %}border-form-border{% endif %} rounded-md text-sm bg-form-bg focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
+                 class="block w-full px-3 py-2 border {% if field.errors %}border-danger{% else %}border-form-border{% endif %} rounded-lg text-sm bg-form-bg focus:outline-none focus:ring-2 focus:ring-primary">
           {% if field.errors %}
             <p class="mt-1 text-xs text-danger">{{ field.errors|join:", " }}</p>
           {% endif %}

--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -97,11 +97,11 @@
   {% if has_po_links %}
   <div class="overflow-x-auto">
     <table class="min-w-full border border-border divide-y divide-border">
-      <thead class="bg-surfaceSubtle">
+      <thead class="bg-surfaceSubtle text-xs font-semibold uppercase tracking-wider text-gray-600">
         <tr>
-          <th class="px-3 py-2 text-left text-sm font-semibold text-bodyText">Item</th>
-          <th class="px-3 py-2 text-left text-sm font-semibold text-bodyText">PO</th>
-          <th class="px-3 py-2 text-right text-sm font-semibold text-bodyText">Planned Qty</th>
+          <th class="px-3 py-2.5 text-left">Item</th>
+          <th class="px-3 py-2.5 text-left">PO</th>
+          <th class="px-3 py-2.5 text-right">Planned Qty</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-border">
@@ -111,7 +111,7 @@
               <td class="px-3 py-2 text-sm">{{ ii.item.name }}</td>
               <td class="px-3 py-2 text-sm">
                 {% with poi=link.po_item %}
-                  <a href="{% url 'purchase_order_detail' poi.purchase_order_id %}" class="text-blue-600 hover:underline">PO {{ poi.purchase_order_id }}</a>
+                  <a href="{% url 'purchase_order_detail' poi.purchase_order_id %}" class="text-primary hover:underline">PO {{ poi.purchase_order_id }}</a>
                 {% endwith %}
               </td>
               <td class="px-3 py-2 text-sm text-right">{{ link.planned_qty }}</td>

--- a/templates/inventory/indent_issue_form.html
+++ b/templates/inventory/indent_issue_form.html
@@ -10,7 +10,7 @@
     {{ formset.management_form }}
     <div class="bg-surface border border-border rounded-xl shadow-card">
       <table class="min-w-full divide-y divide-border">
-        <thead class="bg-surfaceSubtle text-left text-xs font-semibold uppercase tracking-wide text-gray-600">
+        <thead class="bg-surfaceSubtle text-left text-xs font-semibold uppercase tracking-wider text-gray-600">
           <tr>
             <th class="px-3 py-2">Item</th>
             <th class="px-3 py-2 text-right">Requested</th>

--- a/templates/inventory/indents_consolidate_preview.html
+++ b/templates/inventory/indents_consolidate_preview.html
@@ -46,9 +46,9 @@
                   <div class="font-semibold text-gray-800">{{ group.supplier.name|default:"(Unknown Supplier)" }}</div>
                   <div class="flex items-center gap-3">
                     {# Select-all / deselect-all per group (Fix 4) #}
-                    <button type="button" class="text-xs text-blue-600 hover:underline" data-select-all="group-{{ forloop.counter }}">Select all</button>
+                    <button type="button" class="text-xs text-primary hover:underline" data-select-all="group-{{ forloop.counter }}">Select all</button>
                     <span class="text-gray-300">|</span>
-                    <button type="button" class="text-xs text-blue-600 hover:underline" data-deselect-all="group-{{ forloop.counter }}">Deselect all</button>
+                    <button type="button" class="text-xs text-primary hover:underline" data-deselect-all="group-{{ forloop.counter }}">Deselect all</button>
                     <span class="text-xs text-gray-500 ml-2">{{ group.total_lines }} item{{ group.total_lines|pluralize }}</span>
                   </div>
                 </div>

--- a/templates/inventory/purchase_orders/_receive_partial.html
+++ b/templates/inventory/purchase_orders/_receive_partial.html
@@ -13,7 +13,7 @@
         {% endfor %}
         <div>
           <label class="block text-sm font-medium text-bodyText mb-1">Attachment (PDF/Image)</label>
-          <input type="file" name="attachment" accept="application/pdf,image/*" class="block w-full text-sm text-bodyText border border-gray-300 rounded-lg cursor-pointer bg-surface focus:outline-none" />
+          <input type="file" name="attachment" accept="application/pdf,image/*" class="block w-full text-sm text-bodyText border border-form-border rounded-lg cursor-pointer bg-surface focus:outline-none" />
           <p class="mt-1 text-xs text-gray-500">Optional: upload the scanned GRN or invoice.</p>
         </div>
       </div>

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -49,12 +49,12 @@
   <h2 class="text-h2 md:text-h2 mb-4 mt-8">Linked Indent Lines</h2>
   <div class="overflow-x-auto">
     <table class="min-w-full border border-border divide-y divide-border">
-      <thead class="bg-surfaceSubtle">
+      <thead class="bg-surfaceSubtle text-xs font-semibold uppercase tracking-wider text-gray-600">
         <tr>
-          <th class="px-3 py-2 text-left text-sm font-semibold text-bodyText">PO Item</th>
-          <th class="px-3 py-2 text-left text-sm font-semibold text-bodyText">Indent</th>
-          <th class="px-3 py-2 text-left text-sm font-semibold text-bodyText">Item</th>
-          <th class="px-3 py-2 text-right text-sm font-semibold text-bodyText">Planned Qty</th>
+          <th class="px-3 py-2.5 text-left">PO Item</th>
+          <th class="px-3 py-2.5 text-left">Indent</th>
+          <th class="px-3 py-2.5 text-left">Item</th>
+          <th class="px-3 py-2.5 text-right">Planned Qty</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-border">
@@ -63,7 +63,7 @@
             <tr>
               <td class="px-3 py-2 text-sm">{{ it.item.name }}</td>
               <td class="px-3 py-2 text-sm">
-                <a href="{% url 'indent_detail' link.indent_item.indent_id %}" class="text-blue-600 hover:underline">Indent {{ link.indent_item.indent_id }}</a>
+                <a href="{% url 'indent_detail' link.indent_item.indent_id %}" class="text-primary hover:underline">Indent {{ link.indent_item.indent_id }}</a>
               </td>
               <td class="px-3 py-2 text-sm">{{ link.indent_item.item.name }}</td>
               <td class="px-3 py-2 text-sm text-right">{{ link.planned_qty }}</td>
@@ -82,7 +82,7 @@
         {% for g in grns %}
           {% if g.attachment %}
             <li>
-              <a href="{{ g.attachment.url }}" target="_blank" class="text-blue-600 hover:underline">GRN {{ g.pk }} Attachment</a>
+              <a href="{{ g.attachment.url }}" target="_blank" class="text-primary hover:underline">GRN #{{ g.pk }} — Attachment</a>
               <span class="text-gray-500">(received {{ g.received_date }})</span>
             </li>
           {% endif %}

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -11,7 +11,7 @@
     {% endfor %}
     <div>
       <label class="block text-sm font-medium text-bodyText mb-1">Attachment (PDF/Image)</label>
-      <input type="file" name="attachment" accept="application/pdf,image/*" class="block w-full text-sm text-bodyText border border-gray-300 rounded-lg cursor-pointer bg-surface focus:outline-none" />
+      <input type="file" name="attachment" accept="application/pdf,image/*" class="block w-full text-sm text-bodyText border border-form-border rounded-lg cursor-pointer bg-surface focus:outline-none" />
       <p class="mt-1 text-xs text-gray-500">Optional: upload the scanned GRN or invoice.</p>
     </div>
   </div>

--- a/templates/inventory/recipes/food_cost_report.html
+++ b/templates/inventory/recipes/food_cost_report.html
@@ -33,13 +33,13 @@
       <table class="min-w-full text-sm">
         <thead class="bg-surfaceSubtle border-b border-border">
           <tr>
-            <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Recipe</th>
-            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Ingredient Cost</th>
-            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Selling Price</th>
-            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Food Cost %</th>
-            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Target %</th>
-            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Gross Margin</th>
-            <th scope="col" class="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wide text-gray-600">Status</th>
+            <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">Recipe</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-600">Ingredient Cost</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-600">Selling Price</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-600">Food Cost %</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-600">Target %</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-600">Gross Margin</th>
+            <th scope="col" class="px-4 py-3 text-center text-xs font-semibold uppercase tracking-wider text-gray-600">Status</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-border">

--- a/templates/inventory/settings.html
+++ b/templates/inventory/settings.html
@@ -163,7 +163,7 @@
              oninput="filterTable(this, 'units-table')">
       <div class="overflow-x-auto">
         <table class="min-w-full text-sm text-bodyText" id="units-table">
-          <thead class="text-xs font-semibold uppercase tracking-wider bg-surfaceSubtle text-gray-500">
+          <thead class="text-xs font-semibold uppercase tracking-wider bg-surfaceSubtle text-gray-600">
             <tr>
               <th class="px-4 py-2.5 text-left rounded-tl-lg">Purchase Unit</th>
               <th class="px-4 py-2.5 text-left">Base Unit</th>
@@ -249,7 +249,7 @@
              oninput="filterTable(this, 'categories-table')">
       <div class="overflow-x-auto max-h-96 overflow-y-auto">
         <table class="min-w-full text-sm text-bodyText" id="categories-table">
-          <thead class="text-xs font-semibold uppercase tracking-wider bg-surfaceSubtle text-gray-500 sticky top-0">
+          <thead class="text-xs font-semibold uppercase tracking-wider bg-surfaceSubtle text-gray-600 sticky top-0">
             <tr>
               <th class="px-4 py-2.5 text-left">Category</th>
               <th class="px-4 py-2.5 text-left">Subcategory</th>
@@ -328,7 +328,7 @@
              oninput="filterTable(this, 'departments-table')">
       <div class="overflow-x-auto">
         <table class="min-w-full text-sm text-bodyText" id="departments-table">
-          <thead class="text-xs font-semibold uppercase tracking-wider bg-surfaceSubtle text-gray-500">
+          <thead class="text-xs font-semibold uppercase tracking-wider bg-surfaceSubtle text-gray-600">
             <tr>
               <th class="px-4 py-2.5 text-left">Name</th>
               <th class="px-4 py-2.5"></th>

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -16,7 +16,7 @@
 {% block hero_extra %}
   {# C1 + C7: Collapsible guidance panel — Wastage vs Adjustment #}
   <details class="mt-4 group bg-surfaceSubtle border border-dashed border-border rounded-lg text-sm text-gray-600 open:border-solid open:border-blue-200 open:bg-blue-50">
-    <summary class="flex items-center justify-between px-3 py-2.5 cursor-pointer list-none select-none font-medium text-bodyText group-open:text-blue-700">
+    <summary class="flex items-center justify-between px-3 py-2.5 cursor-pointer list-none select-none font-medium text-bodyText group-open:text-primary">
       <span class="flex items-center gap-1.5">
         <svg class="w-4 h-4 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
@@ -28,19 +28,19 @@
       </svg>
     </summary>
     <div class="px-4 pb-4 pt-2 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-      <div class="rounded-md bg-white border border-border p-3">
+      <div class="rounded-md bg-surface border border-border p-3">
         <p class="font-semibold text-success mb-1">Receive Stock</p>
         <p class="text-xs text-gray-600">Goods have arrived from a supplier. Links the receipt to a Purchase Order and updates stock upward.</p>
       </div>
-      <div class="rounded-md bg-white border border-border p-3">
-        <p class="font-semibold text-blue-700 mb-1">Adjust Stock</p>
+      <div class="rounded-md bg-surface border border-border p-3">
+        <p class="font-semibold text-primary mb-1">Adjust Stock</p>
         <p class="text-xs text-gray-600">Correct a stock count discrepancy found during a physical count or cycle count. Use this when the stock ledger is wrong — not when items are spoiled.</p>
       </div>
-      <div class="rounded-md bg-white border border-border p-3">
+      <div class="rounded-md bg-surface border border-border p-3">
         <p class="font-semibold text-danger mb-1">Record Wastage</p>
         <p class="text-xs text-gray-600">Items have been spoiled, expired, or discarded. Choose this when stock is genuinely lost, so wastage metrics stay accurate.</p>
       </div>
-      <div class="rounded-md bg-white border border-border p-3">
+      <div class="rounded-md bg-surface border border-border p-3">
         <p class="font-semibold text-gray-700 mb-1">Bulk Upload</p>
         <p class="text-xs text-gray-600">Import many movements at once from a CSV file. Useful for end-of-month reconciliations or migrating from another system.</p>
       </div>

--- a/templates/inventory/stock_take_count.html
+++ b/templates/inventory/stock_take_count.html
@@ -26,10 +26,10 @@
         <table class="min-w-full text-sm">
           <thead class="bg-surfaceSubtle border-b border-border">
             <tr>
-              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Item</th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">System Qty</th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Physical Count <span class="text-primary normal-case">*</span></th>
-              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Notes</th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">Item</th>
+              <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-600">System Qty</th>
+              <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-600">Physical Count <span class="text-primary normal-case">*</span></th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">Notes</th>
             </tr>
           </thead>
           <tbody class="divide-y divide-border">

--- a/templates/inventory/stock_take_list.html
+++ b/templates/inventory/stock_take_list.html
@@ -29,12 +29,12 @@
     <table class="min-w-full text-sm">
       <thead class="bg-surfaceSubtle border-b border-border">
         <tr>
-          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">#</th>
-          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Date</th>
-          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Department</th>
-          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Status</th>
-          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Created By</th>
-          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Actions</th>
+          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">#</th>
+          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">Date</th>
+          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">Department</th>
+          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">Status</th>
+          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">Created By</th>
+          <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">Actions</th>
         </tr>
       </thead>
       <tbody class="divide-y divide-border">

--- a/templates/inventory/stock_take_review.html
+++ b/templates/inventory/stock_take_review.html
@@ -58,11 +58,11 @@
       <table class="min-w-full text-sm">
         <thead class="bg-surfaceSubtle border-b border-border">
           <tr>
-            <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Item</th>
-            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">System</th>
-            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Physical</th>
-            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-600">Variance</th>
-            <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-600">Notes</th>
+            <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">Item</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-600">System</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-600">Physical</th>
+            <th scope="col" class="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-gray-600">Variance</th>
+            <th scope="col" class="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">Notes</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-border">

--- a/templates/inventory/user_profile_edit.html
+++ b/templates/inventory/user_profile_edit.html
@@ -15,20 +15,20 @@
           <label for="id_first_name" class="block text-xs font-medium text-gray-700 mb-1">First Name</label>
           <input type="text" id="id_first_name" name="first_name"
                  value="{{ request.user.first_name }}"
-                 class="block w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
+                 class="block w-full px-3 py-2 border border-form-border rounded-lg text-sm bg-form-bg focus:outline-none focus:ring-2 focus:ring-primary">
         </div>
         <div>
           <label for="id_last_name" class="block text-xs font-medium text-gray-700 mb-1">Last Name</label>
           <input type="text" id="id_last_name" name="last_name"
                  value="{{ request.user.last_name }}"
-                 class="block w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
+                 class="block w-full px-3 py-2 border border-form-border rounded-lg text-sm bg-form-bg focus:outline-none focus:ring-2 focus:ring-primary">
         </div>
       </div>
       <div>
         <label for="id_email" class="block text-xs font-medium text-gray-700 mb-1">Email</label>
         <input type="email" id="id_email" name="email"
                value="{{ request.user.email }}"
-               class="block w-full px-3 py-2 border border-gray-300 rounded-md text-sm bg-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
+               class="block w-full px-3 py-2 border border-form-border rounded-lg text-sm bg-form-bg focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div class="flex gap-3 pt-2">
         <button type="submit"


### PR DESCRIPTION
## Summary
- **Table headers**: Standardize all thead to bg-surfaceSubtle + tracking-wider + text-gray-600
- **Form inputs**: Replace border-gray-300/bg-white with border-form-border/bg-form-bg
- **Navigation bar**: Replace ~40 hardcoded blue/white/red colors with semantic tokens
- **Links**: text-blue-600/700 replaced with text-primary across 5 files
- **Containers**: bg-white replaced with bg-surface in stock movements and ML dashboard

17 files changed, 98 insertions, 98 deletions.

## Test plan
- [ ] Settings page table headers look consistent
- [ ] Stock takes and food cost report table headers match
- [ ] Profile edit form inputs use correct tokens
- [ ] Nav dropdowns use primary color for active items
- [ ] Mobile nav uses surface bg and primary highlights
- [ ] Stock movements info cards use bg-surface

Generated with Claude Code