### PR TITLE
fix: pass issued_qty=0 when creating IndentItem records

### DIFF
--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -1211,6 +1211,7 @@ def generate_low_stock_indent(request):
                         indent=indent,
                         item_id=entry["item"].pk,
                         requested_qty=entry["suggested_qty"],
+                        issued_qty=0,
                     )
         except (DatabaseError, IntegrityError):
             logger.exception("Failed to create low-stock indent (mrn=%s)", mrn)

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -752,6 +752,7 @@ def recipe_create_indent(request, pk: int):
             indent=indent,
             item=item,
             requested_qty=effective_qty,
+            issued_qty=0,
         )
 
     messages.success(request, f"Indent {mrn} created from recipe", extra_tags="toast")


### PR DESCRIPTION
## Root Cause

`indent_items.issued_qty` is `NOT NULL` in PostgreSQL with a DB default of `0`. But the Django model declares it as `null=True` with no Python default. When Django builds the INSERT, it includes **all** fields — sending `NULL` for `issued_qty`, which bypasses the DB default and hits the NOT NULL constraint.

This is the same class of schema drift that caused the `department_id` issue (migration 0016 updated Django state without running DDL).

## Fix

Pass `issued_qty=0` explicitly in both IndentItem creation paths:
- `inventory/views/indents.py` — low-stock auto-indent
- `inventory/views/recipes.py` — recipe-to-indent

## Test plan
- [ ] 4/4 low-stock indent tests pass
- [ ] Click "Create Indent (6 items)" on live site → redirects to indent detail with SUBMITTED status

🤖 Generated with [Claude Code](https://claude.com/claude-code)