### PR TITLE
fix: align Supabase schema fields

### DIFF
--- a/inventory/migrations/0043_supabase_schema_alignment.py
+++ b/inventory/migrations/0043_supabase_schema_alignment.py
@@ -1,0 +1,168 @@
+from django.db import migrations, models
+
+
+def _table_exists(connection, table_name):
+    with connection.cursor() as cursor:
+        return table_name in connection.introspection.table_names(cursor)
+
+
+def _column_exists(connection, table_name, column_name):
+    with connection.cursor() as cursor:
+        columns = connection.introspection.get_table_description(cursor, table_name)
+    return any(column.name == column_name for column in columns)
+
+
+def ensure_grn_number(apps, schema_editor):
+    connection = schema_editor.connection
+    table = "goods_received_notes"
+    if not _table_exists(connection, table):
+        return
+
+    if connection.vendor == "postgresql":
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                ALTER TABLE goods_received_notes
+                ADD COLUMN IF NOT EXISTS grn_number varchar(100)
+                """)
+            cursor.execute("""
+                WITH duplicate_numbers AS (
+                    SELECT grn_number
+                    FROM goods_received_notes
+                    WHERE grn_number IS NOT NULL AND grn_number <> ''
+                    GROUP BY grn_number
+                    HAVING COUNT(*) > 1
+                )
+                UPDATE goods_received_notes
+                SET grn_number = 'GRN-' || lpad(grn_id::text, 4, '0')
+                WHERE grn_number IS NULL
+                   OR grn_number = ''
+                   OR grn_number IN (SELECT grn_number FROM duplicate_numbers)
+                """)
+            cursor.execute("""
+                ALTER TABLE goods_received_notes
+                ALTER COLUMN grn_number SET NOT NULL
+                """)
+            cursor.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS
+                    goods_received_notes_grn_number_uniq
+                ON goods_received_notes (grn_number)
+                """)
+        return
+
+    if not _column_exists(connection, table, "grn_number"):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "ALTER TABLE goods_received_notes ADD COLUMN grn_number varchar(100)"
+            )
+
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            UPDATE goods_received_notes
+            SET grn_number = 'GRN-' || printf('%04d', grn_id)
+            WHERE grn_number IS NULL OR grn_number = ''
+            """)
+        cursor.execute("""
+            CREATE UNIQUE INDEX IF NOT EXISTS
+                goods_received_notes_grn_number_uniq
+            ON goods_received_notes (grn_number)
+            """)
+
+
+def ensure_sales_transactions(apps, schema_editor):
+    SaleTransaction = apps.get_model("inventory", "SaleTransaction")
+    if _table_exists(schema_editor.connection, SaleTransaction._meta.db_table):
+        return
+    schema_editor.create_model(SaleTransaction)
+
+
+def repair_status_defaults(apps, schema_editor):
+    connection = schema_editor.connection
+    with connection.cursor() as cursor:
+        if _table_exists(connection, "purchase_orders"):
+            cursor.execute("""
+                UPDATE purchase_orders
+                SET status = CASE status
+                    WHEN 'Draft' THEN 'DRAFT'
+                    WHEN 'Sent to Supplier' THEN 'SENT'
+                    WHEN 'Sent' THEN 'SENT'
+                    WHEN 'Received' THEN 'RECEIVED'
+                    WHEN 'Cancelled' THEN 'CANCELLED'
+                    ELSE status
+                END
+                WHERE status IN (
+                    'Draft', 'Sent to Supplier', 'Sent', 'Received', 'Cancelled'
+                )
+                """)
+        if _table_exists(connection, "indents"):
+            cursor.execute("""
+                UPDATE indents
+                SET status = CASE status
+                    WHEN 'Pending' THEN 'PENDING'
+                    WHEN 'Submitted' THEN 'SUBMITTED'
+                    WHEN 'Processing' THEN 'PROCESSING'
+                    WHEN 'Approved' THEN 'APPROVED'
+                    WHEN 'Completed' THEN 'COMPLETED'
+                    WHEN 'Cancelled' THEN 'CANCELLED'
+                    ELSE status
+                END
+                WHERE status IN (
+                    'Pending', 'Submitted', 'Processing', 'Approved',
+                    'Completed', 'Cancelled'
+                )
+                """)
+        if _table_exists(connection, "indent_items"):
+            cursor.execute("""
+                UPDATE indent_items
+                SET item_status = CASE item_status
+                    WHEN 'Pending Issue' THEN 'PENDING'
+                    WHEN 'Pending' THEN 'PENDING'
+                    WHEN 'Issued' THEN 'ISSUED'
+                    WHEN 'Cancelled' THEN 'CANCELLED'
+                    ELSE item_status
+                END
+                WHERE item_status IN (
+                    'Pending Issue', 'Pending', 'Issued', 'Cancelled'
+                )
+                """)
+
+        if connection.vendor == "postgresql":
+            cursor.execute(
+                "ALTER TABLE purchase_orders ALTER COLUMN status SET DEFAULT 'DRAFT'"
+            )
+            cursor.execute(
+                "ALTER TABLE indents ALTER COLUMN status SET DEFAULT 'SUBMITTED'"
+            )
+            cursor.execute(
+                "ALTER TABLE indent_items ALTER COLUMN item_status SET DEFAULT 'PENDING'"
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("inventory", "0042_vendor_item_price"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunPython(ensure_grn_number, migrations.RunPython.noop),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="goodsreceivednote",
+                    name="grn_number",
+                    field=models.CharField(
+                        blank=True, default="", max_length=100, unique=True
+                    ),
+                ),
+            ],
+        ),
+        migrations.RunPython(
+            ensure_sales_transactions,
+            migrations.RunPython.noop,
+        ),
+        migrations.RunPython(
+            repair_status_defaults,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/inventory/models/orders.py
+++ b/inventory/models/orders.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from django.db import models
-from django.db.models import Sum
+from django.db.models import Max, Sum
 
 from .departments import Department
 from .enums import IndentStatus, ItemStatus, PurchaseOrderStatus
@@ -223,6 +223,7 @@ class GoodsReceivedNote(models.Model):
     """Acknowledges receipt of goods for a purchase order."""
 
     grn_id = models.AutoField(primary_key=True)
+    grn_number = models.CharField(max_length=100, unique=True, blank=True, default="")
     # D6: Made nullable to support ad-hoc GRNs without a PO
     purchase_order = models.ForeignKey(
         PurchaseOrder,
@@ -243,10 +244,19 @@ class GoodsReceivedNote(models.Model):
         help_text="Delivery note or invoice number",
     )
 
+    def save(self, *args, **kwargs):
+        if not self.grn_number:
+            next_id = (
+                GoodsReceivedNote.objects.aggregate(m=Max("grn_id"))["m"] or 0
+            ) + 1
+            self.grn_number = f"GRN-{next_id:04d}"
+        super().save(*args, **kwargs)
+
     def __str__(self) -> str:  # pragma: no cover - simple representation
+        label = self.grn_number or f"GRN {self.pk}"
         if self.purchase_order_id:
-            return f"GRN {self.pk} for PO {self.purchase_order_id}"
-        return f"GRN {self.pk} (Ad-hoc)"
+            return f"{label} for PO {self.purchase_order_id}"
+        return f"{label} (Ad-hoc)"
 
     class Meta:
         managed = True

--- a/inventory/serializers.py
+++ b/inventory/serializers.py
@@ -32,6 +32,11 @@ class ItemSerializer(serializers.ModelSerializer):
             "name",
             "unit_id",
             "category_id",
+            "initial_purchase_price",
+            "last_purchase_price",
+            "preferred_supplier",
+            "minimum_order_qty",
+            "lead_time_days",
             "reorder_point",
             "current_stock",
             "notes",
@@ -69,6 +74,10 @@ class SupplierSerializer(serializers.ModelSerializer):
             "phone",
             "email",
             "address",
+            "tax_id",
+            "payment_terms",
+            "credit_limit",
+            "supplier_rating",
             "notes",
             "is_active",
             "updated_at",
@@ -154,6 +163,7 @@ class PurchaseOrderSerializer(serializers.ModelSerializer):
         model = PurchaseOrder
         fields = [
             "po_id",
+            "po_number",
             "supplier",
             "order_date",
             "expected_delivery_date",
@@ -187,9 +197,12 @@ class GoodsReceivedNoteSerializer(serializers.ModelSerializer):
         model = GoodsReceivedNote
         fields = [
             "grn_id",
+            "grn_number",
             "purchase_order",
             "supplier",
             "received_date",
+            "delivery_note_number",
+            "attachment",
             "notes",
         ]
 

--- a/inventory/services/goods_receiving_service.py
+++ b/inventory/services/goods_receiving_service.py
@@ -48,6 +48,7 @@ def _create_grn_header(
         else None
     )
     grn = GoodsReceivedNote.objects.create(
+        grn_number=generate_grn_number(),
         purchase_order=po,
         supplier=supplier,
         received_date=grn_data["received_date"],
@@ -63,7 +64,7 @@ def _process_items(
     user_id: str,
     po: Optional[PurchaseOrder],
 ) -> None:
-    grn_number = generate_grn_number()
+    grn_number = grn.grn_number
     item_ids = {d["item_id"] for d in items_received_data}
     po_item_ids = {d["po_item_id"] for d in items_received_data}
     items = Item.objects.in_bulk(item_ids)

--- a/inventory/views/goods_received.py
+++ b/inventory/views/goods_received.py
@@ -518,8 +518,9 @@ def create_adhoc_grn(request):
                     with db_transaction.atomic():
                         grn = form.save(commit=False)
                         grn.purchase_order = None
+                        grn.grn_number = generate_grn_number()
                         grn.save()
-                        grn_number = generate_grn_number()
+                        grn_number = grn.grn_number
                         user_id = (
                             getattr(request.user, "username", "System") or "System"
                         )

--- a/tests/test_goods_receiving_service_django.py
+++ b/tests/test_goods_receiving_service_django.py
@@ -3,7 +3,13 @@ from decimal import Decimal
 
 import pytest
 
-from inventory.models import PurchaseOrder, PurchaseOrderItem, SavingsLedger, Supplier
+from inventory.models import (
+    GoodsReceivedNote,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    SavingsLedger,
+    Supplier,
+)
 from inventory.services import goods_receiving_service, purchase_order_service
 
 
@@ -35,6 +41,8 @@ def test_create_grn_updates_stock_and_po(item_factory):
     ]
     success, msg, grn_id = goods_receiving_service.create_grn(grn_data, items_data)
     assert success, msg
+    grn = GoodsReceivedNote.objects.get(pk=grn_id)
+    assert grn.grn_number == "GRN-0001"
     item.refresh_from_db()
     assert item.current_stock == 5
     po_item.refresh_from_db()

--- a/tests/test_recipe_service.py
+++ b/tests/test_recipe_service.py
@@ -11,12 +11,11 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture(scope="module", autouse=True)
 def create_tables(django_db_blocker):
-    """Ensure the temporary SaleTransaction table exists for this module.
+    """Ensure the permanent SaleTransaction table exists for this module.
 
     The table is created by migrations in normal operation, so it may already
     be present. Attempting to create it again raises an ``OperationalError``.
-    To make the tests resilient we ignore the error if the table already exists
-    and likewise ignore missing-table errors on cleanup.
+    To make the tests resilient we ignore the error if the table already exists.
     """
 
     with django_db_blocker.unblock():
@@ -26,12 +25,6 @@ def create_tables(django_db_blocker):
             except OperationalError:
                 pass
     yield
-    with django_db_blocker.unblock():
-        with connection.schema_editor() as editor:
-            try:
-                editor.delete_model(SaleTransaction)
-            except OperationalError:
-                pass
 
 
 def _create_item(name="Flour", unit_id=19, stock=20):

--- a/tests/test_supabase_schema_alignment.py
+++ b/tests/test_supabase_schema_alignment.py
@@ -1,0 +1,123 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from django.db import connection
+from django.urls import reverse
+
+from inventory.models import (
+    GoodsReceivedNote,
+    Indent,
+    IndentItem,
+    PurchaseOrder,
+    SaleTransaction,
+    Supplier,
+)
+from inventory.serializers import (
+    GoodsReceivedNoteSerializer,
+    ItemSerializer,
+    PurchaseOrderSerializer,
+    SupplierSerializer,
+)
+
+
+@pytest.mark.django_db
+def test_adhoc_grn_creation_persists_grn_number(client, item_factory):
+    supplier = Supplier.objects.create(name="Adhoc Vendor")
+    item = item_factory(name="Adhoc Tomato", current_stock=Decimal("0"))
+
+    response = client.post(
+        reverse("grn_create_adhoc"),
+        {
+            "supplier": supplier.pk,
+            "received_date": date.today().isoformat(),
+            "delivery_note_number": "INV-001",
+            "notes": "Direct receipt",
+            "lines-TOTAL_FORMS": "3",
+            "lines-INITIAL_FORMS": "0",
+            "lines-MIN_NUM_FORMS": "1",
+            "lines-MAX_NUM_FORMS": "1000",
+            "lines-0-item": item.pk,
+            "lines-0-quantity_received": "2.00",
+            "lines-0-unit_price": "30.00",
+            "lines-0-item_notes": "",
+            "lines-1-item": "",
+            "lines-1-quantity_received": "",
+            "lines-1-unit_price": "",
+            "lines-1-item_notes": "",
+            "lines-2-item": "",
+            "lines-2-quantity_received": "",
+            "lines-2-unit_price": "",
+            "lines-2-item_notes": "",
+        },
+    )
+
+    assert response.status_code == 302
+    grn = GoodsReceivedNote.objects.get(supplier=supplier)
+    assert grn.grn_number == "GRN-0001"
+    assert grn.delivery_note_number == "INV-001"
+
+
+@pytest.mark.django_db
+def test_sales_transactions_table_exists_and_model_writes():
+    assert SaleTransaction._meta.db_table in connection.introspection.table_names()
+    sale = SaleTransaction.objects.create(quantity=Decimal("3.00"), notes="Walk-in")
+    assert sale.sale_id
+
+
+@pytest.mark.django_db
+def test_api_serializers_expose_stored_planning_and_document_fields(item_factory):
+    supplier = Supplier.objects.create(
+        name="API Vendor",
+        tax_id="GST123",
+        payment_terms="Net 30",
+        credit_limit=Decimal("5000.00"),
+        supplier_rating=4,
+    )
+    item = item_factory(
+        name="API Rice",
+        initial_purchase_price=Decimal("40.00"),
+        last_purchase_price=Decimal("44.00"),
+        preferred_supplier=supplier,
+        minimum_order_qty=Decimal("5.00"),
+        lead_time_days=2,
+    )
+    po = PurchaseOrder.objects.create(supplier=supplier, order_date=date.today())
+    grn = GoodsReceivedNote.objects.create(
+        supplier=supplier,
+        purchase_order=po,
+        received_date=date.today(),
+        delivery_note_number="DN-7",
+    )
+
+    item_data = ItemSerializer(item).data
+    supplier_data = SupplierSerializer(supplier).data
+    po_data = PurchaseOrderSerializer(po).data
+    grn_data = GoodsReceivedNoteSerializer(grn).data
+
+    assert item_data["initial_purchase_price"] == "40.00"
+    assert item_data["last_purchase_price"] == "44.00"
+    assert item_data["preferred_supplier"] == supplier.pk
+    assert item_data["minimum_order_qty"] == "5.00"
+    assert item_data["lead_time_days"] == 2
+    assert supplier_data["tax_id"] == "GST123"
+    assert supplier_data["payment_terms"] == "Net 30"
+    assert supplier_data["credit_limit"] == "5000.00"
+    assert supplier_data["supplier_rating"] == 4
+    assert po_data["po_number"] == po.po_number
+    assert grn_data["grn_number"] == grn.grn_number
+    assert grn_data["delivery_note_number"] == "DN-7"
+    assert "attachment" in grn_data
+
+
+@pytest.mark.django_db
+def test_model_status_defaults_are_uppercase_enum_values(item_factory):
+    supplier = Supplier.objects.create(name="Default Vendor")
+    item = item_factory(name="Default Flour")
+    indent = Indent.objects.create(mrn="MRN-DEFAULT")
+    indent_item = IndentItem.objects.create(indent=indent, item=item)
+    po = PurchaseOrder.objects.create(supplier=supplier, order_date=date.today())
+
+    assert indent.status == "SUBMITTED"
+    assert indent_item.item_status == "PENDING"
+    assert po.status == "DRAFT"


### PR DESCRIPTION
## Summary
- add Django schema repair migration for GRN numbers, missing sales_transactions, and uppercase status defaults
- persist grn_number during PO-based and ad-hoc GRN creation
- expose stored planning/document fields in API serializers
- treat sales_transactions as a permanent table in tests

## Verification
- .\\.venv\\Scripts\\python.exe manage.py migrate inventory 0043 --settings=inventory_app.settings.dev
- .\\.venv\\Scripts\\python.exe manage.py check --settings=inventory_app.settings.test
- .\\.venv\\Scripts\\python.exe manage.py makemigrations --check --dry-run --settings=inventory_app.settings.test
- .\\.venv\\Scripts\\python.exe -m ruff check inventory\\models\\orders.py inventory\\services\\goods_receiving_service.py inventory\\views\\goods_received.py inventory\\serializers.py inventory\\migrations\\0043_supabase_schema_alignment.py tests\\test_goods_receiving_service_django.py tests\\test_supabase_schema_alignment.py tests\\test_recipe_service.py
- .\\.venv\\Scripts\\python.exe -m pytest -q

## Supabase note
Read-only verification against sjvdhxbskucotbbpobww still shows the pre-migration drift: sales_transactions missing, grn_number present, and status defaults using display strings. This PR fixes those once the Django migration is applied.