### PR TITLE
refactor: Phase 3 — collapse bloated action bars into dropdowns

### DIFF
--- a/templates/inventory/indent_detail.html
+++ b/templates/inventory/indent_detail.html
@@ -42,16 +42,23 @@
   </div>
 {% endblock %}
 {% block actions %}
-  <a href="{% url 'indent_pdf' indent.indent_id %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Download PDF</a>
   {% if not edit_mode %}
-    {% if indent.status|upper == 'SUBMITTED' or indent.status|upper == 'APPROVED' %}
-    <a href="{% url 'indent_detail' indent.indent_id %}?edit=1" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Edit</a>
-    {% endif %}
     <a href="{% url 'issue_indent' indent.indent_id %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Fulfill Indent</a>
   {% endif %}
-  {% if wa_url %}
-  <a href="{{ wa_url }}" target="_blank" rel="noopener" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Prepare WhatsApp</a>
-  {% endif %}
+  <!-- More actions dropdown -->
+  <div class="relative" x-data="{ open: false }" @keydown.escape="open = false" @click.outside="open = false">
+    <button type="button" @click="open = !open" :aria-expanded="open.toString()" class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">
+      More
+      <svg class="w-4 h-4 transition-transform" :class="open ? 'rotate-180' : ''" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
+    </button>
+    <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95" class="absolute right-0 mt-1 w-44 rounded-lg bg-surface border border-border shadow-card z-30 py-1" role="menu">
+      <a href="{% url 'indent_pdf' indent.indent_id %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Download PDF</a>
+      {% if not edit_mode %}{% if indent.status|upper == 'SUBMITTED' or indent.status|upper == 'APPROVED' %}
+      <a href="{% url 'indent_detail' indent.indent_id %}?edit=1" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Edit</a>
+      {% endif %}{% endif %}
+      {% if wa_url %}<a href="{{ wa_url }}" target="_blank" rel="noopener" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Prepare WhatsApp</a>{% endif %}
+    </div>
+  </div>
   <a href="{% url 'indents_list' %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Back</a>
 {% endblock %}
 {% block detail_table %}

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -4,10 +4,10 @@
 {% block table_id %}items-container{% endblock %}
 
 
-{% block page_title %}Item Master Management{% endblock %}
-{% block page_heading %}Item Master Management{% endblock %}
+{% block page_title %}Items – Inventory Pro{% endblock %}
+{% block page_heading %}Items{% endblock %}
 {% block page_subtitle %}
-  <p class="text-sm text-gray-600">Manage catalogue details, stock levels, and supplier assignments.</p>
+  <p class="text-sm text-gray-600">Manage your ingredient and product catalogue.</p>
 {% endblock %}
 {% block page_meta %}
   <div class="flex flex-wrap items-center gap-2 text-xs font-medium text-gray-600">
@@ -17,7 +17,7 @@
 {% endblock %}
 {% block hero_extra %}
   <div class="mt-4 bg-surfaceSubtle border border-dashed border-border rounded-lg p-3 text-sm text-gray-600">
-    <span class="font-medium text-bodyText">Tip:</span> Use the filters to narrow by category or supplier; actions update instantly via the new responsive table.
+    <span class="font-medium text-bodyText">Tip:</span> Use the filters to narrow by category, supplier, or stock status. Tick rows to bulk-deactivate or reassign departments.
   </div>
 {% endblock %}
 
@@ -61,19 +61,29 @@
           </div>
           <div class="flex flex-wrap items-center gap-2 justify-end">
             <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong" data-modal-url="{% url 'item_create_partial' %}" data-modal-type="drawer" data-modal-prefetch="eager" data-modal-inline-template="inline-item-create-drawer">Add Item</button>
-            <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" data-modal-url="{% url 'items_bulk_upload' %}?partial=1" data-modal-type="drawer" data-modal-prefetch="idle">Bulk Upload</button>
-            <button type="submit" form="filters" formaction="{{ export_url }}" formmethod="get" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Export</button>
-            {% if stats.low_stock_count %}
-            <a href="{% url 'low_stock_indent' %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-warning text-white hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-warning border border-transparent">Generate Indent ({{ stats.low_stock_count }} low)</a>
-            {% endif %}
-                <div id="bulk-actions-top" class="hidden border border-border bg-surfaceSubtle px-3 py-2 rounded-lg flex items-center gap-2" role="region" aria-label="Bulk actions">
-                  <span id="bulk-count-top" class="text-sm text-bodyText">0 selected</span>
-                  <div class="flex items-center gap-2">
-                    <button type="button" data-bulk-action="deactivate" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Deactivate</button>
-                    <button type="button" data-bulk-action="assign" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Assign Dept</button>
-                    <button type="button" data-bulk-action="delete" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-danger-soft text-danger border border-danger hover:bg-danger-soft focus:outline-none focus:ring-2 focus:ring-danger">Delete Selected</button>
-                  </div>
-                </div>
+            <!-- More actions dropdown -->
+            <div class="relative" x-data="{ open: false }" @keydown.escape="open = false" @click.outside="open = false">
+              <button type="button" @click="open = !open" :aria-expanded="open.toString()" class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">
+                More
+                <svg class="w-4 h-4 transition-transform" :class="open ? 'rotate-180' : ''" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
+              </button>
+              <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95" class="absolute right-0 mt-1 w-48 rounded-lg bg-surface border border-border shadow-card z-30 py-1" role="menu">
+                <button type="button" @click="open = false" data-modal-url="{% url 'items_bulk_upload' %}?partial=1" data-modal-type="drawer" data-modal-prefetch="idle" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Bulk Upload</button>
+                <button type="submit" form="filters" formaction="{{ export_url }}" formmethod="get" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Export CSV</button>
+                {% if stats.low_stock_count %}
+                <div class="border-t border-border my-1"></div>
+                <a href="{% url 'low_stock_indent' %}" class="block px-4 py-2 text-sm text-warning font-medium hover:bg-warning-soft" role="menuitem">Generate Indent ({{ stats.low_stock_count }} low)</a>
+                {% endif %}
+              </div>
+            </div>
+            <div id="bulk-actions-top" class="hidden border border-border bg-surfaceSubtle px-3 py-2 rounded-lg flex items-center gap-2" role="region" aria-label="Bulk actions">
+              <span id="bulk-count-top" class="text-sm text-bodyText">0 selected</span>
+              <div class="flex items-center gap-2">
+                <button type="button" data-bulk-action="deactivate" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Deactivate</button>
+                <button type="button" data-bulk-action="assign" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Assign Dept</button>
+                <button type="button" data-bulk-action="delete" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-danger-soft text-danger border border-danger hover:bg-danger-soft focus:outline-none focus:ring-2 focus:ring-danger">Delete Selected</button>
+              </div>
+            </div>
             <div class="relative" data-col-menu-container>
               <button type="button" class="inline-flex items-center justify-center w-8 h-8 p-0 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" aria-label="Show/Hide Columns" title="Show/Hide Columns" aria-haspopup="true" aria-expanded="false" aria-controls="columns-menu" data-col-menu-button>{% icon 'cog-6-tooth' 'w-4 h-4' %}</button>
               <!-- Column visibility dropdown -->

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -29,15 +29,25 @@
   </div>
 {% endblock %}
 {% block actions %}
-  <a href="{% url 'purchase_order_edit' po.pk %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Edit</a>
   <a href="{% url 'purchase_order_receive' po.pk %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Receive Goods</a>
-  <a href="{% url 'grn_list' %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">View GRNs</a>
-  {% if po.status == 'DRAFT' %}
-  <form action="{% url 'purchase_order_mark_ordered' po.pk %}" method="post" class="inline">
-    {% csrf_token %}
-    <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Send to Supplier</button>
-  </form>
-  {% endif %}
+  <!-- More actions dropdown -->
+  <div class="relative" x-data="{ open: false }" @keydown.escape="open = false" @click.outside="open = false">
+    <button type="button" @click="open = !open" :aria-expanded="open.toString()" class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">
+      More
+      <svg class="w-4 h-4 transition-transform" :class="open ? 'rotate-180' : ''" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
+    </button>
+    <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95" class="absolute right-0 mt-1 w-44 rounded-lg bg-surface border border-border shadow-card z-30 py-1" role="menu">
+      <a href="{% url 'purchase_order_edit' po.pk %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Edit</a>
+      {% if po.status == 'DRAFT' %}
+      <form action="{% url 'purchase_order_mark_ordered' po.pk %}" method="post">
+        {% csrf_token %}
+        <button type="submit" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Send to Supplier</button>
+      </form>
+      {% endif %}
+      <div class="border-t border-border my-1"></div>
+      <a href="{% url 'grn_list' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">View GRNs</a>
+    </div>
+  </div>
   <a href="{% url 'purchase_orders_list' %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Back</a>
 {% endblock %}
 {% block detail_table %}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -4,7 +4,7 @@
 {% block page_title %}Transactions – Stock Movements{% endblock %}
 {% block page_heading %}Stock Movements{% endblock %}
 {% block page_subtitle %}
-  <p class="text-sm text-gray-600">Record receipts, adjustments, and wastage in one place.</p>
+  <p class="text-sm text-gray-600">Record stock receipts, adjustments, wastage, and transfers.</p>
 {% endblock %}
 {% block page_meta %}
   <div class="flex flex-wrap items-center gap-2 text-xs font-medium text-gray-600">
@@ -64,11 +64,21 @@
         </div>
         <div class="flex flex-wrap items-center gap-2 justify-end">
           <button id="receive-open" type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">Receive Stock</button>
-          <button id="adjust-open" type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Adjust Stock</button>
-          <button id="waste-open" type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Record Wastage</button>
-          <button id="transfer-open" type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Transfer Stock</button>
-          <button id="bulk-open" type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Bulk Upload</button>
-          <a href="{% url 'history_reports' %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">View Reports</a>
+          <!-- More actions dropdown -->
+          <div class="relative" x-data="{ open: false }" @keydown.escape="open = false" @click.outside="open = false">
+            <button type="button" @click="open = !open" :aria-expanded="open.toString()" class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">
+              More Actions
+              <svg class="w-4 h-4 transition-transform" :class="open ? 'rotate-180' : ''" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
+            </button>
+            <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95" class="absolute right-0 mt-1 w-44 rounded-lg bg-surface border border-border shadow-card z-30 py-1" role="menu">
+              <button id="adjust-open" type="button" @click="open = false" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Adjust Stock</button>
+              <button id="waste-open" type="button" @click="open = false" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Record Wastage</button>
+              <button id="transfer-open" type="button" @click="open = false" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Transfer Stock</button>
+              <button id="bulk-open" type="button" @click="open = false" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Bulk Upload</button>
+              <div class="border-t border-border my-1"></div>
+              <a href="{% url 'history_reports' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">View Reports</a>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **stock_movements**: 6 buttons →  CTA +  dropdown
- **items_list**: 4+ buttons →  CTA +  dropdown
- **indent_detail**: 5 buttons →  CTA +  dropdown
- **purchase_orders/detail**: 5 buttons →  CTA +  dropdown

All dropdowns use Alpine.js with Esc dismiss, outside-click dismiss, and role="menu" accessibility.

## Test plan
- [ ] Stock Movements: Receive opens modal; More shows Adjust/Wastage/Transfer/Bulk/Reports
- [ ] Items: Add Item opens drawer; More shows Bulk/Export/Generate Indent
- [ ] Indent detail: Fulfill works; More shows PDF/Edit/WhatsApp
- [ ] PO detail: Receive Goods works; More shows Edit/Send/View GRNs

🤖 Generated with [Claude Code](https://claude.com/claude-code)