### PR TITLE
fix: scrollable drawers and Add Item pinned actions

### DIFF
--- a/static/src/app.css
+++ b/static/src/app.css
@@ -270,7 +270,7 @@ html.dark .bg-white\/40 {
 
   /* Drawer layout for modal.js openDrawer() wrapper */
   .drawer {
-    @apply flex flex-col max-h-[90vh] overflow-y-auto;
+    @apply flex min-h-0 flex-col max-h-[90vh] overflow-y-auto;
   }
   .drawer.right {
     @apply ml-auto;

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -139,7 +139,7 @@
           aria-label="Close modal"
         ></div>
         <div class="absolute inset-0 flex items-center justify-center p-4">
-          <div id="modal-content" class="max-w-7xl w-full max-h-[90vh] overflow-y-auto"></div>
+          <div id="modal-content" class="max-w-7xl w-full max-h-[90vh] min-h-0 overflow-y-auto"></div>
         </div>
       </div>
 

--- a/templates/inventory/_item_create_bare.html
+++ b/templates/inventory/_item_create_bare.html
@@ -1,13 +1,13 @@
 {% load form_tags %}
-<div class="bg-surface border border-border rounded-2xl shadow-overlay overflow-hidden drawer-panel max-w-drawer-xl">
-  <div class="px-4 py-3 border-b border-border bg-surfaceSubtle flex items-center justify-between">
+<div class="bg-surface border border-border rounded-2xl shadow-overlay overflow-hidden drawer-panel max-w-drawer-xl flex flex-col min-h-0 max-h-[90vh]">
+  <div class="shrink-0 px-4 py-3 border-b border-border bg-surfaceSubtle flex items-center justify-between">
     <h3 class="text-lg font-semibold text-bodyText">Add New Item</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
   </div>
-  <div class="p-4">
-    <form method="post" data-modal-form action="{% url 'items_list' %}">
-      {% csrf_token %}
-      <input type="hidden" name="partial" value="1"/>
+  <form method="post" data-modal-form action="{% url 'items_list' %}" class="flex flex-col flex-1 min-h-0">
+    {% csrf_token %}
+    <input type="hidden" name="partial" value="1"/>
+    <div class="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
       <div class="grid grid-cols-2 gap-3">
         <div>
           <label class="block text-sm font-medium text-bodyText mb-1">Name</label>
@@ -55,19 +55,19 @@
           <label class="block text-sm font-medium text-bodyText mb-1">Notes</label>
           {{ form.notes }}
         </div>
-        <div class="col-span-2 flex justify-between items-center gap-2">
-          <div>
-            <label class="inline-flex items-center gap-2 text-bodyText">
-              {{ form.is_active }}
-              <span>Active</span>
-            </label>
-          </div>
-          <div>
-            <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Cancel</button>
-            <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">Create</button>
-          </div>
-        </div>
       </div>
-    </form>
-  </div>
+    </div>
+    <div class="shrink-0 border-t border-border bg-surfaceSubtle px-4 py-3 flex justify-between items-center gap-2">
+      <div>
+        <label class="inline-flex items-center gap-2 text-bodyText">
+          {{ form.is_active }}
+          <span>Active</span>
+        </label>
+      </div>
+      <div class="flex flex-wrap gap-2 justify-end">
+        <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Cancel</button>
+        <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">Create</button>
+      </div>
+    </div>
+  </form>
 </div>

--- a/templates/inventory/_item_create_partial.html
+++ b/templates/inventory/_item_create_partial.html
@@ -1,14 +1,14 @@
 {% load form_tags %}
-<div class="bg-surface rounded-2xl shadow-card border border-border overflow-hidden drawer-panel max-w-drawer-xl">
-  <div class="px-4 py-3 border-b border-border bg-surfaceSubtle flex items-center justify-between">
+<div class="bg-surface rounded-2xl shadow-card border border-border overflow-hidden drawer-panel max-w-drawer-xl flex flex-col min-h-0 max-h-[90vh]">
+  <div class="shrink-0 px-4 py-3 border-b border-border bg-surfaceSubtle flex items-center justify-between">
     <h3 class="text-lg font-semibold text-bodyText">Add New Item</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
   </div>
-  <div class="p-4 space-y-4">
-    <p class="text-sm text-gray-600">Fill in catalogue details. Fields marked * are required.</p>
-    <form method="post" data-modal-form action="{% url 'items_list' %}">
-      {% csrf_token %}
-      <input type="hidden" name="partial" value="1"/>
+  <form method="post" data-modal-form action="{% url 'items_list' %}" class="flex flex-col flex-1 min-h-0">
+    {% csrf_token %}
+    <input type="hidden" name="partial" value="1"/>
+    <div class="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+      <p class="text-sm text-gray-600">Fill in catalogue details. Fields marked * are required.</p>
       <div class="grid grid-cols-2 gap-3">
         <div>
           <label for="{{ form.name.id_for_label }}" class="block text-sm font-medium text-bodyText mb-1">Name<span class="text-danger"> *</span></label>
@@ -67,20 +67,20 @@
           {{ form.notes|add_class:"block w-full px-3 py-2 border border-form-border rounded-md bg-form-bg focus:outline-none focus:ring-2 focus:ring-primary resize-y" }}
           {% include "forms/feedback.html" %}
         </div>
-        <div class="col-span-2 flex justify-between items-center gap-2">
-          <div>
-            <label for="{{ form.is_active.id_for_label }}" class="inline-flex items-center gap-2 text-bodyText">
-              {{ form.is_active }}
-              <span>Active</span>
-            </label>
-            {% include "forms/feedback.html" %}
-          </div>
-          <div>
-            <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" data-modal-close>Cancel</button>
-            <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Create</button>
-          </div>
-        </div>
       </div>
-    </form>
-  </div>
+    </div>
+    <div class="shrink-0 border-t border-border bg-surfaceSubtle px-4 py-3 flex justify-between items-center gap-2">
+      <div>
+        <label for="{{ form.is_active.id_for_label }}" class="inline-flex items-center gap-2 text-bodyText">
+          {{ form.is_active }}
+          <span>Active</span>
+        </label>
+        {% include "forms/feedback.html" %}
+      </div>
+      <div class="flex flex-wrap gap-2 justify-end">
+        <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" data-modal-close>Cancel</button>
+        <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Create</button>
+      </div>
+    </div>
+  </form>
 </div>

--- a/tests/test_items_list.py
+++ b/tests/test_items_list.py
@@ -156,10 +156,7 @@ def test_item_create_partial_departments_multiselect_container(client):
     resp = client.get(reverse("item_create_partial"))
     assert resp.status_code == 200
     soup = BeautifulSoup(resp.content, "html.parser")
-    root_div = soup.find(
-        "div",
-        class_="bg-white rounded-xl shadow border border-gray-200 overflow-hidden drawer-panel max-w-drawer-xl",
-    )
+    root_div = soup.select_one("div.drawer-panel.max-w-drawer-xl")
     assert root_div is not None
     container = soup.find("div", {"data-multiselect": "chips"})
     assert container is not None


### PR DESCRIPTION
## Summary
Long drawer content (especially Add New Item) could clip the bottom so Create was off-screen with no scrollbar. Fixes flexbox min-height behavior and improves the create-item layout.

## Changes
- `#modal-content` in `_base.html`: add `min-h-0` so the flex child can shrink and scrolling works.
- `.drawer` in `static/src/app.css`: add `min-h-0` for all drawer flows.
- Item create partials: flex column with fixed header/footer and scrollable middle.
- Test `test_item_create_partial_departments_multiselect_container` updated for current drawer-panel classes.

## Post-merge
Run `npm run build` to refresh compiled `static/css/app.css` (gitignored).
