### PR TITLE
feat: recipe yield unit by type (portion for final, base units for sub)

### DIFF
--- a/inventory/forms/recipe_forms.py
+++ b/inventory/forms/recipe_forms.py
@@ -3,7 +3,20 @@ from decimal import Decimal
 from django import forms
 
 from ..models import Item, Recipe, RecipeItem
+from ..services.form_service import FormService
 from .base import StyledFormMixin
+
+
+def _match_base_unit(raw: str, choices: tuple[tuple[str, str], ...]) -> str | None:
+    """Return canonical base_unit code from choices, or None if no match."""
+    if not raw or not choices:
+        return None
+    r = str(raw).strip()
+    for code, _label in choices:
+        if str(code).strip().upper() == r.upper():
+            return str(code).strip()
+    return None
+
 
 INPUT_CLASS = (
     "w-full px-3 py-2 text-sm border border-gray-300 rounded-lg "
@@ -49,8 +62,8 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
     default_yield_unit = forms.CharField(
         required=False,
         max_length=50,
-        widget=forms.TextInput(attrs={"class": INPUT_CLASS}),
-        help_text="Unit for the yield quantity",
+        widget=forms.HiddenInput(),
+        help_text="Unit for the yield quantity (sub-recipes only; finals use portion).",
     )
     plating_notes = forms.CharField(
         required=False,
@@ -120,6 +133,9 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        choices = tuple(FormService.get_base_unit_choices())
+        self.sub_yield_unit_choices = choices
+
         description = self.initial.get("description") or getattr(
             self.instance, "description", ""
         )
@@ -137,12 +153,56 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
                 self.initial.setdefault("description_and_plating", combined)
                 self.fields["description_and_plating"].initial = combined
 
+            eff_type = self._effective_recipe_type()
+            raw_unit = (
+                self.initial.get("default_yield_unit")
+                or getattr(self.instance, "default_yield_unit", None)
+                or ""
+            )
+            if eff_type == Recipe.Type.FINAL:
+                self.initial["default_yield_unit"] = "portion"
+                self.fields["default_yield_unit"].initial = "portion"
+            else:
+                matched = _match_base_unit(str(raw_unit), choices)
+                pick = matched if matched else (choices[0][0] if choices else "")
+                self.initial["default_yield_unit"] = pick
+                self.fields["default_yield_unit"].initial = pick
+
+    def _effective_recipe_type(self) -> str:
+        if self.is_bound:
+            raw = self.data.get(self.add_prefix("type"))
+            if raw in (Recipe.Type.FINAL, Recipe.Type.SUB):
+                return raw
+        inst_type = getattr(self.instance, "type", None)
+        if inst_type in (Recipe.Type.FINAL, Recipe.Type.SUB):
+            return inst_type
+        ini = self.initial.get("type")
+        if ini in (Recipe.Type.FINAL, Recipe.Type.SUB):
+            return ini
+        return Recipe.Type.FINAL
+
     def clean(self):
         cleaned_data = super().clean()
         combined = cleaned_data.get("description_and_plating", "")
         combined_text = str(combined).strip()
         cleaned_data["description"] = combined_text
         cleaned_data["plating_notes"] = combined_text
+
+        recipe_type = cleaned_data.get("type")
+        choices = tuple(FormService.get_base_unit_choices())
+
+        if recipe_type == Recipe.Type.FINAL:
+            cleaned_data["default_yield_unit"] = "portion"
+        elif recipe_type == Recipe.Type.SUB:
+            raw = (cleaned_data.get("default_yield_unit") or "").strip()
+            canonical = _match_base_unit(raw, choices)
+            if not canonical or not choices:
+                self.add_error(
+                    "default_yield_unit",
+                    "Select a valid base unit for the yield.",
+                )
+            else:
+                cleaned_data["default_yield_unit"] = canonical
         return cleaned_data
 
 

--- a/inventory/services/recipe_service.py
+++ b/inventory/services/recipe_service.py
@@ -198,6 +198,9 @@ def create_recipe(
                 "plating_notes": data.get("plating_notes"),
                 "tags": _parse_tags(data.get("tags")),
             }
+            rtype = fields.get("type")
+            if rtype in (None, "", Recipe.Type.FINAL, "FINAL"):
+                fields["default_yield_unit"] = "portion"
             recipe = Recipe.objects.create(**fields)
             for item_data in items:
                 ri = RecipeItem(
@@ -230,6 +233,9 @@ def update_recipe(
                     setattr(recipe, k, _parse_tags(v))
                 else:
                     setattr(recipe, k, v)
+            eff_type = data.get("type", recipe.type)
+            if eff_type in (None, "", Recipe.Type.FINAL, "FINAL"):
+                recipe.default_yield_unit = "portion"
             recipe.save()
             RecipeItem.objects.filter(recipe=recipe).delete()
             for item_data in items:

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -59,6 +59,8 @@
           window.initPredictiveDatalistOverlay(content);
         if (window.initRecipeComponentsTable)
           window.initRecipeComponentsTable(content);
+        if (window.initRecipeYieldUnitRoots)
+          window.initRecipeYieldUnitRoots(content);
       });
     }
     setAria(root, content);
@@ -81,6 +83,8 @@
           window.initPredictiveDatalistOverlay(content);
         if (window.initRecipeComponentsTable)
           window.initRecipeComponentsTable(content);
+        if (window.initRecipeYieldUnitRoots)
+          window.initRecipeYieldUnitRoots(content);
       });
     }
     setAria(root, content);

--- a/static/js/recipe-yield-unit.js
+++ b/static/js/recipe-yield-unit.js
@@ -1,0 +1,84 @@
+/**
+ * Sync recipe default_yield_unit hidden input with recipe type (FINAL → portion)
+ * and sub-recipe base-unit select. Used by templates/inventory/recipes/_form_fields.html.
+ * Call initRecipeYieldUnitRoots(container) after injecting recipe form HTML (e.g. modal drawer).
+ */
+(function () {
+  function sync(root) {
+    if (!root) {
+      return;
+    }
+    var typeEl = root.querySelector("#id_type");
+    if (!typeEl) {
+      return;
+    }
+    var hidden = root.querySelector('input[name="default_yield_unit"]');
+    var subSel = root.querySelector("#id_default_yield_unit_sub_select");
+    var finalBlock = root.querySelector("[data-recipe-yield-final]");
+    var subBlock = root.querySelector("[data-recipe-yield-sub]");
+    if (!hidden || !subSel || !finalBlock || !subBlock) {
+      return;
+    }
+    var isFinal = typeEl.value === "FINAL";
+    finalBlock.classList.toggle("hidden", !isFinal);
+    subBlock.classList.toggle("hidden", isFinal);
+    if (isFinal) {
+      hidden.value = "portion";
+    } else {
+      hidden.value = subSel.value || hidden.value;
+    }
+  }
+
+  function bindRoot(root) {
+    if (!root) {
+      return;
+    }
+    var typeEl = root.querySelector("#id_type");
+    if (!typeEl) {
+      return;
+    }
+    typeEl.addEventListener("change", function () {
+      sync(root);
+    });
+    var subSel = root.querySelector("#id_default_yield_unit_sub_select");
+    if (subSel) {
+      subSel.addEventListener("change", function () {
+        if (typeEl.value !== "FINAL") {
+          var hidden = root.querySelector('input[name="default_yield_unit"]');
+          if (hidden) {
+            hidden.value = subSel.value;
+          }
+        }
+      });
+    }
+    var form = root.closest("form[data-modal-form]") || root.closest("form");
+    if (form) {
+      form.addEventListener("submit", function () {
+        sync(root);
+      });
+    }
+    sync(root);
+  }
+
+  function initRecipeYieldUnitRoots(container) {
+    var scope = container || document;
+    scope.querySelectorAll("[data-recipe-yield-unit-root]").forEach(function (root) {
+      if (root.dataset.recipeYieldUnitInit === "1") {
+        return;
+      }
+      root.dataset.recipeYieldUnitInit = "1";
+      bindRoot(root);
+    });
+  }
+
+  window.initRecipeYieldUnitRoots = initRecipeYieldUnitRoots;
+
+  function boot() {
+    initRecipeYieldUnitRoots(document);
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", boot);
+  } else {
+    boot();
+  }
+})();

--- a/templates/inventory/recipes/_form_fields.html
+++ b/templates/inventory/recipes/_form_fields.html
@@ -1,9 +1,35 @@
 {% load form_tags %}
-<div class="grid gap-4 md:grid-cols-3">
+<div class="grid gap-4 md:grid-cols-3" data-recipe-yield-unit-root>
   {% include "components/form_field.html" with field=form.name container_class="md:col-span-2" help_text_class="text-xs text-gray-500 leading-snug" %}
   {% include "components/form_field.html" with field=form.type help_text_class="text-xs text-gray-500 leading-snug" %}
   {% include "components/form_field.html" with field=form.default_yield_qty help_text_class="text-xs text-gray-500 leading-snug" %}
-  {% include "components/form_field.html" with field=form.default_yield_unit help_text_class="text-xs text-gray-500 leading-snug" %}
+  <!-- Default yield unit: hidden field + type-dependent UI (see static/js/recipe-yield-unit.js) -->
+  <div class="space-y-1">
+    {{ form.default_yield_unit }}
+    <label class="block text-sm font-medium text-bodyText" for="id_default_yield_unit_sub_select">Default yield unit</label>
+    <div data-recipe-yield-final class="space-y-1 hidden">
+      <p class="block w-full px-3 py-2.5 border border-form-border rounded-md bg-form-bg text-form-text text-sm">Portion</p>
+      <p class="text-xs text-gray-500 leading-snug">Final recipes always yield portions.</p>
+    </div>
+    <div data-recipe-yield-sub class="space-y-1 hidden">
+      <select id="id_default_yield_unit_sub_select"
+              class="block w-full px-3 py-2.5 border border-form-border rounded-md bg-form-bg text-form-text shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary leading-normal"
+              autocomplete="off"
+              aria-describedby="id_default_yield_unit_sub_help">
+        {% for code, label in form.sub_yield_unit_choices %}
+          <option value="{{ code }}"{% if form.default_yield_unit.value == code %} selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+      <p id="id_default_yield_unit_sub_help" class="text-xs text-gray-500 leading-snug">Base unit this sub-recipe yields (from inventory units).</p>
+    </div>
+    {% if form.default_yield_unit.errors %}
+      <ul class="text-sm text-danger list-disc pl-5 leading-normal">
+        {% for error in form.default_yield_unit.errors %}
+          <li class="leading-normal">{{ error }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </div>
   {# D2: Selling price and food cost target #}
   {% include "components/form_field.html" with field=form.selling_price help_text_class="text-xs text-gray-500 leading-snug" %}
   {% include "components/form_field.html" with field=form.target_food_cost_pct help_text_class="text-xs text-gray-500 leading-snug" %}

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -1,6 +1,7 @@
 {% extends "components/form_layout.html" %}
 {% load static form_tags %}
 {% block extra_head_js %}
+  <script src="{% static 'js/recipe-yield-unit.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/recipe-components.js' %}?v={{ STATIC_VERSION }}" defer></script>
 {% endblock %}
 {% block title %}Recipe Detail – Inventory Pro{% endblock %}

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -1,6 +1,7 @@
 {% extends "components/create_manage_layout.html" %}
 {% load static %}
 {% block extra_head_js %}
+  <script src="{% static 'js/recipe-yield-unit.js' %}?v={{ STATIC_VERSION }}" defer></script>
   <script src="{% static 'js/recipe-components.js' %}?v={{ STATIC_VERSION }}" defer></script>
 {% endblock %}
 {% block page_title %}Recipes – Inventory Pro{% endblock %}

--- a/tests/test_recipe_drawer.py
+++ b/tests/test_recipe_drawer.py
@@ -201,6 +201,8 @@ def test_recipe_create_partial_success_returns_close_only_payload(client, item_f
     assert payload.get("reload") not in (True, "true")
     assert payload["recipe"]["name"] == "Test Bread"
     assert Recipe.objects.filter(name="Test Bread").exists()
+    saved = Recipe.objects.get(name="Test Bread")
+    assert saved.default_yield_unit == "portion"
     assert payload.get("htmx", {}).get("event") == "recipes:refresh"
     assert payload.get("htmx", {}).get("detail", {}).get("action") == "created"
 
@@ -248,10 +250,78 @@ def test_recipe_create_partial_persists_sub_recipe_line(client, item_factory):
     )
     assert response.status_code == 200
     recipe = Recipe.objects.get(name="Mother Sauce")
+    assert recipe.default_yield_unit == "portion"
     ri = recipe.items.first()
     assert ri is not None
     assert ri.sub_recipe_id == sub.pk
     assert ri.item_id is None
+
+
+@pytest.mark.django_db
+def test_recipe_create_partial_sub_recipe_requires_base_yield_unit(
+    client, item_factory
+):
+    """Sub-recipes must post a valid inventory base unit for default_yield_unit."""
+    item = item_factory(name="Flour")
+    url = reverse("recipe_create_partial")
+    data = {
+        "name": "Sauce Base",
+        "description_and_plating": "",
+        "is_active": "on",
+        "type": Recipe.Type.SUB,
+        "default_yield_qty": "1",
+        "default_yield_unit": "portion",
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "0",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-ingredient": f"i:{item.pk}",
+        "items-0-quantity": "1",
+        "items-0-unit": "kg",
+        "items-0-loss_pct": "0",
+        "items-0-DELETE": "",
+    }
+    response = client.post(
+        url,
+        data,
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["errors"]["form"]["default_yield_unit"]
+
+
+@pytest.mark.django_db
+def test_recipe_create_partial_sub_recipe_accepts_base_unit(client, item_factory):
+    item = item_factory(name="Flour")
+    url = reverse("recipe_create_partial")
+    data = {
+        "name": "Roux Stock",
+        "description_and_plating": "",
+        "is_active": "on",
+        "type": Recipe.Type.SUB,
+        "default_yield_qty": "2",
+        "default_yield_unit": "GM",
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "0",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-ingredient": f"i:{item.pk}",
+        "items-0-quantity": "100",
+        "items-0-unit": "kg",
+        "items-0-loss_pct": "0",
+        "items-0-DELETE": "",
+    }
+    response = client.post(
+        url,
+        data,
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+    assert response.status_code == 200
+    recipe = Recipe.objects.get(name="Roux Stock")
+    assert recipe.type == Recipe.Type.SUB
+    assert recipe.default_yield_unit == "GM"
 
 
 @pytest.mark.django_db

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -166,5 +166,5 @@ def test_recipe_metadata_fields():
 
     recipe = Recipe.objects.get(pk=rid)
     assert recipe.type == "FINAL"
-    assert recipe.default_yield_unit == "plate"
+    assert recipe.default_yield_unit == "portion"
     assert recipe.tags == ["vegan", "healthy"]


### PR DESCRIPTION
- RecipeForm: hidden default_yield_unit, SUB choices from FormService, clean() forces portion for FINAL
- recipe_service: normalize FINAL yield to portion on create/update
- Template: read-only Portion vs base-unit select; recipe-yield-unit.js + modal init
- Tests: drawer and service expectations, SUB validation cases

Made-with: Cursor

<!-- Please review our [Contribution Guidelines](../CONTRIBUTING.md) before submitting. -->

## Summary

-

## Testing

- [ ] `flake8`
- [ ] `pytest`
- [ ] Other:

## Checklist

- [ ] Documentation updated
- [ ] Tests added or updated
- [ ] Ready for review
