### PR TITLE
feat: unified recipe ingredient dropdown and drawer sub-recipe save

### DIFF
--- a/inventory/forms/recipe_forms.py
+++ b/inventory/forms/recipe_forms.py
@@ -146,33 +146,36 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
         return cleaned_data
 
 
-class RecipeItemForm(StyledFormMixin, forms.ModelForm):
-    """Form for Recipe Items - simplified from RecipeComponent."""
+class IngredientSelect(forms.Select):
+    """Select for encoded ingredient values (`i:<pk>` / `r:<pk>`) with kind markers."""
 
-    item = forms.ModelChoiceField(
-        queryset=Item.objects.filter(is_active=True),
+    def create_option(
+        self, name, value, label, selected, index, subindex=None, attrs=None
+    ):
+        option = super().create_option(
+            name, value, label, selected, index, subindex=subindex, attrs=attrs
+        )
+        if value not in (None, ""):
+            val = str(value)
+            if val.startswith("i:"):
+                option.setdefault("attrs", {})["data-ingredient-kind"] = "item"
+            elif val.startswith("r:"):
+                option.setdefault("attrs", {})["data-ingredient-kind"] = "sub"
+        return option
+
+
+class RecipeItemForm(StyledFormMixin, forms.ModelForm):
+    """Single dropdown for inventory item or sub-recipe; maps to model FKs on save."""
+
+    ingredient = forms.ChoiceField(
         required=False,
-        widget=forms.Select(
+        choices=[],
+        widget=IngredientSelect(
             attrs={
-                "class": INPUT_CLASS + " predictive",
-                "data-placeholder": "Select an item",
+                "data-placeholder": "Select ingredient",
             }
         ),
-        label="Item",
-        empty_label="— Select item —",
-    )
-    # D1: sub-recipe selector
-    sub_recipe = forms.ModelChoiceField(
-        queryset=Recipe.objects.filter(is_active=True, type=Recipe.Type.SUB),
-        required=False,
-        widget=forms.Select(
-            attrs={
-                "class": INPUT_CLASS + " predictive",
-                "data-placeholder": "Select sub-recipe",
-            }
-        ),
-        label="Sub-Recipe",
-        empty_label="— Select sub-recipe —",
+        label="Ingredient",
     )
     quantity = forms.DecimalField(
         min_value=0.01,
@@ -222,8 +225,6 @@ class RecipeItemForm(StyledFormMixin, forms.ModelForm):
     class Meta:
         model = RecipeItem
         fields = [
-            "item",
-            "sub_recipe",
             "quantity",
             "unit",
             "loss_pct",
@@ -239,31 +240,116 @@ class RecipeItemForm(StyledFormMixin, forms.ModelForm):
             if unit_value:
                 self.initial.setdefault("unit", unit_value)
                 self.initial.setdefault("unit_display", unit_value)
-        # Keep the form fields in sync with the initial data so the template
-        # renders the stored unit immediately while the JS metadata loads.
         self.fields["unit"].initial = self.initial.get("unit", unit_value)
         self.fields["unit_display"].initial = self.initial.get(
             "unit_display", unit_value
         )
+
+        items_qs = Item.objects.filter(is_active=True).order_by("name")
+        subs_qs = Recipe.objects.filter(is_active=True, type=Recipe.Type.SUB).order_by(
+            "name"
+        )
+        parent_rid = getattr(instance, "recipe_id", None)
+        if parent_rid:
+            subs_qs = subs_qs.exclude(pk=parent_rid)
+
+        item_choices = [(f"i:{obj.pk}", obj.name) for obj in items_qs]
+        sub_choices = [(f"r:{obj.pk}", obj.name) for obj in subs_qs]
+
+        choices: list = [("", "— Select ingredient —")]
+        if item_choices:
+            choices.append(("Inventory items", item_choices))
+        if sub_choices:
+            choices.append(("Sub-recipes", sub_choices))
+
+        self.fields["ingredient"].choices = choices
+
+        if has_instance:
+            if instance.item_id:
+                self.initial.setdefault("ingredient", f"i:{instance.item_id}")
+            elif instance.sub_recipe_id:
+                self.initial.setdefault("ingredient", f"r:{instance.sub_recipe_id}")
+
+    def clean(self):
+        cleaned_data = super().clean()
+        cleaned_data["item"] = None
+        cleaned_data["sub_recipe"] = None
+        key = (cleaned_data.get("ingredient") or "").strip()
+        if not key:
+            qty = cleaned_data.get("quantity")
+            if qty is not None:
+                try:
+                    if qty > 0:
+                        self.add_error(
+                            "ingredient",
+                            "Select an ingredient or clear the quantity.",
+                        )
+                except (TypeError, ValueError):
+                    pass
+            return cleaned_data
+        try:
+            if key.startswith("i:"):
+                pk = int(key[2:], 10)
+                item = Item.objects.get(pk=pk, is_active=True)
+                cleaned_data["item"] = item
+            elif key.startswith("r:"):
+                pk = int(key[2:], 10)
+                sub = Recipe.objects.get(pk=pk, is_active=True, type=Recipe.Type.SUB)
+                parent_rid = getattr(self.instance, "recipe_id", None)
+                if parent_rid and pk == parent_rid:
+                    self.add_error(
+                        "ingredient",
+                        "A recipe cannot use itself as an ingredient.",
+                    )
+                    return cleaned_data
+                cleaned_data["sub_recipe"] = sub
+            else:
+                self.add_error("ingredient", "Select a valid ingredient.")
+                return cleaned_data
+        except (ValueError, Item.DoesNotExist, Recipe.DoesNotExist):
+            self.add_error("ingredient", "Select a valid ingredient.")
+            return cleaned_data
+        return cleaned_data
+
+    def _post_clean(self):
+        if self.cleaned_data.get("DELETE"):
+            super()._post_clean()
+            return
+        ingredient = (self.cleaned_data.get("ingredient") or "").strip()
+        item_obj = self.cleaned_data.get("item")
+        sub_obj = self.cleaned_data.get("sub_recipe")
+        if not ingredient and not item_obj and not sub_obj:
+            # Blank formset row: skip RecipeItem.clean() (FKs still null on instance).
+            return
+        self.instance.item = item_obj
+        self.instance.sub_recipe = sub_obj
+        super()._post_clean()
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+        instance.item = self.cleaned_data.get("item")
+        instance.sub_recipe = self.cleaned_data.get("sub_recipe")
+        if commit:
+            instance.save()
+        return instance
 
 
 RecipeItemFormSet = forms.inlineformset_factory(
     Recipe,
     RecipeItem,
     form=RecipeItemForm,
-    fk_name="recipe",  # D1: disambiguate from sub_recipe FK
-    fields=["item", "sub_recipe", "quantity", "unit", "loss_pct"],
+    fk_name="recipe",
+    fields=["ingredient", "quantity", "unit", "loss_pct"],
     extra=1,
     can_delete=True,
 )
 
-# Edit views use extra=0 so no blank row is pre-appended when existing items load.
 RecipeItemEditFormSet = forms.inlineformset_factory(
     Recipe,
     RecipeItem,
     form=RecipeItemForm,
-    fk_name="recipe",  # D1: disambiguate from sub_recipe FK
-    fields=["item", "sub_recipe", "quantity", "unit", "loss_pct"],
+    fk_name="recipe",
+    fields=["ingredient", "quantity", "unit", "loss_pct"],
     extra=0,
     can_delete=True,
 )

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -73,6 +73,7 @@ from .views.recipes import (
     recipe_create,
     recipe_create_indent,
     recipe_detail,
+    recipe_meta,
 )
 from .views.settings import change_password_view, profile_edit_view, settings_view
 from .views.stock import POSearchView, UserSearchView, history_reports, stock_movements
@@ -99,8 +100,14 @@ from .views.suppliers import (
 from .views.visualizations import visualizations
 
 urlpatterns = [
-    path("explore/", RedirectView.as_view(url="/items/", permanent=True), name="explore"),
-    path("explore/export/", RedirectView.as_view(url="/items/", permanent=True), name="explore_export"),
+    path(
+        "explore/", RedirectView.as_view(url="/items/", permanent=True), name="explore"
+    ),
+    path(
+        "explore/export/",
+        RedirectView.as_view(url="/items/", permanent=True),
+        name="explore_export",
+    ),
     path("items/", ItemsListView.as_view(), name="items_list"),
     path("items/table/", ItemsTableView.as_view(), name="items_table"),
     path("items/export/", ItemsExportView.as_view(), name="items_export"),
@@ -263,6 +270,11 @@ urlpatterns = [
     path("recipes/", RecipesListView.as_view(), name="recipes_list"),
     path("recipes/table/", RecipesTableView.as_view(), name="recipes_table"),
     path("recipes/food-cost-report/", food_cost_report, name="food_cost_report"),
+    path(
+        "recipes/meta/<int:recipe_id>/",
+        recipe_meta,
+        name="recipe_meta",
+    ),
     path("recipes/create/", recipe_create, name="recipe_create"),
     path(
         "recipes/create/partial/",

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -9,6 +9,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.views import View
+from django.views.decorators.http import require_GET
 from django.views.generic import DeleteView, TemplateView
 
 from ..forms.recipe_forms import RecipeForm, RecipeItemEditFormSet, RecipeItemFormSet
@@ -111,6 +112,55 @@ def _build_form_error_payload(form, formset):
             "formset": formset_errors,
         },
     }
+
+
+def _collect_recipe_line_items(formset):
+    """Build line-item dicts for recipe_service from a validated item formset."""
+
+    items = []
+    for f in formset.forms:
+        if f.cleaned_data.get("DELETE"):
+            continue
+        item_obj = f.cleaned_data.get("item")
+        sub_recipe_obj = f.cleaned_data.get("sub_recipe")
+        if not item_obj and not sub_recipe_obj:
+            continue
+        items.append(
+            {
+                "item_id": int(item_obj.pk) if item_obj else None,
+                "sub_recipe_id": (int(sub_recipe_obj.pk) if sub_recipe_obj else None),
+                "quantity": float(f.cleaned_data.get("quantity") or 0),
+                "unit": f.cleaned_data.get("unit"),
+                "loss_pct": float(f.cleaned_data.get("loss_pct") or 0),
+            }
+        )
+    return items
+
+
+@require_GET
+def recipe_meta(request, recipe_id: int):
+    """JSON metadata for sub-recipe rows (cost per yield unit, display unit)."""
+
+    recipe = get_object_or_404(Recipe, pk=recipe_id)
+    total = recipe.get_total_cost()
+    sub_yield = Decimal(str(recipe.default_yield_qty or 1)) or Decimal("1")
+    try:
+        cost_per = float(total / sub_yield) if sub_yield else 0.0
+    except (ArithmeticError, ZeroDivisionError):
+        cost_per = 0.0
+    base_unit = (recipe.default_yield_unit or "").strip()
+    return JsonResponse(
+        {
+            "ok": True,
+            "recipe_id": recipe.recipe_id,
+            "name": recipe.name,
+            "base_unit": base_unit,
+            "unit": base_unit,
+            "cost_per_base_unit": cost_per,
+            "category": "Sub-Recipe",
+            "subcategory": "",
+        }
+    )
 
 
 def _serialize_recipe(recipe):
@@ -261,25 +311,7 @@ def recipe_create(request):
         formset = RecipeItemFormSet(request.POST, prefix="items")
         if form.is_valid() and formset.is_valid():
             data = form.cleaned_data
-            items = []
-            for f in formset.forms:
-                if f.cleaned_data.get("DELETE"):
-                    continue
-                item_obj = f.cleaned_data.get("item")
-                sub_recipe_obj = f.cleaned_data.get("sub_recipe")
-                if not item_obj and not sub_recipe_obj:
-                    continue
-                items.append(
-                    {
-                        "item_id": int(item_obj.pk) if item_obj else None,
-                        "sub_recipe_id": (
-                            int(sub_recipe_obj.pk) if sub_recipe_obj else None
-                        ),
-                        "quantity": float(f.cleaned_data.get("quantity") or 0),
-                        "unit": f.cleaned_data.get("unit"),
-                        "loss_pct": float(f.cleaned_data.get("loss_pct") or 0),
-                    }
-                )
+            items = _collect_recipe_line_items(formset)
             ok, msg, rid = recipe_service.create_recipe(data, items)
             if ok and rid:
                 messages.success(request, "Recipe created", extra_tags="toast")
@@ -314,25 +346,7 @@ def recipe_detail(request, pk: int):
         formset = RecipeItemEditFormSet(request.POST, instance=recipe, prefix="items")
         if form.is_valid() and formset.is_valid():
             data = form.cleaned_data
-            items = []
-            for f in formset.forms:
-                if f.cleaned_data.get("DELETE"):
-                    continue
-                item_obj = f.cleaned_data.get("item")
-                sub_recipe_obj = f.cleaned_data.get("sub_recipe")
-                if not item_obj and not sub_recipe_obj:
-                    continue
-                items.append(
-                    {
-                        "item_id": int(item_obj.pk) if item_obj else None,
-                        "sub_recipe_id": (
-                            int(sub_recipe_obj.pk) if sub_recipe_obj else None
-                        ),
-                        "quantity": float(f.cleaned_data.get("quantity") or 0),
-                        "unit": f.cleaned_data.get("unit"),
-                        "loss_pct": float(f.cleaned_data.get("loss_pct") or 0),
-                    }
-                )
+            items = _collect_recipe_line_items(formset)
             ok, msg = recipe_service.update_recipe(recipe.pk, data, items)
             if ok:
                 messages.success(request, "Recipe updated", extra_tags="toast")
@@ -388,21 +402,7 @@ class RecipeCreatePartialView(View):
         formset = RecipeItemFormSet(request.POST, prefix="items")
         if form.is_valid() and formset.is_valid():
             data = form.cleaned_data
-            items = []
-            for f in formset.forms:
-                if f.cleaned_data.get("DELETE"):
-                    continue
-                item_id = f.cleaned_data.get("item")
-                if not item_id:
-                    continue
-                items.append(
-                    {
-                        "item_id": int(item_id.pk),
-                        "quantity": float(f.cleaned_data.get("quantity") or 0),
-                        "unit": f.cleaned_data.get("unit"),
-                        "loss_pct": float(f.cleaned_data.get("loss_pct") or 0),
-                    }
-                )
+            items = _collect_recipe_line_items(formset)
             ok, msg, rid = recipe_service.create_recipe(data, items)
             if ok and rid:
                 recipe = Recipe.objects.filter(pk=rid).first()
@@ -477,21 +477,7 @@ class RecipeEditPartialView(View):
         formset = RecipeItemEditFormSet(request.POST, instance=recipe, prefix="items")
         if form.is_valid() and formset.is_valid():
             data = form.cleaned_data
-            items = []
-            for f in formset.forms:
-                if f.cleaned_data.get("DELETE"):
-                    continue
-                item_id = f.cleaned_data.get("item")
-                if not item_id:
-                    continue
-                items.append(
-                    {
-                        "item_id": int(item_id.pk),
-                        "quantity": float(f.cleaned_data.get("quantity") or 0),
-                        "unit": f.cleaned_data.get("unit"),
-                        "loss_pct": float(f.cleaned_data.get("loss_pct") or 0),
-                    }
-                )
+            items = _collect_recipe_line_items(formset)
             ok, msg = recipe_service.update_recipe(recipe.pk, data, items)
             if ok:
                 recipe.refresh_from_db()

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -603,14 +603,19 @@
         }
         if (!hasValidLine) {
           const inlineItems = Array.from(
-            form.querySelectorAll('select[name^="items-"][name$="-item"]'),
+            form.querySelectorAll(
+              'select[name^="items-"][name$="-item"], select[name^="items-"][name$="-ingredient"]',
+            ),
           );
           if (inlineItems.length) {
             checkedSources = true;
             for (const select of inlineItems) {
               const value = (select.value || "").trim();
               if (!value) continue;
-              const baseName = (select.name || "").replace(/-item$/, "");
+              const baseName = (select.name || "").replace(
+                /-(item|ingredient)$/,
+                "",
+              );
               if (!baseName) continue;
               const qtyField =
                 form.querySelector(

--- a/static/js/predictive-dropdown.js
+++ b/static/js/predictive-dropdown.js
@@ -40,6 +40,10 @@
       value: opt.value,
       selected: opt.selected,
       disabled: opt.disabled,
+      ingredientKind:
+        opt.dataset.ingredientKind ||
+        opt.getAttribute("data-ingredient-kind") ||
+        "",
     }));
 
     const emptyOption = rawOptions.find((o) => !o.value && !o.disabled);
@@ -80,7 +84,10 @@
       list.forEach((opt) => {
         const el = document.createElement("div");
         el.className =
-          "px-3 py-2 cursor-pointer hover:bg-blue-50 border-b border-gray-100 last:border-b-0";
+          "predictive-dropdown-option px-3 py-2 cursor-pointer hover:bg-blue-50 dark:hover:bg-white/10 border-b border-gray-100 dark:border-gray-700 last:border-b-0";
+        if (opt.ingredientKind === "sub") {
+          el.classList.add("predictive-dropdown-option--sub");
+        }
         el.textContent = opt.text;
         el.addEventListener("click", () => {
           textInput.value = opt.text;

--- a/static/js/recipe-components.js
+++ b/static/js/recipe-components.js
@@ -90,7 +90,7 @@
 
     var hasItem = row.dataset.hasItem === "1";
     if (!hasItem) {
-      var select = row.querySelector('select[id$="-item"]');
+      var select = row.querySelector('select[id$="-ingredient"]');
       hasItem = !!(select && select.value);
     }
     var hasZeroPrice = hasItem && quantity > 0 && costPerBase === 0;
@@ -101,11 +101,61 @@
     }
   }
 
-  function handleItemChange(row, itemSelect, scope) {
-    var value = itemSelect.value;
+  function parseIngredientValue(value) {
+    if (!value || typeof value !== "string") {
+      return null;
+    }
+    if (value.indexOf("i:") === 0) {
+      return { kind: "item", id: value.slice(2) };
+    }
+    if (value.indexOf("r:") === 0) {
+      return { kind: "sub", id: value.slice(2) };
+    }
+    return null;
+  }
+
+  function applyIngredientMeta(row, ingredientSelect, scope, data) {
+    var baseId = ingredientSelect.id.replace(/-ingredient$/, "");
+    var unitHidden = document.getElementById(baseId + "-unit");
+    var unitDisplay = document.getElementById(baseId + "-unit_display");
+    if (!data || !data.ok) {
+      return;
+    }
+    var baseUnitValue = data.base_unit;
+    if (!baseUnitValue || !String(baseUnitValue).trim()) {
+      baseUnitValue = data.unit;
+    }
+    var resolvedUnit = baseUnitValue ? String(baseUnitValue).trim() : "";
+    if (unitHidden) {
+      unitHidden.value = resolvedUnit;
+    }
+    if (unitDisplay) {
+      unitDisplay.value = resolvedUnit;
+    }
+    row.dataset.category = (data.category || "").trim();
+    row.dataset.subcategory = (data.subcategory || "").trim();
+    row.dataset.itemName = (data.name || "").trim();
+
+    var costPerBaseUnit = toNumber(data.cost_per_base_unit);
+    if (!costPerBaseUnit && data.last_purchase_price !== undefined) {
+      var lastPrice = toNumber(data.last_purchase_price);
+      var conversion = toNumber(data.conversion_factor) || 1;
+      costPerBaseUnit = conversion ? lastPrice / conversion : 0;
+    }
+    if (!Number.isFinite(costPerBaseUnit) || costPerBaseUnit < 0) {
+      costPerBaseUnit = 0;
+    }
+    row.dataset.costPerBaseUnit = String(costPerBaseUnit);
+    row.dataset.hasZeroPrice = costPerBaseUnit === 0 ? "1" : "0";
+
+    updateRowCost(row, { scope: scope });
+  }
+
+  function handleIngredientChange(row, ingredientSelect, scope) {
+    var value = ingredientSelect.value;
     row.dataset.hasItem = value ? "1" : "0";
 
-    var baseId = itemSelect.id.replace("-item", "");
+    var baseId = ingredientSelect.id.replace(/-ingredient$/, "");
     var unitHidden = document.getElementById(baseId + "-unit");
     var unitDisplay = document.getElementById(baseId + "-unit_display");
 
@@ -125,56 +175,41 @@
       return;
     }
 
-    if (itemSelect.dataset.recipeFetching === "1") {
+    var parsed = parseIngredientValue(value);
+    if (!parsed || !parsed.id) {
+      row.dataset.category = "";
+      row.dataset.subcategory = "";
+      row.dataset.itemName = "";
+      row.dataset.costPerBaseUnit = "0";
+      updateRowCost(row, { scope: scope });
       return;
     }
-    itemSelect.dataset.recipeFetching = "1";
 
-    fetch("/items/meta/" + value + "/")
+    if (ingredientSelect.dataset.recipeFetching === "1") {
+      return;
+    }
+    ingredientSelect.dataset.recipeFetching = "1";
+
+    var url =
+      parsed.kind === "sub"
+        ? "/recipes/meta/" + encodeURIComponent(parsed.id) + "/"
+        : "/items/meta/" + encodeURIComponent(parsed.id) + "/";
+
+    fetch(url)
       .then(function (response) {
         if (!response.ok) {
-          throw new Error("Failed to fetch item metadata");
+          throw new Error("Failed to fetch ingredient metadata");
         }
         return response.json();
       })
       .then(function (data) {
-        if (!data || !data.ok) {
-          return;
-        }
-        var baseUnitValue = data.base_unit;
-        if (!baseUnitValue || !String(baseUnitValue).trim()) {
-          baseUnitValue = data.unit;
-        }
-        var resolvedUnit = baseUnitValue ? String(baseUnitValue).trim() : "";
-        if (unitHidden) {
-          unitHidden.value = resolvedUnit;
-        }
-        if (unitDisplay) {
-          unitDisplay.value = resolvedUnit;
-        }
-        row.dataset.category = (data.category || "").trim();
-        row.dataset.subcategory = (data.subcategory || "").trim();
-        row.dataset.itemName = (data.name || "").trim();
-
-        var costPerBaseUnit = toNumber(data.cost_per_base_unit);
-        if (!costPerBaseUnit) {
-          var lastPrice = toNumber(data.last_purchase_price);
-          var conversion = toNumber(data.conversion_factor) || 1;
-          costPerBaseUnit = conversion ? lastPrice / conversion : 0;
-        }
-        if (!Number.isFinite(costPerBaseUnit) || costPerBaseUnit < 0) {
-          costPerBaseUnit = 0;
-        }
-        row.dataset.costPerBaseUnit = String(costPerBaseUnit);
-        row.dataset.hasZeroPrice = costPerBaseUnit === 0 ? "1" : "0";
-
-        updateRowCost(row, { scope: scope });
+        applyIngredientMeta(row, ingredientSelect, scope, data);
       })
       .catch(function (err) {
-        console.error("Unable to fetch item metadata", err);
+        console.error("Unable to fetch ingredient metadata", err);
       })
       .finally(function () {
-        delete itemSelect.dataset.recipeFetching;
+        delete ingredientSelect.dataset.recipeFetching;
       });
   }
 
@@ -184,11 +219,11 @@
     }
     row.dataset.recipeEventsBound = "1";
 
-    var itemSelect = row.querySelector('select[id$="-item"]');
-    if (itemSelect) {
-      itemSelect.addEventListener("change", function () {
+    var ingredientSelect = row.querySelector('select[id$="-ingredient"]');
+    if (ingredientSelect) {
+      ingredientSelect.addEventListener("change", function () {
         row.dataset.recipeBootstrapped = "1";
-        handleItemChange(row, itemSelect, scope);
+        handleIngredientChange(row, ingredientSelect, scope);
       });
     }
 
@@ -232,10 +267,10 @@
       updateRowCost(row, { scope: scope, silent: true });
       return;
     }
-    var itemSelect = row.querySelector('select[id$="-item"]');
-    if (itemSelect && itemSelect.value) {
+    var ingredientSelect = row.querySelector('select[id$="-ingredient"]');
+    if (ingredientSelect && ingredientSelect.value) {
       row.dataset.recipeBootstrapped = "1";
-      handleItemChange(row, itemSelect, scope);
+      handleIngredientChange(row, ingredientSelect, scope);
     } else {
       updateRowCost(row, { scope: scope, silent: true });
     }
@@ -384,7 +419,7 @@
 
       var hasItem = row.dataset.hasItem === "1";
       if (!hasItem) {
-        var select = row.querySelector('select[id$="-item"]');
+        var select = row.querySelector('select[id$="-ingredient"]');
         hasItem = !!(select && select.value);
       }
       var quantityValue = toNumber(row.dataset.quantity);

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -48,8 +48,11 @@
     }
     .predictive-overlay [role="option"],
     .predictive-dropdown-list [role="option"],
-    .predictive-dropdown-list div {
+    .predictive-dropdown-list div.predictive-dropdown-option:not(.predictive-dropdown-option--sub) {
       color: inherit !important;
+    }
+    .predictive-dropdown-list .predictive-dropdown-option--sub {
+      color: var(--color-accent-text) !important;
     }
   </style>
   <script src="{% static 'js/predictive-dropdown.js' %}?v={{ STATIC_VERSION }}" defer></script>

--- a/templates/inventory/recipes/_components_form_table.html
+++ b/templates/inventory/recipes/_components_form_table.html
@@ -2,7 +2,7 @@
 {% block caption %}<caption>Recipe Items</caption>{% endblock %}
 
 {% block headers %}
-  <th scope="col" class="normal-case">Ingredient <span class="font-normal text-gray-500">(item or sub-recipe)</span></th>
+  <th scope="col" class="normal-case">Ingredient <span class="font-normal text-gray-500 dark:text-gray-400">(items and sub-recipes)</span></th>
   <th scope="col">Qty</th>
   <th scope="col">Unit</th>
   <th scope="col">Loss %</th>
@@ -14,10 +14,8 @@
   {% for cform in formset.forms %}
   <tr class="form-row" data-form-index="{{ forloop.counter0 }}" data-recipe-row="true" data-has-item="0" data-quantity="0" data-cost-per-base-unit="0">
     <td class="px-3 py-2">
-      <div class="flex flex-col gap-1 min-w-[12rem]">
-        {% include "components/form_field_table.html" with field=cform.item %}
-        <p class="text-center text-xs text-gray-500 py-0.5">or</p>
-        {% include "components/form_field_table.html" with field=cform.sub_recipe %}
+      <div class="min-w-[12rem]">
+        {% include "components/form_field_table.html" with field=cform.ingredient %}
       </div>
     </td>
     <td class="px-3 py-2">{% include "components/form_field_table.html" with field=cform.quantity %}</td>
@@ -35,13 +33,11 @@
     </td>
   </tr>
   {% endfor %}
-  {# empty form template row #}
+  <!-- empty form template row -->
   <tr class="form-row hidden" id="items-empty-row" data-recipe-row="true" data-has-item="0" data-quantity="0" data-cost-per-base-unit="0">
     <td class="px-3 py-2">
-      <div class="flex flex-col gap-1 min-w-[12rem]">
-        {% include "components/form_field_table.html" with field=formset.empty_form.item %}
-        <p class="text-center text-xs text-gray-500 py-0.5">or</p>
-        {% include "components/form_field_table.html" with field=formset.empty_form.sub_recipe %}
+      <div class="min-w-[12rem]">
+        {% include "components/form_field_table.html" with field=formset.empty_form.ingredient %}
       </div>
     </td>
     <td class="px-3 py-2">{% include "components/form_field_table.html" with field=formset.empty_form.quantity %}</td>

--- a/tests/test_recipe_drawer.py
+++ b/tests/test_recipe_drawer.py
@@ -14,23 +14,24 @@ from inventory.services.recipe_service import (
 
 
 @pytest.mark.django_db
-def test_recipe_create_partial_invalid_ajax_returns_json(client):
+def test_recipe_create_partial_invalid_ajax_returns_json(client, item_factory):
+    item = item_factory(name="Flour")
     url = reverse("recipe_create_partial")
     data = {
         "name": "",
         "description_and_plating": "",
         "is_active": "on",
-        "type": "",
+        "type": Recipe.Type.FINAL,
         "default_yield_qty": "",
         "default_yield_unit": "",
         "items-TOTAL_FORMS": "1",
         "items-INITIAL_FORMS": "0",
         "items-MIN_NUM_FORMS": "0",
         "items-MAX_NUM_FORMS": "1000",
-        "items-0-item": "",
-        "items-0-quantity": "",
-        "items-0-unit": "",
-        "items-0-loss_pct": "",
+        "items-0-ingredient": f"i:{item.pk}",
+        "items-0-quantity": "1",
+        "items-0-unit": "kg",
+        "items-0-loss_pct": "0",
         "items-0-DELETE": "",
     }
 
@@ -46,30 +47,28 @@ def test_recipe_create_partial_invalid_ajax_returns_json(client):
     assert payload["message"]
     assert "<" not in payload["message"]
     assert payload["errors"]["form"]["name"][0] == "This field is required."
-    assert (
-        payload["errors"]["formset"][0]["errors"]["item"][0]
-        == "This field is required."
-    )
+    assert not payload["errors"]["formset"]
 
 
 @pytest.mark.django_db
-def test_recipe_create_partial_invalid_non_ajax_returns_html(client):
+def test_recipe_create_partial_invalid_non_ajax_returns_html(client, item_factory):
+    item = item_factory(name="Flour")
     url = reverse("recipe_create_partial")
     data = {
         "name": "",
         "description_and_plating": "",
         "is_active": "on",
-        "type": "",
+        "type": Recipe.Type.FINAL,
         "default_yield_qty": "",
         "default_yield_unit": "",
         "items-TOTAL_FORMS": "1",
         "items-INITIAL_FORMS": "0",
         "items-MIN_NUM_FORMS": "0",
         "items-MAX_NUM_FORMS": "1000",
-        "items-0-item": "",
-        "items-0-quantity": "",
-        "items-0-unit": "",
-        "items-0-loss_pct": "",
+        "items-0-ingredient": f"i:{item.pk}",
+        "items-0-quantity": "1",
+        "items-0-unit": "kg",
+        "items-0-loss_pct": "0",
         "items-0-DELETE": "",
     }
 
@@ -105,7 +104,7 @@ def test_recipe_edit_partial_invalid_ajax_returns_json(client, item_factory):
         "items-MIN_NUM_FORMS": "0",
         "items-MAX_NUM_FORMS": "1000",
         "items-0-id": str(recipe_item.pk),
-        "items-0-item": str(item.pk),
+        "items-0-ingredient": f"i:{item.pk}",
         "items-0-quantity": "1",
         "items-0-unit": recipe_item.unit or "",
         "items-0-loss_pct": "0",
@@ -151,7 +150,7 @@ def test_recipe_edit_partial_invalid_non_ajax_returns_html(client, item_factory)
         "items-MIN_NUM_FORMS": "0",
         "items-MAX_NUM_FORMS": "1000",
         "items-0-id": str(recipe_item.pk),
-        "items-0-item": str(item.pk),
+        "items-0-ingredient": f"i:{item.pk}",
         "items-0-quantity": "1",
         "items-0-unit": recipe_item.unit or "",
         "items-0-loss_pct": "0",
@@ -173,14 +172,14 @@ def test_recipe_create_partial_success_returns_close_only_payload(client, item_f
         "name": "Test Bread",
         "description_and_plating": "",
         "is_active": "on",
-        "type": "",
+        "type": Recipe.Type.FINAL,
         "default_yield_qty": "1",
         "default_yield_unit": "loaf",
         "items-TOTAL_FORMS": "1",
         "items-INITIAL_FORMS": "0",
         "items-MIN_NUM_FORMS": "0",
         "items-MAX_NUM_FORMS": "1000",
-        "items-0-item": str(item.pk),
+        "items-0-ingredient": f"i:{item.pk}",
         "items-0-quantity": "2.5",
         "items-0-unit": "kg",
         "items-0-unit_display": "kg",
@@ -204,6 +203,81 @@ def test_recipe_create_partial_success_returns_close_only_payload(client, item_f
     assert Recipe.objects.filter(name="Test Bread").exists()
     assert payload.get("htmx", {}).get("event") == "recipes:refresh"
     assert payload.get("htmx", {}).get("detail", {}).get("action") == "created"
+
+
+@pytest.mark.django_db
+def test_recipe_create_partial_persists_sub_recipe_line(client, item_factory):
+    flour = item_factory(name="Flour")
+    sub = Recipe.objects.create(
+        name="Roux Base",
+        is_active=True,
+        type=Recipe.Type.SUB,
+        default_yield_qty=Decimal("1"),
+        default_yield_unit="kg",
+    )
+    RecipeItem.objects.create(
+        recipe=sub,
+        item=flour,
+        quantity=Decimal("1"),
+        unit="kg",
+        loss_pct=Decimal("0"),
+    )
+    url = reverse("recipe_create_partial")
+    data = {
+        "name": "Mother Sauce",
+        "description_and_plating": "",
+        "is_active": "on",
+        "type": Recipe.Type.FINAL,
+        "default_yield_qty": "1",
+        "default_yield_unit": "L",
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "0",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-ingredient": f"r:{sub.pk}",
+        "items-0-quantity": "0.5",
+        "items-0-unit": "kg",
+        "items-0-unit_display": "kg",
+        "items-0-loss_pct": "0",
+        "items-0-DELETE": "",
+    }
+    response = client.post(
+        url,
+        data,
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+    assert response.status_code == 200
+    recipe = Recipe.objects.get(name="Mother Sauce")
+    ri = recipe.items.first()
+    assert ri is not None
+    assert ri.sub_recipe_id == sub.pk
+    assert ri.item_id is None
+
+
+@pytest.mark.django_db
+def test_recipe_meta_returns_cost_per_yield_unit(client, item_factory):
+    flour = item_factory(name="Flour", last_purchase_price=Decimal("10.00"))
+    sub = Recipe.objects.create(
+        name="Meta Sub",
+        is_active=True,
+        type=Recipe.Type.SUB,
+        default_yield_qty=Decimal("2"),
+        default_yield_unit="kg",
+    )
+    RecipeItem.objects.create(
+        recipe=sub,
+        item=flour,
+        quantity=Decimal("1"),
+        unit="kg",
+        loss_pct=Decimal("0"),
+    )
+    url = reverse("recipe_meta", args=[sub.pk])
+    response = client.get(url)
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["category"] == "Sub-Recipe"
+    assert payload["cost_per_base_unit"] == pytest.approx(5.0)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
- Single ingredient select with encoded values (i:/r:) and optgroups
- Map ingredient to item/sub_recipe in RecipeItemForm clean/save; skip model validation on blank formset rows
- Drawer create/edit use shared line-item payload (fixes missing sub_recipe_id)
- GET /recipes/meta/<id>/ for sub-recipe cost and unit in recipe-components.js
- Predictive dropdown marks sub-recipes; base CSS allows accent color on rows
- Modal line-item guard includes -ingredient selects
- Tests: ingredient field, sub-recipe persistence, recipe_meta

Made-with: Cursor

<!-- Please review our [Contribution Guidelines](../CONTRIBUTING.md) before submitting. -->

## Summary

-

## Testing

- [ ] `flake8`
- [ ] `pytest`
- [ ] Other:

## Checklist

- [ ] Documentation updated
- [ ] Tests added or updated
- [ ] Ready for review
