### PR TITLE
fix: recipe ingredient unit/cost sync and sub-recipe UX

### DIFF
--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -114,6 +114,80 @@ def _build_form_error_payload(form, formset):
     }
 
 
+def _normalize_unit_token(unit_raw: str) -> str:
+    u = (unit_raw or "").strip().upper().replace(".", "")
+    u = "".join(u.split())
+    return u
+
+
+def _recipe_yield_physical_amount(qty: Decimal, unit_raw: str) -> tuple[str, float]:
+    """Dimension and amount in grams (mass), ml (volume), or count (each)."""
+
+    q = float(qty or 1) or 1.0
+    t = _normalize_unit_token(unit_raw)
+    if t in ("KG", "KILO", "KILOS", "KILOGRAM", "KILOGRAMS"):
+        return "mass", q * 1000.0
+    if t in ("G", "GM", "GRAM", "GRAMS"):
+        return "mass", q
+    if t in ("L", "LITER", "LITRE", "LITERS", "LITRES"):
+        return "volume", q * 1000.0
+    if t in ("ML", "MILLILITER", "MILLILITERS", "MILLILITRE", "MILLILITRES"):
+        return "volume", q
+    return "count", q
+
+
+def _unit_choices_for_dimension(dim: str) -> list[dict[str, str]]:
+    if dim == "mass":
+        return [
+            {"code": "GM", "label": "g"},
+            {"code": "KG", "label": "kg"},
+        ]
+    if dim == "volume":
+        return [
+            {"code": "ML", "label": "ml"},
+            {"code": "L", "label": "L"},
+        ]
+    return [{"code": "PC", "label": "pc"}]
+
+
+def _default_display_unit_code(unit_raw: str, dim: str) -> str:
+    t = _normalize_unit_token(unit_raw)
+    if dim == "mass":
+        if t in ("KG", "KILO", "KILOS", "KILOGRAM", "KILOGRAMS"):
+            return "KG"
+        return "GM"
+    if dim == "volume":
+        if t in ("L", "LITER", "LITRE", "LITERS", "LITRES"):
+            return "L"
+        return "ML"
+    return "PC"
+
+
+def _sanitize_display_code(dim: str, code: str) -> str | None:
+    c = (code or "").strip().upper()
+    if dim == "mass":
+        return c if c in ("GM", "KG") else None
+    if dim == "volume":
+        return c if c in ("ML", "L") else None
+    return c if c == "PC" else None
+
+
+def _cost_and_label_for_display(
+    dim: str, cost_per_phys: float, display_code: str
+) -> tuple[float, str]:
+    """cost_per_phys is $ per g, per ml, or per count."""
+
+    if dim == "mass":
+        if display_code == "KG":
+            return cost_per_phys * 1000.0, "kg"
+        return cost_per_phys, "g"
+    if dim == "volume":
+        if display_code == "L":
+            return cost_per_phys * 1000.0, "L"
+        return cost_per_phys, "ml"
+    return cost_per_phys, "pc"
+
+
 def _collect_recipe_line_items(formset):
     """Build line-item dicts for recipe_service from a validated item formset."""
 
@@ -139,26 +213,43 @@ def _collect_recipe_line_items(formset):
 
 @require_GET
 def recipe_meta(request, recipe_id: int):
-    """JSON metadata for sub-recipe rows (cost per yield unit, display unit)."""
+    """JSON metadata for sub-recipe rows (cost per display unit, unit choices)."""
 
     recipe = get_object_or_404(Recipe, pk=recipe_id)
     total = recipe.get_total_cost()
-    sub_yield = Decimal(str(recipe.default_yield_qty or 1)) or Decimal("1")
+    yield_qty = Decimal(str(recipe.default_yield_qty or 1)) or Decimal("1")
+    yield_unit_raw = (recipe.default_yield_unit or "").strip()
+
+    dim, phys_amt = _recipe_yield_physical_amount(yield_qty, yield_unit_raw)
+    if phys_amt <= 0:
+        phys_amt = 1.0
     try:
-        cost_per = float(total / sub_yield) if sub_yield else 0.0
-    except (ArithmeticError, ZeroDivisionError):
-        cost_per = 0.0
-    base_unit = (recipe.default_yield_unit or "").strip()
+        cost_per_phys = float(total) / phys_amt
+    except (ArithmeticError, ZeroDivisionError, ValueError, TypeError):
+        cost_per_phys = 0.0
+
+    unit_choices = _unit_choices_for_dimension(dim)
+    default_code = _default_display_unit_code(yield_unit_raw, dim)
+    req_code = (request.GET.get("display_unit") or "").strip().upper()
+    display_code = _sanitize_display_code(dim, req_code) or default_code
+    cost_per, unit_label = _cost_and_label_for_display(dim, cost_per_phys, display_code)
+
     return JsonResponse(
         {
             "ok": True,
             "recipe_id": recipe.recipe_id,
             "name": recipe.name,
-            "base_unit": base_unit,
-            "unit": base_unit,
+            "base_unit": unit_label,
+            "unit": unit_label,
             "cost_per_base_unit": cost_per,
             "category": "Sub-Recipe",
             "subcategory": "",
+            "yield_dimension": dim,
+            "unit_choices": unit_choices,
+            "display_unit_code": display_code,
+            "default_display_unit_code": default_code,
+            "yield_qty": float(yield_qty),
+            "yield_unit_raw": yield_unit_raw,
         }
     )
 

--- a/static/js/predictive-dropdown.js
+++ b/static/js/predictive-dropdown.js
@@ -14,6 +14,59 @@
     return txt;
   }
 
+  function collapseWhitespace(s) {
+    return String(s || "")
+      .trim()
+      .replace(/\s+/g, " ");
+  }
+
+  /**
+   * Match typed text to an option value (for syncing hidden select with visible label).
+   * Tries exact (case-insensitive), collapsed-whitespace exact, single includes-match,
+   * then unique prefix match.
+   */
+  function resolveOptionValueFromTyped(typed, options) {
+    const raw = String(typed || "").trim();
+    if (!raw || !options.length) return "";
+    const q = raw.toLowerCase();
+    const qCollapsed = collapseWhitespace(raw).toLowerCase();
+
+    let exact = options.find((o) => o.text.toLowerCase() === q);
+    if (exact) return exact.value;
+
+    exact = options.find(
+      (o) => collapseWhitespace(o.text).toLowerCase() === qCollapsed,
+    );
+    if (exact) return exact.value;
+
+    const includes = options.filter((o) =>
+      o.text.toLowerCase().includes(q),
+    );
+    if (includes.length === 1) return includes[0].value;
+
+    const prefixes = options.filter((o) =>
+      o.text.toLowerCase().startsWith(q),
+    );
+    if (prefixes.length === 1) return prefixes[0].value;
+
+    return "";
+  }
+
+  function applyResolvedValue(originalSelect, textInput, options, newVal) {
+    const prev = originalSelect.value;
+    originalSelect.value = newVal;
+    const match = options.find((o) => o.value === originalSelect.value);
+    if (match) {
+      textInput.value = match.text;
+    } else if (!newVal) {
+      textInput.value = "";
+    }
+    if (originalSelect.value !== prev) {
+      originalSelect.dispatchEvent(new Event("input", { bubbles: true }));
+      originalSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+  }
+
   function upgradeSelect(originalSelect) {
     // Only enhance selects explicitly marked as predictive
     if (!originalSelect.classList.contains("predictive")) return;
@@ -72,30 +125,28 @@
     const selected = rawOptions.find((o) => o.selected && o.value);
     if (selected) textInput.value = selected.text;
 
-    // Helper: dispatch change/input on the original select (category_id)
-    function dispatchSelectChange() {
-      originalSelect.dispatchEvent(new Event("input", { bubbles: true }));
-      originalSelect.dispatchEvent(new Event("change", { bubbles: true }));
-    }
-
     // Render dropdown options
     function renderOptions(list) {
       dropdown.innerHTML = "";
       list.forEach((opt) => {
         const el = document.createElement("div");
         el.className =
-          "predictive-dropdown-option px-3 py-2 cursor-pointer hover:bg-surfaceSubtle border-b border-border last:border-b-0 text-bodyText";
+          "predictive-dropdown-option flex items-center gap-2 px-3 py-2 cursor-pointer hover:bg-surfaceSubtle border-b border-border last:border-b-0 text-bodyText";
         if (opt.ingredientKind === "sub") {
           el.classList.add("predictive-dropdown-option--sub");
+          const badge = document.createElement("span");
+          badge.className = "predictive-dropdown-option-badge shrink-0";
+          badge.textContent = "Sub";
+          el.appendChild(badge);
         }
-        el.textContent = opt.text;
+        const label = document.createElement("span");
+        label.className = "min-w-0 truncate";
+        label.textContent = opt.text;
+        el.appendChild(label);
         el.addEventListener("click", () => {
-          textInput.value = opt.text;
-          const prev = originalSelect.value;
-          originalSelect.value = opt.value;
           dropdown.classList.add("hidden");
           textInput.blur();
-          if (originalSelect.value !== prev) dispatchSelectChange();
+          applyResolvedValue(originalSelect, textInput, options, opt.value);
         });
         dropdown.appendChild(el);
       });
@@ -113,18 +164,18 @@
       renderOptions(filtered);
       dropdown.classList.remove("hidden");
 
-      // Exact match → select and notify
-      const exact = filtered.find((o) => o.text.toLowerCase() === q.trim());
-      const newVal = exact ? exact.value : "";
-      if (originalSelect.value !== newVal) {
-        originalSelect.value = newVal;
-        dispatchSelectChange();
+      const newVal = resolveOptionValueFromTyped(e.target.value, filtered);
+      const prev = originalSelect.value;
+      originalSelect.value = newVal;
+      if (originalSelect.value !== prev) {
+        originalSelect.dispatchEvent(new Event("input", { bubbles: true }));
+        originalSelect.dispatchEvent(new Event("change", { bubbles: true }));
       }
     });
 
     // Keyboard navigation
     textInput.addEventListener("keydown", (e) => {
-      const rows = dropdown.querySelectorAll("div");
+      const rows = dropdown.querySelectorAll(".predictive-dropdown-option");
       let idx = Array.from(rows).findIndex((n) =>
         n.classList.contains("bg-blue-100"),
       );
@@ -182,13 +233,8 @@
       setTimeout(() => {
         dropdown.classList.add("hidden");
         if (dropdown._cleanup) dropdown._cleanup();
-        const typed = textInput.value.trim().toLowerCase();
-        const match = options.find((o) => o.text.toLowerCase() === typed);
-        const newVal = match ? match.value : "";
-        if (originalSelect.value !== newVal) {
-          originalSelect.value = newVal;
-          dispatchSelectChange();
-        }
+        const newVal = resolveOptionValueFromTyped(textInput.value, options);
+        applyResolvedValue(originalSelect, textInput, options, newVal);
       }, 150);
     });
 

--- a/static/js/recipe-components.js
+++ b/static/js/recipe-components.js
@@ -114,24 +114,114 @@
     return null;
   }
 
-  function applyIngredientMeta(row, ingredientSelect, scope, data) {
-    var baseId = ingredientSelect.id.replace(/-ingredient$/, "");
-    var unitHidden = document.getElementById(baseId + "-unit");
-    var unitDisplay = document.getElementById(baseId + "-unit_display");
+  function getRowUnitHidden(row) {
+    return row.querySelector(
+      'input[id$="-unit"]:not([id$="-unit_display"])',
+    );
+  }
+
+  function getRowUnitDisplay(row) {
+    return row.querySelector('input[id$="-unit_display"]');
+  }
+
+  function setSubRecipeBadgeVisible(row, show) {
+    var badge = row.querySelector("[data-recipe-sub-badge]");
+    if (!badge) {
+      return;
+    }
+    if (show) {
+      badge.classList.remove("hidden");
+    } else {
+      badge.classList.add("hidden");
+    }
+  }
+
+  function removeSubRecipeUnitSelect(row) {
+    var cell = row.querySelector("[data-recipe-unit-cell]");
+    if (!cell) {
+      return;
+    }
+    var sel = cell.querySelector("select.recipe-subrecipe-unit-select");
+    if (sel) {
+      sel.remove();
+    }
+  }
+
+  function ensureSubRecipeUnitSelect(row, data, ingredientSelect, scope) {
+    var cell = row.querySelector("[data-recipe-unit-cell]");
+    if (!cell || !data.unit_choices || !data.unit_choices.length) {
+      return;
+    }
+    removeSubRecipeUnitSelect(row);
+    var sel = document.createElement("select");
+    sel.className =
+      "recipe-subrecipe-unit-select w-full rounded-md border border-form-border bg-form-bg px-2 py-2 text-sm text-form-text focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary";
+    sel.setAttribute("aria-label", "Sub-recipe quantity unit");
+    data.unit_choices.forEach(function (opt) {
+      var o = document.createElement("option");
+      o.value = opt.code;
+      o.textContent = opt.label;
+      if (String(opt.code) === String(data.display_unit_code)) {
+        o.selected = true;
+      }
+      sel.appendChild(o);
+    });
+    sel.addEventListener("change", function () {
+      var parsed = parseIngredientValue(ingredientSelect.value);
+      if (!parsed || parsed.kind !== "sub") {
+        return;
+      }
+      fetchSubRecipeMeta(row, parsed.id, sel.value, ingredientSelect, scope);
+    });
+    cell.appendChild(sel);
+  }
+
+  function fetchSubRecipeMeta(row, recipeId, displayCode, ingredientSelect, scope) {
+    if (ingredientSelect.dataset.recipeFetching === "1") {
+      return;
+    }
+    ingredientSelect.dataset.recipeFetching = "1";
+    var q = displayCode ? "?display_unit=" + encodeURIComponent(displayCode) : "";
+    fetch("/recipes/meta/" + encodeURIComponent(recipeId) + "/" + q)
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error("Failed to fetch sub-recipe metadata");
+        }
+        return response.json();
+      })
+      .then(function (data) {
+        applyIngredientMeta(row, ingredientSelect, scope, data, {
+          subUnitRefresh: true,
+        });
+      })
+      .catch(function (err) {
+        console.error("Unable to fetch sub-recipe metadata", err);
+      })
+      .finally(function () {
+        delete ingredientSelect.dataset.recipeFetching;
+      });
+  }
+
+  function applyIngredientMeta(row, ingredientSelect, scope, data, metaOpts) {
+    metaOpts = metaOpts || {};
+    var unitHidden = getRowUnitHidden(row);
+    var unitDisplay = getRowUnitDisplay(row);
     if (!data || !data.ok) {
       return;
     }
+    var parsed = parseIngredientValue(ingredientSelect.value);
+    var isSub =
+      parsed &&
+      parsed.kind === "sub" &&
+      Array.isArray(data.unit_choices) &&
+      data.unit_choices.length > 0;
+
     var baseUnitValue = data.base_unit;
     if (!baseUnitValue || !String(baseUnitValue).trim()) {
       baseUnitValue = data.unit;
     }
     var resolvedUnit = baseUnitValue ? String(baseUnitValue).trim() : "";
-    if (unitHidden) {
-      unitHidden.value = resolvedUnit;
-    }
-    if (unitDisplay) {
-      unitDisplay.value = resolvedUnit;
-    }
+
     row.dataset.category = (data.category || "").trim();
     row.dataset.subcategory = (data.subcategory || "").trim();
     row.dataset.itemName = (data.name || "").trim();
@@ -148,6 +238,36 @@
     row.dataset.costPerBaseUnit = String(costPerBaseUnit);
     row.dataset.hasZeroPrice = costPerBaseUnit === 0 ? "1" : "0";
 
+    if (isSub) {
+      setSubRecipeBadgeVisible(row, true);
+      if (unitDisplay) {
+        unitDisplay.classList.add("hidden");
+        unitDisplay.readOnly = true;
+      }
+      if (unitHidden) {
+        unitHidden.value = resolvedUnit;
+      }
+      if (metaOpts.subUnitRefresh) {
+        var existing = row.querySelector("select.recipe-subrecipe-unit-select");
+        if (existing && data.display_unit_code) {
+          existing.value = String(data.display_unit_code);
+        }
+      } else {
+        ensureSubRecipeUnitSelect(row, data, ingredientSelect, scope);
+      }
+    } else {
+      setSubRecipeBadgeVisible(row, false);
+      removeSubRecipeUnitSelect(row);
+      if (unitDisplay) {
+        unitDisplay.classList.remove("hidden");
+        unitDisplay.readOnly = true;
+        unitDisplay.value = resolvedUnit;
+      }
+      if (unitHidden) {
+        unitHidden.value = resolvedUnit;
+      }
+    }
+
     updateRowCost(row, { scope: scope });
   }
 
@@ -155,16 +275,19 @@
     var value = ingredientSelect.value;
     row.dataset.hasItem = value ? "1" : "0";
 
-    var baseId = ingredientSelect.id.replace(/-ingredient$/, "");
-    var unitHidden = document.getElementById(baseId + "-unit");
-    var unitDisplay = document.getElementById(baseId + "-unit_display");
+    var unitHidden = getRowUnitHidden(row);
+    var unitDisplay = getRowUnitDisplay(row);
 
     if (!value) {
+      setSubRecipeBadgeVisible(row, false);
+      removeSubRecipeUnitSelect(row);
       if (unitHidden) {
         unitHidden.value = "";
       }
       if (unitDisplay) {
         unitDisplay.value = "";
+        unitDisplay.classList.remove("hidden");
+        unitDisplay.readOnly = true;
       }
       row.dataset.category = "";
       row.dataset.subcategory = "";
@@ -203,7 +326,7 @@
         return response.json();
       })
       .then(function (data) {
-        applyIngredientMeta(row, ingredientSelect, scope, data);
+        applyIngredientMeta(row, ingredientSelect, scope, data, {});
       })
       .catch(function (err) {
         console.error("Unable to fetch ingredient metadata", err);
@@ -218,14 +341,6 @@
       return;
     }
     row.dataset.recipeEventsBound = "1";
-
-    var ingredientSelect = row.querySelector('select[id$="-ingredient"]');
-    if (ingredientSelect) {
-      ingredientSelect.addEventListener("change", function () {
-        row.dataset.recipeBootstrapped = "1";
-        handleIngredientChange(row, ingredientSelect, scope);
-      });
-    }
 
     var quantityInput = row.querySelector('input[id$="-quantity"]');
     if (quantityInput) {
@@ -259,6 +374,35 @@
     ) {
       window.initPredictiveDropdowns(row);
       row.dataset.predictiveInit = "1";
+    }
+
+    var ingredientSelect = row.querySelector('select[id$="-ingredient"]');
+    if (ingredientSelect) {
+      var lastIngValue = ingredientSelect.value;
+      ingredientSelect.addEventListener("change", function () {
+        lastIngValue = ingredientSelect.value;
+        row.dataset.recipeBootstrapped = "1";
+        handleIngredientChange(row, ingredientSelect, scope);
+      });
+      ingredientSelect.addEventListener("input", function () {
+        if (ingredientSelect.value === lastIngValue) {
+          return;
+        }
+        lastIngValue = ingredientSelect.value;
+        row.dataset.recipeBootstrapped = "1";
+        handleIngredientChange(row, ingredientSelect, scope);
+      });
+      if (ingredientSelect.id) {
+        var predText = document.getElementById(ingredientSelect.id + "_text");
+        if (predText) {
+          predText.addEventListener("blur", function () {
+            setTimeout(function () {
+              lastIngValue = ingredientSelect.value;
+              handleIngredientChange(row, ingredientSelect, scope);
+            }, 220);
+          });
+        }
+      }
     }
   }
 

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -52,7 +52,19 @@
       color: inherit !important;
     }
     .predictive-dropdown-list .predictive-dropdown-option--sub {
-      color: var(--color-accent-text) !important;
+      border-left: 3px solid var(--color-accent) !important;
+      background-color: var(--color-accent-soft) !important;
+      color: var(--color-body-text) !important;
+    }
+    .predictive-dropdown-list .predictive-dropdown-option-badge {
+      font-size: 0.65rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 0.1rem 0.35rem;
+      border-radius: 0.25rem;
+      background: var(--color-accent);
+      color: var(--color-surface);
     }
   </style>
   <script src="{% static 'js/predictive-dropdown.js' %}?v={{ STATIC_VERSION }}" defer></script>

--- a/templates/inventory/recipes/_components_form_table.html
+++ b/templates/inventory/recipes/_components_form_table.html
@@ -14,12 +14,13 @@
   {% for cform in formset.forms %}
   <tr class="form-row" data-form-index="{{ forloop.counter0 }}" data-recipe-row="true" data-has-item="0" data-quantity="0" data-cost-per-base-unit="0">
     <td class="px-3 py-2">
-      <div class="min-w-[12rem]">
+      <div class="min-w-[12rem] flex flex-col gap-1">
+        <span class="hidden self-start rounded px-1.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide bg-info-soft text-info-text" data-recipe-sub-badge>Sub-recipe</span>
         {% include "components/form_field_table.html" with field=cform.ingredient %}
       </div>
     </td>
     <td class="px-3 py-2">{% include "components/form_field_table.html" with field=cform.quantity %}</td>
-    <td class="px-3 py-2">
+    <td class="px-3 py-2 recipe-unit-cell" data-recipe-unit-cell>
       {{ cform.unit }}
       {% include "components/form_field_table.html" with field=cform.unit_display %}
     </td>
@@ -36,12 +37,13 @@
   <!-- empty form template row -->
   <tr class="form-row hidden" id="items-empty-row" data-recipe-row="true" data-has-item="0" data-quantity="0" data-cost-per-base-unit="0">
     <td class="px-3 py-2">
-      <div class="min-w-[12rem]">
+      <div class="min-w-[12rem] flex flex-col gap-1">
+        <span class="hidden self-start rounded px-1.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide bg-info-soft text-info-text" data-recipe-sub-badge>Sub-recipe</span>
         {% include "components/form_field_table.html" with field=formset.empty_form.ingredient %}
       </div>
     </td>
     <td class="px-3 py-2">{% include "components/form_field_table.html" with field=formset.empty_form.quantity %}</td>
-    <td class="px-3 py-2">
+    <td class="px-3 py-2 recipe-unit-cell" data-recipe-unit-cell>
       {{ formset.empty_form.unit }}
       {% include "components/form_field_table.html" with field=formset.empty_form.unit_display %}
     </td>

--- a/tests/test_recipe_drawer.py
+++ b/tests/test_recipe_drawer.py
@@ -278,6 +278,35 @@ def test_recipe_meta_returns_cost_per_yield_unit(client, item_factory):
     assert payload["ok"] is True
     assert payload["category"] == "Sub-Recipe"
     assert payload["cost_per_base_unit"] == pytest.approx(5.0)
+    assert payload["yield_dimension"] == "mass"
+    assert any(c["code"] == "GM" for c in payload["unit_choices"])
+
+
+@pytest.mark.django_db
+def test_recipe_meta_respects_display_unit_query(client, item_factory):
+    flour = item_factory(name="Flour", last_purchase_price=Decimal("10.00"))
+    sub = Recipe.objects.create(
+        name="Meta Sub GM",
+        is_active=True,
+        type=Recipe.Type.SUB,
+        default_yield_qty=Decimal("2"),
+        default_yield_unit="kg",
+    )
+    RecipeItem.objects.create(
+        recipe=sub,
+        item=flour,
+        quantity=Decimal("1"),
+        unit="kg",
+        loss_pct=Decimal("0"),
+    )
+    url = reverse("recipe_meta", args=[sub.pk])
+    response = client.get(url, {"display_unit": "GM"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["display_unit_code"] == "GM"
+    assert payload["base_unit"] == "g"
+    assert payload["cost_per_base_unit"] == pytest.approx(0.005)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
- Predictive dropdown: fuzzy label matching, Sub badge in list rows, flex layout
- recipe-components: row-scoped unit fields, select input+change+text blur hooks
- recipe_meta: physical yield basis (g/ml/count), display_unit query, unit_choices
- Sub-recipe rows: unit dropdown + refetch for converted cost; Sub-recipe badge
- _base: stronger sub-option styling and badge pill
- Tests: recipe_meta dimension, display_unit=GM

Made-with: Cursor

<!-- Please review our [Contribution Guidelines](../CONTRIBUTING.md) before submitting. -->

## Summary

-

## Testing

- [ ] `flake8`
- [ ] `pytest`
- [ ] Other:

## Checklist

- [ ] Documentation updated
- [ ] Tests added or updated
- [ ] Ready for review
