### PR TITLE
fix: indent modal item suggestions and line-item layout

### DIFF
--- a/inventory/views/items/list.py
+++ b/inventory/views/items/list.py
@@ -6,6 +6,7 @@ from django.db import DatabaseError, IntegrityError
 from django.db.models import (
     BooleanField,
     Case,
+    Count,
     F,
     Prefetch,
     Q,
@@ -457,9 +458,19 @@ class ItemSearchView(TemplateView):
         if dep_raw:
             try:
                 if str(dep_raw).isdigit():
-                    qs = qs.filter(departments__department_id=int(dep_raw))
+                    dep_id = int(dep_raw)
+                    qs = (
+                        qs.annotate(_ndept=Count("departments", distinct=True))
+                        .filter(Q(_ndept=0) | Q(departments__department_id=dep_id))
+                        .distinct()
+                    )
                 else:
-                    qs = qs.filter(departments__name__iexact=str(dep_raw))
+                    name = str(dep_raw)
+                    qs = (
+                        qs.annotate(_ndept=Count("departments", distinct=True))
+                        .filter(Q(_ndept=0) | Q(departments__name__iexact=name))
+                        .distinct()
+                    )
             except Exception:
                 pass
         items = qs[:20]

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -50,6 +50,9 @@
     if (!skipInit) {
       // Defer heavy enhancements to next frame to keep first paint snappy
       requestAnimationFrame(() => {
+        if (window.htmx && typeof window.htmx.process === "function") {
+          window.htmx.process(content);
+        }
         if (window.initMultiselectChips) window.initMultiselectChips(content);
         // Initialize indent form first so it can mark inputs to opt out of overlays
         if (window.initIndentForm) window.initIndentForm(content);
@@ -75,6 +78,9 @@
     content.innerHTML = `<div class="drawer ${side} wide">${html}</div>`;
     if (!skipInit) {
       requestAnimationFrame(() => {
+        if (window.htmx && typeof window.htmx.process === "function") {
+          window.htmx.process(content);
+        }
         if (window.initMultiselectChips) window.initMultiselectChips(content);
         if (window.initIndentForm) window.initIndentForm(content);
         if (window.initPredictiveDropdowns)

--- a/static/js/predictive-datalist-overlay.js
+++ b/static/js/predictive-datalist-overlay.js
@@ -1,4 +1,23 @@
 (function () {
+  function invalidateItemSuggestCache() {
+    const dl = document.getElementById("item-options");
+    if (dl) dl.removeAttribute("data-last-suggest-key");
+  }
+
+  if (!window._itemSuggestDeptInvalidateBound) {
+    window._itemSuggestDeptInvalidateBound = true;
+    document.addEventListener("change", function (e) {
+      const t = e.target;
+      if (t && (t.id === "department-ui" || t.id === "id_department")) {
+        invalidateItemSuggestCache();
+      }
+    });
+    document.addEventListener("input", function (e) {
+      const t = e.target;
+      if (t && t.id === "department-ui") invalidateItemSuggestCache();
+    });
+  }
+
   function buildOverlay(input) {
     const overlayPref = (
       input.getAttribute("data-overlay") || ""
@@ -31,32 +50,34 @@
 
     let activeIndex = -1;
     async function render(filter) {
-      const q = (filter || "").toLowerCase();
+      const rawFilter = filter || "";
+      const q = rawFilter.toLowerCase();
       // If this input has an hx-get for suggestions, proactively refresh the datalist
       // Some environments don't reliably send the event to HTMX when typing inside
       // overlays; refreshing here guarantees options are current.
+      const depHidden = document.getElementById("id_department");
+      const depUI = document.getElementById("department-ui");
+      const depVal =
+        (depHidden && depHidden.value) || (depUI && depUI.value) || "";
       try {
         const suggestUrl =
           input.getAttribute("hx-get") ||
           input.getAttribute("data-suggest-url");
         if (suggestUrl) {
-          const lastQ = datalist.getAttribute("data-last-q") || "";
-          if (q !== lastQ) {
-            datalist.setAttribute("data-last-q", q);
+          const suggestKey = depVal + "\u001e" + q;
+          const lastKey = datalist.getAttribute("data-last-suggest-key");
+          if (lastKey !== suggestKey) {
             const url = new URL(suggestUrl, window.location.origin);
-            if (q) url.searchParams.set("q", q);
-            // Also include the field's name form for servers expecting *-item
-            if (input.name && q) url.searchParams.set(input.name, q);
-            const depHidden = document.getElementById("id_department");
-            const depUI = document.getElementById("department-ui");
-            const depVal =
-              (depHidden && depHidden.value) || (depUI && depUI.value) || "";
+            url.searchParams.set("q", rawFilter.trim());
+            if (input.name) url.searchParams.set(input.name, rawFilter.trim());
             if (depVal) url.searchParams.set("department", depVal);
-            const html = await fetch(url.toString(), {
+            const resp = await fetch(url.toString(), {
               headers: { "X-Requested-With": "fetch" },
-            }).then((r) => (r.ok ? r.text() : ""));
-            if (html) {
-              datalist.innerHTML = html;
+            });
+            if (resp.ok) {
+              const html = await resp.text();
+              datalist.innerHTML = html || "";
+              datalist.setAttribute("data-last-suggest-key", suggestKey);
             }
           }
         }
@@ -72,7 +93,8 @@
       activeIndex = -1;
       items.forEach((o, idx) => {
         const row = document.createElement("div");
-        row.className = "px-3 py-2 cursor-pointer hover:bg-blue-50";
+        row.className =
+          "px-3 py-2 cursor-pointer hover:bg-surfaceSubtle text-bodyText";
         const label = o.textContent || o.value || "";
         row.textContent = label;
         row.setAttribute("role", "option");
@@ -89,7 +111,14 @@
       if (items.length === 0) {
         const msg = document.createElement("div");
         msg.className = "px-3 py-2 text-gray-500";
-        msg.textContent = q ? "No matches" : "Type to search...";
+        const optCount = datalist.querySelectorAll("option").length;
+        if (optCount === 0) {
+          msg.textContent = depVal
+            ? "No items for this department. Try another department or type to search."
+            : "No items available.";
+        } else {
+          msg.textContent = q ? "No matches" : "Type to search…";
+        }
         overlay.appendChild(msg);
       }
     }
@@ -175,14 +204,14 @@
       if (e.key === "ArrowDown") {
         e.preventDefault();
         activeIndex = Math.min(activeIndex + 1, rows.length - 1);
-        rows.forEach((r) => r.classList.remove("bg-blue-50"));
-        rows[activeIndex].classList.add("bg-blue-50");
+        rows.forEach((r) => r.classList.remove("bg-surfaceSubtle"));
+        rows[activeIndex].classList.add("bg-surfaceSubtle");
         rows[activeIndex].scrollIntoView({ block: "nearest" });
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         activeIndex = Math.max(activeIndex - 1, 0);
-        rows.forEach((r) => r.classList.remove("bg-blue-50"));
-        rows[activeIndex].classList.add("bg-blue-50");
+        rows.forEach((r) => r.classList.remove("bg-surfaceSubtle"));
+        rows[activeIndex].classList.add("bg-surfaceSubtle");
         rows[activeIndex].scrollIntoView({ block: "nearest" });
       } else if (e.key === "Enter" && activeIndex >= 0) {
         e.preventDefault();

--- a/templates/components/responsive_table.html
+++ b/templates/components/responsive_table.html
@@ -9,7 +9,7 @@ and data hooks for sort and column toggles. Consumers can override blocks.
   data-table-key="{% if table_id %}{{ table_id }}{% elif container_id %}{{ container_id }}{% else %}{{ request.path|default:'default' }}{% endif %}">
   {% block actions %}{% endblock %}
   <div class="sr-only" aria-live="polite" data-table-announcer></div>
-  <table class="min-w-full w-full table-auto text-label"{% if table_id %} id="{{ table_id }}"{% endif %}>
+  <table class="{% block table_class %}min-w-full w-full table-auto text-label{% endblock %}"{% if table_id %} id="{{ table_id }}"{% endif %}>
     {% block caption %}<caption class="sr-only">List</caption>{% endblock %}
     {% block thead_class %}<thead class="text-left text-xs font-semibold uppercase tracking-wider bg-surfaceSubtle text-gray-600">{% endblock %}
       <tr>

--- a/templates/inventory/_indent_items_form_table.html
+++ b/templates/inventory/_indent_items_form_table.html
@@ -1,27 +1,62 @@
 {% extends "components/responsive_table.html" %}
+{% load form_tags %}
 
-{% block caption %}<caption>Indent Items</caption>{% endblock %}
+{% block caption %}
+<caption class="text-left text-sm font-semibold text-bodyText py-2 px-1 [caption-side:top]">Indent Items</caption>
+{% endblock %}
+
+{% block table_class %}min-w-full w-full table-fixed text-label{% endblock %}
 
 {% block headers %}
-  <th scope="col">Item</th>
-  <th scope="col">Qty</th>
-  <th scope="col">Notes</th>
-  <th scope="col"></th>
+  <th scope="col" class="w-[48%] min-w-[10rem] align-bottom pb-2">Item</th>
+  <th scope="col" class="w-[14%] min-w-[5rem] align-bottom pb-2">Qty</th>
+  <th scope="col" class="w-[30%] min-w-[6rem] align-bottom pb-2">Notes</th>
+  <th scope="col" class="w-12 align-bottom pb-2" aria-label="Actions"></th>
 {% endblock %}
 
 {% block rows %}
   {% for item_form in formset %}
-    <tr class="form-row" data-indent-table>
-      <td>
-        {% include "components/form_field.html" with field=item_form.item %}
+    <tr class="form-row align-top" data-indent-table>
+      <td class="align-top py-2 pr-2">
+        <div class="space-y-1">
+          <label for="{{ item_form.item.id_for_label }}" class="sr-only">{{ item_form.item.label }}</label>
+          {{ item_form.item|add_class:"h-9 text-sm w-full max-w-full" }}
+          {% if item_form.item.errors %}
+          <ul class="text-xs text-danger list-disc pl-4">
+            {% for error in item_form.item.errors %}<li>{{ error }}</li>{% endfor %}
+          </ul>
+          {% endif %}
+        </div>
         <div data-item-meta class="mt-1 text-xs text-gray-500"></div>
         <div data-item-error class="mt-1 text-xs text-danger hidden"></div>
       </td>
-    <td>{% include "components/form_field.html" with field=item_form.requested_qty %}</td>
-    <td>{% include "components/form_field.html" with field=item_form.notes %}</td>
-    <td><button type="button" class="remove-row p-1.5 text-gray-400 hover:text-danger rounded focus:outline-none focus:ring-2 focus:ring-danger transition" title="Remove row" aria-label="Remove row">
-      <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
-    </button></td>
-  </tr>
+      <td class="align-top py-2 pr-2">
+        <div class="space-y-1">
+          <label for="{{ item_form.requested_qty.id_for_label }}" class="sr-only">{{ item_form.requested_qty.label }}</label>
+          {{ item_form.requested_qty|add_class:"h-9 text-sm w-full max-w-full" }}
+          {% if item_form.requested_qty.errors %}
+          <ul class="text-xs text-danger list-disc pl-4">
+            {% for error in item_form.requested_qty.errors %}<li>{{ error }}</li>{% endfor %}
+          </ul>
+          {% endif %}
+        </div>
+      </td>
+      <td class="align-top py-2 pr-2">
+        <div class="space-y-1">
+          <label for="{{ item_form.notes.id_for_label }}" class="sr-only">{{ item_form.notes.label }}</label>
+          {{ item_form.notes|add_class:"h-9 text-sm w-full max-w-full" }}
+          {% if item_form.notes.errors %}
+          <ul class="text-xs text-danger list-disc pl-4">
+            {% for error in item_form.notes.errors %}<li>{{ error }}</li>{% endfor %}
+          </ul>
+          {% endif %}
+        </div>
+      </td>
+      <td class="align-top py-2 text-right">
+        <button type="button" class="remove-row p-1.5 text-gray-400 hover:text-danger rounded focus:outline-none focus:ring-2 focus:ring-danger transition" title="Remove row" aria-label="Remove row">
+          <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+        </button>
+      </td>
+    </tr>
   {% endfor %}
 {% endblock %}

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 
 from inventory.models import Item, StockTransaction
+from inventory.models.departments import Department
 from inventory.services import item_service
 
 pytestmark = pytest.mark.django_db
@@ -203,3 +204,17 @@ def test_toggle_item_post(client):
     assert resp.status_code == 200
     item.refresh_from_db()
     assert item.is_active is True
+
+
+def test_item_search_includes_unassigned_when_department_filter(client):
+    """Department-scoped search still lists items with no department (indent UX)."""
+    dept = Department.objects.create(name="Kitchen SearchDept")
+    _create_item(name="Sugar Universal")
+    assigned = _create_item(name="Sugar Kitchen Only")
+    assigned.departments.add(dept)
+    url = reverse("item_search")
+    resp = client.get(url, {"q": "Sugar", "department": str(dept.department_id)})
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    assert "Sugar Universal" in content
+    assert "Sugar Kitchen Only" in content


### PR DESCRIPTION
## Summary
Implements the indent modal UX plan: reliable item suggestions in the drawer, department-aware search, HTMX registration for injected partials, and cleaner line-item table layout.

## Changes
- **predictive-datalist-overlay.js**: Composite cache key (department + query), fetch on first focus with explicit \q\, invalidate cache on department UI changes, improved empty-state copy, theme tokens for hover/keyboard highlight (\surfaceSubtle\).
- **ItemSearchView**: When filtering by department, include items with **no** department assignment (Count-based filter + distinct).
- **modal.js**: Call \htmx.process(content)\ after modal/drawer HTML injection.
- **\_indent_items_form_table.html**: \sr-only\ labels, \	able-fixed\ column widths, consistent \h-9\ inputs; caption styling.
- **responsive_table.html**: Optional \	able_class\ block for consumers.
- **test_item_views.py**: \	est_item_search_includes_unassigned_when_department_filter\.

## Target branch
\eature/django-refactor\ (per project workflow).

Made with [Cursor](https://cursor.com)