### PR TITLE
feat: add phase 2 savings ledger and recovered profit rollup

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -63,7 +63,7 @@
     <div class="bg-surface border border-border rounded-xl px-4 py-4 flex flex-col gap-1">
       <p class="text-[11px] font-medium uppercase tracking-wide text-gray-400">Recovered Profit This Month</p>
       <p class="text-2xl font-semibold text-success leading-tight">&#8377;{{ recovered_profit_this_month|floatformat:0 }}</p>
-      <p class="text-[11px] text-gray-400">Savings ledger starts in Phase 2</p>
+      <p class="text-[11px] text-gray-400">From confirmed and verified savings ledger entries</p>
     </div>
 
     <div class="bg-surface border border-border rounded-xl px-4 py-4 flex flex-col gap-1">

--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -14,6 +14,7 @@ from .models import (
     Recipe,
     RecipeItem,
     SaleTransaction,
+    SavingsLedger,
     StockTransaction,
     SubCategory,
     Supplier,
@@ -33,6 +34,7 @@ for model in [
     PurchaseOrderItem,
     GoodsReceivedNote,
     GRNItem,
+    SavingsLedger,
     Department,
     ItemDepartment,
 ]:

--- a/inventory/migrations/0041_savings_ledger.py
+++ b/inventory/migrations/0041_savings_ledger.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("inventory", "0040_align_not_null_with_models"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SavingsLedger",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("date", models.DateField(db_index=True)),
+                ("outlet", models.CharField(blank=True, max_length=120, null=True)),
+                ("saving_type", models.CharField(choices=[("VENDOR_SAVING", "Vendor saving"), ("INVOICE_MISMATCH_CAUGHT", "Invoice mismatch caught"), ("RECIPE_OPTIMISATION", "Recipe optimisation"), ("WASTE_REDUCTION", "Waste reduction"), ("VARIANCE_REDUCTION", "Variance reduction"), ("MENU_PRICE_CORRECTION", "Menu price correction")], max_length=40)),
+                ("source_document_type", models.CharField(blank=True, default="", max_length=50)),
+                ("source_document_id", models.CharField(blank=True, default="", max_length=80)),
+                ("baseline_price", models.DecimalField(decimal_places=2, default=0, max_digits=12)),
+                ("selected_price", models.DecimalField(decimal_places=2, default=0, max_digits=12)),
+                ("invoice_price", models.DecimalField(decimal_places=2, default=0, max_digits=12)),
+                ("quantity", models.DecimalField(decimal_places=3, default=0, max_digits=12)),
+                ("estimated_saving", models.DecimalField(decimal_places=2, default=0, max_digits=14)),
+                ("confirmed_saving", models.DecimalField(decimal_places=2, default=0, max_digits=14)),
+                ("lost_saving", models.DecimalField(decimal_places=2, default=0, max_digits=14)),
+                ("status", models.CharField(choices=[("ESTIMATED", "Estimated"), ("CONFIRMED", "Confirmed"), ("LOST", "Lost"), ("REJECTED", "Rejected"), ("VERIFIED", "Verified")], default="ESTIMATED", max_length=16)),
+                ("notes", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("item", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to="inventory.item")),
+            ],
+            options={
+                "db_table": "savings_ledger",
+                "ordering": ["-date", "-id"],
+                "indexes": [
+                    models.Index(fields=["date"], name="sav_ledger_date_idx"),
+                    models.Index(fields=["status"], name="sav_ledger_status_idx"),
+                    models.Index(fields=["saving_type"], name="sav_ledger_type_idx"),
+                    models.Index(fields=["item", "date"], name="sav_ledger_item_date_idx"),
+                ],
+            },
+        ),
+    ]

--- a/inventory/models/__init__.py
+++ b/inventory/models/__init__.py
@@ -12,6 +12,7 @@ from .orders import (
     PurchaseOrder,
     PurchaseOrderItem,
 )
+from .recovery import SavingsLedger
 from .recipes import Recipe, RecipeItem, SaleTransaction
 from .site_config import SiteConfig
 from .stock_take import StockTake, StockTakeItem
@@ -33,6 +34,7 @@ __all__ = [
     "PurchaseOrderItem",
     "GoodsReceivedNote",
     "GRNItem",
+    "SavingsLedger",
     "IndentStatus",
     "ItemStatus",
     "PurchaseOrderStatus",

--- a/inventory/models/recovery.py
+++ b/inventory/models/recovery.py
@@ -1,0 +1,54 @@
+from django.db import models
+
+
+class SavingsLedger(models.Model):
+    class SavingType(models.TextChoices):
+        VENDOR_SAVING = "VENDOR_SAVING", "Vendor saving"
+        INVOICE_MISMATCH_CAUGHT = "INVOICE_MISMATCH_CAUGHT", "Invoice mismatch caught"
+        RECIPE_OPTIMISATION = "RECIPE_OPTIMISATION", "Recipe optimisation"
+        WASTE_REDUCTION = "WASTE_REDUCTION", "Waste reduction"
+        VARIANCE_REDUCTION = "VARIANCE_REDUCTION", "Variance reduction"
+        MENU_PRICE_CORRECTION = "MENU_PRICE_CORRECTION", "Menu price correction"
+
+    class Status(models.TextChoices):
+        ESTIMATED = "ESTIMATED", "Estimated"
+        CONFIRMED = "CONFIRMED", "Confirmed"
+        LOST = "LOST", "Lost"
+        REJECTED = "REJECTED", "Rejected"
+        VERIFIED = "VERIFIED", "Verified"
+
+    date = models.DateField(db_index=True)
+    outlet = models.CharField(max_length=120, blank=True, null=True)
+    item = models.ForeignKey(
+        "inventory.Item", on_delete=models.SET_NULL, blank=True, null=True
+    )
+    saving_type = models.CharField(max_length=40, choices=SavingType.choices)
+    source_document_type = models.CharField(max_length=50, blank=True, default="")
+    source_document_id = models.CharField(max_length=80, blank=True, default="")
+    baseline_price = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+    selected_price = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+    invoice_price = models.DecimalField(max_digits=12, decimal_places=2, default=0)
+    quantity = models.DecimalField(max_digits=12, decimal_places=3, default=0)
+    estimated_saving = models.DecimalField(max_digits=14, decimal_places=2, default=0)
+    confirmed_saving = models.DecimalField(max_digits=14, decimal_places=2, default=0)
+    lost_saving = models.DecimalField(max_digits=14, decimal_places=2, default=0)
+    status = models.CharField(
+        max_length=16, choices=Status.choices, default=Status.ESTIMATED
+    )
+    notes = models.TextField(blank=True, default="")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "savings_ledger"
+        ordering = ["-date", "-id"]
+        indexes = [
+            models.Index(fields=["date"], name="sav_ledger_date_idx"),
+            models.Index(fields=["status"], name="sav_ledger_status_idx"),
+            models.Index(fields=["saving_type"], name="sav_ledger_type_idx"),
+            models.Index(fields=["item", "date"], name="sav_ledger_item_date_idx"),
+        ]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        item_name = self.item.name if self.item else "No item"
+        return f"{self.get_saving_type_display()} - {item_name} ({self.date})"

--- a/inventory/services/recovery_dashboard_service.py
+++ b/inventory/services/recovery_dashboard_service.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Dict
 
+from django.db.models import DecimalField, Sum
+from django.db.models.functions import Coalesce
 from django.urls import reverse
 
+from inventory.models import SavingsLedger
 from inventory.services import dashboard_kpis as dkpis
 
 MONEY_PLACES = Decimal("0.01")
@@ -149,6 +152,24 @@ def _weekly_action_plan(
     return actions
 
 
+def _recovered_profit_this_month(end_date) -> Decimal:
+    total = SavingsLedger.objects.filter(
+        date__year=end_date.year,
+        date__month=end_date.month,
+        status__in=[
+            SavingsLedger.Status.CONFIRMED,
+            SavingsLedger.Status.VERIFIED,
+        ],
+    ).aggregate(
+        total=Coalesce(
+            Sum("confirmed_saving"),
+            Decimal("0"),
+            output_field=DecimalField(max_digits=14, decimal_places=2),
+        )
+    )["total"]
+    return _money(total or ZERO_MONEY)
+
+
 def build_owner_money_dashboard(
     start,
     end,
@@ -188,7 +209,7 @@ def build_owner_money_dashboard(
     unrealised_profit = _positive_money(
         sales_revenue * positive_gap_pct / Decimal("100")
     )
-    recovered_profit_this_month = ZERO_MONEY
+    recovered_profit_this_month = _recovered_profit_this_month(end)
     remaining_opportunity = _positive_money(
         unrealised_profit - recovered_profit_this_month
     )

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from core.viewmodels import DashboardContext
-from inventory.models import Recipe, SaleTransaction, StockTransaction
+from inventory.models import Recipe, SaleTransaction, SavingsLedger, StockTransaction
 from inventory.services import dashboard_kpis as dkpis
 
 
@@ -112,3 +112,35 @@ def test_dashboard_renders_chart_and_kpis(client, django_user_model):
     assert "Consumption vs Wastage" in html
     assert "Consumption breakdown" in html
     assert "Top movers" in html
+
+
+@pytest.mark.django_db
+def test_dashboard_recovered_profit_uses_confirmed_and_verified_ledger_entries(
+    client, django_user_model
+):
+    user = django_user_model.objects.create_user(username="owner2", password="pw")
+    client.force_login(user)
+
+    today = timezone.now().date()
+    SavingsLedger.objects.create(
+        date=today,
+        saving_type=SavingsLedger.SavingType.VENDOR_SAVING,
+        status=SavingsLedger.Status.CONFIRMED,
+        confirmed_saving=Decimal("1200.00"),
+    )
+    SavingsLedger.objects.create(
+        date=today,
+        saving_type=SavingsLedger.SavingType.WASTE_REDUCTION,
+        status=SavingsLedger.Status.VERIFIED,
+        confirmed_saving=Decimal("800.00"),
+    )
+    SavingsLedger.objects.create(
+        date=today,
+        saving_type=SavingsLedger.SavingType.RECIPE_OPTIMISATION,
+        status=SavingsLedger.Status.ESTIMATED,
+        confirmed_saving=Decimal("9999.00"),
+    )
+
+    resp = client.get(reverse("root"))
+    assert resp.status_code == 200
+    assert resp.context["recovered_profit_this_month"] == Decimal("2000.00")


### PR DESCRIPTION
Summary: adds SavingsLedger model + migration, wires recovered profit this month from CONFIRMED/VERIFIED ledger entries, updates dashboard KPI helper text, and adds dashboard test coverage for rollup. Validation: manage.py check (test settings), pytest tests/test_dashboard.py, pytest tests/test_recipe_total_cost_units.py tests/test_purchase_order_service_django.py tests/test_goods_receiving_service_django.py.