### PR TITLE
feat: modal validation UX, PO save service, and drawer migration docs

### DIFF
--- a/.claude/skills/fix-prompt-generator/references/example-prompt.md
+++ b/.claude/skills/fix-prompt-generator/references/example-prompt.md
@@ -16,7 +16,7 @@ This is a real example of a well-structured fix prompt generated for a Django in
 After all three fixes:
 1. Manual PO creation saves a PO and returns `{"ok": true}`
 2. Consolidation Planner → Confirm & Create → redirects to `/purchase-orders/` with new POs listed
-3. Quick PO button opens a drawer (or is hidden if the view doesn't exist)
+3. **New Purchase Order** (drawer) opens, saves, and returns `{"ok": true}` when valid
 
 ## Forbidden Actions
 
@@ -76,16 +76,16 @@ Set `line_total = quantity * unit_price` before saving each PO item.
 ✅ Fix 2 applied: line_total auto-computed in model save() and view
 ```
 
-## Fix 3 of 3 — Quick PO button does nothing
+## Fix 3 of 3 — PO create drawer does not save (JS / JSON)
 
 ### Steps
-1. Check if URL exists: `grep -rn "quick.create" --include="*.py"`
-2. If no URL → hide the button (safest)
-3. If URL exists → debug the JS handler (check event delegation)
+1. Confirm partial URL and `data-modal-form` wiring: `purchase_order_create_partial`
+2. Ensure POST returns JSON for `X-Requested-With: XMLHttpRequest` and `partial=1`
+3. If validation fails, return 400 with structured `errors` for the modal list
 
 ### Checkpoint Output
 ```
-✅ Fix 3 applied: Quick PO button [hidden/fixed]
+✅ Fix 3 applied: PO create drawer saves and surfaces field errors in the modal
 ```
 
 ## Final Verification

--- a/docs/CRUD_POST_SUBMIT_AUDIT.md
+++ b/docs/CRUD_POST_SUBMIT_AUDIT.md
@@ -29,7 +29,6 @@ All primary nav targets from `NAVIGATION_GROUPS` resolve to names in `ui_urls.py
 | Stock | Adjust / waste / transfer modals | `stock_movements` | FullPageForm | Redirect + `?section=...` on errors; PRG flash | Same pattern |
 | Stock | Bulk CSV modal | `stock_movements` | FullPageForm | Posts to same view | `_stock_bulk_modal.html` |
 | PO | Create / edit drawer | `purchase_order_create_partial`, `purchase_order_edit_partial` | Drawer JSON | JSON | `data-requires-line-items` |
-| PO | Quick create | `purchase_order_quick_create_partial` | Drawer JSON | JSON | — |
 | PO | Receive drawer | `purchase_order_receive_partial` | Drawer JSON | JSON `redirect` → PO detail | `data-modal-form` |
 | PO | Mark ordered | `purchase_order_mark_ordered` | FullPageForm | Redirect detail | Full page on PO detail |
 | Indents | Create drawer | `indent_create` `?partial=1` | Drawer JSON | JSON | — |
@@ -48,7 +47,9 @@ All primary nav targets from `NAVIGATION_GROUPS` resolve to names in `ui_urls.py
 ## Pattern grep — `data-modal-form` coverage
 
 Templates **with** `data-modal-form` (drawer JSON path):  
-`recipes/_form_partial.html`, `purchase_orders/_receive_partial.html`, `purchase_orders/_form_partial.html`, `purchase_orders/_quick_form_partial.html`, `_supplier_form_partial.html`, `_item_create_partial.html`, `_item_form_partial.html`, `_indent_create_partial.html`, `_bulk_upload_partial.html`, `_indent_detail_partial.html` (main update form only), `_item_create_bare.html`.
+`recipes/_form_partial.html`, `purchase_orders/_receive_partial.html`, `purchase_orders/_form_partial.html`, `_supplier_form_partial.html`, `_item_create_partial.html`, `_item_form_partial.html`, `_indent_create_partial.html`, `_bulk_upload_partial.html`, `_indent_detail_partial.html` (main update form only), `_item_create_bare.html`.
+
+See [drawer_modal_htmx_migration.md](drawer_modal_htmx_migration.md) for a full inventory and HTMX migration notes.
 
 **Native modals on stock** (`action=""`, no `data-modal-form`):  
 `_receive_form_modal.html`, `_adjust_form_modal.html`, `_waste_form_modal.html` — rely on current page URL being `/stock-movements/`.

--- a/docs/drawer_modal_htmx_migration.md
+++ b/docs/drawer_modal_htmx_migration.md
@@ -1,0 +1,46 @@
+# Drawer (`data-modal-form`) inventory and HTMX follow-ups
+
+## Todo 7 — Inventory: `data-modal-form` endpoints (complete list)
+
+Forms intercepted by `static/js/modal.js` (`fetch` POST, `partial=1`, JSON success; structured `errors` on 400 from `build_form_error_payload` where implemented).
+
+| Template | POST action (URL name / pattern) | Notes |
+|----------|----------------------------------|--------|
+| `inventory/purchase_orders/_form_partial.html` | `purchase_order_create_partial`, `purchase_order_edit_partial` | `data-formset-prefix`; `initPurchaseOrderDrawer` |
+| `inventory/purchase_orders/_receive_partial.html` | `purchase_order_receive_partial` | `multipart/form-data`; line qty validation |
+| `inventory/recipes/_form_partial.html` | `recipe_create_partial`, `recipe_edit_partial` | `data-formset-prefix`; `initRecipeComponentsTable` |
+| `inventory/_supplier_form_partial.html` | `supplier_create`, `supplier_edit` | `?partial=1` |
+| `inventory/_item_form_partial.html` | `item_edit` | `?partial=1` |
+| `inventory/_item_create_partial.html` | `items_list` | Item create drawer |
+| `inventory/_item_create_bare.html` | `items_list` | Bare / inline create |
+| `inventory/_indent_create_partial.html` | `indent_create` | `initIndentForm`, line items |
+| `inventory/_indent_detail_partial.html` | `indent_update` | Edit indent in drawer |
+| `inventory/_bulk_upload_partial.html` | `{{ upload_url }}`, `upload_csv?partial=1` | Two forms; multipart |
+
+**Client hub:** `static/js/modal.js` — delegated `submit` on `[data-modal-form]`; summary + per-field highlights for `errors` matching `build_form_error_payload`.
+
+**Init hooks after `innerHTML` (drawer open):** `initIndentForm`, `initRecipeComponentsTable`, `initRecipeYieldUnitRoots`, `initPurchaseOrderDrawer`, predictive dropdowns, multiselect chips, `htmx.process`.
+
+## Todo 7 — Migration strategy (HTMX)
+
+1. Do **not** migrate a single flow in isolation; pick a **cluster** (e.g. PO create/edit + receive, or items + suppliers).
+2. Target pattern: `hx-post` on the form, `hx-target` / `hx-swap` for error HTML, `HX-Redirect` or `HX-Trigger` on success; move behaviors to `htmx:afterSwap` initializers instead of inline `<script>` in partials.
+3. Until migration, keep **one JSON error shape** (`build_form_error_payload` and friends) for remaining `modal.js` forms.
+
+## Quick PO (removed)
+
+Single entry: **New Purchase Order** drawer (`purchase_order_create_partial`). List helper describes supplier, dates, and line items.
+
+## Todo 8 — PO service symmetry
+
+- **Single valid path:** `purchase_order_service.save_purchase_order_from_forms(form, formset)` — create delegates to `create_po`; update uses `form.save()` + `formset.save()` (stable line PKs for GRNs / indents).
+- **Direct `create_po`** remains for programmatic callers (e.g. indent consolidation, tests, goods receiving fixtures).
+
+## Todo 9 — Backlog (explicit out of scope for PO drawer work)
+
+Track as separate tickets when prioritized:
+
+- **PO Receive / GRN / consolidation:** Align validation JSON or HTMX with the same patterns as PO create where it reduces user confusion.
+- **Schema:** New `PurchaseOrder` / `PurchaseOrderItem` migrations only when product requires them.
+- **Full-page PO form:** Further deduplication with drawer partial (shared includes for lines where practical).
+- **E2E:** Playwright (or similar) smoke for drawer open → add line → save, if CI budget allows.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -30,7 +30,7 @@ flowchart LR
    - If no eligible items remain, an info toast explains why.
 
 4. **Generate Purchase Orders** (`/purchase-orders/`)
-   - Quick create drawer and list hero highlight outstanding receipts (orders in `ORDERED`/`PARTIAL`).
+   - New Purchase Order drawer (supplier, dates, line items) and list hero highlight outstanding receipts (orders in `ORDERED`/`PARTIAL`).
    - Detail hero chips show supplier, order dates, and provide CTA for receiving goods.
 
 5. **Receive Goods (GRN)** (`/purchase-orders/<id>/receive/` or `/grns/`)

--- a/inventory/forms/purchase_forms.py
+++ b/inventory/forms/purchase_forms.py
@@ -1,3 +1,4 @@
+import re
 from decimal import Decimal
 
 from django import forms
@@ -11,6 +12,40 @@ from ..models import (
     Supplier,
 )
 from .base import INPUT_CLASS, StyledFormMixin
+
+
+def _resolve_supplier_from_raw(raw: str) -> Supplier:
+    """Map typed datalist / POST value to a Supplier (active only)."""
+    raw = str(raw or "").strip()
+    if not raw:
+        raise forms.ValidationError("Choose a valid supplier from the list.")
+
+    qs = Supplier.objects.filter(is_active=True)
+
+    m = re.match(r"^(\d+)\s*[-–]\s*(.+)$", raw)
+    if m:
+        found = qs.filter(pk=int(m.group(1))).first()
+        if found:
+            return found
+
+    if raw.isdigit():
+        found = qs.filter(pk=int(raw)).first()
+        if found:
+            return found
+
+    exact = qs.filter(name__iexact=raw).first()
+    if exact:
+        return exact
+
+    candidates = list(qs.filter(name__istartswith=raw)[:2])
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        raise forms.ValidationError(
+            "Multiple suppliers match. Please choose from the list."
+        )
+
+    raise forms.ValidationError("Choose a valid supplier from the list.")
 
 
 class PurchaseOrderForm(StyledFormMixin, forms.ModelForm):
@@ -48,7 +83,40 @@ class PurchaseOrderForm(StyledFormMixin, forms.ModelForm):
                 status_field.choices = filtered
         except Exception:
             pass
+        if supplier_suggest_url:
+            supplier_label = self.fields["supplier"].label
+            self.fields["supplier"] = forms.CharField(
+                label=supplier_label,
+                required=True,
+                widget=forms.TextInput(
+                    attrs={
+                        "data-predictive-input": "1",
+                        "autocomplete": "off",
+                        "autocapitalize": "none",
+                        "autocorrect": "off",
+                        "spellcheck": "false",
+                        "placeholder": "Type to search suppliers...",
+                        "hx-get": supplier_suggest_url,
+                        "hx-trigger": "keyup changed delay:300ms",
+                        "hx-target": "#supplier-options",
+                        "hx-swap": "innerHTML",
+                        "list": "supplier-options",
+                    }
+                ),
+            )
+            if getattr(self.instance, "pk", None) and getattr(
+                self.instance, "supplier_id", None
+            ):
+                try:
+                    self.initial["supplier"] = self.instance.supplier.name
+                except Supplier.DoesNotExist:
+                    pass
         self.apply_styling()
+
+    def clean_supplier(self):
+        if not isinstance(self.fields["supplier"], forms.CharField):
+            return self.cleaned_data.get("supplier")
+        return _resolve_supplier_from_raw(self.cleaned_data.get("supplier", ""))
 
 
 class PurchaseOrderItemForm(StyledFormMixin, forms.ModelForm):

--- a/inventory/services/purchase_order_service.py
+++ b/inventory/services/purchase_order_service.py
@@ -5,16 +5,65 @@ from typing import Any, Dict, List, Optional
 from django.db import IntegrityError, transaction
 from django.db.models import Max, Sum
 
+from inventory.forms.purchase_forms import PurchaseOrderForm, PurchaseOrderItemFormSet
 from inventory.models import Item, PurchaseOrder, PurchaseOrderItem, Supplier
 
 from .exceptions import PurchaseOrderServiceError
 
 logger = logging.getLogger(__name__)
 
+# Create uses ``create_po``; update uses ``ModelForm`` + formset save (stable line PKs).
+# ``save_purchase_order_from_forms`` is the single entry point once forms are valid.
+
 
 def generate_po_number() -> str:
     next_id = (PurchaseOrder.objects.aggregate(m=Max("po_id"))["m"] or 0) + 1
     return f"PO-{next_id:04d}"
+
+
+def _po_header_dict_from_cleaned_form(form: PurchaseOrderForm) -> Dict[str, Any]:
+    """Header fields for ``create_po`` (form must be valid)."""
+
+    return {
+        "supplier_id": form.cleaned_data["supplier"].pk,
+        "order_date": form.cleaned_data["order_date"],
+        "expected_delivery_date": form.cleaned_data.get("expected_delivery_date"),
+        "status": form.cleaned_data.get("status"),
+        "notes": form.cleaned_data.get("notes"),
+    }
+
+
+def _po_line_items_from_formset_cleaned(cleaned_rows: list) -> List[Dict[str, Any]]:
+    """Line payloads for ``create_po`` from a validated ``PurchaseOrderItemFormSet``."""
+
+    items_data: List[Dict[str, Any]] = []
+    for row in cleaned_rows:
+        if row and not row.get("DELETE", False):
+            items_data.append(
+                {
+                    "item_id": row["item"].pk,
+                    "quantity_ordered": row["quantity_ordered"],
+                    "unit_price": row["unit_price"],
+                }
+            )
+    return items_data
+
+
+def save_purchase_order_from_forms(
+    form: PurchaseOrderForm,
+    formset: PurchaseOrderItemFormSet,
+) -> PurchaseOrder:
+    """Persist header and lines. Call only when ``form`` and ``formset`` are valid."""
+
+    if form.instance.pk:
+        po = form.save()
+        formset.save()
+        return po
+
+    po_data = _po_header_dict_from_cleaned_form(form)
+    items_data = _po_line_items_from_formset_cleaned(formset.cleaned_data)
+    po_id = create_po(po_data, items_data)
+    return PurchaseOrder.objects.get(pk=po_id)
 
 
 def create_po(po_data: Dict[str, Any], items_data: List[Dict[str, Any]]) -> int:

--- a/inventory/views/purchase_orders.py
+++ b/inventory/views/purchase_orders.py
@@ -417,34 +417,17 @@ class PurchaseOrderCreatePartialView(View):
         form = PurchaseOrderForm(request.POST, supplier_suggest_url=supplier_url)
         formset = PurchaseOrderItemFormSet(request.POST, prefix="items")
         if form.is_valid() and formset.is_valid():
-            po_data: dict[str, Any] = {
-                "supplier_id": form.cleaned_data["supplier"].pk,
-                "order_date": form.cleaned_data["order_date"],
-                "expected_delivery_date": form.cleaned_data.get(
-                    "expected_delivery_date"
-                ),
-                "status": form.cleaned_data.get("status"),
-                "notes": form.cleaned_data.get("notes"),
-            }
-            items_data: list[dict[str, Any]] = []
-            for item_form in formset.cleaned_data:
-                if item_form and not item_form.get("DELETE", False):
-                    items_data.append(
-                        {
-                            "item_id": item_form["item"].pk,
-                            "quantity_ordered": item_form["quantity_ordered"],
-                            "unit_price": item_form["unit_price"],
-                        }
-                    )
             try:
-                po_id = purchase_order_service.create_po(po_data, items_data)
+                po = purchase_order_service.save_purchase_order_from_forms(
+                    form, formset
+                )
                 return JsonResponse(
                     {
                         "ok": True,
-                        "id": po_id,
+                        "id": po.pk,
                         "message": "Purchase order created",
                         "redirect": reverse(
-                            "purchase_order_detail", kwargs={"pk": po_id}
+                            "purchase_order_detail", kwargs={"pk": po.pk}
                         ),
                     }
                 )
@@ -467,27 +450,8 @@ def purchase_order_create(request):
         form = PurchaseOrderForm(request.POST, supplier_suggest_url=supplier_url)
         formset = PurchaseOrderItemFormSet(request.POST, prefix="items")
         if form.is_valid() and formset.is_valid():
-            po_data = {
-                "supplier_id": form.cleaned_data["supplier"].pk,
-                "order_date": form.cleaned_data["order_date"],
-                "expected_delivery_date": form.cleaned_data.get(
-                    "expected_delivery_date"
-                ),
-                "status": form.cleaned_data.get("status"),
-                "notes": form.cleaned_data.get("notes"),
-            }
-            items_data: list[dict[str, Any]] = []
-            for item_form in formset.cleaned_data:
-                if item_form and not item_form.get("DELETE", False):
-                    items_data.append(
-                        {
-                            "item_id": item_form["item"].pk,
-                            "quantity_ordered": item_form["quantity_ordered"],
-                            "unit_price": item_form["unit_price"],
-                        }
-                    )
             try:
-                purchase_order_service.create_po(po_data, items_data)
+                purchase_order_service.save_purchase_order_from_forms(form, formset)
                 return redirect("purchase_orders_list")
             except PurchaseOrderServiceError as exc:
                 messages.error(request, str(exc), extra_tags="toast")
@@ -515,8 +479,7 @@ def purchase_order_edit(request, pk: int):
         )
         formset = PurchaseOrderItemFormSet(request.POST, instance=po, prefix="items")
         if form.is_valid() and formset.is_valid():
-            form.save()
-            formset.save()
+            purchase_order_service.save_purchase_order_from_forms(form, formset)
             return redirect("purchase_order_detail", pk=pk)
     else:
         form = PurchaseOrderForm(instance=po, supplier_suggest_url=supplier_url)
@@ -564,8 +527,7 @@ class PurchaseOrderEditPartialView(View):
         )
         formset = PurchaseOrderItemFormSet(request.POST, instance=po, prefix="items")
         if form.is_valid() and formset.is_valid():
-            form.save()
-            formset.save()
+            purchase_order_service.save_purchase_order_from_forms(form, formset)
             return JsonResponse(
                 {
                     "ok": True,

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -545,6 +545,82 @@
     if (!form.hasAttribute("data-modal-form")) return;
     e.preventDefault();
     try {
+      const cssEscape = (s) => {
+        try {
+          return window.CSS && window.CSS.escape
+            ? window.CSS.escape(String(s))
+            : String(s);
+        } catch (_) {
+          return String(s);
+        }
+      };
+      const clearModalStructuredErrors = (formRoot) => {
+        formRoot.querySelectorAll("[data-modal-field-error]").forEach((el) => {
+          el.remove();
+        });
+        formRoot.querySelectorAll("[data-modal-invalid-outline]").forEach((el) => {
+          el.classList.remove("ring-2", "ring-red-400", "border-red-400");
+          el.removeAttribute("data-modal-invalid-outline");
+        });
+      };
+      /** Map ``build_form_error_payload``-shaped errors onto Django widget ids; return first control for focus. */
+      const applyStructuredFieldErrors = (formRoot, errors) => {
+        if (!errors || typeof errors !== "object") return null;
+        const prefix = formRoot.getAttribute("data-formset-prefix") || "items";
+        let firstEl = null;
+        const markFirst = (el) => {
+          if (el instanceof HTMLElement && !firstEl) firstEl = el;
+        };
+        const attachMsg = (control, messages) => {
+          if (!(control instanceof HTMLElement) || !messages || !messages.length)
+            return;
+          const box = document.createElement("div");
+          box.setAttribute("data-modal-field-error", "");
+          box.className = "text-sm text-red-600 mt-1 space-y-0.5";
+          messages.forEach((m) => {
+            const p = document.createElement("p");
+            p.textContent = m;
+            box.appendChild(p);
+          });
+          control.insertAdjacentElement("afterend", box);
+          control.classList.add("ring-2", "ring-red-400", "border-red-400");
+          control.setAttribute("data-modal-invalid-outline", "");
+          markFirst(control);
+        };
+        const findByIdOrName = (id, name) => {
+          const byId = id ? formRoot.querySelector(`#${cssEscape(id)}`) : null;
+          if (byId) return byId;
+          if (name)
+            return formRoot.querySelector(`[name="${cssEscape(name)}"]`);
+          return null;
+        };
+        if (errors.form && typeof errors.form === "object") {
+          Object.keys(errors.form).forEach((fieldName) => {
+            const msgs = errors.form[fieldName];
+            if (!Array.isArray(msgs) || !msgs.length) return;
+            const id = `id_${fieldName}`;
+            const el = findByIdOrName(id, fieldName);
+            if (el) attachMsg(el, msgs);
+          });
+        }
+        if (Array.isArray(errors.formset)) {
+          errors.formset.forEach((row) => {
+            if (!row || typeof row !== "object" || !row.errors) return;
+            const idx = row.index;
+            if (!Number.isInteger(idx)) return;
+            Object.keys(row.errors).forEach((fieldName) => {
+              const msgs = row.errors[fieldName];
+              if (!Array.isArray(msgs) || !msgs.length) return;
+              const id = `id_${prefix}-${idx}-${fieldName}`;
+              const name = `${prefix}-${idx}-${fieldName}`;
+              const el = findByIdOrName(id, name);
+              if (el) attachMsg(el, msgs);
+            });
+          });
+        }
+        return firstEl;
+      };
+      clearModalStructuredErrors(form);
       // Pre-submit guard: sync department hidden field from UI select if present
       try {
         const hiddenDept = form.querySelector("#id_department");
@@ -601,14 +677,19 @@
       };
       const showInlineError = (msg, detail) => {
         try {
+          clearModalStructuredErrors(form);
           let alert = form.querySelector("[data-modal-error]");
           if (!alert) {
             alert = document.createElement("div");
             alert.setAttribute("data-modal-error", "");
-            alert.className =
-              "mb-3 px-3 py-2 rounded-md border border-red-200 bg-red-50 text-red-700 text-sm";
             form.insertBefore(alert, form.firstElementChild);
           }
+          alert.setAttribute("role", "alert");
+          alert.setAttribute("aria-live", "assertive");
+          alert.setAttribute("aria-atomic", "true");
+          alert.setAttribute("tabindex", "-1");
+          alert.className =
+            "mb-3 px-3 py-2 rounded-md border border-red-200 bg-red-50 text-red-700 text-sm outline-none focus:ring-2 focus:ring-red-300";
           alert.replaceChildren();
           const lead = document.createElement("div");
           lead.textContent = msg;
@@ -618,17 +699,16 @@
               ? formatStructuredErrors(detail.errors)
               : null;
           if (extra) alert.appendChild(extra);
-          alert.scrollIntoView({ behavior: "smooth", block: "center" });
+          const firstBad = applyStructuredFieldErrors(
+            form,
+            detail && detail.errors,
+          );
+          const focusTarget = firstBad || alert;
+          focusTarget.scrollIntoView({ behavior: "smooth", block: "center" });
+          try {
+            focusTarget.focus({ preventScroll: true });
+          } catch (_) {}
         } catch (_) {}
-      };
-      const cssEscape = (s) => {
-        try {
-          return window.CSS && window.CSS.escape
-            ? window.CSS.escape(String(s))
-            : String(s);
-        } catch (_) {
-          return String(s);
-        }
       };
       const hiddenDept = form.querySelector("#id_department");
       const uiDept = form.querySelector("#department-ui");
@@ -832,11 +912,18 @@
           form.querySelector("[data-modal-error]") ||
           document.createElement("div");
         alert.setAttribute("data-modal-error", "");
+        alert.setAttribute("role", "alert");
+        alert.setAttribute("aria-live", "assertive");
+        alert.setAttribute("aria-atomic", "true");
+        alert.setAttribute("tabindex", "-1");
         alert.className =
-          "mb-3 px-3 py-2 rounded-md border border-red-200 bg-red-50 text-red-700 text-sm";
+          "mb-3 px-3 py-2 rounded-md border border-red-200 bg-red-50 text-red-700 text-sm outline-none focus:ring-2 focus:ring-red-300";
         alert.textContent = msg;
         if (!alert.parentElement)
           form.insertBefore(alert, form.firstElementChild);
+        try {
+          alert.focus({ preventScroll: true });
+        } catch (_) {}
       } catch (_) {}
       if (window.console) console.error("[modal] fatal submit error", fatal);
       if (window.notifications) window.notifications.showToast(msg, "error");

--- a/templates/inventory/recipes/_form_partial.html
+++ b/templates/inventory/recipes/_form_partial.html
@@ -1,6 +1,6 @@
 {% load form_tags %}
 <div class="bg-surface rounded-2xl shadow-card border border-border drawer-panel max-w-drawer-xl">
-  <form method="post" data-modal-form data-requires-line-items action="{% if is_edit and recipe %}{% url 'recipe_edit_partial' recipe.pk %}{% else %}{% url 'recipe_create_partial' %}{% endif %}">
+  <form method="post" data-modal-form data-formset-prefix="{{ formset.prefix }}" data-requires-line-items action="{% if is_edit and recipe %}{% url 'recipe_edit_partial' recipe.pk %}{% else %}{% url 'recipe_create_partial' %}{% endif %}">
     {% csrf_token %}
     <div class="px-4 py-3 border-b border-border bg-surfaceSubtle">
       <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/tests/test_purchase_order_drawer_partial.py
+++ b/tests/test_purchase_order_drawer_partial.py
@@ -33,6 +33,8 @@ def test_purchase_order_create_partial_get_has_drawer_hooks(po_staff_client):
     assert 'id="po-item-prices"' in content
     assert 'type="application/json"' in content
     assert 'id="items-formset"' in content
+    assert "supplier-options" in content
+    assert "hx-get" in content
 
 
 def test_purchase_order_create_partial_post_validation_returns_json(po_staff_client):

--- a/tests/test_purchase_order_service_django.py
+++ b/tests/test_purchase_order_service_django.py
@@ -2,6 +2,7 @@ from datetime import date
 
 import pytest
 
+from inventory.forms.purchase_forms import PurchaseOrderForm, PurchaseOrderItemFormSet
 from inventory.models import (
     GoodsReceivedNote,
     GRNItem,
@@ -10,6 +11,39 @@ from inventory.models import (
     Supplier,
 )
 from inventory.services import purchase_order_service
+
+
+@pytest.mark.django_db
+def test_save_purchase_order_from_forms_creates(item_factory):
+    supplier = Supplier.objects.create(name="Vendor", is_active=True)
+    item = item_factory(name="Widget")
+    form = PurchaseOrderForm(
+        {
+            "supplier": str(supplier.pk),
+            "order_date": str(date.today()),
+            "expected_delivery_date": "",
+            "status": "DRAFT",
+            "notes": "",
+        }
+    )
+    formset = PurchaseOrderItemFormSet(
+        {
+            "items-TOTAL_FORMS": "1",
+            "items-INITIAL_FORMS": "0",
+            "items-MIN_NUM_FORMS": "0",
+            "items-MAX_NUM_FORMS": "1000",
+            "items-0-item": str(item.pk),
+            "items-0-quantity_ordered": "2",
+            "items-0-unit_price": "3.00",
+        },
+        prefix="items",
+    )
+    assert form.is_valid(), form.errors
+    assert formset.is_valid(), formset.errors
+    po = purchase_order_service.save_purchase_order_from_forms(form, formset)
+    assert po.pk
+    assert po.supplier_id == supplier.pk
+    assert po.purchaseorderitem_set.count() == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- **Modal forms:** On failed JSON saves, modal.js now clears prior hints, shows the server summary, maps uild_form_error_payload-shaped errors to Django field ids (using data-formset-prefix where set), and focuses the first invalid control. Error toasts are unchanged for failed saves.
- **Purchase orders:** Introduces save_purchase_order_from_forms in purchase_order_service (create delegates to create_po; update uses form + formset save). Drawer and full-page create/edit call this single entry point after validation.
- **PO form:** Supplier typeahead path via PurchaseOrderForm CharField + clean_supplier resolution (aligned with drawer usage).
- **Recipes:** Recipe drawer form exposes data-formset-prefix for correct formset error mapping.
- **Docs:** Adds docs/drawer_modal_htmx_migration.md (full data-modal-form inventory, HTMX strategy, backlog). Updates workflow handbook and related audit/skill references.

## Testing
- pytest tests/test_purchase_order_service_django.py tests/test_purchase_order_drawer_partial.py (6 passed).

Targets **feature/django-refactor** per project convention.

Made with [Cursor](https://cursor.com)