### PR TITLE
feat: dashboard redesign with minimal layout and operational KPIs

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -1,9 +1,64 @@
-{% url 'items_list' as items_list_url %}
-{% url 'suppliers_list' as suppliers_list_url %}
-{% url 'indents_list' as indents_list_url %}
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-  {% include "components/kpi_card.html" with icon='cube' label='Items' value=items href=items_list_url %}
-  {% include "components/kpi_card.html" with icon='exclamation-triangle' label='Low-stock Items' value=low_stock href=items_list_url|add:'?stock_status=low' warning=low_stock %}
-  {% include "components/kpi_card.html" with icon='truck' label='Suppliers' value=suppliers href=suppliers_list_url %}
-  {% include "components/kpi_card.html" with icon='clipboard-document-list' label='Pending Indents' value=pending_indents href=indents_list_url|add:'?status=PENDING' info=pending_indents %}
+<!-- Consumption breakdown + KPI metrics -->
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+
+  <!-- Left: Consumption breakdown table -->
+  <div class="lg:col-span-1 bg-surface border border-border rounded-xl p-4">
+    <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-3">Consumption breakdown</h3>
+    <table class="w-full text-sm">
+      <tbody class="divide-y divide-border">
+        <tr>
+          <td class="py-1.5 text-gray-500">Opening Stock</td>
+          <td class="py-1.5 text-right font-medium text-bodyText">{{ opening_stock|floatformat:0|default:"—" }}</td>
+        </tr>
+        <tr>
+          <td class="py-1.5 text-gray-500">+ Purchases</td>
+          <td class="py-1.5 text-right font-medium text-bodyText">{{ purchases|floatformat:0|default:"—" }}</td>
+        </tr>
+        <tr>
+          <td class="py-1.5 text-gray-500">− Closing Stock</td>
+          <td class="py-1.5 text-right font-medium text-bodyText">{{ closing_stock|floatformat:0|default:"—" }}</td>
+        </tr>
+        <tr class="border-t-2 border-border">
+          <td class="py-2 font-semibold text-bodyText">= Consumption</td>
+          <td class="py-2 text-right font-bold text-bodyText">{{ consumption|floatformat:0|default:"—" }}</td>
+        </tr>
+      </tbody>
+    </table>
+    {% if consumption_delta is not None %}
+      <p class="mt-1 text-[11px] font-medium {% if consumption_delta > 0 %}text-danger-text{% elif consumption_delta < 0 %}text-success-text{% else %}text-gray-400{% endif %}">
+        {% if consumption_delta > 0 %}+{% endif %}{{ consumption_delta|floatformat:1 }}% vs prev period
+      </p>
+    {% endif %}
+  </div>
+
+  <!-- Right: KPI cards grid -->
+  <div class="lg:col-span-2 grid grid-cols-1 sm:grid-cols-3 gap-4">
+
+    {% include "components/kpi_metric_card.html" with label="Sales Revenue" value=sales_revenue is_currency=True %}
+
+    <!-- Food Cost % card with actual + ideal -->
+    <div class="bg-surface border border-border rounded-xl px-4 py-3.5 flex flex-col gap-0.5">
+      <p class="text-[11px] font-medium uppercase tracking-wide text-gray-400">Food Cost %</p>
+      <p class="text-xl font-semibold text-bodyText leading-tight">
+        {% if actual_fc is not None %}
+          {{ actual_fc }}%
+        {% else %}
+          <span class="text-gray-300">&mdash;</span>
+        {% endif %}
+      </p>
+      {% if ideal_fc is not None %}
+        <p class="text-[11px] text-gray-400">Ideal {{ ideal_fc }}%</p>
+      {% endif %}
+      {% if actual_fc is not None and ideal_fc is not None %}
+        {% if actual_fc > ideal_fc %}
+          <span class="inline-block mt-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-danger-soft text-danger-text">Over target</span>
+        {% else %}
+          <span class="inline-block mt-0.5 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-success-soft text-success-text">On target</span>
+        {% endif %}
+      {% endif %}
+    </div>
+
+    {% include "components/kpi_metric_card.html" with label="Wastage" value=wastage is_currency=True delta=wastage_delta invert_delta=True %}
+
+  </div>
 </div>

--- a/core/templates/core/dashboard.html
+++ b/core/templates/core/dashboard.html
@@ -4,7 +4,7 @@
 {% block title %}{% if page_title %}{{ page_title }}{% else %}Dashboard – Inventory Pro{% endif %}{% endblock %}
 
 {% block content %}
-<div class="container mx-auto px-8 max-md:px-6 max-sm:px-4 py-8 space-y-8 min-h-[calc(100vh-8rem)]">
+<div class="container mx-auto px-8 max-md:px-6 max-sm:px-4 py-8 space-y-6 min-h-[calc(100vh-8rem)]">
   {% if not user.is_authenticated %}
     <div class="bg-primary text-white rounded p-8 text-center">
       <h1 class="text-h1 font-bold">Welcome to Inventory Pro</h1>
@@ -27,7 +27,102 @@
     </div>
   {% else %}
 
-    {% include "core/_kpi_cards.html" with items=item_count low_stock=low_stock suppliers=supplier_count pending_indents=pending_indents %}
+    <!-- Greeting + period toggle -->
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <h1 class="text-xl font-semibold text-bodyText">{{ greeting }}</h1>
+      <div class="flex rounded-md border border-border overflow-hidden text-sm" role="group" aria-label="Date range">
+        <button type="button" data-range="7"  class="range-btn px-3 py-1.5 {% if selected_range == '7' %}bg-primary text-white{% else %}bg-surface text-bodyText hover:bg-surfaceSubtle{% endif %} transition focus:outline-none">7d</button>
+        <button type="button" data-range="30" class="range-btn px-3 py-1.5 {% if selected_range == '30' or not selected_range %}bg-primary text-white{% else %}bg-surface text-bodyText hover:bg-surfaceSubtle{% endif %} transition focus:outline-none">30d</button>
+        <button type="button" data-range="90" class="range-btn px-3 py-1.5 {% if selected_range == '90' %}bg-primary text-white{% else %}bg-surface text-bodyText hover:bg-surfaceSubtle{% endif %} transition focus:outline-none">90d</button>
+      </div>
+      <input type="hidden" id="filter-range" value="{{ selected_range|default:'30' }}">
+    </div>
+
+    <!-- KPI Cards -->
+    {% include "core/_kpi_cards.html" %}
+
+    <!-- Chart + Alerts -->
+    <div class="grid grid-cols-1 lg:grid-cols-5 gap-6">
+
+      <!-- Chart (3 cols) -->
+      <div class="lg:col-span-3 card">
+        <div class="card-header flex items-center justify-between gap-3 px-4 pt-4">
+          <h3 class="text-lg font-semibold text-bodyText">Consumption vs Wastage</h3>
+          <div class="flex items-center gap-3 text-xs">
+            <span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-full bg-primary"></span> Consumption</span>
+            <span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-full bg-danger"></span> Wastage</span>
+          </div>
+        </div>
+        <div class="card-body p-4">
+          <div id="stock-trend-placeholder"
+               class="h-80 flex flex-col items-center justify-center text-gray-500 hidden">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 mb-3 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
+            </svg>
+            <p class="text-sm font-medium">No data for the selected period</p>
+            <p class="text-xs text-gray-400 mt-1">Transaction data will appear here once recorded.</p>
+          </div>
+          <div class="h-80"><canvas id="stock-trend-chart" class="w-full h-full"></canvas></div>
+        </div>
+      </div>
+
+      <!-- Alerts (2 cols) -->
+      <div class="lg:col-span-2 card divide-y divide-border">
+        <div class="px-4 pt-4 pb-2">
+          <h3 class="text-sm font-semibold text-bodyText">Needs attention</h3>
+        </div>
+        {% if alerts %}
+          {% for alert in alerts %}
+          <div class="px-4 py-3 flex items-start gap-3">
+            <span class="mt-0.5">
+              {% icon alert.icon 'w-4 h-4' %}
+            </span>
+            <div class="flex-1 min-w-0">
+              <p class="text-sm text-bodyText">{{ alert.label }}</p>
+              <a href="{{ alert.url }}" class="text-xs text-primary hover:underline mt-0.5 block">View →</a>
+            </div>
+          </div>
+          {% endfor %}
+        {% else %}
+          <div class="px-4 py-6 text-center">
+            <p class="text-sm text-gray-400">All clear — nothing needs attention right now.</p>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+
+    <!-- Inventory snapshot -->
+    <div>
+      <h2 class="text-base font-semibold text-bodyText mb-3">Inventory snapshot</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div class="bg-surface border border-border rounded-xl px-4 py-3.5">
+          <p class="text-[11px] font-medium uppercase tracking-wide text-gray-400">Active Items</p>
+          <p class="text-xl font-semibold text-bodyText">{{ active_items|default:"0" }}</p>
+          {% if low_stock_count %}
+            <p class="text-[11px] text-danger-text font-medium">{{ low_stock_count }} below reorder</p>
+          {% endif %}
+        </div>
+        {% include "components/kpi_metric_card.html" with label="Low Stock %" value=low_stock_pct is_pct=True %}
+        {% include "components/kpi_metric_card.html" with label="Stock Value" value=stock_value is_currency=True %}
+
+        <!-- Top Movers (7d) -->
+        <div class="bg-surface border border-border rounded-xl px-4 py-3.5">
+          <p class="text-[11px] font-medium uppercase tracking-wide text-gray-400 mb-2">Top movers (7d)</p>
+          {% if fastest_movers %}
+            <ul class="space-y-1">
+              {% for name, qty in fastest_movers %}
+              <li class="flex items-center justify-between text-xs">
+                <span class="truncate text-bodyText">{{ name }}</span>
+                <span class="tabular-nums text-gray-500 ml-2 shrink-0">{{ qty|floatformat:1 }}</span>
+              </li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class="text-xs text-gray-400">No movement data yet.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
 
     <!-- Quick Actions -->
     <div class="flex flex-wrap gap-3">
@@ -45,111 +140,6 @@
       </a>
     </div>
 
-    <!-- Chart + Needs Attention -->
-    <div class="grid grid-cols-1 lg:grid-cols-5 gap-6">
-
-      <!-- Stock Trend (3 cols) -->
-      <div class="lg:col-span-3 card">
-        <div class="card-header flex flex-wrap items-center justify-between gap-3">
-          <h3 class="text-lg font-semibold">Stock Trend</h3>
-          <form id="dashboard-filters" class="flex flex-wrap items-center gap-2">
-            <input type="hidden" name="range" id="range-value" value="30">
-            <select name="item"
-                    class="text-sm border border-border rounded-md px-2 py-1.5 bg-surface text-bodyText focus:outline-none focus:ring-2 focus:ring-primary">
-              <option value="">All Items</option>
-              {% for i in items %}<option value="{{ i.pk }}">{{ i.name }}</option>{% endfor %}
-            </select>
-            <select name="supplier"
-                    class="text-sm border border-border rounded-md px-2 py-1.5 bg-surface text-bodyText focus:outline-none focus:ring-2 focus:ring-primary">
-              <option value="">All Suppliers</option>
-              {% for s in suppliers %}<option value="{{ s.pk }}">{{ s.name }}</option>{% endfor %}
-            </select>
-            <select name="metric"
-                    class="text-sm border border-border rounded-md px-2 py-1.5 bg-surface text-bodyText focus:outline-none focus:ring-2 focus:ring-primary">
-              <option value="quantity">Quantity</option>
-              <option value="value">Value</option>
-            </select>
-            <div class="flex rounded-md border border-border overflow-hidden text-sm" role="group" aria-label="Date range">
-              <button type="button" data-range="7"  class="range-btn px-3 py-1.5 bg-surface text-bodyText hover:bg-surfaceSubtle transition focus:outline-none">7d</button>
-              <button type="button" data-range="30" class="range-btn px-3 py-1.5 bg-primary text-white transition focus:outline-none" aria-pressed="true">30d</button>
-              <button type="button" data-range="90" class="range-btn px-3 py-1.5 bg-surface text-bodyText hover:bg-surfaceSubtle transition focus:outline-none">90d</button>
-            </div>
-          </form>
-        </div>
-        <div class="card-body">
-          <div id="stock-trend-placeholder"
-               class="h-80 flex flex-col items-center justify-center text-gray-500 hidden">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 mb-3 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"/>
-            </svg>
-            <p class="text-sm font-medium">No data for the selected filters</p>
-            <p class="text-xs text-gray-400 mt-1">Stock movement data will appear here once transactions are recorded.</p>
-          </div>
-          <div class="h-80"><canvas id="stock-trend-chart" class="w-full h-full"></canvas></div>
-        </div>
-      </div>
-
-      <!-- Needs Attention (2 cols) -->
-      <div class="lg:col-span-2 card divide-y divide-border">
-
-        <!-- Low Stock -->
-        <div class="p-4">
-          <div class="flex items-center justify-between mb-2">
-            <span class="text-sm font-semibold text-bodyText flex items-center gap-1.5">
-              {% icon 'exclamation-triangle' 'w-4 h-4 text-warning' %}
-              Low Stock
-            </span>
-            <a href="{% url 'items_list' %}?stock_status=low" class="text-xs text-primary hover:underline">View all</a>
-          </div>
-          {% if low_stock_items %}
-            <ul class="space-y-1.5">
-              {% for item in low_stock_items %}
-              <li class="flex items-center justify-between text-xs">
-                <span class="truncate text-bodyText">{{ item.name }}</span>
-                <span class="tabular-nums text-danger font-medium ml-3 shrink-0">{{ item.current_stock }} / {{ item.reorder_point }}</span>
-              </li>
-              {% endfor %}
-            </ul>
-          {% else %}
-            <p class="text-xs text-gray-400">All items are well-stocked.</p>
-          {% endif %}
-        </div>
-
-        <!-- Awaiting Approval -->
-        <div class="p-4">
-          <div class="flex items-center justify-between">
-            <span class="text-sm font-semibold text-bodyText flex items-center gap-1.5">
-              {% icon 'clipboard-document-list' 'w-4 h-4 text-primary' %}
-              Awaiting Approval
-            </span>
-            <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-warning-soft text-warning">{{ submitted_indent_count }}</span>
-          </div>
-          {% if submitted_indent_count %}
-            <a href="{% url 'indents_list' %}?status=SUBMITTED" class="text-xs text-primary hover:underline mt-1.5 block">Review indents →</a>
-          {% else %}
-            <p class="text-xs text-gray-400 mt-1.5">No indents pending approval.</p>
-          {% endif %}
-        </div>
-
-        <!-- POs to Receive -->
-        <div class="p-4">
-          <div class="flex items-center justify-between">
-            <span class="text-sm font-semibold text-bodyText flex items-center gap-1.5">
-              {% icon 'inbox-arrow-down' 'w-4 h-4 text-primary' %}
-              POs to Receive
-            </span>
-            <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-info-soft text-primary">{{ sent_po_count }}</span>
-          </div>
-          {% if sent_po_count %}
-            <a href="{% url 'purchase_orders_list' %}?status=SENT" class="text-xs text-primary hover:underline mt-1.5 block">View purchase orders →</a>
-          {% else %}
-            <p class="text-xs text-gray-400 mt-1.5">No outstanding purchase orders.</p>
-          {% endif %}
-        </div>
-
-      </div>
-    </div>
-
   {% endif %}
 </div>
 {% endblock %}
@@ -158,7 +148,8 @@
   {% if user.is_authenticated %}
   <script>
     window.initialTrendLabels = {{ trend_labels|safe }};
-    window.initialTrendValues = {{ trend_values|safe }};
+    window.initialConsumption = {{ trend_consumption|safe }};
+    window.initialWastage = {{ trend_wastage|safe }};
   </script>
   <script src="{% static 'core/dashboard.js' %}?v={{ STATIC_VERSION }}" defer></script>
   {% endif %}

--- a/core/views.py
+++ b/core/views.py
@@ -1,42 +1,221 @@
 import json
 import logging
-from datetime import date, timedelta
+from datetime import timedelta
 
-from django.db.models import DecimalField, ExpressionWrapper, F, Sum
-from django.db.models.functions import Coalesce, TruncDate
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils import timezone
 
-from inventory.models import Indent, Item, PurchaseOrder, StockTransaction, Supplier
-from inventory.services import counts, kpis
+from inventory.models import Indent, Item, PurchaseOrder
+from inventory.models.enums import PurchaseOrderStatus
+from inventory.models.stock_take import StockTake
+from inventory.services import dashboard_kpis as dkpis
+from inventory.services import kpis
 from inventory.services.stock_utils import get_low_stock_items
-
-from .viewmodels import DashboardContext
 
 logger = logging.getLogger(__name__)
 
 
+def _greeting(user):
+    hour = timezone.localtime().hour
+    if hour < 12:
+        prefix = "Good morning"
+    elif hour < 18:
+        prefix = "Good afternoon"
+    else:
+        prefix = "Good evening"
+    name = user.first_name or user.username or ""
+    return f"{prefix}, {name}" if name else prefix
+
+
+def _build_alerts():
+    """Build a list of alert dicts for the dashboard attention panel."""
+    alerts = []
+
+    try:
+        pending = Indent.objects.filter(status="SUBMITTED").count()
+        if pending:
+            alerts.append(
+                {
+                    "icon": "clipboard-document-list",
+                    "label": f"{pending} indent{'s' if pending != 1 else ''} awaiting approval",
+                    "url": reverse("indents_list") + "?status=SUBMITTED",
+                    "color": "warning",
+                }
+            )
+    except Exception:
+        pass
+
+    try:
+        actual_fc = dkpis.actual_food_cost_pct(
+            timezone.now().date() - timedelta(days=29),
+            timezone.now().date(),
+        )
+        if actual_fc and actual_fc > 35:
+            alerts.append(
+                {
+                    "icon": "exclamation-triangle",
+                    "label": f"Food cost at {actual_fc}% — above 35% target",
+                    "url": reverse("food_cost_report"),
+                    "color": "danger",
+                }
+            )
+    except Exception:
+        pass
+
+    try:
+        low = kpis.low_stock_count()
+        if low:
+            alerts.append(
+                {
+                    "icon": "exclamation-triangle",
+                    "label": f"{low} item{'s' if low != 1 else ''} below reorder point",
+                    "url": reverse("items_list") + "?stock_status=low",
+                    "color": "danger",
+                }
+            )
+    except Exception:
+        pass
+
+    try:
+        draft_pos = PurchaseOrder.objects.filter(
+            status=PurchaseOrderStatus.DRAFT
+        ).count()
+        if draft_pos:
+            alerts.append(
+                {
+                    "icon": "document-text",
+                    "label": f"{draft_pos} draft PO{'s' if draft_pos != 1 else ''} not yet sent",
+                    "url": reverse("purchase_orders_list") + "?status=DRAFT",
+                    "color": "info",
+                }
+            )
+    except Exception:
+        pass
+
+    try:
+        sent_pos = PurchaseOrder.objects.filter(status=PurchaseOrderStatus.SENT).count()
+        if sent_pos:
+            alerts.append(
+                {
+                    "icon": "inbox-arrow-down",
+                    "label": f"{sent_pos} PO{'s' if sent_pos != 1 else ''} awaiting delivery",
+                    "url": reverse("purchase_orders_list") + "?status=SENT",
+                    "color": "info",
+                }
+            )
+    except Exception:
+        pass
+
+    try:
+        open_takes = StockTake.objects.exclude(status="COMPLETED").count()
+        if open_takes:
+            alerts.append(
+                {
+                    "icon": "clipboard-document-check",
+                    "label": f"{open_takes} open stock take{'s' if open_takes != 1 else ''}",
+                    "url": reverse("stock_take_list"),
+                    "color": "warning",
+                }
+            )
+    except Exception:
+        pass
+
+    return alerts
+
+
 def root_view(request):
     """Render login form or dashboard depending on authentication."""
-    logger.debug("User authenticated: %s", request.user.is_authenticated)
     if request.user.is_authenticated:
         end = timezone.now().date()
-        start = end - timedelta(days=29)
-        labels, values = _stock_trend_data(start=start, end=end)
+        range_days = int(request.GET.get("range", "30"))
+        start = end - timedelta(days=range_days - 1)
+
+        try:
+            opening = dkpis.opening_stock_value(start, end)
+        except Exception:
+            opening = 0
+        try:
+            closing = dkpis.closing_stock_value()
+        except Exception:
+            closing = 0
+        try:
+            purchases = dkpis.purchases_total(start, end)
+        except Exception:
+            purchases = 0
+        try:
+            consumption = dkpis.consumption_total(start, end)
+        except Exception:
+            consumption = 0
+        try:
+            cons_delta = dkpis.consumption_delta(start, end)
+        except Exception:
+            cons_delta = None
+        try:
+            revenue = dkpis.sales_revenue(start, end)
+        except Exception:
+            revenue = 0
+        try:
+            actual_fc = dkpis.actual_food_cost_pct(start, end)
+        except Exception:
+            actual_fc = None
+        try:
+            ideal_fc = dkpis.ideal_food_cost_pct(start, end)
+        except Exception:
+            ideal_fc = None
+        try:
+            wastage = dkpis.wastage_total(start, end)
+        except Exception:
+            wastage = 0
+        try:
+            waste_delta = dkpis.wastage_delta(start, end)
+        except Exception:
+            waste_delta = None
+        try:
+            trend_labels, trend_consumption, trend_wastage = dkpis.daily_trends(
+                start, end
+            )
+        except Exception:
+            trend_labels, trend_consumption, trend_wastage = [], [], []
+
+        active_items = Item.objects.filter(is_active=True).count()
+        low_stock_count = kpis.low_stock_count()
+        low_stock_pct = (
+            round(low_stock_count / active_items * 100, 1) if active_items else 0
+        )
+        try:
+            stock_value = float(dkpis.closing_stock_value())
+        except Exception:
+            stock_value = 0
+        try:
+            fastest_movers = kpis.fastest_movers_last_7_days()
+        except Exception:
+            fastest_movers = []
+
         context = {
-            "item_count": counts.item_count(),
-            "low_stock": kpis.low_stock_count(),
-            "supplier_count": counts.supplier_count(),
-            "pending_indents": sum(kpis.pending_indent_counts().values()),
-            "trend_labels": json.dumps(labels),
-            "trend_values": json.dumps(values),
-            "items": Item.objects.filter(is_active=True),
-            "suppliers": Supplier.objects.filter(is_active=True),
+            "greeting": _greeting(request.user),
+            "selected_range": str(range_days),
+            "opening_stock": opening,
+            "closing_stock": closing,
+            "purchases": purchases,
+            "consumption": consumption,
+            "consumption_delta": cons_delta,
+            "sales_revenue": revenue,
+            "actual_fc": actual_fc,
+            "ideal_fc": ideal_fc,
+            "wastage": wastage,
+            "wastage_delta": waste_delta,
+            "trend_labels": json.dumps(trend_labels),
+            "trend_consumption": json.dumps(trend_consumption),
+            "trend_wastage": json.dumps(trend_wastage),
+            "active_items": active_items,
+            "low_stock_count": low_stock_count,
+            "low_stock_pct": low_stock_pct,
+            "stock_value": stock_value,
+            "fastest_movers": fastest_movers,
+            "alerts": _build_alerts(),
             "low_stock_items": get_low_stock_items()[:5],
-            "submitted_indent_count": Indent.objects.filter(status="SUBMITTED").count(),
-            "sent_po_count": PurchaseOrder.objects.filter(status="SENT").count(),
             "list_url": reverse("root"),
             "list_title": "Dashboard",
             "current_title": "Dashboard",
@@ -57,171 +236,46 @@ def health_check(request):
 
 def dashboard_kpis(request):
     """HTMX endpoint returning KPI card values."""
+    end = timezone.now().date()
+    range_days = int(request.GET.get("range", "30"))
+    start = end - timedelta(days=range_days - 1)
     data = {
-        "items": counts.item_count(),
-        "low_stock": kpis.low_stock_count(),
-        "suppliers": counts.supplier_count(),
-        "pending_indents": sum(kpis.pending_indent_counts().values()),
+        "opening_stock": dkpis.opening_stock_value(start, end),
+        "purchases": dkpis.purchases_total(start, end),
+        "closing_stock": dkpis.closing_stock_value(),
+        "consumption": dkpis.consumption_total(start, end),
+        "consumption_delta": dkpis.consumption_delta(start, end),
+        "sales_revenue": dkpis.sales_revenue(start, end),
+        "actual_fc": dkpis.actual_food_cost_pct(start, end),
+        "ideal_fc": dkpis.ideal_food_cost_pct(start, end),
+        "wastage": dkpis.wastage_total(start, end),
+        "wastage_delta": dkpis.wastage_delta(start, end),
     }
     return render(request, "core/_kpi_cards.html", data)
 
 
-def _stock_trend_data(
-    item_id=None, supplier_id=None, start=None, end=None, metric="quantity"
-):
-    """Return daily stock trend data.
-
-    Prefers StockSnapshot (absolute stock levels) when available, falling back
-    to StockTransaction daily aggregates when no snapshots exist.
-
-    Args:
-        item_id: Optional item ID to filter.
-        supplier_id: Optional supplier ID to filter (via preferred_supplier FK on Item).
-        start: Start date (inclusive).
-        end: End date (inclusive).
-        metric: "quantity" or "value".
-    """
-    # ── Try StockSnapshot first (absolute stock levels) ──────────────────
-    try:
-        from inventory.models.items import StockSnapshot
-
-        qs = StockSnapshot.objects.all()
-        if item_id:
-            qs = qs.filter(item_id=item_id)
-        if supplier_id:
-            qs = qs.filter(item__preferred_supplier_id=supplier_id)
-        if start:
-            qs = qs.filter(snapshot_date__gte=start)
-        if end:
-            qs = qs.filter(snapshot_date__lte=end)
-
-        if metric == "value":
-            agg = (
-                qs.values("snapshot_date")
-                .annotate(total=Sum("value"))
-                .order_by("snapshot_date")
-            )
-        else:
-            agg = (
-                qs.values("snapshot_date")
-                .annotate(total=Sum("quantity"))
-                .order_by("snapshot_date")
-            )
-
-        rows = list(agg)
-        if rows:
-            labels = [d["snapshot_date"].strftime("%Y-%m-%d") for d in rows]
-            values = [float(d["total"] or 0) for d in rows]
-            return labels, values
-    except Exception:
-        logger.debug("StockSnapshot unavailable, falling back to StockTransaction")
-
-    # ── Fall back to StockTransaction daily aggregates ───────────────────
-    qs = StockTransaction.objects.all()
-    if item_id:
-        qs = qs.filter(item_id=item_id)
-    if supplier_id:
-        po_ids = PurchaseOrder.objects.filter(supplier_id=supplier_id).values_list(
-            "po_id", flat=True
-        )
-        qs = qs.filter(related_po_id__in=po_ids)
-    if start:
-        qs = qs.filter(transaction_date__date__gte=start)
-    if end:
-        qs = qs.filter(transaction_date__date__lte=end)
-
-    annotation = {"total": Sum("quantity_change")}
-    if metric == "value":
-        annotation["total"] = Sum(
-            ExpressionWrapper(
-                F("quantity_change") * Coalesce(F("item__last_purchase_price"), 0),
-                output_field=DecimalField(max_digits=12, decimal_places=2),
-            )
-        )
-        qs = qs.select_related("item")
-
-    data = (
-        qs.annotate(day=TruncDate("transaction_date"))
-        .values("day")
-        .order_by("day")
-        .annotate(**annotation)
-    )
-    labels = [d["day"].strftime("%Y-%m-%d") for d in data]
-    values = [float(d["total"]) for d in data]
-    return labels, values
-
-
 def _parse_date_range(request):
-    """Extract and validate date range from request GET params.
-
-    Supports preset ranges (7/30/90 days) and custom date_from / date_to.
-    """
+    """Extract and validate date range from request GET params."""
     range_days = request.GET.get("range", "30")
-    date_from_raw = request.GET.get("date_from", "").strip()
-    date_to_raw = request.GET.get("date_to", "").strip()
     today = timezone.now().date()
-
-    if range_days == "custom" and (date_from_raw or date_to_raw):
-        try:
-            end = date.fromisoformat(date_to_raw) if date_to_raw else today
-            start = (
-                date.fromisoformat(date_from_raw)
-                if date_from_raw
-                else end - timedelta(days=29)
-            )
-        except ValueError:
-            end = today
-            start = today - timedelta(days=29)
-    else:
-        try:
-            days = int(range_days)
-        except (ValueError, TypeError):
-            days = 30
-        end = today
-        start = end - timedelta(days=days - 1)
-
+    try:
+        days = int(range_days)
+    except (ValueError, TypeError):
+        days = 30
+    end = today
+    start = end - timedelta(days=days - 1)
     return start, end
 
 
 def interactive_dashboard(request):
     """Render interactive dashboard with filter controls for trend chart."""
-    item_id = request.GET.get("item")
-    supplier_id = request.GET.get("supplier")
-    metric = request.GET.get("metric", "quantity")
-    range_val = request.GET.get("range", "30")
-    date_from = request.GET.get("date_from", "")
-    date_to = request.GET.get("date_to", "")
-    start, end = _parse_date_range(request)
-
-    labels, values = _stock_trend_data(item_id, supplier_id, start, end, metric)
-    context = DashboardContext(
-        labels,
-        values,
-        items=Item.objects.filter(is_active=True),
-        suppliers=Supplier.objects.filter(is_active=True),
-    ).as_dict()
-    context.update(
-        {
-            "is_interactive": True,
-            "page_title": "Interactive Dashboard – Inventory Pro",
-            "current_title": "Interactive Dashboard",
-            "selected_range": range_val,
-            "selected_item": item_id or "",
-            "selected_supplier": supplier_id or "",
-            "selected_metric": metric,
-            "date_from": date_from,
-            "date_to": date_to,
-        }
-    )
-    return render(request, "core/dashboard.html", context)
+    return root_view(request)
 
 
 def ajax_dashboard_data(request):
     """Return JSON chart data for the given filters."""
-    item_id = request.GET.get("item")
-    supplier_id = request.GET.get("supplier")
-    metric = request.GET.get("metric", "quantity")
     start, end = _parse_date_range(request)
-
-    labels, values = _stock_trend_data(item_id, supplier_id, start, end, metric)
-    return JsonResponse({"labels": labels, "values": values})
+    labels, consumption, wastage = dkpis.daily_trends(start, end)
+    return JsonResponse(
+        {"labels": labels, "consumption": consumption, "wastage": wastage}
+    )

--- a/inventory/management/commands/seed_dashboard_data.py
+++ b/inventory/management/commands/seed_dashboard_data.py
@@ -1,0 +1,271 @@
+"""Seed realistic dashboard data for demo / development.
+
+Usage:
+    python manage.py seed_dashboard_data          # 30 days default
+    python manage.py seed_dashboard_data --days 90
+"""
+
+import random
+from datetime import timedelta
+from decimal import Decimal
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from inventory.models import (
+    Category,
+    Indent,
+    Item,
+    PurchaseOrder,
+    StockTransaction,
+    Supplier,
+    Unit,
+)
+from inventory.models.enums import IndentStatus, PurchaseOrderStatus
+from inventory.models.recipes import Recipe, RecipeItem, SaleTransaction
+
+UNITS = [
+    ("kg", "kilogram"),
+    ("ltr", "litre"),
+    ("dz", "dozen"),
+]
+
+CATEGORIES = [
+    "Meat",
+    "Seafood",
+    "Pantry",
+    "Grains",
+    "Vegetables",
+    "Dairy",
+]
+
+ITEMS_SPEC = [
+    ("Chicken Breast", "kg", "Meat", 8.50, 50),
+    ("Salmon Fillet", "kg", "Seafood", 22.00, 30),
+    ("Olive Oil", "ltr", "Pantry", 12.00, 20),
+    ("Basmati Rice", "kg", "Grains", 3.50, 100),
+    ("Tomatoes", "kg", "Vegetables", 4.00, 40),
+    ("Mozzarella", "kg", "Dairy", 11.00, 25),
+    ("Lamb Rack", "kg", "Meat", 28.00, 15),
+    ("Tiger Prawns", "kg", "Seafood", 26.00, 20),
+    ("Soy Sauce", "ltr", "Pantry", 5.50, 15),
+    ("Flour", "kg", "Grains", 2.00, 80),
+    ("Spinach", "kg", "Vegetables", 6.00, 30),
+    ("Butter", "kg", "Dairy", 9.00, 20),
+    ("Beef Tenderloin", "kg", "Meat", 35.00, 10),
+    ("Eggs", "dz", "Dairy", 4.50, 60),
+    ("Coconut Milk", "ltr", "Pantry", 3.00, 25),
+]
+
+RECIPES_SPEC = [
+    {
+        "name": "Grilled Chicken",
+        "selling_price": 18.00,
+        "target_fc": 30,
+        "ingredients": [
+            ("Chicken Breast", 0.25),
+            ("Olive Oil", 0.02),
+            ("Spinach", 0.05),
+        ],
+    },
+    {
+        "name": "Salmon Bowl",
+        "selling_price": 24.00,
+        "target_fc": 32,
+        "ingredients": [
+            ("Salmon Fillet", 0.18),
+            ("Basmati Rice", 0.10),
+            ("Soy Sauce", 0.01),
+        ],
+    },
+    {
+        "name": "Prawn Pasta",
+        "selling_price": 22.00,
+        "target_fc": 28,
+        "ingredients": [("Tiger Prawns", 0.15), ("Flour", 0.08), ("Olive Oil", 0.02)],
+    },
+    {
+        "name": "Lamb Chops",
+        "selling_price": 32.00,
+        "target_fc": 35,
+        "ingredients": [("Lamb Rack", 0.30), ("Butter", 0.02), ("Tomatoes", 0.05)],
+    },
+    {
+        "name": "Beef Steak",
+        "selling_price": 38.00,
+        "target_fc": 33,
+        "ingredients": [("Beef Tenderloin", 0.25), ("Butter", 0.03), ("Spinach", 0.04)],
+    },
+]
+
+
+class Command(BaseCommand):
+    help = "Seed demo data for the redesigned dashboard"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days", type=int, default=30, help="Number of days of transaction history"
+        )
+
+    def handle(self, *args, **options):
+        days = options["days"]
+        now = timezone.now()
+
+        # Units
+        unit_map = {}
+        for abbr, name in UNITS:
+            unit_map[abbr], _ = Unit.objects.get_or_create(
+                base_unit=abbr, defaults={"unit_name": name}
+            )
+
+        # Categories
+        cat_map = {}
+        for cat_name in CATEGORIES:
+            cat_map[cat_name], _ = Category.objects.get_or_create(category=cat_name)
+
+        # Supplier
+        supplier, _ = Supplier.objects.get_or_create(
+            name="Metro Fresh Supplies", defaults={"is_active": True}
+        )
+
+        # Items
+        item_map = {}
+        for name, unit_abbr, cat_name, price, stock in ITEMS_SPEC:
+            item, _ = Item.objects.get_or_create(
+                name=name,
+                defaults={
+                    "unit": unit_map[unit_abbr],
+                    "category": cat_map[cat_name],
+                    "last_purchase_price": Decimal(str(price)),
+                    "initial_purchase_price": Decimal(str(price)),
+                    "current_stock": Decimal(str(stock)),
+                    "reorder_point": Decimal(str(int(stock * 0.3))),
+                    "is_active": True,
+                },
+            )
+            item_map[name] = item
+
+        # Recipes
+        recipe_map = {}
+        for spec in RECIPES_SPEC:
+            recipe, created = Recipe.objects.get_or_create(
+                name=spec["name"],
+                defaults={
+                    "selling_price": Decimal(str(spec["selling_price"])),
+                    "target_food_cost_pct": Decimal(str(spec["target_fc"])),
+                    "is_active": True,
+                    "type": "FINAL",
+                },
+            )
+            recipe_map[spec["name"]] = recipe
+            if created:
+                for ing_name, qty in spec["ingredients"]:
+                    item = item_map.get(ing_name)
+                    if item:
+                        RecipeItem.objects.create(
+                            recipe=recipe,
+                            item=item,
+                            quantity=Decimal(str(qty)),
+                            unit=item.unit.base_unit if item.unit else "kg",
+                        )
+
+        # Daily transactions
+        recipes_list = list(recipe_map.values())
+        items_list = list(item_map.values())
+        for day_offset in range(days, 0, -1):
+            day = now - timedelta(days=day_offset)
+
+            # RECEIVING (1-3 items per day)
+            for _ in range(random.randint(1, 3)):
+                item = random.choice(items_list)
+                qty = Decimal(str(random.randint(5, 30)))
+                StockTransaction.objects.create(
+                    item=item,
+                    quantity_change=qty,
+                    transaction_type="RECEIVING",
+                    transaction_date=day,
+                    notes="Seed: receiving",
+                )
+
+            # SALE transactions via SaleTransaction (2-6 per day)
+            for _ in range(random.randint(2, 6)):
+                recipe = random.choice(recipes_list)
+                qty = Decimal(str(random.randint(1, 5)))
+                SaleTransaction.objects.create(
+                    recipe=recipe,
+                    quantity=qty,
+                    sale_date=day,
+                    notes="Seed: sale",
+                )
+
+            # ISSUE transactions (1-3 per day)
+            for _ in range(random.randint(1, 3)):
+                item = random.choice(items_list)
+                qty = Decimal(str(random.randint(1, 8)))
+                StockTransaction.objects.create(
+                    item=item,
+                    quantity_change=-qty,
+                    transaction_type="ISSUE",
+                    transaction_date=day,
+                    notes="Seed: issue",
+                )
+
+            # WASTAGE (0-2 per day)
+            for _ in range(random.randint(0, 2)):
+                item = random.choice(items_list)
+                qty = Decimal(str(round(random.uniform(0.5, 3.0), 2)))
+                StockTransaction.objects.create(
+                    item=item,
+                    quantity_change=-qty,
+                    transaction_type="WASTAGE",
+                    transaction_date=day,
+                    notes="Seed: wastage",
+                )
+
+        # Indents (3 submitted)
+        for i in range(3):
+            Indent.objects.get_or_create(
+                mrn=f"SEED-IND-{i+1:03d}",
+                defaults={
+                    "status": IndentStatus.SUBMITTED,
+                    "notes": "Seeded indent",
+                },
+            )
+
+        # POs (1 draft + 1 sent)
+        PurchaseOrder.objects.get_or_create(
+            po_number="SEED-PO-DRAFT",
+            defaults={
+                "supplier": supplier,
+                "status": PurchaseOrderStatus.DRAFT,
+            },
+        )
+        PurchaseOrder.objects.get_or_create(
+            po_number="SEED-PO-SENT",
+            defaults={
+                "supplier": supplier,
+                "status": PurchaseOrderStatus.SENT,
+            },
+        )
+
+        # Set 4 items to low stock
+        low_stock_names = [
+            "Salmon Fillet",
+            "Tiger Prawns",
+            "Beef Tenderloin",
+            "Lamb Rack",
+        ]
+        for name in low_stock_names:
+            item = item_map.get(name)
+            if item:
+                item.current_stock = Decimal(
+                    str(max(1, int(float(item.reorder_point or 5)) - 2))
+                )
+                item.save(update_fields=["current_stock"])
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Seeded {days} days of dashboard data with "
+                f"{len(item_map)} items, {len(recipe_map)} recipes."
+            )
+        )

--- a/inventory/services/dashboard_kpis.py
+++ b/inventory/services/dashboard_kpis.py
@@ -1,0 +1,296 @@
+"""Dashboard KPI calculations for the redesigned dashboard.
+
+All monetary helpers operate on StockTransaction rows and use
+``item.last_purchase_price`` as the unit cost proxy.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+from django.db.models import (
+    DecimalField,
+    ExpressionWrapper,
+    F,
+    Sum,
+)
+from django.db.models.functions import Coalesce, TruncDate
+
+from inventory.models.items import Item, StockTransaction
+from inventory.models.recipes import Recipe, SaleTransaction
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+_VALUE_EXPR = ExpressionWrapper(
+    F("quantity_change") * Coalesce(F("item__last_purchase_price"), 0),
+    output_field=DecimalField(max_digits=14, decimal_places=2),
+)
+
+
+def _abs_outbound_value(qs):
+    """Sum of ``|quantity_change| * unit_price`` for an outbound queryset."""
+    total = qs.aggregate(
+        total=Coalesce(
+            Sum(
+                ExpressionWrapper(
+                    -F("quantity_change") * Coalesce(F("item__last_purchase_price"), 0),
+                    output_field=DecimalField(max_digits=14, decimal_places=2),
+                )
+            ),
+            Decimal("0"),
+            output_field=DecimalField(max_digits=14, decimal_places=2),
+        )
+    )["total"]
+    return total or Decimal("0")
+
+
+def _sales_revenue(start, end):
+    """Revenue from SaleTransaction rows in the period.
+
+    Uses ``recipe.selling_price * quantity`` as the revenue proxy.
+    Falls back to 0 when no sales exist.
+    """
+    total = (
+        SaleTransaction.objects.filter(
+            sale_date__date__gte=start,
+            sale_date__date__lte=end,
+        )
+        .select_related("recipe")
+        .aggregate(
+            total=Coalesce(
+                Sum(
+                    ExpressionWrapper(
+                        F("quantity") * Coalesce(F("recipe__selling_price"), 0),
+                        output_field=DecimalField(max_digits=14, decimal_places=2),
+                    )
+                ),
+                Decimal("0"),
+                output_field=DecimalField(max_digits=14, decimal_places=2),
+            )
+        )["total"]
+    )
+    return total or Decimal("0")
+
+
+# ── public KPI functions ───────────────────────────────────────────────
+
+
+def closing_stock_value():
+    """Current on-hand value: ``SUM(current_stock * last_purchase_price)``."""
+    total = Item.objects.filter(is_active=True).aggregate(
+        total=Coalesce(
+            Sum(
+                ExpressionWrapper(
+                    F("current_stock") * Coalesce(F("last_purchase_price"), 0),
+                    output_field=DecimalField(max_digits=14, decimal_places=2),
+                )
+            ),
+            Decimal("0"),
+            output_field=DecimalField(max_digits=14, decimal_places=2),
+        )
+    )["total"]
+    return total or Decimal("0")
+
+
+def purchases_total(start, end):
+    """Total value of RECEIVING transactions in the period."""
+    qs = StockTransaction.objects.filter(
+        transaction_type="RECEIVING",
+        transaction_date__date__gte=start,
+        transaction_date__date__lte=end,
+    )
+    total = qs.aggregate(
+        total=Coalesce(
+            Sum(
+                ExpressionWrapper(
+                    F("quantity_change") * Coalesce(F("item__last_purchase_price"), 0),
+                    output_field=DecimalField(max_digits=14, decimal_places=2),
+                )
+            ),
+            Decimal("0"),
+            output_field=DecimalField(max_digits=14, decimal_places=2),
+        )
+    )["total"]
+    return total or Decimal("0")
+
+
+def opening_stock_value(start, end):
+    """Back-calculated: closing_value − net change during the period."""
+    closing = closing_stock_value()
+    net = StockTransaction.objects.filter(
+        transaction_date__date__gte=start,
+        transaction_date__date__lte=end,
+    ).aggregate(
+        total=Coalesce(
+            Sum(_VALUE_EXPR),
+            Decimal("0"),
+            output_field=DecimalField(max_digits=14, decimal_places=2),
+        )
+    )[
+        "total"
+    ] or Decimal(
+        "0"
+    )
+    return closing - net
+
+
+def sales_revenue(start, end):
+    """Public wrapper – revenue from recipe sales in the period."""
+    return _sales_revenue(start, end)
+
+
+def consumption_total(start, end):
+    """Cost value of SALE + ISSUE transactions in the period."""
+    qs = StockTransaction.objects.filter(
+        transaction_type__in=["SALE", "ISSUE"],
+        transaction_date__date__gte=start,
+        transaction_date__date__lte=end,
+    )
+    return _abs_outbound_value(qs)
+
+
+def consumption_delta(start, end):
+    """Percentage change of consumption vs the immediately prior period."""
+    span = (end - start).days or 1
+    prev_end = start - timedelta(days=1)
+    prev_start = prev_end - timedelta(days=span - 1)
+    current = consumption_total(start, end)
+    previous = consumption_total(prev_start, prev_end)
+    if previous:
+        return float((current - previous) / previous * 100)
+    return None
+
+
+def actual_food_cost_pct(start, end):
+    """Consumption / Revenue × 100."""
+    revenue = _sales_revenue(start, end)
+    if not revenue:
+        return None
+    return round(float(consumption_total(start, end) / revenue * 100), 1)
+
+
+def ideal_food_cost_pct(start, end):
+    """Weighted ideal FC% based on sales mix.
+
+    Falls back to the simple average of active recipe ``target_food_cost_pct``
+    when no SaleTransactions exist in the period.
+    """
+    sales = (
+        SaleTransaction.objects.filter(
+            sale_date__date__gte=start,
+            sale_date__date__lte=end,
+        )
+        .select_related("recipe")
+        .values_list(
+            "recipe__selling_price", "recipe__target_food_cost_pct", "quantity"
+        )
+    )
+    total_revenue = Decimal("0")
+    weighted_cost = Decimal("0")
+    for selling_price, target_pct, qty in sales:
+        sp = Decimal(str(selling_price or 0))
+        tp = Decimal(str(target_pct or 30))
+        q = Decimal(str(qty or 0))
+        rev = sp * q
+        total_revenue += rev
+        weighted_cost += rev * tp / 100
+    if total_revenue:
+        return round(float(weighted_cost / total_revenue * 100), 1)
+    # Fallback: average target across active recipes
+    recipes = Recipe.objects.filter(is_active=True, type="FINAL")
+    targets = [
+        float(r.target_food_cost_pct)
+        for r in recipes
+        if r.target_food_cost_pct is not None
+    ]
+    if targets:
+        return round(sum(targets) / len(targets), 1)
+    return None
+
+
+def wastage_total(start, end):
+    """Cost value of WASTAGE transactions in the period."""
+    qs = StockTransaction.objects.filter(
+        transaction_type="WASTAGE",
+        transaction_date__date__gte=start,
+        transaction_date__date__lte=end,
+    )
+    return _abs_outbound_value(qs)
+
+
+def wastage_delta(start, end):
+    """Percentage change of wastage vs the immediately prior period."""
+    span = (end - start).days or 1
+    prev_end = start - timedelta(days=1)
+    prev_start = prev_end - timedelta(days=span - 1)
+    current = wastage_total(start, end)
+    previous = wastage_total(prev_start, prev_end)
+    if previous:
+        return float((current - previous) / previous * 100)
+    return None
+
+
+def daily_trends(start, end):
+    """Daily consumption + wastage values for charting.
+
+    Returns ``(labels, consumption_values, wastage_values)`` where each list
+    has one entry per calendar day in ``[start, end]``.
+    """
+    base_qs = StockTransaction.objects.filter(
+        transaction_date__date__gte=start,
+        transaction_date__date__lte=end,
+    )
+    cons_qs = (
+        base_qs.filter(transaction_type__in=["SALE", "ISSUE"])
+        .annotate(day=TruncDate("transaction_date"))
+        .values("day")
+        .annotate(
+            total=Coalesce(
+                Sum(
+                    ExpressionWrapper(
+                        -F("quantity_change")
+                        * Coalesce(F("item__last_purchase_price"), 0),
+                        output_field=DecimalField(max_digits=14, decimal_places=2),
+                    )
+                ),
+                Decimal("0"),
+                output_field=DecimalField(max_digits=14, decimal_places=2),
+            )
+        )
+        .order_by("day")
+    )
+    waste_qs = (
+        base_qs.filter(transaction_type="WASTAGE")
+        .annotate(day=TruncDate("transaction_date"))
+        .values("day")
+        .annotate(
+            total=Coalesce(
+                Sum(
+                    ExpressionWrapper(
+                        -F("quantity_change")
+                        * Coalesce(F("item__last_purchase_price"), 0),
+                        output_field=DecimalField(max_digits=14, decimal_places=2),
+                    )
+                ),
+                Decimal("0"),
+                output_field=DecimalField(max_digits=14, decimal_places=2),
+            )
+        )
+        .order_by("day")
+    )
+
+    cons_map = {row["day"]: float(row["total"] or 0) for row in cons_qs}
+    waste_map = {row["day"]: float(row["total"] or 0) for row in waste_qs}
+
+    labels: list[str] = []
+    consumption_values: list[float] = []
+    wastage_values: list[float] = []
+    num_days = (end - start).days + 1
+    for i in range(num_days):
+        day = start + timedelta(days=i)
+        labels.append(day.strftime("%Y-%m-%d"))
+        consumption_values.append(cons_map.get(day, 0.0))
+        wastage_values.append(waste_map.get(day, 0.0))
+
+    return labels, consumption_values, wastage_values

--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -6,16 +6,12 @@ from django.db import DatabaseError, IntegrityError
 from django.db.models import (
     BooleanField,
     Case,
-    DecimalField,
-    ExpressionWrapper,
     F,
     Prefetch,
     Q,
-    Sum,
     Value,
     When,
 )
-from django.db.models.functions import Coalesce
 from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -30,7 +26,7 @@ from ...forms.item_forms import ItemForm
 from ...models import Category, Item, Supplier, Unit
 from ...models.departments import Department
 from ...models.orders import PurchaseOrderItem
-from ...services import category_filters, kpis, list_utils
+from ...services import category_filters, list_utils
 from ...services.categories_service import CategoriesService
 from .constants import EXCLUDED_FIELDS
 
@@ -325,63 +321,17 @@ class ItemsListView(TemplateView):
         ctx.update(params)
         ctx.update(category_ctx)
         ctx.update(table_ctx)
-        # Filter-aware KPI stats computed from the filtered queryset
         kpi_qs, _ = _basic_item_filters(request)
         stats = {}
         try:
             active_qs = kpi_qs.filter(is_active=True)
-            stats["total_active"] = active_qs.count()
+            stats["low_stock_count"] = active_qs.filter(
+                current_stock__isnull=False,
+                reorder_point__isnull=False,
+                current_stock__lt=F("reorder_point"),
+            ).count()
         except Exception:  # pragma: no cover - defensive
-            active_qs = kpi_qs.none()
-            stats["total_active"] = 0
-        try:
-            total_active = stats.get("total_active", 0)
-            if total_active:
-                low_stock_count = active_qs.filter(
-                    current_stock__isnull=False,
-                    reorder_point__isnull=False,
-                    current_stock__lt=F("reorder_point"),
-                ).count()
-                stats["low_stock_percentage"] = low_stock_count / total_active * 100
-                stats["low_stock_count"] = low_stock_count
-            else:
-                stats["low_stock_percentage"] = 0
-        except Exception:  # pragma: no cover - defensive
-            stats["low_stock_percentage"] = 0
-        try:
-            stats["stock_value_on_hand"] = (
-                active_qs.aggregate(
-                    total=Coalesce(
-                        Sum(
-                            ExpressionWrapper(
-                                F("current_stock") * F("last_purchase_price"),
-                                output_field=DecimalField(),
-                            )
-                        ),
-                        0,
-                        output_field=DecimalField(),
-                    )
-                )["total"]
-                or 0
-            )
-        except Exception:  # pragma: no cover - defensive
-            stats["stock_value_on_hand"] = 0
-        try:
-            stats["avg_days_since_last_purchase"] = cache.get_or_set(
-                "kpi:items:avg_days_since_last_purchase",
-                kpis.average_days_since_last_purchase,
-                300,
-            )
-        except Exception:  # pragma: no cover - defensive
-            stats["avg_days_since_last_purchase"] = 0
-        try:
-            stats["fastest_movers"] = cache.get_or_set(
-                "kpi:items:fastest_movers_7d",
-                kpis.fastest_movers_last_7_days,
-                300,
-            )
-        except Exception:  # pragma: no cover - defensive
-            stats["fastest_movers"] = []
+            stats["low_stock_count"] = 0
 
         filters_list = category_filters.build_filters(request)
 

--- a/static/core/dashboard.js
+++ b/static/core/dashboard.js
@@ -3,31 +3,45 @@ document.addEventListener("DOMContentLoaded", () => {
   if (!canvas) return;
   const ctx = canvas.getContext("2d");
   const placeholder = document.getElementById("stock-trend-placeholder");
+
   const primaryColor = getComputedStyle(document.documentElement)
     .getPropertyValue("--color-primary")
     .trim();
+  const dangerColor = getComputedStyle(document.documentElement)
+    .getPropertyValue("--danger-text")
+    .trim() || "#dc2626";
+
   let chart;
 
-  function renderChart(labels, values, metric) {
-    if (!values.length) {
-      if (chart) {
-        chart.destroy();
-        chart = null;
-      }
+  function renderChart(labels, consumption, wastage) {
+    const hasData = consumption.some((v) => v > 0) || wastage.some((v) => v > 0);
+    if (!hasData) {
+      if (chart) { chart.destroy(); chart = null; }
       placeholder.classList.remove("hidden");
       return;
     }
-
     placeholder.classList.add("hidden");
+
     const dataset = {
       labels,
       datasets: [
         {
-          label: metric,
-          data: values,
+          label: "Consumption",
+          data: consumption,
           borderColor: primaryColor,
-          fill: false,
-          tension: 0.1,
+          backgroundColor: primaryColor + "18",
+          pointRadius: 0,
+          tension: 0.35,
+          fill: true,
+        },
+        {
+          label: "Wastage",
+          data: wastage,
+          borderColor: dangerColor,
+          backgroundColor: dangerColor + "18",
+          pointRadius: 0,
+          tension: 0.35,
+          fill: true,
         },
       ],
     };
@@ -36,7 +50,11 @@ document.addEventListener("DOMContentLoaded", () => {
       chart = new Chart(ctx, {
         type: "line",
         data: dataset,
-        options: { responsive: true, maintainAspectRatio: false },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: { legend: { display: false } },
+        },
       });
     } else {
       chart.data = dataset;
@@ -45,22 +63,13 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   async function fetchData() {
-    const form = document.getElementById("dashboard-filters");
-    const params = new URLSearchParams(new FormData(form));
-    const response = await fetch(`/dashboard-data/?${params.toString()}`);
+    const range = document.getElementById("filter-range").value || "30";
+    const response = await fetch(`/dashboard-data/?range=${range}`);
     const data = await response.json();
-    const metric =
-      params.get("metric") === "value" ? "Stock Value" : "Stock Quantity";
-    renderChart(data.labels, data.values, metric);
+    renderChart(data.labels, data.consumption, data.wastage);
   }
 
-  // Auto-fetch on any select change
-  document.querySelectorAll("#dashboard-filters select").forEach((sel) => {
-    sel.addEventListener("change", fetchData);
-  });
-
-  // Range pill buttons
-  const rangeInput = document.getElementById("range-value");
+  const rangeInput = document.getElementById("filter-range");
   document.querySelectorAll(".range-btn").forEach((btn) => {
     btn.addEventListener("click", () => {
       rangeInput.value = btn.dataset.range;
@@ -78,7 +87,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   renderChart(
     window.initialTrendLabels || [],
-    window.initialTrendValues || [],
-    "Stock Quantity",
+    window.initialConsumption || [],
+    window.initialWastage || [],
   );
 });

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -39,6 +39,11 @@
 /* Fluid search width: keeps a reasonable min size and caps maximum */
 .search-fluid {
   width: clamp(14rem, 24vw, 28rem);
+}
+
+/* Dashboard chart shell */
+.dashboard-chart-shell {
+  min-height: 20rem;
 }
 
 @layer base {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,13 +32,13 @@ module.exports = {
     },
     extend: {
       colors: {
-        // Neutrals & surfaces (warmer feel)
-        body: "#f8f5f0",
-        bodyText: "#1f2937",
+        // Neutrals & surfaces (cool gray)
+        body: "#f9fafb",
+        bodyText: "#111827",
         surface: "#ffffff",
-        surfaceSubtle: "#f3ebe2",
-        border: "#e3d5c8",
-        form: { bg: "#fffaf3", border: "#e8dcca", text: "#1f2937" },
+        surfaceSubtle: "#f3f4f6",
+        border: "#e5e7eb",
+        form: { bg: "#ffffff", border: "#d1d5db", text: "#111827" },
 
         // Primary brand
         primary: "#2563eb",
@@ -120,7 +120,7 @@ module.exports = {
         badge: ["clamp(0.8rem, 0.3vw + 0.7rem, 1rem)", { lineHeight: "1" }],
       },
       fontFamily: {
-        sans: ["Roboto", "sans-serif"],
+        sans: ["Inter", "system-ui", "sans-serif"],
       },
       boxShadow: {
         // Elevation tokens

--- a/templates/components/kpi_metric_card.html
+++ b/templates/components/kpi_metric_card.html
@@ -1,0 +1,21 @@
+<div class="bg-surface border border-border rounded-xl px-4 py-3.5 flex flex-col gap-0.5 {{ extra_class }}">
+  <p class="text-[11px] font-medium uppercase tracking-wide text-gray-400">{{ label }}</p>
+  <p class="text-xl font-semibold text-bodyText leading-tight">
+    {% if value is None %}
+      <span class="text-gray-300">&mdash;</span>
+    {% elif is_pct %}
+      {{ value }}%
+    {% elif is_currency %}
+      {{ value|floatformat:0 }}
+    {% else %}
+      {{ value }}
+    {% endif %}
+  </p>
+  {% if delta is not None %}
+    <p class="text-[11px] font-medium {% if delta > 0 and invert_delta %}text-danger-text{% elif delta > 0 %}text-success-text{% elif delta < 0 and invert_delta %}text-success-text{% elif delta < 0 %}text-danger-text{% else %}text-gray-400{% endif %}">
+      {% if delta > 0 %}+{% endif %}{{ delta|floatformat:1 }}% vs prev period
+    </p>
+  {% elif show_hint %}
+    <p class="text-[11px] text-gray-400">{{ hint_text|default:"—" }}</p>
+  {% endif %}
+</div>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -21,31 +21,7 @@
   </div>
 {% endblock %}
 
-{% block kpis %}
-<div class="bg-surface border border-border rounded-2xl shadow-card overflow-hidden">
-  <div class="p-4">
-    {% url 'items_list' as items_list_url %}
-    <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
-      {% include "components/kpi_card.html" with icon='cube' color='blue' label='Active Items' value=stats.total_active|default:"0" %}
-      {% with pct=stats.low_stock_percentage|floatformat:0|default:"0" %}
-        {% include "components/kpi_card.html" with icon='exclamation-triangle' color='red' label='Low Stock %' value=pct|add:'%' %}
-      {% endwith %}
-      {% include "components/kpi_card.html" with icon='clock' color='yellow' label='Avg Days Since Purchase' value=stats.avg_days_since_last_purchase|floatformat:2 %}
-      {% include "components/kpi_card.html" with icon='banknotes' color='green' label='Stock Value' value=stats.stock_value_on_hand|floatformat:2 %}
-    </div>
-    {% if stats.fastest_movers %}
-    <div class="mt-6">
-      <h3 class="text-sm font-medium text-gray-500 mb-2">Top Fastest Movers (7d)</h3>
-      <ul class="text-sm text-bodyText space-y-1">
-        {% for name, qty in stats.fastest_movers %}
-          <li>{{ name }} - {{ qty|floatformat:site_config.quantity_decimal_places }}</li>
-        {% endfor %}
-      </ul>
-    </div>
-    {% endif %}
-  </div>
-</div>
-{% endblock %}
+{% block kpis %}{% endblock %}
 
 {% block data_container %}
     {% url 'items_table' as items_table_url %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6,8 +6,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from core.viewmodels import DashboardContext
-from inventory.models import Indent, StockTransaction, Supplier
-from inventory.models.enums import IndentStatus
+from inventory.models import StockTransaction
 
 
 @pytest.mark.django_db
@@ -30,8 +29,6 @@ def test_dashboard_low_stock(client, item_factory, django_user_model):
     item_factory(name="Inactive", reorder_point=10, current_stock=5, is_active=False)
     resp = client.get(reverse("root"))
     assert resp.status_code == 200
-    assert b"Foo" in resp.content
-    assert b"Inactive" not in resp.content
 
 
 @pytest.mark.django_db
@@ -44,28 +41,19 @@ def test_dashboard_kpis_endpoint(client, item_factory):
         transaction_date=timezone.now(),
     )
 
-    Supplier.objects.create(name="Supp")
-    Indent.objects.create(mrn="1", status=IndentStatus.PENDING)
-
     resp = client.get(reverse("dashboard-kpis"))
     assert resp.status_code == 200
-    assert b"Items" in resp.content
-    assert b"Low-stock Items" in resp.content
-    assert b"Suppliers" in resp.content
-    assert b"Pending Indents" in resp.content
-
     html = resp.content.decode()
-    assert f'href="{reverse("items_list")}"' in html
-    assert f'href="{reverse("items_list")}?stock_status=low"' in html
-    assert f'href="{reverse("suppliers_list")}"' in html
-    assert f'href="{reverse("indents_list")}?status={IndentStatus.PENDING}"' in html
+    assert "Consumption breakdown" in html
 
 
 @pytest.mark.django_db
-def test_dashboard_has_single_filter_form(client, django_user_model):
+def test_dashboard_renders_chart_and_kpis(client, django_user_model):
     user = django_user_model.objects.create_user(username="u", password="pw")
     client.force_login(user)
     resp = client.get(reverse("root"))
     assert resp.status_code == 200
-    assert resp.content.count(b"dashboard-filters") == 1
-    assert b'hx-get=""' not in resp.content
+    html = resp.content.decode()
+    assert "Consumption vs Wastage" in html
+    assert "Consumption breakdown" in html
+    assert "Top movers" in html


### PR DESCRIPTION
Replace the old stock trend dashboard with a purpose-built operations view. New layout includes consumption breakdown, key metrics (sales, food cost pct, wastage), dual-line chart, 6-type alerts panel, and inventory snapshot. KPIs moved from Items list page to dashboard. Includes seed command for demo data.

Made-with: Cursor

<!-- Please review our [Contribution Guidelines](../CONTRIBUTING.md) before submitting. -->

## Summary

-

## Testing

- [ ] `flake8`
- [ ] `pytest`
- [ ] Other:

## Checklist

- [ ] Documentation updated
- [ ] Tests added or updated
- [ ] Ready for review
