### PR TITLE
fix: align DB NOT NULL constraints with Django models (schema drift)

### DIFF
--- a/inventory/migrations/0040_align_not_null_with_models.py
+++ b/inventory/migrations/0040_align_not_null_with_models.py
@@ -1,0 +1,58 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """
+    Align PostgreSQL NOT NULL constraints with Django model definitions.
+
+    The database was originally created outside Django (Supabase). Many columns
+    are NOT NULL in PostgreSQL but the Django models declare them null=True.
+    When Django builds an INSERT it includes ALL fields, sending NULL for unset
+    ones — bypassing any DB defaults and violating NOT NULL constraints.
+
+    This migration drops NOT NULL on every column where the Django model allows
+    null, permanently eliminating this class of IntegrityError.
+    """
+
+    dependencies = [
+        ("inventory", "0039_indent_department_nullable"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                -- indents: requested_by is null=True in Django model
+                ALTER TABLE indents ALTER COLUMN requested_by DROP NOT NULL;
+
+                -- indent_items: all data columns are null=True in Django model
+                ALTER TABLE indent_items ALTER COLUMN indent_id DROP NOT NULL;
+                ALTER TABLE indent_items ALTER COLUMN item_id DROP NOT NULL;
+                ALTER TABLE indent_items ALTER COLUMN requested_qty DROP NOT NULL;
+                ALTER TABLE indent_items ALTER COLUMN issued_qty DROP NOT NULL;
+                ALTER TABLE indent_items ALTER COLUMN item_status DROP NOT NULL;
+
+                -- grn_items: item_id is null=True in Django model
+                ALTER TABLE grn_items ALTER COLUMN item_id DROP NOT NULL;
+
+                -- stock_transactions: core columns are null=True in Django model
+                ALTER TABLE stock_transactions ALTER COLUMN item_id DROP NOT NULL;
+                ALTER TABLE stock_transactions ALTER COLUMN quantity_change DROP NOT NULL;
+                ALTER TABLE stock_transactions ALTER COLUMN transaction_type DROP NOT NULL;
+            """,
+            reverse_sql="""
+                ALTER TABLE indents ALTER COLUMN requested_by SET NOT NULL;
+
+                ALTER TABLE indent_items ALTER COLUMN indent_id SET NOT NULL;
+                ALTER TABLE indent_items ALTER COLUMN item_id SET NOT NULL;
+                ALTER TABLE indent_items ALTER COLUMN requested_qty SET NOT NULL;
+                ALTER TABLE indent_items ALTER COLUMN issued_qty SET NOT NULL;
+                ALTER TABLE indent_items ALTER COLUMN item_status SET NOT NULL;
+
+                ALTER TABLE grn_items ALTER COLUMN item_id SET NOT NULL;
+
+                ALTER TABLE stock_transactions ALTER COLUMN item_id SET NOT NULL;
+                ALTER TABLE stock_transactions ALTER COLUMN quantity_change SET NOT NULL;
+                ALTER TABLE stock_transactions ALTER COLUMN transaction_type SET NOT NULL;
+            """,
+        ),
+    ]

--- a/inventory/services/goods_receiving_service.py
+++ b/inventory/services/goods_receiving_service.py
@@ -83,6 +83,7 @@ def _process_items(
             GRNItem(
                 grn=grn,
                 po_item=po_item,
+                item=item,
                 quantity_ordered_on_po=Decimal(
                     str(item_d.get("quantity_ordered_on_po", po_item.quantity_ordered))
                 ),

--- a/inventory/views/recipes.py
+++ b/inventory/views/recipes.py
@@ -730,9 +730,9 @@ def recipe_create_indent(request, pk: int):
 
     indent = Indent.objects.create(
         mrn=mrn,
+        requested_by=getattr(request.user, "username", "") or "",
         notes=f"Recipe: {recipe.name}",
-        status="DRAFT",
-        date_required=None,
+        status="SUBMITTED",
     )
 
     for row in recipe.items.all():


### PR DESCRIPTION
## Summary

The PostgreSQL database was created outside Django (Supabase). Many columns are `NOT NULL` but Django models declare them `null=True`. Django's INSERT includes ALL fields, sending `NULL` for unset ones — bypassing DB defaults and causing IntegrityErrors (500 errors).

- **Migration 0040** drops NOT NULL on 10 columns across 4 tables (indents, indent_items, grn_items, stock_transactions), permanently eliminating this class of bug
- **recipes.py** — recipe-to-indent was missing `requested_by` and used wrong status `"DRAFT"` → `"SUBMITTED"`
- **goods_receiving_service.py** — GRN bulk_create was missing `item=` on GRNItem

## Test plan
- [ ] All 44 passing tests still pass (3 failures are pre-existing)
- [ ] After deploy: verify columns are nullable via Supabase SQL
- [ ] Test: low-stock indent, recipe-to-indent, GRN from PO

🤖 Generated with [Claude Code](https://claude.com/claude-code)