### PR TITLE
fix: food cost report and recipe costing use unit conversion

### DIFF
--- a/inventory/models/recipes.py
+++ b/inventory/models/recipes.py
@@ -76,10 +76,10 @@ class Recipe(models.Model):
                 if sub_yield:
                     total += (sub_cost / sub_yield) * qty * loss_mult
             elif recipe_item.item:
+                from inventory.services.units_service import UnitsService
+
                 item = recipe_item.item
-                price = Decimal(str(item.last_purchase_price or 0))
-                if not price:
-                    price = Decimal(str(item.initial_purchase_price or 0))
+                cost_per_base = UnitsService.cost_per_base_for_item(item)
                 qty = Decimal(str(recipe_item.quantity or 0))
                 loss_pct = Decimal(str(recipe_item.loss_pct or 0))
                 if qty and loss_pct and loss_pct < 100:
@@ -89,7 +89,7 @@ class Recipe(models.Model):
                         effective_qty = qty
                 else:
                     effective_qty = qty
-                total += price * effective_qty
+                total += cost_per_base * effective_qty
         return total
 
     @property
@@ -245,9 +245,9 @@ class RecipeItem(models.Model):
                 return (sub_cost / sub_yield) * qty * loss_mult
             return Decimal("0")
         if self.item:
-            price = Decimal(str(self.item.last_purchase_price or 0))
-            if not price:
-                price = Decimal(str(self.item.initial_purchase_price or 0))
+            from inventory.services.units_service import UnitsService
+
+            cost_per_base = UnitsService.cost_per_base_for_item(self.item)
             qty = Decimal(str(self.quantity or 0))
             loss_pct = Decimal(str(self.loss_pct or 0))
             if qty and loss_pct and loss_pct < 100:
@@ -257,7 +257,7 @@ class RecipeItem(models.Model):
                     effective_qty = qty
             else:
                 effective_qty = qty
-            return price * effective_qty
+            return cost_per_base * effective_qty
         return Decimal("0")
 
     def __str__(self):

--- a/inventory/services/units_service.py
+++ b/inventory/services/units_service.py
@@ -21,8 +21,9 @@ Usage:
 """
 
 import logging
+from decimal import Decimal
 from functools import lru_cache
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from inventory.models.unit import Unit
 
@@ -92,6 +93,30 @@ class UnitsService:
         """Get the base_unit for recipe calculations."""
         unit_info = UnitsService.get_unit_info(unit_id)
         return unit_info["base_unit"]
+
+    @staticmethod
+    def cost_per_base_for_item(item: Any) -> Decimal:
+        """Cost per base unit for recipe costing (purchase price / conversion_factor).
+
+        ``last_purchase_price`` / ``initial_purchase_price`` are per purchase_unit;
+        recipe line quantities are in base_unit.
+        """
+        last = Decimal(str(getattr(item, "last_purchase_price", None) or 0))
+        if not last:
+            last = Decimal(str(getattr(item, "initial_purchase_price", None) or 0))
+        unit_id = getattr(item, "unit_id", None)
+        if unit_id is None:
+            return last if last else Decimal("0")
+        unit_info = UnitsService.get_unit_info(unit_id)
+        conv = Decimal(str(unit_info.get("conversion_factor") or 1))
+        if conv <= 0:
+            conv = Decimal("1")
+        if not last:
+            return Decimal("0")
+        try:
+            return last / conv
+        except ArithmeticError:
+            return Decimal("0")
 
     @staticmethod
     def convert_purchase_to_base(quantity: float, unit_id: int) -> float:

--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -502,7 +502,7 @@ def item_meta(request, item_id: int):
     conv = float(uinfo.get("conversion_factor") or 1.0)
     price_source = item.last_purchase_price or item.initial_purchase_price or 0
     last_price = float(price_source or 0)
-    cost_per_base = (last_price / conv) if conv else 0.0
+    cost_per_base = float(UnitsService.cost_per_base_for_item(item))
     cat = getattr(item, "category", None)
     category = getattr(cat, "category", "")
     subcategory = getattr(cat, "sub_category", "")

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -646,9 +646,6 @@ class RecipeViewPartialView(View):
             subcategory = ""
             base_unit_display = ""
 
-            conversion = Decimal("1")
-            last_price = Decimal("0")
-
             if item:
                 category_obj = getattr(item, "category", None)
                 category = getattr(category_obj, "category", "") or ""
@@ -656,34 +653,21 @@ class RecipeViewPartialView(View):
                 unit_id = getattr(item, "unit_id", None)
                 if unit_id:
                     try:
-                        unit_info = UnitsService.get_unit_info(unit_id) or {}
+                        base_unit_display = (
+                            UnitsService.get_base_unit_display(unit_id) or ""
+                        )
                     except Exception:  # pragma: no cover - defensive
-                        unit_info = {}
-                    conversion = _to_decimal(unit_info.get("conversion_factor") or 1)
-                    if not conversion:
-                        conversion = Decimal("1")
-                    base_unit_display = (
-                        UnitsService.get_base_unit_display(unit_id) or ""
-                    )
-                last_price = _to_decimal(getattr(item, "last_purchase_price", None))
-                if not last_price:
-                    last_price = _to_decimal(
-                        getattr(item, "initial_purchase_price", None)
-                    )
+                        base_unit_display = ""
 
             if not unit_label:
                 unit_label = base_unit_display
 
-            cost_per_base = Decimal("0")
-            if conversion:
-                try:
-                    cost_per_base = last_price / conversion
-                except ArithmeticError:  # pragma: no cover - defensive
-                    cost_per_base = Decimal("0")
-
-            cost_per_base = (
-                cost_per_base.quantize(TWOPLACES) if cost_per_base else Decimal("0.00")
-            )
+            if item:
+                cost_per_base = UnitsService.cost_per_base_for_item(item).quantize(
+                    TWOPLACES
+                )
+            else:
+                cost_per_base = Decimal("0.00")
             # Apply loss %: effective_qty = qty / (1 - loss_pct/100)
             effective_qty = qty
             if qty and loss_pct and loss_pct < 100:

--- a/tests/test_recipe_total_cost_units.py
+++ b/tests/test_recipe_total_cost_units.py
@@ -1,0 +1,68 @@
+"""Recipe total cost must use purchase-unit price / conversion (same as recipe drawer)."""
+
+from decimal import Decimal
+
+import pytest
+
+from inventory.models import Item, Recipe, RecipeItem
+from inventory.services.units_service import UnitsService
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_total_cost_divides_by_conversion_factor():
+    """Unit 19 in test schema: KG purchase, GM base, factor 1000."""
+    UnitsService.get_unit_info.cache_clear()
+    item = Item.objects.create(
+        name="Flour Cost Test",
+        unit_id=19,
+        category_id=1,
+        reorder_point=0,
+        current_stock=0,
+        is_active=True,
+        last_purchase_price=Decimal("1000.00"),
+    )
+    recipe = Recipe.objects.create(
+        name="Recipe Cost Conversion Test",
+        is_active=True,
+        type=Recipe.Type.FINAL,
+    )
+    RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=Decimal("500"),
+        unit="GM",
+        loss_pct=Decimal("0"),
+    )
+    # 1000 per KG → 1 per GM → 500 GM → 500
+    assert recipe.get_total_cost() == Decimal("500")
+    row = RecipeItem.objects.get(recipe=recipe)
+    assert row.get_line_cost() == Decimal("500")
+
+
+def test_get_total_cost_conversion_factor_one():
+    """Unit 55: PC base, factor 1 — cost equals price × qty."""
+    UnitsService.get_unit_info.cache_clear()
+    item = Item.objects.create(
+        name="Bun Cost Test",
+        unit_id=55,
+        category_id=1,
+        reorder_point=0,
+        current_stock=0,
+        is_active=True,
+        last_purchase_price=Decimal("2.50"),
+    )
+    recipe = Recipe.objects.create(
+        name="Recipe PC Unit Cost Test",
+        is_active=True,
+        type=Recipe.Type.FINAL,
+    )
+    RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=Decimal("4"),
+        unit="PC",
+        loss_pct=Decimal("0"),
+    )
+    assert recipe.get_total_cost() == Decimal("10")
+    assert RecipeItem.objects.get(recipe=recipe).get_line_cost() == Decimal("10")


### PR DESCRIPTION
## Summary
Food Cost Report and \Recipe.get_total_cost()\ showed inflated ingredient totals whenever an item's purchase unit has a \conversion_factor\ other than 1 (e.g. price per KG with recipe quantities in grams). The recipe detail drawer already divided purchase price by the conversion factor; the model path did not.

## Changes
- Add \UnitsService.cost_per_base_for_item(item)\ for a single, Decimal-safe **cost per base unit**.
- Use it in \Recipe.get_total_cost()\ and \RecipeItem.get_line_cost()\ (lazy import to avoid circular imports).
- Refactor \RecipeViewPartialView\ and \item_meta\ to call the same helper so UI and reports stay aligned.
- Add \	ests/test_recipe_total_cost_units.py\ (conversion factor 1000 and factor 1).

## Notes
Selling price is still required for food cost % and margin on the report; this fix only corrects the ingredient cost column.

Also on this branch: prior commits cover recipe yield unit by type and related recipe UX (see branch history).