### PR TITLE
refactor: UX cleanup sprint — remove duplicates, consolidate pages, clarify navigation

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -49,10 +49,6 @@
          class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-gray-300 rounded-md bg-white text-gray-700 hover:bg-gray-50 transition focus:outline-none focus:ring-2 focus:ring-primary">
         <span aria-hidden="true">&#177;</span> Adjust Stock
       </a>
-      <a href="{% url 'items_list' %}?stock_status=low"
-         class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-amber-400 rounded-md bg-amber-50 text-amber-700 hover:bg-amber-100 transition focus:outline-none focus:ring-2 focus:ring-amber-400">
-        <span aria-hidden="true">&#9888;</span> View Low Stock
-      </a>
     </div>
 
     <!-- Filters + Chart -->

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
+from django.views.generic import RedirectView
 
 from .views import ajax_dashboard_data, interactive_dashboard
 
 urlpatterns = [
-    path("interactive-dashboard/", interactive_dashboard, name="interactive-dashboard"),
+    path("interactive-dashboard/", RedirectView.as_view(url="/", permanent=True), name="interactive-dashboard"),
     path("dashboard-data/", ajax_dashboard_data, name="ajax-dashboard-data"),
 ]

--- a/inventory/middleware/snapshot_middleware.py
+++ b/inventory/middleware/snapshot_middleware.py
@@ -13,7 +13,7 @@ import threading
 
 logger = logging.getLogger(__name__)
 
-_DASHBOARD_PATHS = frozenset(["/", "/interactive-dashboard/"])
+_DASHBOARD_PATHS = frozenset(["/"])
 
 # Thread-local flag to avoid recursive calls within the same request
 _taking_snapshot = threading.local()

--- a/inventory/services/category_filters.py
+++ b/inventory/services/category_filters.py
@@ -153,4 +153,16 @@ def build_filters(request) -> List[Dict[str, Any]]:
             "options": department_options,
             "multiple": True,
         },
+        {
+            "name": "stock_status",
+            "label": "Stock",
+            "value": request.GET.get("stock_status", ""),
+            "options": [
+                {"value": "", "label": "All Stock"},
+                {"value": "out", "label": "Out of Stock"},
+                {"value": "low", "label": "Low Stock"},
+                {"value": "normal", "label": "In Stock"},
+            ],
+            "multiple": False,
+        },
     ]

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.views.generic import RedirectView
 
 from .views.explore import explore, explore_export
 from .views.goods_received import (
@@ -98,8 +99,8 @@ from .views.suppliers import (
 from .views.visualizations import visualizations
 
 urlpatterns = [
-    path("explore/", explore, name="explore"),
-    path("explore/export/", explore_export, name="explore_export"),
+    path("explore/", RedirectView.as_view(url="/items/", permanent=True), name="explore"),
+    path("explore/export/", RedirectView.as_view(url="/items/", permanent=True), name="explore_export"),
     path("items/", ItemsListView.as_view(), name="items_list"),
     path("items/table/", ItemsTableView.as_view(), name="items_table"),
     path("items/export/", ItemsExportView.as_view(), name="items_export"),

--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -340,7 +340,7 @@ class ItemsListView(TemplateView):
                 low_stock_count = active_qs.filter(
                     current_stock__isnull=False,
                     reorder_point__isnull=False,
-                    current_stock__lte=F("reorder_point"),
+                    current_stock__lt=F("reorder_point"),
                 ).count()
                 stats["low_stock_percentage"] = low_stock_count / total_active * 100
                 stats["low_stock_count"] = low_stock_count

--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -25,8 +25,8 @@ NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
         [
             {
                 "title": "Overview",
-                "description": "Daily numbers, charts, and alerts.",
-                "url_name": "visualizations",
+                "description": "Live stock overview, KPIs, and trend charts.",
+                "url_name": "root",
             },
             {
                 "title": "Food Cost",
@@ -37,6 +37,11 @@ NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
                 "title": "History",
                 "description": "Past stock activity and audit trail.",
                 "url_name": "history_reports",
+            },
+            {
+                "title": "Stock Charts",
+                "description": "Interactive stock trend chart with filters.",
+                "url_name": "visualizations",
             },
             {
                 "title": "Reorder Suggestions",
@@ -75,8 +80,8 @@ NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
         [
             {
                 "title": "Stock Levels",
-                "description": "What you have on hand right now.",
-                "url_name": "explore",
+                "description": "Your products, stock levels, and settings.",
+                "url_name": "items_list",
             },
             {
                 "title": "Movements",
@@ -93,11 +98,6 @@ NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
     (
         "Master Data",
         [
-            {
-                "title": "Items",
-                "description": "Your products and stock settings.",
-                "url_name": "items_list",
-            },
             {
                 "title": "Recipes",
                 "description": "Ingredients, portions, and costings.",

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -36,7 +36,8 @@
                 <li role="none">
                   {% if request.resolver_match.url_name == link.url_name %}
                     <a role="menuitem" href="{{ link.url }}" class="flex items-start gap-2 px-4 py-2 text-sm font-semibold text-primary bg-primary/10" data-nav-link>
-                      {% if link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% if link.url_name == 'root' %}{% icon 'home' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-primary' aria_label='' %}
                       {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-primary' aria_label='' %}
                       {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-primary' aria_label='' %}
                       {% elif link.url_name == 'ml_dashboard' %}{% icon 'sparkles' 'h-4 w-4 text-primary' aria_label='' %}
@@ -60,7 +61,8 @@
                     </a>
                   {% else %}
                     <a role="menuitem" href="{{ link.url }}" class="flex items-start gap-2 px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" data-nav-link>
-                      {% if link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% if link.url_name == 'root' %}{% icon 'home' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'ml_dashboard' %}{% icon 'sparkles' 'h-4 w-4 text-gray-500' aria_label='' %}
@@ -156,11 +158,11 @@
           </button>
           <div x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-surface ring-1 ring-black ring-opacity-5 z-50">
             <div class="py-1" role="menu">
-              <a href="{% url 'interactive-dashboard' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Dashboard</a>
+              <a href="{% url 'root' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Dashboard</a>
               <a href="{% url 'settings' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Settings</a>
               <a href="{% url 'workflow_guide' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Help &amp; Guide</a>
               <div class="border-t border-border my-1"></div>
-              <a href="/admin/" class="block px-4 py-2 text-sm text-gray-500 hover:bg-surfaceSubtle" role="menuitem">Admin Panel</a>
+              {% if user.is_superuser %}<a href="/admin/" class="block px-4 py-2 text-sm text-gray-500 hover:bg-surfaceSubtle" role="menuitem">Admin Panel</a>{% endif %}
               <a href="{% url 'logout' %}" class="block px-4 py-2 text-sm text-danger hover:bg-danger-soft" role="menuitem">Sign out</a>
             </div>
           </div>

--- a/templates/inventory/_history_table.html
+++ b/templates/inventory/_history_table.html
@@ -2,14 +2,7 @@
 
 {% block caption %}<caption>Transaction History</caption>{% endblock %}
 
-{% block actions %}
-  <div class="flex items-center justify-end px-4 py-3 bg-surfaceSubtle border-b border-border rounded-t-xl">
-    <div class="hidden md:flex items-center gap-1" role="group" aria-label="Table density">
-      <button type="button" data-density-btn data-value="compact" class="inline-flex items-center px-2 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" title="Compact rows">Compact</button>
-      <button type="button" data-density-btn data-value="comfortable" class="inline-flex items-center px-2 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" title="Comfortable rows">Comfortable</button>
-    </div>
-  </div>
-{% endblock %}
+{% block actions %}{% endblock %}
 
 {% block headers %}
 <th scope="col" class="px-4 py-2 text-right">

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -50,6 +50,9 @@
 
           </div>
         </th>
+  <th scope="col" class="sticky z-10 px-4 py-2.5 bg-surfaceSubtle border-b border-border group-data-[shadow=true]:shadow-md" data-col="abc_class" data-field="abc_class" data-sort="col8" aria-sort="none">
+          <div class="flex items-center gap-1"><span>ABC</span></div>
+        </th>
         <th scope="col" class="sticky z-10 w-30 px-4 py-2.5 bg-surfaceSubtle border-b border-border group-data-[shadow=true]:shadow-md">
           Actions
         </th>
@@ -134,6 +137,17 @@
         <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-success-soft text-success">Active</span>
         {% else %}
         <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-danger-soft text-danger">Inactive</span>
+        {% endif %}
+      </td>
+      <td data-col="abc_class" class="px-4 py-2 whitespace-normal break-words">
+        {% if item.abc_class == 'A' %}
+          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-danger-soft text-danger">A</span>
+        {% elif item.abc_class == 'B' %}
+          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-warning-soft text-warning">B</span>
+        {% elif item.abc_class == 'C' %}
+          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-surfaceSubtle text-bodyText">C</span>
+        {% else %}
+          <span class="text-gray-400">—</span>
         {% endif %}
       </td>
       <td class="px-4 py-2 whitespace-normal break-words">

--- a/templates/inventory/grns/list.html
+++ b/templates/inventory/grns/list.html
@@ -28,9 +28,6 @@
     {% icon 'plus' 'w-4 h-4 mr-2' %}
     New GRN
   </a>
-  <a href="{% url 'grn_create_adhoc' %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">
-    Receive Without PO
-  </a>
 {% endblock %}
 
 {% block kpis %}
@@ -74,44 +71,7 @@
   </div>
 {% endblock %}
 
-{% block extra_top %}
-  {# Quick GRN Entry #}
-  <div class="bg-surface border border-border rounded-2xl shadow-card mb-6">
-    <button type="button" class="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-bodyText hover:bg-surfaceSubtle rounded-xl transition" onclick="this.closest('div').querySelector('.quick-form-body').classList.toggle('hidden')">
-      <span>{% icon 'bolt' 'w-4 h-4 mr-2 inline' %} Quick GRN Entry (receive all items from a PO)</span>
-      <span>{% icon 'chevron-down' 'w-4 h-4' %}</span>
-    </button>
-    <div class="quick-form-body hidden border-t border-border p-4">
-      <form method="post" class="grid gap-4 max-w-lg">
-        {% csrf_token %}
-        {% if quick_form.non_field_errors %}
-          <ul class="text-danger list-disc pl-5 text-sm">
-            {% for e in quick_form.non_field_errors %}<li>{{ e }}</li>{% endfor %}
-          </ul>
-        {% endif %}
-        <div>
-          <label for="id_po" class="block text-sm font-medium text-bodyText mb-1">Purchase Order</label>
-          <select id="id_po" name="po" class="block w-full px-3 py-2 border border-form-border rounded-lg bg-form-bg focus:outline-none focus:ring-2 focus:ring-primary predictive" required>
-            <option value="">Select a PO...</option>
-            {% for po in open_pos %}
-              <option value="{{ po.pk }}">PO #{{ po.pk }} — {{ po.supplier.name }} ({{ po.get_status_display }})</option>
-            {% endfor %}
-          </select>
-          {% if not open_pos %}<p class="text-xs text-gray-500 mt-1">No POs awaiting receipt.</p>{% endif %}
-        </div>
-        {% for field in quick_form %}
-          {% include "components/form_field.html" with field=field %}
-        {% endfor %}
-        <div>
-          <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">
-            Create GRN (Receive All)
-          </button>
-          <a href="{% url 'grn_create' %}" class="ml-3 text-sm text-primary hover:underline">Or enter quantities manually →</a>
-        </div>
-      </form>
-    </div>
-  </div>
-{% endblock %}
+{% block extra_top %}{% endblock %}
 
 {% block data_container %}
   <ol class="relative border-l border-border">

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -96,6 +96,7 @@
                   <li><label class="inline-flex items-center gap-2"><input type="checkbox" class="h-4 w-4" data-col-toggle value="stock_status" checked> <span>Stock Status</span></label></li>
                   <li><label class="inline-flex items-center gap-2"><input type="checkbox" class="h-4 w-4" data-col-toggle value="departments" checked> <span>Departments</span></label></li>
                   <li><label class="inline-flex items-center gap-2"><input type="checkbox" class="h-4 w-4" data-col-toggle value="status" checked> <span>Status</span></label></li>
+                  <li><label class="inline-flex items-center gap-2"><input type="checkbox" class="h-4 w-4" data-col-toggle value="abc_class"> <span>ABC Class</span></label></li>
                 </ul>
               </div>
             </div>
@@ -118,15 +119,6 @@
       <template id="inline-item-create-drawer">
         {% include 'inventory/_item_create_bare.html' %}
       </template>
-      <!-- Bulk Actions Bar -->
-  <div id="bulk-actions" class="hidden border-t border-border bg-surfaceSubtle px-4 py-3 flex items-center justify-between" role="region" aria-label="Bulk actions bar">
-        <span id="bulk-count" class="text-sm text-bodyText">0 selected</span>
-        <div class="flex items-center gap-2">
-          <button type="button" data-bulk-action="deactivate" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Deactivate</button>
-          <button type="button" data-bulk-action="assign" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Assign Dept</button>
-          <button type="button" data-bulk-action="delete" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-danger-soft text-danger border border-danger hover:bg-danger-soft focus:outline-none focus:ring-2 focus:ring-danger">Delete Selected</button>
-        </div>
-      </div>
 
     </div>
   <div id="items-aria-live" class="sr-only" aria-live="polite"></div>

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -14,11 +14,7 @@
       </div>
     </div>
     <div class="flex items-center gap-2">
-      <div class="hidden md:flex items-center gap-1" role="group" aria-label="Table density">
-        <button type="button" data-density-btn data-value="compact" class="inline-flex items-center px-2 py-1.5 text-xs font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" title="Compact rows">Compact</button>
-        <button type="button" data-density-btn data-value="comfortable" class="inline-flex items-center px-2 py-1.5 text-xs font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" title="Comfortable rows">Comfortable</button>
-      </div>
-      <div class="relative" data-col-menu-container x-data="{open:false}" @click.outside="open=false">
+<div class="relative" data-col-menu-container x-data="{open:false}" @click.outside="open=false">
       <button type="button" data-col-menu-button @click="open=!open" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">
         Columns
         <svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
@@ -130,11 +126,7 @@
   </td>
   <td class="px-4 py-2" data-col="actions">
     <div class="flex justify-end gap-2">
-      <a href="{% url 'purchase_order_detail' po.pk %}" class="text-primary" title="View">
-        {% icon 'eye' 'w-5 h-5' %}
-        <span class="sr-only">View</span>
-      </a>
-      <a href="{% url 'purchase_order_edit' po.pk %}"
+<a href="{% url 'purchase_order_edit' po.pk %}"
          data-modal-url="{% url 'purchase_order_edit_partial' po.pk %}"
          data-modal-type="drawer"
          data-modal-prefetch="hover"

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -40,21 +40,27 @@
 {% endblock %}
 
 {% block primary_actions %}
-  <button type="button"
-          class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong"
-          data-modal-url="{% url 'purchase_order_create_partial' %}"
-          data-modal-type="drawer"
-          data-modal-prefetch="idle">
-    {% icon 'plus' 'w-4 h-4 mr-2' %}
-    New Purchase Order
-  </button>
-  <button type="button"
-          class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary"
-          data-modal-url="{% url 'purchase_order_quick_create_partial' %}"
-          data-modal-type="drawer"
-          data-modal-prefetch="idle">
-    {% icon 'bolt' 'w-4 h-4 mr-2' %} Quick PO
-  </button>
+  <div class="flex flex-col items-center">
+    <button type="button"
+            class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong"
+            data-modal-url="{% url 'purchase_order_create_partial' %}"
+            data-modal-type="drawer"
+            data-modal-prefetch="idle">
+      {% icon 'plus' 'w-4 h-4 mr-2' %}
+      New Purchase Order
+    </button>
+    <span class="text-xs text-mutedText mt-0.5">Full form with details</span>
+  </div>
+  <div class="flex flex-col items-center">
+    <button type="button"
+            class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary"
+            data-modal-url="{% url 'purchase_order_quick_create_partial' %}"
+            data-modal-type="drawer"
+            data-modal-prefetch="idle">
+      {% icon 'bolt' 'w-4 h-4 mr-2' %} Quick PO
+    </button>
+    <span class="text-xs text-mutedText mt-0.5">From approved indents</span>
+  </div>
 {% endblock %}
 
 {% block secondary_actions %}
@@ -91,33 +97,20 @@
 {% block filters %}
 <div class="bg-surface rounded-2xl shadow-card border border-border overflow-hidden mb-6">
   <div class="p-4 space-y-4">
-    {# Search Bar #}
-    <div>
-      <form method="get" class="flex gap-2">
-        <div class="flex-1">
-          <input
-            type="search"
-            name="q"
-            id="po-search-input"
-            value="{{ q|default:'' }}"
-            placeholder="Search PO #, supplier, notes..."
-            class="block w-full px-4 py-2 border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
-            autocomplete="off"
-          />
-        </div>
-        <button
-          type="submit"
-          class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong"
-        >
-          {% icon 'magnifying-glass' 'w-4 h-4 mr-2' %}
-          Search
-        </button>
-      </form>
-    </div>
-
     {# Filters Row #}
-    <form method="get" class="grid grid-cols-1 lg:grid-cols-5 gap-4">
-      <input type="hidden" name="q" value="{{ q|default:'' }}" />
+    <form method="get" class="grid grid-cols-1 lg:grid-cols-6 gap-4">
+      <div class="lg:col-span-2">
+        <label for="po-search-input" class="block text-sm font-medium text-bodyText mb-1">Search</label>
+        <input
+          type="search"
+          name="q"
+          id="po-search-input"
+          value="{{ q|default:'' }}"
+          placeholder="Search PO #, supplier, notes..."
+          class="block w-full px-3 py-2 border border-form-border rounded-lg bg-form-bg focus:outline-none focus:ring-2 focus:ring-primary"
+          autocomplete="off"
+        />
+      </div>
       <div>
         <label for="status" class="block text-sm font-medium text-bodyText mb-1">Status</label>
         <select id="status" name="status" class="block w-full px-3 py-2 border border-form-border rounded-lg bg-form-bg focus:outline-none focus:ring-2 focus:ring-primary predictive" autocomplete="off">

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -75,8 +75,6 @@
               <button id="waste-open" type="button" @click="open = false" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Record Wastage</button>
               <button id="transfer-open" type="button" @click="open = false" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Transfer Stock</button>
               <button id="bulk-open" type="button" @click="open = false" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Bulk Upload</button>
-              <div class="border-t border-border my-1"></div>
-              <a href="{% url 'history_reports' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">View Reports</a>
             </div>
           </div>
         </div>

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -31,13 +31,14 @@
 {% endblock %}
 
 {% block secondary_actions %}
-  {% url 'suppliers_bulk_delete' as suppliers_bulk_delete_url %}
-  <button id="bulk-delete-btn"
-          disabled
-          onclick="window.location='{{ suppliers_bulk_delete_url }}'"
-          class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-40 disabled:cursor-not-allowed bg-danger text-white hover:opacity-90 focus:ring-2 focus:ring-danger">
-    Bulk Delete
-  </button>
+  {% url 'suppliers_list' as suppliers_list_url %}
+  {% if view == 'cards' %}
+    {% include "components/button.html" with href=suppliers_list_url variant='secondary' label='Table View' %}
+  {% else %}
+    {% with card_view_url=suppliers_list_url|add:'?view=cards' %}
+      {% include "components/button.html" with href=card_view_url variant='secondary' label='Card View' %}
+    {% endwith %}
+  {% endif %}
   {% url 'suppliers_table' as suppliers_table_url %}
   {% with export_url=suppliers_table_url|add:'?export=1' %}
     {% include "components/button.html" with href=export_url variant='secondary' label='Export CSV' %}
@@ -49,14 +50,35 @@
           data-modal-prefetch="idle">
     Bulk Upload
   </button>
-  {% url 'suppliers_list' as suppliers_list_url %}
-  {% if view == 'cards' %}
-    {% include "components/button.html" with href=suppliers_list_url variant='secondary' label='Table View' %}
-  {% else %}
-    {% with card_view_url=suppliers_list_url|add:'?view=cards' %}
-      {% include "components/button.html" with href=card_view_url variant='secondary' label='Card View' %}
-    {% endwith %}
-  {% endif %}
+  <!-- More dropdown (contains destructive actions) -->
+  {% url 'suppliers_bulk_delete' as suppliers_bulk_delete_url %}
+  <div class="relative" x-data="{ open: false }" @keydown.escape="open = false" @click.outside="open = false">
+    <button type="button"
+            @click="open = !open"
+            :aria-expanded="open.toString()"
+            class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">
+      More
+      <svg class="w-4 h-4 transition-transform" :class="open ? 'rotate-180' : ''" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
+    </button>
+    <div x-show="open"
+         x-transition:enter="transition ease-out duration-100"
+         x-transition:enter-start="opacity-0 scale-95"
+         x-transition:enter-end="opacity-100 scale-100"
+         x-transition:leave="transition ease-in duration-75"
+         x-transition:leave-start="opacity-100 scale-100"
+         x-transition:leave-end="opacity-0 scale-95"
+         class="absolute right-0 mt-1 w-44 rounded-lg bg-surface border border-border shadow-card z-30 py-1"
+         role="menu">
+      <button id="bulk-delete-btn"
+              type="button"
+              disabled
+              @click="open = false; window.location='{{ suppliers_bulk_delete_url }}'"
+              class="w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-surfaceSubtle disabled:opacity-40 disabled:cursor-not-allowed"
+              role="menuitem">
+        Bulk Delete
+      </button>
+    </div>
+  </div>
 {% endblock %}
 
 {% block filters %}

--- a/tests/test_explore_view.py
+++ b/tests/test_explore_view.py
@@ -18,24 +18,15 @@ def _create_item(name="Widget", active=True):
     )
 
 
-def test_explore_filters_by_query_and_active(client):
-    _create_item("Apple", True)
-    _create_item("Banana", False)
+def test_explore_redirects_to_items(client):
     url = reverse("explore") + "?q=Banana&active=0"
     resp = client.get(url)
-    assert resp.status_code == 200
-    content = resp.content.decode()
-    assert "Banana" in content
-    assert "Apple" not in content
+    assert resp.status_code == 301
+    assert resp["Location"] == "/items/"
 
 
-def test_explore_export_csv(client):
-    _create_item("Apple", True)
+def test_explore_export_redirects_to_items(client):
     url = reverse("explore_export")
     resp = client.get(url)
-    assert resp.status_code == 200
-    assert resp["Content-Type"] == "text/csv"
-    assert "attachment; filename=items.csv" in resp["Content-Disposition"]
-    rows = list(csv.reader(resp.content.decode().splitlines()))
-    assert rows[0] == ["ID", "Name", "Unit", "Current Stock", "Active"]
-    assert rows[1][1] == "Apple"
+    assert resp.status_code == 301
+    assert resp["Location"] == "/items/"

--- a/tests/test_interactive_dashboard.py
+++ b/tests/test_interactive_dashboard.py
@@ -55,9 +55,9 @@ def test_ajax_dashboard_data_filters(client, item_factory):
 
 
 @pytest.mark.django_db
-def test_interactive_dashboard_template(client, django_user_model):
+def test_interactive_dashboard_redirects(client, django_user_model):
     user = django_user_model.objects.create_user(username="u", password="pw")
     client.force_login(user)
     resp = client.get(reverse("interactive-dashboard"))
-    assert resp.status_code == 200
-    assert b"dashboard-filters" in resp.content
+    assert resp.status_code == 301
+    assert resp["Location"] == "/"


### PR DESCRIPTION
## Summary

- **P0 — Duplicates removed:** bottom bulk-action bar on Items, View link on PO rows, View Low Stock quick action on dashboard, Bulk Delete on Suppliers moved into a More dropdown
- **P1 — Pages consolidated:** `/interactive-dashboard/` and `/explore/` now redirect to `/` and `/items/` respectively; Items page gains stock status filter + ABC class column; GRN list trimmed to single "New GRN" entry point; Nav "Insights > Overview" points to main dashboard
- **P2 — Clarity:** PO button subtitles, search merged into filter panel, low-stock count mismatch fixed (`lte→lt`), View Reports link removed from Stock Movements
- **P3 — Polish:** density toggles removed from PO/History tables; Admin Panel hidden for non-superusers

## Test plan

- [x] `test_interactive_dashboard` updated to assert 301 redirect
- [x] `test_explore_view` updated to assert 301 redirects
- [x] `test_items_table_header` passes with new ABC column (`data-sort="col8"`)
- [x] 30 targeted tests pass, 0 regressions introduced
- [ ] Smoke-test key pages: `/`, `/items/`, `/purchase-orders/`, `/suppliers/`, `/grns/`, `/stock-movements/`
- [ ] Verify `/interactive-dashboard/` and `/explore/` redirect correctly
- [ ] Confirm notification bell count matches "Generate Indent (N low)" on Items page

🤖 Generated with [Claude Code](https://claude.com/claude-code)