### PR TITLE
[codex] fix date pickers and modal scrolling

### DIFF
--- a/inventory/forms/base.py
+++ b/inventory/forms/base.py
@@ -33,6 +33,20 @@ class StyledFormMixin:
                 self._append_class(widget, CHECKBOX_CLASS)
                 continue
 
+            # Ensure native pickers for date/time widgets unless explicitly overridden
+            if isinstance(widget, forms.DateInput) and "type" not in widget.attrs:
+                widget.input_type = "date"
+                widget.attrs["type"] = "date"
+            elif (
+                isinstance(widget, forms.DateTimeInput)
+                and "type" not in widget.attrs
+            ):
+                widget.input_type = "datetime-local"
+                widget.attrs["type"] = "datetime-local"
+            elif isinstance(widget, forms.TimeInput) and "type" not in widget.attrs:
+                widget.input_type = "time"
+                widget.attrs["type"] = "time"
+
             # All other inputs get the base INPUT_CLASS
             self._append_class(widget, INPUT_CLASS)
 

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -265,12 +265,12 @@ html.dark .bg-white\/40 {
     @apply bg-surface border border-border rounded-xl shadow-card;
   }
   .drawer-panel {
-    @apply bg-surface border border-border rounded-xl max-w-drawer-md shadow-overlay;
+    @apply bg-surface border border-border rounded-xl max-w-drawer-md shadow-overlay max-h-[calc(100vh-2rem)] min-h-0 overflow-y-auto;
   }
 
   /* Drawer layout for modal.js openDrawer() wrapper */
   .drawer {
-    @apply flex min-h-0 flex-col max-h-[90vh] overflow-y-auto;
+    @apply flex min-h-0 flex-col max-h-[calc(100vh-2rem)] overflow-y-auto;
   }
   .drawer.right {
     @apply ml-auto;

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -139,8 +139,13 @@
           data-modal-close
           aria-label="Close modal"
         ></div>
-        <div class="absolute inset-0 flex items-center justify-center p-4">
-          <div id="modal-content" class="max-w-7xl w-full max-h-[90vh] min-h-0 overflow-y-auto"></div>
+        <div class="absolute inset-0 overflow-y-auto p-4">
+          <div class="min-h-full flex items-start justify-center sm:items-center">
+            <div
+              id="modal-content"
+              class="max-w-7xl w-full max-h-[calc(100vh-2rem)] min-h-0 overflow-y-auto"
+            ></div>
+          </div>
         </div>
       </div>
 

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -3,8 +3,9 @@ Generic modal component. Include with:
 {% include "components/modal.html" with id="my-modal" open_id="open-btn" title="Optional Title" content_template="path/to/template.html" %}
 The `content_template` is rendered inside the modal panel.
 {% endcomment %}
-<div id="{{ id }}" class="fixed inset-0 hidden z-50 bg-black/50 flex items-center justify-center p-4 overflow-y-auto">
-  <div class="bg-surface rounded-2xl shadow-card border border-border w-full max-w-lg md:max-w-xl lg:max-w-2xl relative max-h-[90vh] overflow-y-auto">
+<div id="{{ id }}" class="fixed inset-0 hidden z-50 bg-black/50 overflow-y-auto p-4">
+  <div class="min-h-full flex items-start justify-center sm:items-center">
+  <div class="bg-surface rounded-2xl shadow-card border border-border w-full max-w-lg md:max-w-xl lg:max-w-2xl relative max-h-[calc(100vh-2rem)] overflow-y-auto">
     {% if title %}
     <div class="sticky top-0 bg-surface px-6 pt-6 pb-4 border-b border-border">
       <h3 class="text-lg font-semibold text-gray-900">{{ title }}</h3>
@@ -20,6 +21,7 @@ The `content_template` is rendered inside the modal panel.
     <div class="p-6">
       {% include content_template %}
     </div>
+  </div>
   </div>
 
 </div>

--- a/tests/test_form_mixin_predictive.py
+++ b/tests/test_form_mixin_predictive.py
@@ -5,6 +5,7 @@ from inventory.forms.base import StyledFormMixin
 
 class DummyForm(StyledFormMixin, forms.Form):
     a_text = forms.CharField()
+    a_date = forms.DateField()
     a_select = forms.ChoiceField(choices=[("1", "One"), ("2", "Two")])
     a_multi = forms.MultipleChoiceField(
         choices=[("x", "X"), ("y", "Y")], widget=forms.SelectMultiple
@@ -15,6 +16,8 @@ def test_styled_form_mixin_adds_predictive_to_selects():
     f = DummyForm()
     # text input shouldn't have predictive
     assert "predictive" not in (f.fields["a_text"].widget.attrs.get("class") or "")
+    assert f.fields["a_date"].widget.input_type == "date"
+    assert f.fields["a_date"].widget.attrs.get("type") == "date"
     # select widgets should have predictive
     assert "predictive" in (f.fields["a_select"].widget.attrs.get("class") or "")
     assert "predictive" in (f.fields["a_multi"].widget.attrs.get("class") or "")

--- a/tests/test_stock_forms.py
+++ b/tests/test_stock_forms.py
@@ -38,6 +38,9 @@ def test_stock_movements_page_has_datalist(client):
     assert 'hx-target="#item-options"' in content
     assert 'hx-trigger="keyup changed delay:500ms"' in content
     assert 'list="item-options"' in content
+    assert 'id="modal-root"' in content
+    assert "min-h-full flex items-start justify-center sm:items-center" in content
+    assert "max-h-[calc(100vh-2rem)]" in content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What changed
- enforced native date/time input types in shared StyledFormMixin so date widgets render as picker controls across forms
- updated shared modal containers to allow long modal/drawer forms to scroll reliably
- updated shared drawer panel height/overflow styles for consistent behavior
- added regression coverage for date widget typing and modal container scroll classes

## Why
Some forms were rendering date fields as plain text inputs, and long modal forms were not scrollable in several flows. Both issues were due to shared rendering/layout behavior rather than page-specific code.

## Validation
- python -m pytest tests/test_form_mixin_predictive.py tests/test_stock_forms.py -q
- python -m pytest -q
