### PR TITLE
fix: make indents.department_id nullable in the database

### DIFF
--- a/inventory/migrations/0039_indent_department_nullable.py
+++ b/inventory/migrations/0039_indent_department_nullable.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """
+    Make indents.department_id nullable in the actual database.
+
+    Migration 0016 used SeparateDatabaseAndState with empty database_operations,
+    meaning it only updated Django's model state but never ran the DDL. The real
+    PostgreSQL column was left as NOT NULL (its original schema definition),
+    causing an IntegrityError whenever an indent is created without a department
+    (e.g. the auto-generated low-stock indent).
+    """
+
+    dependencies = [
+        ("inventory", "0038_add_performance_indexes"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="ALTER TABLE indents ALTER COLUMN department_id DROP NOT NULL;",
+            reverse_sql="ALTER TABLE indents ALTER COLUMN department_id SET NOT NULL;",
+        ),
+    ]


### PR DESCRIPTION
## Root Cause

Querying the live Supabase database revealed that `indents.department_id` is `NOT NULL` with no default — but every other indent creation path (including the low-stock auto-indent) omits `department_id`.

Migration `0016_indent_department_fk` used `SeparateDatabaseAndState` with **empty `database_operations`**, meaning it only updated Django's in-memory model state but never ran any DDL. The real PostgreSQL column stayed `NOT NULL` from the original schema.

Result: `Indent.objects.create(...)` without a department throws an `IntegrityError` → caught by the new try-except → shows "Could not create indent" toast.

## Fix

Migration `0039` runs:
```sql
ALTER TABLE indents ALTER COLUMN department_id DROP NOT NULL;
```

This aligns the database with the Django model (`null=True, blank=True`) that was always the intended state.

## Test plan

- [ ] All 4 low-stock indent tests pass (`pytest tests/test_low_stock_indent_flow.py`)
- [ ] On deploy: "Create Indent" button works and redirects to the new SUBMITTED indent detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)