### PR TITLE
[codex] fix purchase order drawer scroll and notes layout

### DIFF
--- a/templates/inventory/purchase_orders/_form_partial.html
+++ b/templates/inventory/purchase_orders/_form_partial.html
@@ -1,18 +1,23 @@
 {% load form_tags %}
-<div class="bg-surface border border-border rounded-2xl shadow-overlay overflow-hidden drawer-panel max-w-drawer-xl">
+<div class="bg-surface border border-border rounded-2xl shadow-overlay drawer-panel max-w-drawer-xl flex flex-col min-h-0">
   <div class="px-4 py-3 border-b border-border bg-surfaceSubtle flex items-center justify-between">
     <h3 class="text-base font-semibold text-bodyText">{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
   </div>
-  <div class="p-4">
-  <form method="post" id="po-drawer-form" data-drawer="purchase-order" data-formset-prefix="{{ formset.prefix }}" data-modal-form data-requires-line-items action="{% if is_edit %}{% url 'purchase_order_edit_partial' po.pk %}{% else %}{% url 'purchase_order_create_partial' %}{% endif %}">
+  <div class="p-4 flex-1 min-h-0 overflow-y-auto">
+  <form method="post" id="po-drawer-form" class="flex flex-col gap-4" data-drawer="purchase-order" data-formset-prefix="{{ formset.prefix }}" data-modal-form data-requires-line-items action="{% if is_edit %}{% url 'purchase_order_edit_partial' po.pk %}{% else %}{% url 'purchase_order_create_partial' %}{% endif %}">
       {% csrf_token %}
       {{ item_prices|json_script:"po-item-prices" }}
       {{ item_vendor_hints|json_script:"po-item-vendor-hints" }}
       <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
         {% for field in form %}
-          {% include "components/form_field.html" with field=field %}
+          {% if field.name != "notes" %}
+            {% include "components/form_field.html" with field=field %}
+          {% endif %}
         {% endfor %}
+      </div>
+      <div class="mt-4">
+        {% include "components/form_field.html" with field=form.notes %}
       </div>
       <datalist id="supplier-options"></datalist>
       {% include "inventory/purchase_orders/_po_line_items.html" with formset=formset %}

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -11,8 +11,13 @@
   {{ item_vendor_hints|json_script:"po-item-vendor-hints" }}
   <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
     {% for field in form %}
-      {% include "components/form_field.html" with field=field %}
+      {% if field.name != "notes" %}
+        {% include "components/form_field.html" with field=field %}
+      {% endif %}
     {% endfor %}
+  </div>
+  <div class="mt-4">
+    {% include "components/form_field.html" with field=form.notes %}
   </div>
   <datalist id="supplier-options"></datalist>
   {% include "inventory/purchase_orders/_po_line_items.html" with formset=formset %}

--- a/tests/test_purchase_order_drawer_partial.py
+++ b/tests/test_purchase_order_drawer_partial.py
@@ -6,6 +6,7 @@ import json
 from datetime import date
 
 import pytest
+from bs4 import BeautifulSoup
 from django.urls import reverse
 
 from inventory.models import PurchaseOrder, Supplier
@@ -35,6 +36,17 @@ def test_purchase_order_create_partial_get_has_drawer_hooks(po_staff_client):
     assert 'id="items-formset"' in content
     assert "supplier-options" in content
     assert "hx-get" in content
+    assert "drawer-panel max-w-drawer-xl flex flex-col min-h-0" in content
+    assert "p-4 flex-1 min-h-0 overflow-y-auto" in content
+
+    soup = BeautifulSoup(content, "html.parser")
+    notes = soup.find("textarea", attrs={"name": "notes"})
+    assert notes is not None
+    grid = soup.find(
+        "div", class_=lambda value: value and "grid-cols-2" in value and "gap-4" in value
+    )
+    assert grid is not None
+    assert grid.find("textarea", attrs={"name": "notes"}) is None
 
 
 def test_purchase_order_create_partial_post_validation_returns_json(po_staff_client):


### PR DESCRIPTION
## What changed
- fixed purchase order drawer partial to use a scrollable body container instead of overflow-hidden
- made PO drawer root/form wrappers flex-safe (min-h-0, lex-1, overflow-y-auto) so long forms can scroll
- moved 
otes out of the two-column grid into a full-width row across the form (drawer + full page)
- added test assertions for drawer scroll hooks and notes placement

## Why
The purchase order form was still not scrollable in the drawer, and notes needed to span the full form width.

## Validation
- python -m pytest tests/test_purchase_order_drawer_partial.py -q
- python -m pytest -q
