### PR TITLE
[codex] fix typed date input and modal scrolling

### DIFF
--- a/inventory/forms/base.py
+++ b/inventory/forms/base.py
@@ -2,6 +2,15 @@ from __future__ import annotations
 
 from django import forms
 
+DATE_INPUT_FORMATS_FALLBACK = (
+    "%Y-%m-%d",
+    "%d-%m-%Y",
+    "%d/%m/%Y",
+    "%m/%d/%Y",
+    "%m-%d-%Y",
+)
+TIME_INPUT_FORMATS_FALLBACK = ("%H:%M", "%H:%M:%S")
+
 INPUT_CLASS = (
     "block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text "
     "focus:outline-none focus:ring-2 focus:ring-primary"
@@ -37,6 +46,8 @@ class StyledFormMixin:
             if isinstance(widget, forms.DateInput) and "type" not in widget.attrs:
                 widget.input_type = "date"
                 widget.attrs["type"] = "date"
+                if not getattr(widget, "format", None):
+                    widget.format = "%Y-%m-%d"
             elif (
                 isinstance(widget, forms.DateTimeInput)
                 and "type" not in widget.attrs
@@ -46,6 +57,20 @@ class StyledFormMixin:
             elif isinstance(widget, forms.TimeInput) and "type" not in widget.attrs:
                 widget.input_type = "time"
                 widget.attrs["type"] = "time"
+                if not getattr(widget, "format", None):
+                    widget.format = "%H:%M"
+
+            # Accept common manual text formats in addition to native picker values.
+            if isinstance(field, forms.DateField):
+                existing = tuple(getattr(field, "input_formats", ()) or ())
+                field.input_formats = tuple(
+                    dict.fromkeys((*DATE_INPUT_FORMATS_FALLBACK, *existing))
+                )
+            elif isinstance(field, forms.TimeField):
+                existing = tuple(getattr(field, "input_formats", ()) or ())
+                field.input_formats = tuple(
+                    dict.fromkeys((*TIME_INPUT_FORMATS_FALLBACK, *existing))
+                )
 
             # All other inputs get the base INPUT_CLASS
             self._append_class(widget, INPUT_CLASS)

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -77,7 +77,7 @@
     const content = document.getElementById("modal-content");
     if (!root || !content) return;
     lastFocused = document.activeElement;
-    content.innerHTML = `<div class="drawer ${side} wide">${html}</div>`;
+    content.innerHTML = `<div class="drawer ${side} wide w-full">${html}</div>`;
     if (!skipInit) {
       requestAnimationFrame(() => {
         if (window.htmx && typeof window.htmx.process === "function") {

--- a/static/src/app.css
+++ b/static/src/app.css
@@ -270,7 +270,7 @@ html.dark .bg-white\/40 {
 
   /* Drawer layout for modal.js openDrawer() wrapper */
   .drawer {
-    @apply flex min-h-0 flex-col max-h-[calc(100vh-2rem)] overflow-y-auto;
+    @apply flex w-full min-h-0 flex-col max-h-[calc(100vh-2rem)] overflow-y-auto overscroll-contain;
   }
   .drawer.right {
     @apply ml-auto;

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -128,24 +128,22 @@
       <!-- Modal Root -->
       <div
         id="modal-root"
-        class="hidden fixed inset-0 z-50"
+        class="hidden fixed inset-0 z-50 overflow-y-auto"
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-heading"
         tabindex="-1"
       >
         <div
-          class="absolute inset-0 bg-black/50"
+          class="fixed inset-0 bg-black/50"
           data-modal-close
           aria-label="Close modal"
         ></div>
-        <div class="absolute inset-0 overflow-y-auto p-4">
-          <div class="min-h-full flex items-start justify-center sm:items-center">
+        <div class="relative min-h-full flex items-start justify-center p-4">
             <div
               id="modal-content"
-              class="max-w-7xl w-full max-h-[calc(100vh-2rem)] min-h-0 overflow-y-auto"
+              class="max-w-7xl w-full max-h-[calc(100vh-2rem)] min-h-0 overflow-y-auto overscroll-contain"
             ></div>
-          </div>
         </div>
       </div>
 

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -4,8 +4,8 @@ Generic modal component. Include with:
 The `content_template` is rendered inside the modal panel.
 {% endcomment %}
 <div id="{{ id }}" class="fixed inset-0 hidden z-50 bg-black/50 overflow-y-auto p-4">
-  <div class="min-h-full flex items-start justify-center sm:items-center">
-  <div class="bg-surface rounded-2xl shadow-card border border-border w-full max-w-lg md:max-w-xl lg:max-w-2xl relative max-h-[calc(100vh-2rem)] overflow-y-auto">
+  <div class="min-h-full flex items-start justify-center">
+  <div class="bg-surface rounded-2xl shadow-card border border-border w-full max-w-lg md:max-w-xl lg:max-w-2xl relative max-h-[calc(100vh-2rem)] overflow-y-auto overscroll-contain">
     {% if title %}
     <div class="sticky top-0 bg-surface px-6 pt-6 pb-4 border-b border-border">
       <h3 class="text-lg font-semibold text-gray-900">{{ title }}</h3>

--- a/tests/test_form_mixin_predictive.py
+++ b/tests/test_form_mixin_predictive.py
@@ -18,6 +18,7 @@ def test_styled_form_mixin_adds_predictive_to_selects():
     assert "predictive" not in (f.fields["a_text"].widget.attrs.get("class") or "")
     assert f.fields["a_date"].widget.input_type == "date"
     assert f.fields["a_date"].widget.attrs.get("type") == "date"
+    assert "%d/%m/%Y" in f.fields["a_date"].input_formats
     # select widgets should have predictive
     assert "predictive" in (f.fields["a_select"].widget.attrs.get("class") or "")
     assert "predictive" in (f.fields["a_multi"].widget.attrs.get("class") or "")

--- a/tests/test_stock_forms.py
+++ b/tests/test_stock_forms.py
@@ -39,7 +39,7 @@ def test_stock_movements_page_has_datalist(client):
     assert 'hx-trigger="keyup changed delay:500ms"' in content
     assert 'list="item-options"' in content
     assert 'id="modal-root"' in content
-    assert "min-h-full flex items-start justify-center sm:items-center" in content
+    assert "min-h-full flex items-start justify-center" in content
     assert "max-h-[calc(100vh-2rem)]" in content
 
 


### PR DESCRIPTION
## What changed
- kept native date picker widgets but expanded accepted manual date input formats in shared form mixin
- adjusted shared modal root/layout to use scroll-safe structure for long forms
- aligned drawer wrapper width/overflow behavior for injected drawer content
- added/updated regression assertions for date formats and modal container classes

## Why
After the previous pass, date widgets showed picker UI but typed entries were rejected in practical flows, and modal form scrolling was still inconsistent.

## Validation
- python -m pytest tests/test_form_mixin_predictive.py tests/test_stock_forms.py -q
- python -m pytest -q
- 
pm.cmd run build
