### PR TITLE
feat: redesign dashboard with actionable Needs Attention panel and inline chart filters

### DIFF
--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "_base.html" %}
-{% load static %}
+{% load static icon_tags %}
 
 {% block title %}{% if page_title %}{{ page_title }}{% else %}Dashboard – Inventory Pro{% endif %}{% endblock %}
 
@@ -26,12 +26,6 @@
       </div>
     </div>
   {% else %}
-    {% if is_interactive %}
-    <div class="flex items-center justify-between">
-      <h1 class="text-2xl font-semibold text-bodyText">Interactive Dashboard</h1>
-      <a href="/" class="text-sm text-primary hover:underline">← Back to Dashboard</a>
-    </div>
-    {% endif %}
 
     {% include "core/_kpi_cards.html" with items=item_count low_stock=low_stock suppliers=supplier_count pending_indents=pending_indents %}
 
@@ -51,78 +45,111 @@
       </a>
     </div>
 
-    <!-- Filters + Chart -->
+    <!-- Chart + Needs Attention -->
     <div class="grid grid-cols-1 lg:grid-cols-5 gap-6">
-      <!-- Filters (1 col) -->
-      <div class="lg:col-span-1 card">
-        <div class="card-header"><h3 class="text-lg font-semibold">Filters</h3></div>
-        <div class="card-body">
-          <form id="dashboard-filters" class="space-y-4">
-            <div>
-              <label for="item" class="block text-sm font-medium text-gray-700 mb-1">Item</label>
-              <select id="item" name="item" class="block w-full p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary">
-                <option value="">All Items</option>
-                {% for i in items %}<option value="{{ i.pk }}" {% if selected_item == i.pk|stringformat:"s" %}selected{% endif %}>{{ i.name }}</option>{% endfor %}
-              </select>
+
+      <!-- Stock Trend (3 cols) -->
+      <div class="lg:col-span-3 card">
+        <div class="card-header flex flex-wrap items-center justify-between gap-3">
+          <h3 class="text-lg font-semibold">Stock Trend</h3>
+          <form id="dashboard-filters" class="flex flex-wrap items-center gap-2">
+            <input type="hidden" name="range" id="range-value" value="30">
+            <select name="item"
+                    class="text-sm border border-border rounded-md px-2 py-1.5 bg-surface text-bodyText focus:outline-none focus:ring-2 focus:ring-primary">
+              <option value="">All Items</option>
+              {% for i in items %}<option value="{{ i.pk }}">{{ i.name }}</option>{% endfor %}
+            </select>
+            <select name="supplier"
+                    class="text-sm border border-border rounded-md px-2 py-1.5 bg-surface text-bodyText focus:outline-none focus:ring-2 focus:ring-primary">
+              <option value="">All Suppliers</option>
+              {% for s in suppliers %}<option value="{{ s.pk }}">{{ s.name }}</option>{% endfor %}
+            </select>
+            <select name="metric"
+                    class="text-sm border border-border rounded-md px-2 py-1.5 bg-surface text-bodyText focus:outline-none focus:ring-2 focus:ring-primary">
+              <option value="quantity">Quantity</option>
+              <option value="value">Value</option>
+            </select>
+            <div class="flex rounded-md border border-border overflow-hidden text-sm" role="group" aria-label="Date range">
+              <button type="button" data-range="7"  class="range-btn px-3 py-1.5 bg-surface text-bodyText hover:bg-surfaceSubtle transition focus:outline-none">7d</button>
+              <button type="button" data-range="30" class="range-btn px-3 py-1.5 bg-primary text-white transition focus:outline-none" aria-pressed="true">30d</button>
+              <button type="button" data-range="90" class="range-btn px-3 py-1.5 bg-surface text-bodyText hover:bg-surfaceSubtle transition focus:outline-none">90d</button>
             </div>
-            <div>
-              <label for="supplier" class="block text-sm font-medium text-gray-700 mb-1">Supplier</label>
-              <select id="supplier" name="supplier" class="block w-full p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary">
-                <option value="">All Suppliers</option>
-                {% for s in suppliers %}<option value="{{ s.pk }}" {% if selected_supplier == s.pk|stringformat:"s" %}selected{% endif %}>{{ s.name }}</option>{% endfor %}
-              </select>
-            </div>
-            <div>
-              <label for="metric" class="block text-sm font-medium text-gray-700 mb-1">Metric</label>
-              <select id="metric" name="metric" class="block w-full p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary">
-                <option value="quantity" {% if selected_metric == 'quantity' %}selected{% endif %}>Quantity</option>
-                <option value="value" {% if selected_metric == 'value' %}selected{% endif %}>Value</option>
-              </select>
-            </div>
-            <div>
-              <label for="range" class="block text-sm font-medium text-gray-700 mb-1">Date Range</label>
-              <select id="range" name="range" class="block w-full p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
-                      onchange="document.getElementById('custom-range').classList.toggle('hidden', this.value !== 'custom')">
-                <option value="7" {% if selected_range == '7' %}selected{% endif %}>Last 7 Days</option>
-                <option value="30" {% if not selected_range or selected_range == '30' %}selected{% endif %}>Last 30 Days</option>
-                <option value="90" {% if selected_range == '90' %}selected{% endif %}>Last 90 Days</option>
-                <option value="custom" {% if selected_range == 'custom' %}selected{% endif %}>Custom Range</option>
-              </select>
-              <div id="custom-range" class="mt-2 space-y-2 {% if selected_range != 'custom' %}hidden{% endif %}">
-                <div>
-                  <label class="text-xs text-gray-600">From</label>
-                  <input type="date" name="date_from" value="{{ date_from }}" class="block w-full p-2 border rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-primary">
-                </div>
-                <div>
-                  <label class="text-xs text-gray-600">To</label>
-                  <input type="date" name="date_to" value="{{ date_to }}" class="block w-full p-2 border rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-primary">
-                </div>
-              </div>
-            </div>
-            <button type="button" id="apply-filters"
-                    class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-primary text-white hover:bg-primaryHover focus:ring-2 focus:ring-primary w-full">
-              Apply Filters
-            </button>
           </form>
         </div>
-      </div>
-
-      <!-- Chart (4 cols) -->
-      <div class="lg:col-span-4 card">
-        <div class="card-header"><h3 class="text-lg font-semibold">Stock Trend</h3></div>
         <div class="card-body">
           <div id="stock-trend-placeholder"
-               class="h-96 flex flex-col items-center justify-center text-gray-500 hidden">
+               class="h-80 flex flex-col items-center justify-center text-gray-500 hidden">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 mb-3 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
             </svg>
             <p class="text-sm font-medium">No data for the selected filters</p>
             <p class="text-xs text-gray-400 mt-1">Stock movement data will appear here once transactions are recorded.</p>
           </div>
-          <div class="h-96"><canvas id="stock-trend-chart" class="w-full h-full"></canvas></div>
+          <div class="h-80"><canvas id="stock-trend-chart" class="w-full h-full"></canvas></div>
         </div>
       </div>
+
+      <!-- Needs Attention (2 cols) -->
+      <div class="lg:col-span-2 card divide-y divide-border">
+
+        <!-- Low Stock -->
+        <div class="p-4">
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-sm font-semibold text-bodyText flex items-center gap-1.5">
+              {% icon 'exclamation-triangle' 'w-4 h-4 text-warning' %}
+              Low Stock
+            </span>
+            <a href="{% url 'items_list' %}?stock_status=low" class="text-xs text-primary hover:underline">View all</a>
+          </div>
+          {% if low_stock_items %}
+            <ul class="space-y-1.5">
+              {% for item in low_stock_items %}
+              <li class="flex items-center justify-between text-xs">
+                <span class="truncate text-bodyText">{{ item.name }}</span>
+                <span class="tabular-nums text-danger font-medium ml-3 shrink-0">{{ item.current_stock }} / {{ item.reorder_point }}</span>
+              </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="text-xs text-gray-400">All items are well-stocked.</p>
+          {% endif %}
+        </div>
+
+        <!-- Awaiting Approval -->
+        <div class="p-4">
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-semibold text-bodyText flex items-center gap-1.5">
+              {% icon 'clipboard-document-list' 'w-4 h-4 text-primary' %}
+              Awaiting Approval
+            </span>
+            <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-warning-soft text-warning">{{ submitted_indent_count }}</span>
+          </div>
+          {% if submitted_indent_count %}
+            <a href="{% url 'indents_list' %}?status=SUBMITTED" class="text-xs text-primary hover:underline mt-1.5 block">Review indents →</a>
+          {% else %}
+            <p class="text-xs text-gray-400 mt-1.5">No indents pending approval.</p>
+          {% endif %}
+        </div>
+
+        <!-- POs to Receive -->
+        <div class="p-4">
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-semibold text-bodyText flex items-center gap-1.5">
+              {% icon 'inbox-arrow-down' 'w-4 h-4 text-primary' %}
+              POs to Receive
+            </span>
+            <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-info-soft text-primary">{{ sent_po_count }}</span>
+          </div>
+          {% if sent_po_count %}
+            <a href="{% url 'purchase_orders_list' %}?status=SENT" class="text-xs text-primary hover:underline mt-1.5 block">View purchase orders →</a>
+          {% else %}
+            <p class="text-xs text-gray-400 mt-1.5">No outstanding purchase orders.</p>
+          {% endif %}
+        </div>
+
+      </div>
     </div>
+
   {% endif %}
 </div>
 {% endblock %}

--- a/core/views.py
+++ b/core/views.py
@@ -9,8 +9,9 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils import timezone
 
-from inventory.models import Item, PurchaseOrder, StockTransaction, Supplier
+from inventory.models import Indent, Item, PurchaseOrder, StockTransaction, Supplier
 from inventory.services import counts, kpis
+from inventory.services.stock_utils import get_low_stock_items
 
 from .viewmodels import DashboardContext
 
@@ -33,6 +34,9 @@ def root_view(request):
             "trend_values": json.dumps(values),
             "items": Item.objects.filter(is_active=True),
             "suppliers": Supplier.objects.filter(is_active=True),
+            "low_stock_items": get_low_stock_items()[:5],
+            "submitted_indent_count": Indent.objects.filter(status="SUBMITTED").count(),
+            "sent_po_count": PurchaseOrder.objects.filter(status="SENT").count(),
             "list_url": reverse("root"),
             "list_title": "Dashboard",
             "current_title": "Dashboard",

--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -79,11 +79,6 @@ NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
         "Stock",
         [
             {
-                "title": "Stock Levels",
-                "description": "Your products, stock levels, and settings.",
-                "url_name": "items_list",
-            },
-            {
                 "title": "Movements",
                 "description": "Transfers, wastage, and adjustments.",
                 "url_name": "stock_movements",

--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -99,6 +99,11 @@ NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
         "Master Data",
         [
             {
+                "title": "Items",
+                "description": "Your products, stock levels, and settings.",
+                "url_name": "items_list",
+            },
+            {
                 "title": "Recipes",
                 "description": "Ingredients, portions, and costings.",
                 "url_name": "recipes_list",

--- a/static/core/dashboard.js
+++ b/static/core/dashboard.js
@@ -54,7 +54,28 @@ document.addEventListener("DOMContentLoaded", () => {
     renderChart(data.labels, data.values, metric);
   }
 
-  document.getElementById("apply-filters").addEventListener("click", fetchData);
+  // Auto-fetch on any select change
+  document.querySelectorAll("#dashboard-filters select").forEach((sel) => {
+    sel.addEventListener("change", fetchData);
+  });
+
+  // Range pill buttons
+  const rangeInput = document.getElementById("range-value");
+  document.querySelectorAll(".range-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      rangeInput.value = btn.dataset.range;
+      document.querySelectorAll(".range-btn").forEach((b) => {
+        b.classList.remove("bg-primary", "text-white");
+        b.classList.add("bg-surface", "text-bodyText");
+        b.removeAttribute("aria-pressed");
+      });
+      btn.classList.add("bg-primary", "text-white");
+      btn.classList.remove("bg-surface", "text-bodyText");
+      btn.setAttribute("aria-pressed", "true");
+      fetchData();
+    });
+  });
+
   renderChart(
     window.initialTrendLabels || [],
     window.initialTrendValues || [],

--- a/templates/components/footer.html
+++ b/templates/components/footer.html
@@ -1,3 +1,3 @@
-<footer class="bg-primary text-nav text-center p-4">
+<footer class="bg-primary text-white text-center p-4">
   <p>&copy; {% now 'Y' %} Inventory Pro</p>
 </footer>

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -35,7 +35,7 @@
               {% for link in group.links %}
                 <li role="none">
                   {% if request.resolver_match.url_name == link.url_name %}
-                    <a role="menuitem" href="{{ link.url }}" class="flex items-start gap-2 px-4 py-2 text-sm font-semibold text-primary bg-primary/10" data-nav-link>
+                    <a role="menuitem" href="{{ link.url }}" class="flex items-start gap-2 mx-1 px-3 py-2 text-sm font-semibold text-primary bg-primary/10 rounded-md" data-nav-link>
                       {% if link.url_name == 'root' %}{% icon 'home' 'h-4 w-4 text-primary' aria_label='' %}
                       {% elif link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-primary' aria_label='' %}
                       {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-primary' aria_label='' %}

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -158,7 +158,6 @@
           </button>
           <div x-cloak x-show="open" @click.outside="open=false" class="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-surface ring-1 ring-black ring-opacity-5 z-50">
             <div class="py-1" role="menu">
-              <a href="{% url 'root' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Dashboard</a>
               <a href="{% url 'settings' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Settings</a>
               <a href="{% url 'workflow_guide' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Help &amp; Guide</a>
               <div class="border-t border-border my-1"></div>

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -167,9 +167,9 @@
               hx-include="#filters"
               hx-indicator="#indents-loading">
           {% csrf_token %}
-          <button type="submit" class="inline-flex items-center justify-center w-8 h-8 p-0 text-xs font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" title="Consolidate to PO" aria-label="Consolidate to PO">
+          <button type="submit" class="inline-flex items-center justify-center w-8 h-8 p-0 text-xs font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" title="Send to Processing" aria-label="Send to Processing">
             {% icon 'play' 'w-4 h-4' %}
-            <span class="sr-only">Consolidate to PO</span>
+            <span class="sr-only">Send to Processing</span>
           </button>
         </form>
         {% endif %}
@@ -229,16 +229,6 @@
       {% endif %}
     {% endif %}
     <div class="flex items-center justify-between max-md:flex-col max-md:items-stretch gap-3">
-    <form id="indents-bulk-actions" class="flex items-center gap-2"
-          hx-post="{% url 'indents_consolidate' %}?{{ querystring|default:'' }}&page={{ page_obj.number }}"
-          hx-target="#indents_table" hx-include="#filters, #indents-bulk-actions" hx-indicator="#indents-loading">
-      {% csrf_token %}
-      <button type="submit" class="inline-flex items-center px-3 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong"
-              title="Consolidate selected indents into POs">
-        Consolidate to PO
-      </button>
-      <span class="text-xs text-gray-500">Selected rows will be grouped by supplier.</span>
-    </form>
     {% include "components/pagination.html" with page_obj=page_obj base_url=table_url extra_query=querystring hx_target="#indents_table" hx_include="#filters" hx_indicator="#indents-loading" %}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- **Needs Attention panel**: shows top 5 low-stock items (with current/reorder point), count of indents awaiting approval, and count of POs ready to receive — all with direct links
- **Inline chart filters**: Item, Supplier, Metric selects + 7d/30d/90d pill buttons sit in the chart card header, replacing the full-column filter sidebar
- **Auto-update**: chart refreshes immediately on any filter/range change, no Apply button needed
- **Backend**: `root_view` now passes `low_stock_items`, `submitted_indent_count`, `sent_po_count` to context

## Test plan
- [ ] Dashboard loads with Needs Attention panel showing correct data
- [ ] Changing Item/Supplier/Metric dropdown auto-updates chart
- [ ] Clicking 7d/30d/90d pill updates chart and highlights active pill
- [ ] Low Stock items link to `/items/?stock_status=low`
- [ ] Awaiting Approval links to `/indents/?status=SUBMITTED`
- [ ] POs to Receive links to `/purchase-orders/?status=SENT`
- [ ] Mobile: columns stack cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)