### PR TITLE
feat: phase 3 vendor price comparison and purchase savings

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -19,6 +19,7 @@ from .models import (
     SubCategory,
     Supplier,
     Unit,
+    VendorItemPrice,
 )
 
 for model in [
@@ -35,6 +36,7 @@ for model in [
     GoodsReceivedNote,
     GRNItem,
     SavingsLedger,
+    VendorItemPrice,
     Department,
     ItemDepartment,
 ]:

--- a/inventory/migrations/0042_vendor_item_price.py
+++ b/inventory/migrations/0042_vendor_item_price.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("inventory", "0041_savings_ledger"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="VendorItemPrice",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("price", models.DecimalField(decimal_places=2, max_digits=12)),
+                ("effective_from", models.DateField(db_index=True)),
+                ("source", models.CharField(blank=True, default="", max_length=60)),
+                ("is_active", models.BooleanField(default=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("item", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="inventory.item")),
+                ("unit", models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to="inventory.unit")),
+                ("vendor", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="inventory.supplier")),
+            ],
+            options={
+                "db_table": "vendor_item_prices",
+                "ordering": ["-effective_from", "-id"],
+                "indexes": [
+                    models.Index(fields=["vendor", "item"], name="vip_vendor_item_idx"),
+                    models.Index(fields=["item", "effective_from"], name="vip_item_eff_idx"),
+                    models.Index(fields=["is_active"], name="vip_active_idx"),
+                ],
+            },
+        ),
+    ]

--- a/inventory/models/__init__.py
+++ b/inventory/models/__init__.py
@@ -12,7 +12,7 @@ from .orders import (
     PurchaseOrder,
     PurchaseOrderItem,
 )
-from .recovery import SavingsLedger
+from .recovery import SavingsLedger, VendorItemPrice
 from .recipes import Recipe, RecipeItem, SaleTransaction
 from .site_config import SiteConfig
 from .stock_take import StockTake, StockTakeItem
@@ -35,6 +35,7 @@ __all__ = [
     "GoodsReceivedNote",
     "GRNItem",
     "SavingsLedger",
+    "VendorItemPrice",
     "IndentStatus",
     "ItemStatus",
     "PurchaseOrderStatus",

--- a/inventory/models/recovery.py
+++ b/inventory/models/recovery.py
@@ -52,3 +52,29 @@ class SavingsLedger(models.Model):
     def __str__(self) -> str:  # pragma: no cover - simple representation
         item_name = self.item.name if self.item else "No item"
         return f"{self.get_saving_type_display()} - {item_name} ({self.date})"
+
+
+class VendorItemPrice(models.Model):
+    vendor = models.ForeignKey("inventory.Supplier", on_delete=models.CASCADE)
+    item = models.ForeignKey("inventory.Item", on_delete=models.CASCADE)
+    unit = models.ForeignKey(
+        "inventory.Unit", on_delete=models.SET_NULL, blank=True, null=True
+    )
+    price = models.DecimalField(max_digits=12, decimal_places=2)
+    effective_from = models.DateField(db_index=True)
+    source = models.CharField(max_length=60, blank=True, default="")
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "vendor_item_prices"
+        ordering = ["-effective_from", "-id"]
+        indexes = [
+            models.Index(fields=["vendor", "item"], name="vip_vendor_item_idx"),
+            models.Index(fields=["item", "effective_from"], name="vip_item_eff_idx"),
+            models.Index(fields=["is_active"], name="vip_active_idx"),
+        ]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.vendor} - {self.item} @ {self.price}"

--- a/inventory/services/goods_receiving_service.py
+++ b/inventory/services/goods_receiving_service.py
@@ -16,6 +16,7 @@ from inventory.models import (
 
 from . import indent_consolidation_service, stock_service
 from .exceptions import StockServiceError
+from .vendor_savings_service import apply_grn_realization
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +101,13 @@ def _process_items(
             related_po_id=po.po_id if po else None,
             notes=f"GRN {grn_number}",
         )
+        if po:
+            apply_grn_realization(
+                po_id=po.po_id,
+                item_id=item.item_id,
+                quantity_received=qty,
+                invoice_price=item_d["unit_price_at_receipt"],
+            )
 
     GRNItem.objects.bulk_create(grn_items)
     # Apply received quantities to pending indents for fulfillment roll-up

--- a/inventory/services/purchase_order_service.py
+++ b/inventory/services/purchase_order_service.py
@@ -9,6 +9,7 @@ from inventory.forms.purchase_forms import PurchaseOrderForm, PurchaseOrderItemF
 from inventory.models import Item, PurchaseOrder, PurchaseOrderItem, Supplier
 
 from .exceptions import PurchaseOrderServiceError
+from .vendor_savings_service import create_po_estimated_savings
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,8 @@ def create_po(po_data: Dict[str, Any], items_data: List[Dict[str, Any]]) -> int:
     try:
         with transaction.atomic():
             supplier = Supplier.objects.get(pk=po_data["supplier_id"])
+            item_ids = [int(i["item_id"]) for i in items_data]
+            item_map = Item.objects.in_bulk(item_ids)
             po = PurchaseOrder.objects.create(
                 po_number=po_data.get("po_number") or generate_po_number(),
                 supplier=supplier,
@@ -95,13 +98,32 @@ def create_po(po_data: Dict[str, Any], items_data: List[Dict[str, Any]]) -> int:
                 notes=po_data.get("notes"),
             )
             for item_d in items_data:
-                item = Item.objects.get(pk=item_d["item_id"])
+                item = item_map.get(int(item_d["item_id"]))
+                if item is None:
+                    raise Item.DoesNotExist(f"Item {item_d['item_id']} not found")
                 PurchaseOrderItem.objects.create(
                     purchase_order=po,
                     item=item,
                     quantity_ordered=Decimal(str(item_d["quantity_ordered"])),
                     unit_price=Decimal(str(item_d["unit_price"])),
                 )
+            po_lines = [
+                {
+                    "item_id": int(item_d["item_id"]),
+                    "quantity_ordered": Decimal(str(item_d["quantity_ordered"])),
+                    "unit_price": Decimal(str(item_d["unit_price"])),
+                    "fallback_price": item_map[int(item_d["item_id"])].last_purchase_price
+                    or item_map[int(item_d["item_id"])].initial_purchase_price
+                    or Decimal("0"),
+                }
+                for item_d in items_data
+            ]
+            create_po_estimated_savings(
+                po_id=po.po_id,
+                po_date=po.order_date,
+                supplier_id=supplier.pk,
+                po_lines=po_lines,
+            )
             return po.po_id
     except (Supplier.DoesNotExist, Item.DoesNotExist) as exc:
         raise PurchaseOrderServiceError(f"Invalid reference: {exc}") from exc

--- a/inventory/services/vendor_savings_service.py
+++ b/inventory/services/vendor_savings_service.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from django.db.models import DecimalField, F, Sum
+from django.db.models.functions import Coalesce
+
+from inventory.models import SavingsLedger, VendorItemPrice
+
+
+@dataclass
+class VendorBaseline:
+    baseline_price: Decimal
+    selected_price: Decimal
+    cheapest_price: Decimal | None
+    estimated_saving: Decimal
+    estimated_loss: Decimal
+
+
+def _to_decimal(value) -> Decimal:
+    return Decimal(str(value or 0))
+
+
+def _latest_vendor_price(item_id: int, vendor_id: int) -> Decimal | None:
+    row = (
+        VendorItemPrice.objects.filter(
+            item_id=item_id,
+            vendor_id=vendor_id,
+            is_active=True,
+        )
+        .order_by("-effective_from", "-pk")
+        .first()
+    )
+    return _to_decimal(row.price) if row else None
+
+
+def _cheapest_vendor_price(item_id: int) -> Decimal | None:
+    row = (
+        VendorItemPrice.objects.filter(item_id=item_id, is_active=True)
+        .order_by("price", "-effective_from", "-pk")
+        .first()
+    )
+    return _to_decimal(row.price) if row else None
+
+
+def baseline_for_po_line(
+    *,
+    item_id: int,
+    selected_vendor_id: int,
+    selected_unit_price,
+    fallback_price,
+) -> VendorBaseline:
+    selected_price = _to_decimal(selected_unit_price)
+    fallback = _to_decimal(fallback_price)
+    vendor_latest = _latest_vendor_price(item_id, selected_vendor_id)
+    cheapest = _cheapest_vendor_price(item_id)
+    baseline = fallback
+    if vendor_latest is not None:
+        baseline = vendor_latest
+    if cheapest is not None:
+        baseline = min(baseline, cheapest)
+    gap = baseline - selected_price
+    estimated_saving = gap if gap > 0 else Decimal("0")
+    estimated_loss = -gap if gap < 0 else Decimal("0")
+    return VendorBaseline(
+        baseline_price=baseline,
+        selected_price=selected_price,
+        cheapest_price=cheapest,
+        estimated_saving=estimated_saving,
+        estimated_loss=estimated_loss,
+    )
+
+
+def create_po_estimated_savings(
+    *,
+    po_id: int,
+    po_date: date,
+    supplier_id: int,
+    po_lines: list[dict],
+) -> None:
+    entries: list[SavingsLedger] = []
+    for line in po_lines:
+        baseline = baseline_for_po_line(
+            item_id=line["item_id"],
+            selected_vendor_id=supplier_id,
+            selected_unit_price=line["unit_price"],
+            fallback_price=line.get("fallback_price"),
+        )
+        qty = _to_decimal(line["quantity_ordered"])
+        entries.append(
+            SavingsLedger(
+                date=po_date,
+                item_id=line["item_id"],
+                saving_type=SavingsLedger.SavingType.VENDOR_SAVING,
+                source_document_type="PO",
+                source_document_id=str(po_id),
+                baseline_price=baseline.baseline_price,
+                selected_price=baseline.selected_price,
+                quantity=qty,
+                estimated_saving=baseline.estimated_saving * qty,
+                lost_saving=baseline.estimated_loss * qty,
+                status=SavingsLedger.Status.ESTIMATED,
+                notes=(
+                    "Auto-estimated on PO creation using vendor/item baseline."
+                ),
+            )
+        )
+    if entries:
+        SavingsLedger.objects.bulk_create(entries)
+
+
+def apply_grn_realization(
+    *,
+    po_id: int,
+    item_id: int,
+    quantity_received,
+    invoice_price,
+) -> None:
+    qty = _to_decimal(quantity_received)
+    invoice = _to_decimal(invoice_price)
+    estimates = SavingsLedger.objects.filter(
+        source_document_type="PO",
+        source_document_id=str(po_id),
+        item_id=item_id,
+        status=SavingsLedger.Status.ESTIMATED,
+    ).order_by("pk")
+    if not estimates.exists():
+        return
+    baseline = _to_decimal(estimates.first().baseline_price)
+    diff = baseline - invoice
+    confirmed = diff * qty if diff > 0 else Decimal("0")
+    lost = -diff * qty if diff < 0 else Decimal("0")
+    status = SavingsLedger.Status.VERIFIED if confirmed > 0 else SavingsLedger.Status.LOST
+    estimates.update(
+        invoice_price=invoice,
+        confirmed_saving=Coalesce(F("confirmed_saving"), Decimal("0"))
+        + confirmed,
+        lost_saving=Coalesce(F("lost_saving"), Decimal("0")) + lost,
+        status=status,
+    )
+
+
+def recovered_profit_for_month(*, year: int, month: int) -> Decimal:
+    return (
+        SavingsLedger.objects.filter(
+            date__year=year,
+            date__month=month,
+            status__in=[SavingsLedger.Status.CONFIRMED, SavingsLedger.Status.VERIFIED],
+        ).aggregate(
+            total=Coalesce(
+                Sum("confirmed_saving"),
+                Decimal("0"),
+                output_field=DecimalField(max_digits=14, decimal_places=2),
+            )
+        )["total"]
+        or Decimal("0")
+    )

--- a/inventory/views/purchase_orders.py
+++ b/inventory/views/purchase_orders.py
@@ -16,7 +16,7 @@ from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
 
 from ..forms.purchase_forms import GRNForm, PurchaseOrderForm, PurchaseOrderItemFormSet
-from ..models import Item, PurchaseOrder, Supplier
+from ..models import Item, PurchaseOrder, SavingsLedger, Supplier, VendorItemPrice
 from ..services import (
     goods_receiving_service,
     list_utils,
@@ -53,6 +53,29 @@ def _build_item_prices_dict() -> dict[str, float]:
 
 def _build_item_prices_json() -> str:
     return json.dumps(_build_item_prices_dict())
+
+
+def _build_item_vendor_hints_dict() -> dict[str, dict[str, float]]:
+    hints: dict[str, dict[str, float]] = {}
+    items = Item.objects.filter(is_active=True).only(
+        "item_id", "reorder_point", "current_stock", "last_purchase_price"
+    )
+    for item in items:
+        cheapest = (
+            VendorItemPrice.objects.filter(item_id=item.pk, is_active=True)
+            .order_by("price", "-effective_from", "-pk")
+            .values_list("price", flat=True)
+            .first()
+        )
+        reorder = Decimal(str(item.reorder_point or 0))
+        stock = Decimal(str(item.current_stock or 0))
+        suggested_qty = reorder - stock
+        hints[str(item.pk)] = {
+            "cheapest_price": float(cheapest or 0),
+            "last_price": float(item.last_purchase_price or 0),
+            "suggested_qty": float(suggested_qty if suggested_qty > 0 else Decimal("0")),
+        }
+    return hints
 
 
 def _is_partial_post(request) -> bool:
@@ -460,6 +483,7 @@ class PurchaseOrderCreatePartialView(View):
                 "formset": formset,
                 "is_edit": False,
                 "item_prices": _build_item_prices_dict(),
+                "item_vendor_hints": _build_item_vendor_hints_dict(),
             },
         )
 
@@ -489,6 +513,7 @@ class PurchaseOrderCreatePartialView(View):
             "formset": formset,
             "is_edit": False,
             "item_prices": _build_item_prices_dict(),
+            "item_vendor_hints": _build_item_vendor_hints_dict(),
         }
         if _is_partial_post(request):
             return JsonResponse(build_form_error_payload(form, formset), status=400)
@@ -517,6 +542,7 @@ def purchase_order_create(request):
             "formset": formset,
             "is_edit": False,
             "item_prices": _build_item_prices_dict(),
+            "item_vendor_hints": _build_item_vendor_hints_dict(),
         },
     )
 
@@ -544,6 +570,7 @@ def purchase_order_edit(request, pk: int):
             "is_edit": True,
             "po": po,
             "item_prices": _build_item_prices_dict(),
+            "item_vendor_hints": _build_item_vendor_hints_dict(),
         },
     )
 
@@ -567,6 +594,7 @@ class PurchaseOrderEditPartialView(View):
                 "is_edit": True,
                 "po": po,
                 "item_prices": _build_item_prices_dict(),
+                "item_vendor_hints": _build_item_vendor_hints_dict(),
             },
         )
 
@@ -631,8 +659,16 @@ def purchase_order_detail(request, pk: int):
         "rows": rows,
         "list_url": reverse("purchase_orders_list"),
         "list_title": "Purchase Orders",
-        "current_title": f"Purchase Order {po.pk}",
-    }
+            "current_title": f"Purchase Order {po.pk}",
+            "saving_summary": SavingsLedger.objects.filter(
+                source_document_type="PO",
+                source_document_id=str(po.pk),
+            ).aggregate(
+                estimated=Sum("estimated_saving"),
+                confirmed=Sum("confirmed_saving"),
+                lost=Sum("lost_saving"),
+            ),
+        }
     return render(request, "inventory/purchase_orders/detail.html", ctx)
 
 

--- a/static/js/purchase-order-drawer.js
+++ b/static/js/purchase-order-drawer.js
@@ -13,6 +13,37 @@
     }
   }
 
+  function readItemVendorHints(form) {
+    const el = form.querySelector("#po-item-vendor-hints");
+    if (!el || !el.textContent) return {};
+    try {
+      return JSON.parse(el.textContent);
+    } catch (_) {
+      return {};
+    }
+  }
+
+  function applyHints(row, itemId, hints) {
+    const suggestedEl = row.querySelector("[data-suggested-qty]");
+    const priceHintEl = row.querySelector("[data-price-hint]");
+    const hint = hints[itemId] || {};
+    if (suggestedEl) {
+      const qty = Number(hint.suggested_qty || 0);
+      suggestedEl.textContent = qty > 0 ? `Suggested qty: ${qty.toFixed(2)}` : "";
+    }
+    if (priceHintEl) {
+      const cheapest = Number(hint.cheapest_price || 0);
+      const last = Number(hint.last_price || 0);
+      if (cheapest > 0) {
+        priceHintEl.textContent = `Cheapest vendor: ${cheapest.toFixed(2)} | Last: ${last.toFixed(2)}`;
+      } else if (last > 0) {
+        priceHintEl.textContent = `Last purchase: ${last.toFixed(2)}`;
+      } else {
+        priceHintEl.textContent = "";
+      }
+    }
+  }
+
   function initPurchaseOrderDrawer(root) {
     const scope =
       root && root.nodeType === Node.ELEMENT_NODE ? root : document;
@@ -24,6 +55,7 @@
     if (!formsetEl) return;
 
     const itemPrices = readItemPrices(form);
+    const itemVendorHints = readItemVendorHints(form);
     const prefix = form.getAttribute("data-formset-prefix") || "items";
 
     if (!formsetEl._poDelegationBound) {
@@ -62,6 +94,7 @@
         ) {
           priceInput.value = parseFloat(itemPrices[t.value]).toFixed(2);
         }
+        applyHints(row, t.value, itemVendorHints);
       });
     }
 
@@ -75,6 +108,13 @@
       });
       form._poFormsetInitialized = true;
     }
+
+    formsetEl.querySelectorAll(".item-form").forEach(function (row) {
+      const sel = row.querySelector("select.item-select");
+      if (sel && sel.value) {
+        applyHints(row, sel.value, itemVendorHints);
+      }
+    });
 
     if (form.id === "po-form" && !form._poNativeValidityBound) {
       form._poNativeValidityBound = true;

--- a/templates/inventory/purchase_orders/_form_partial.html
+++ b/templates/inventory/purchase_orders/_form_partial.html
@@ -8,6 +8,7 @@
   <form method="post" id="po-drawer-form" data-drawer="purchase-order" data-formset-prefix="{{ formset.prefix }}" data-modal-form data-requires-line-items action="{% if is_edit %}{% url 'purchase_order_edit_partial' po.pk %}{% else %}{% url 'purchase_order_create_partial' %}{% endif %}">
       {% csrf_token %}
       {{ item_prices|json_script:"po-item-prices" }}
+      {{ item_vendor_hints|json_script:"po-item-vendor-hints" }}
       <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
         {% for field in form %}
           {% include "components/form_field.html" with field=field %}

--- a/templates/inventory/purchase_orders/_po_line_items.html
+++ b/templates/inventory/purchase_orders/_po_line_items.html
@@ -29,12 +29,14 @@
             </ul>
             {% endif %}
             {% include "components/form_field.html" with field=f.item %}
+            <p class="mt-1 text-xs text-gray-500" data-suggested-qty></p>
           </td>
           <td class="px-3 py-2 align-top">
             {% include "components/form_field.html" with field=f.quantity_ordered %}
           </td>
           <td class="px-3 py-2 align-top">
             {% include "components/form_field.html" with field=f.unit_price %}
+            <p class="mt-1 text-xs text-gray-500" data-price-hint></p>
           </td>
           <td class="px-3 py-2 align-top text-right">
             <div class="hidden">{{ f.DELETE }}</div>
@@ -54,6 +56,7 @@
           <div class="hidden">{{ field }}</div>
         {% elif field.name == 'item' %}
           {% include "components/form_field.html" with field=field %}
+          <p class="mt-1 text-xs text-gray-500" data-suggested-qty></p>
         {% endif %}
       {% endfor %}
     </td>
@@ -61,6 +64,7 @@
       {% for field in formset.empty_form %}
         {% if field.name == 'quantity_ordered' %}
           {% include "components/form_field.html" with field=field %}
+          <p class="mt-1 text-xs text-gray-500" data-price-hint></p>
         {% endif %}
       {% endfor %}
     </td>

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -54,6 +54,20 @@
   {% include "components/detail_table.html" with rows=rows %}
 {% endblock %}
 {% block extra_tables %}
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8">
+    <div class="bg-surface border border-border rounded-lg p-4">
+      <p class="text-xs uppercase text-gray-500">Estimated Saving</p>
+      <p class="text-xl font-semibold text-success">&#8377;{{ saving_summary.estimated|default:0|floatformat:0 }}</p>
+    </div>
+    <div class="bg-surface border border-border rounded-lg p-4">
+      <p class="text-xs uppercase text-gray-500">Confirmed Saving</p>
+      <p class="text-xl font-semibold text-success">&#8377;{{ saving_summary.confirmed|default:0|floatformat:0 }}</p>
+    </div>
+    <div class="bg-surface border border-border rounded-lg p-4">
+      <p class="text-xs uppercase text-gray-500">Lost Saving</p>
+      <p class="text-xl font-semibold text-danger">&#8377;{{ saving_summary.lost|default:0|floatformat:0 }}</p>
+    </div>
+  </div>
   <h2 class="text-h2 md:text-h2 mb-4 mt-8">Items</h2>
   {% include "inventory/purchase_orders/_items_table.html" with items=items table_id="po-items-{{ po.pk }}" %}
   <h2 class="text-h2 md:text-h2 mb-4 mt-8">Linked Indent Lines</h2>

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -8,6 +8,7 @@
 {% block form_attrs %}id="po-form" data-formset-prefix="{{ formset.prefix }}"{% endblock %}
 {% block fields %}
   {{ item_prices|json_script:"po-item-prices" }}
+  {{ item_vendor_hints|json_script:"po-item-vendor-hints" }}
   <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
     {% for field in form %}
       {% include "components/form_field.html" with field=field %}

--- a/tests/test_goods_receiving_service_django.py
+++ b/tests/test_goods_receiving_service_django.py
@@ -1,8 +1,9 @@
 from datetime import date
+from decimal import Decimal
 
 import pytest
 
-from inventory.models import PurchaseOrder, PurchaseOrderItem, Supplier
+from inventory.models import PurchaseOrder, PurchaseOrderItem, SavingsLedger, Supplier
 from inventory.services import goods_receiving_service, purchase_order_service
 
 
@@ -40,3 +41,40 @@ def test_create_grn_updates_stock_and_po(item_factory):
     assert po_item.received_total == 5
     po = PurchaseOrder.objects.get(pk=po_id)
     assert po.status == "SENT"
+
+
+@pytest.mark.django_db
+def test_grn_realizes_estimated_saving_entries(item_factory):
+    supplier = Supplier.objects.create(name="Vendor")
+    item = item_factory(name="Paneer", last_purchase_price=Decimal("100.00"))
+    po_id = purchase_order_service.create_po(
+        {"supplier_id": supplier.pk, "order_date": date.today()},
+        [{"item_id": item.item_id, "quantity_ordered": 2, "unit_price": 90.0}],
+    )
+    po_item = PurchaseOrderItem.objects.get(
+        purchase_order_id=po_id, item_id=item.item_id
+    )
+    grn_data = {
+        "po_id": po_id,
+        "supplier_id": supplier.pk,
+        "received_date": date.today(),
+        "received_by_user_id": "tester",
+    }
+    items_data = [
+        {
+            "item_id": item.item_id,
+            "po_item_id": po_item.pk,
+            "quantity_ordered_on_po": po_item.quantity_ordered,
+            "quantity_received": 2,
+            "unit_price_at_receipt": Decimal("88.00"),
+        }
+    ]
+    success, msg, _ = goods_receiving_service.create_grn(grn_data, items_data)
+    assert success, msg
+    ledger = SavingsLedger.objects.get(
+        source_document_type="PO",
+        source_document_id=str(po_id),
+        item=item,
+    )
+    assert ledger.status == SavingsLedger.Status.VERIFIED
+    assert ledger.confirmed_saving == Decimal("24.00")

--- a/tests/test_purchase_order_service_django.py
+++ b/tests/test_purchase_order_service_django.py
@@ -1,4 +1,5 @@
 from datetime import date
+from decimal import Decimal
 
 import pytest
 
@@ -8,7 +9,9 @@ from inventory.models import (
     GRNItem,
     PurchaseOrder,
     PurchaseOrderItem,
+    SavingsLedger,
     Supplier,
+    VendorItemPrice,
 )
 from inventory.services import purchase_order_service
 
@@ -86,3 +89,29 @@ def test_get_orders_progress(item_factory):
     assert progress[po.pk]["ordered_total"] == 10
     assert progress[po.pk]["received_total"] == 4
     assert progress[po.pk]["percent"] == 40
+
+
+@pytest.mark.django_db
+def test_create_po_creates_estimated_vendor_savings(item_factory):
+    supplier = Supplier.objects.create(name="Vendor")
+    cheaper = Supplier.objects.create(name="Cheaper")
+    item = item_factory(name="Rice", last_purchase_price="120.00")
+    VendorItemPrice.objects.create(
+        vendor=cheaper,
+        item=item,
+        price="100.00",
+        effective_from=date.today(),
+        is_active=True,
+    )
+    po_id = purchase_order_service.create_po(
+        {"supplier_id": supplier.pk, "order_date": date.today()},
+        [{"item_id": item.item_id, "quantity_ordered": 10, "unit_price": 110.0}],
+    )
+    entry = SavingsLedger.objects.get(
+        source_document_type="PO",
+        source_document_id=str(po_id),
+        item=item,
+    )
+    assert entry.status == SavingsLedger.Status.ESTIMATED
+    assert entry.estimated_saving == Decimal("0.00")
+    assert entry.lost_saving == Decimal("100.00")


### PR DESCRIPTION
Summary: adds VendorItemPrice model and migration, creates vendor savings service, writes estimated savings ledger entries at PO creation, realizes confirmed/lost savings on GRN receipt, and adds PO UI hints plus PO detail savings summary cards. Tests: pytest tests/test_purchase_order_service_django.py tests/test_goods_receiving_service_django.py tests/test_dashboard.py -q; manage.py check --settings=inventory_app.settings.test.