### PR TITLE
fix: recipe drawer scroll and merged ingredient column

### DIFF
--- a/templates/inventory/recipes/_components_form_table.html
+++ b/templates/inventory/recipes/_components_form_table.html
@@ -2,8 +2,7 @@
 {% block caption %}<caption>Recipe Items</caption>{% endblock %}
 
 {% block headers %}
-  <th scope="col">Item</th>
-  <th scope="col">Sub-Recipe</th>
+  <th scope="col" class="normal-case">Ingredient <span class="font-normal text-gray-500">(item or sub-recipe)</span></th>
   <th scope="col">Qty</th>
   <th scope="col">Unit</th>
   <th scope="col">Loss %</th>
@@ -15,10 +14,11 @@
   {% for cform in formset.forms %}
   <tr class="form-row" data-form-index="{{ forloop.counter0 }}" data-recipe-row="true" data-has-item="0" data-quantity="0" data-cost-per-base-unit="0">
     <td class="px-3 py-2">
-      {% include "components/form_field_table.html" with field=cform.item %}
-    </td>
-    <td class="px-3 py-2">
-      {% include "components/form_field_table.html" with field=cform.sub_recipe %}
+      <div class="flex flex-col gap-1 min-w-[12rem]">
+        {% include "components/form_field_table.html" with field=cform.item %}
+        <p class="text-center text-xs text-gray-500 py-0.5">or</p>
+        {% include "components/form_field_table.html" with field=cform.sub_recipe %}
+      </div>
     </td>
     <td class="px-3 py-2">{% include "components/form_field_table.html" with field=cform.quantity %}</td>
     <td class="px-3 py-2">
@@ -38,10 +38,11 @@
   {# empty form template row #}
   <tr class="form-row hidden" id="items-empty-row" data-recipe-row="true" data-has-item="0" data-quantity="0" data-cost-per-base-unit="0">
     <td class="px-3 py-2">
-      {% include "components/form_field_table.html" with field=formset.empty_form.item %}
-    </td>
-    <td class="px-3 py-2">
-      {% include "components/form_field_table.html" with field=formset.empty_form.sub_recipe %}
+      <div class="flex flex-col gap-1 min-w-[12rem]">
+        {% include "components/form_field_table.html" with field=formset.empty_form.item %}
+        <p class="text-center text-xs text-gray-500 py-0.5">or</p>
+        {% include "components/form_field_table.html" with field=formset.empty_form.sub_recipe %}
+      </div>
     </td>
     <td class="px-3 py-2">{% include "components/form_field_table.html" with field=formset.empty_form.quantity %}</td>
     <td class="px-3 py-2">

--- a/templates/inventory/recipes/_form_partial.html
+++ b/templates/inventory/recipes/_form_partial.html
@@ -1,5 +1,5 @@
 {% load form_tags %}
-<div class="bg-surface rounded-2xl shadow-card border border-border overflow-hidden drawer-panel max-w-drawer-xl">
+<div class="bg-surface rounded-2xl shadow-card border border-border drawer-panel max-w-drawer-xl">
   <form method="post" data-modal-form data-requires-line-items action="{% if is_edit and recipe %}{% url 'recipe_edit_partial' recipe.pk %}{% else %}{% url 'recipe_create_partial' %}{% endif %}">
     {% csrf_token %}
     <div class="px-4 py-3 border-b border-border bg-surfaceSubtle">


### PR DESCRIPTION
Remove overflow-hidden from the recipe form drawer panel so content scrolls with the outer .drawer. Merge Item and Sub-Recipe into one Ingredient column with an or divider.

Made-with: Cursor

<!-- Please review our [Contribution Guidelines](../CONTRIBUTING.md) before submitting. -->

## Summary

-

## Testing

- [ ] `flake8`
- [ ] `pytest`
- [ ] Other:

## Checklist

- [ ] Documentation updated
- [ ] Tests added or updated
- [ ] Ready for review
