### PR TITLE
[codex] phase 4 role navigation and logout fix

### DIFF
--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -9,6 +9,20 @@ from django.urls import NoReverseMatch, reverse
 
 logger = logging.getLogger(__name__)
 
+ROLE_OWNER = "owner"
+ROLE_PURCHASE = "purchase"
+ROLE_STOREKEEPER = "storekeeper"
+ROLE_HEAD_CHEF = "head_chef"
+ROLE_KITCHEN_STAFF = "kitchen_staff"
+
+ROLE_GROUP_NAME_MAP: Mapping[str, str] = {
+    ROLE_OWNER: "Owner",
+    ROLE_PURCHASE: "Purchase",
+    ROLE_STOREKEEPER: "Storekeeper",
+    ROLE_HEAD_CHEF: "Head Chef",
+    ROLE_KITCHEN_STAFF: "Kitchen Staff",
+}
+
 # ---------------------------------------------------------------------------
 # Central definitions of navigation sections.  Each entry contains the user
 # facing title and the URL name that should resolve to the actual path.  The
@@ -134,6 +148,43 @@ NAVIGATION_LINKS = [
     for link in links
 ]
 
+ROLE_ALLOWED_URLS: Mapping[str, set[str]] = {
+    ROLE_OWNER: {
+        "root",
+        "food_cost_report",
+        "savings_ledger_list",
+        "history_reports",
+        "visualizations",
+        "ml_dashboard",
+        "indents_consolidate_preview",
+        "purchase_orders_list",
+        "grn_list",
+        "vendor_prices_list",
+    },
+    ROLE_PURCHASE: {
+        "indents_consolidate_preview",
+        "vendor_prices_list",
+        "purchase_orders_list",
+        "grn_list",
+        "savings_ledger_list",
+    },
+    ROLE_STOREKEEPER: {
+        "grn_list",
+        "stock_movements",
+        "stock_take_list",
+        "items_list",
+    },
+    ROLE_HEAD_CHEF: {
+        "food_cost_report",
+        "recipes_list",
+        "stock_movements",
+        "ml_dashboard",
+    },
+    ROLE_KITCHEN_STAFF: {
+        "indents_list",
+    },
+}
+
 
 def _resolve_link(link: Mapping[str, str]) -> Mapping[str, str]:
     """Resolve a navigation link to its absolute URL.
@@ -203,6 +254,35 @@ def get_navigation_groups(
     return resolved
 
 
+def get_primary_role(user) -> str | None:
+    """Return the first recognized role from the user's Django groups."""
+    if not getattr(user, "is_authenticated", False):
+        return None
+    if getattr(user, "is_superuser", False):
+        return ROLE_OWNER
+    names = set(user.groups.values_list("name", flat=True))
+    normalized = {name.strip().lower() for name in names}
+    for role_key, group_name in ROLE_GROUP_NAME_MAP.items():
+        if group_name.lower() in normalized:
+            return role_key
+    return None
+
+
+def get_navigation_groups_for_role(role: str | None) -> List[dict]:
+    """Return navigation groups filtered by role, or full groups if no role."""
+    allowed_urls = ROLE_ALLOWED_URLS.get(role)
+    if not allowed_urls:
+        return get_navigation_groups()
+    scoped_groups: List[tuple[str, List[Mapping[str, str]]]] = []
+    for category, links in NAVIGATION_GROUPS:
+        filtered_links = [
+            link for link in links if link.get("url_name", "") in allowed_urls
+        ]
+        if filtered_links:
+            scoped_groups.append((category, filtered_links))
+    return get_navigation_groups(groups=scoped_groups)
+
+
 def primary_navigation(request):
     """Provide grouped navigation data and notification counts for the top nav."""
     match = getattr(request, "resolver_match", None)
@@ -220,7 +300,12 @@ def primary_navigation(request):
             "notification_count": 0,
             "notifications": [],
         }
-    ctx = {"navigation_groups": get_navigation_groups()}
+    user = getattr(request, "user", None)
+    role = get_primary_role(user)
+    ctx = {
+        "navigation_groups": get_navigation_groups_for_role(role),
+        "primary_role": role,
+    }
     if hasattr(request, "user") and request.user.is_authenticated:
         try:
             from inventory.services.nav_kpis import get_cached_nav_kpis

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -163,7 +163,10 @@
               <a href="{% url 'workflow_guide' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Help &amp; Guide</a>
               <div class="border-t border-border my-1"></div>
               {% if user.is_superuser %}<a href="/admin/" class="block px-4 py-2 text-sm text-gray-500 hover:bg-surfaceSubtle" role="menuitem">Admin Panel</a>{% endif %}
-              <a href="{% url 'logout' %}" class="block px-4 py-2 text-sm text-danger hover:bg-danger-soft" role="menuitem">Sign out</a>
+              <form method="post" action="{% url 'logout' %}">
+                {% csrf_token %}
+                <button type="submit" class="w-full text-left block px-4 py-2 text-sm text-danger hover:bg-danger-soft" role="menuitem">Sign out</button>
+              </form>
             </div>
           </div>
         </div>

--- a/tests/test_auth_logout.py
+++ b/tests/test_auth_logout.py
@@ -1,0 +1,15 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_logout_post_clears_authenticated_session(client, django_user_model):
+    user = django_user_model.objects.create_user(username="logout_user", password="pw")
+    client.force_login(user)
+
+    assert "_auth_user_id" in client.session
+
+    response = client.post(reverse("logout"))
+
+    assert response.status_code in {200, 302}
+    assert "_auth_user_id" not in client.session

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.auth.models import Group
 from django.template.loader import render_to_string
 from django.test import RequestFactory
 from django.urls import NoReverseMatch, reverse
@@ -49,3 +50,76 @@ def test_get_navigation_links_raises_for_missing(monkeypatch):
     monkeypatch.setattr(navigation, "NAVIGATION_LINKS", bad_links)
     with pytest.raises(NoReverseMatch):
         navigation.get_navigation_links()
+
+
+@pytest.mark.django_db
+def test_role_owner_sees_owner_money_navigation(django_user_model):
+    owner_group, _ = Group.objects.get_or_create(name="Owner")
+    user = django_user_model.objects.create_user(username="owner", password="pw")
+    user.groups.add(owner_group)
+
+    role = navigation.get_primary_role(user)
+    groups = navigation.get_navigation_groups_for_role(role)
+    visible_urls = {link["url_name"] for group in groups for link in group["links"]}
+
+    assert role == navigation.ROLE_OWNER
+    assert "root" in visible_urls
+    assert "savings_ledger_list" in visible_urls
+    assert "vendor_prices_list" in visible_urls
+    assert "indents_list" not in visible_urls
+
+
+@pytest.mark.django_db
+def test_role_purchase_sees_procurement_only_navigation(django_user_model):
+    purchase_group, _ = Group.objects.get_or_create(name="Purchase")
+    user = django_user_model.objects.create_user(username="purchase", password="pw")
+    user.groups.add(purchase_group)
+
+    role = navigation.get_primary_role(user)
+    groups = navigation.get_navigation_groups_for_role(role)
+    visible_urls = {link["url_name"] for group in groups for link in group["links"]}
+
+    assert role == navigation.ROLE_PURCHASE
+    assert "purchase_orders_list" in visible_urls
+    assert "grn_list" in visible_urls
+    assert "vendor_prices_list" in visible_urls
+    assert "items_list" not in visible_urls
+    assert "recipes_list" not in visible_urls
+
+
+@pytest.mark.django_db
+def test_role_kitchen_staff_sees_indent_requests_only(django_user_model):
+    kitchen_group, _ = Group.objects.get_or_create(name="Kitchen Staff")
+    user = django_user_model.objects.create_user(username="kitchen", password="pw")
+    user.groups.add(kitchen_group)
+
+    role = navigation.get_primary_role(user)
+    groups = navigation.get_navigation_groups_for_role(role)
+    visible_urls = {link["url_name"] for group in groups for link in group["links"]}
+
+    assert role == navigation.ROLE_KITCHEN_STAFF
+    assert visible_urls == {"indents_list"}
+
+
+@pytest.mark.django_db
+def test_primary_navigation_hx_request_still_returns_empty(django_user_model):
+    user = django_user_model.objects.create_user(username="hx", password="pw")
+    request = RequestFactory().get("/", HTTP_HX_REQUEST="true")
+    request.user = user
+    request.resolver_match = None
+
+    ctx = navigation.primary_navigation(request)
+
+    assert ctx["navigation_groups"] == []
+
+
+@pytest.mark.django_db
+def test_top_nav_uses_post_logout_form(django_user_model):
+    user = django_user_model.objects.create_user(username="logout_u", password="pw")
+    rf = RequestFactory()
+    request = rf.get("/")
+    request.user = user
+    html = render_to_string("components/top_nav.html", request=request)
+
+    assert f'action="{reverse("logout")}"' in html
+    assert 'method="post"' in html


### PR DESCRIPTION
## What changed
- Added Phase 4 role-based navigation filtering using Django Groups in `inventory_app/navigation.py`.
- Limited top-nav links per role (`Owner`, `Purchase`, `Storekeeper`, `Head Chef`, `Kitchen Staff`).
- Fixed logout flow by switching top-nav sign-out from GET link to CSRF-protected POST form in `templates/components/top_nav.html`.
- Added/updated tests:
  - `tests/test_navigation.py` role-scoped navigation coverage and logout form assertion.
  - `tests/test_auth_logout.py` to verify POST logout clears the authenticated session.

## Why
- Staff should see task-focused screens while owners see money-focused surfaces (Phase 4 direction).
- Logout was failing because the UI used GET while the auth endpoint expects POST.

## Impact
- Cleaner role-specific UI exposure from the top navigation.
- Reliable sign-out behavior from the app menu.

## Validation
- `pytest tests/test_navigation.py tests/test_auth_logout.py tests/test_root_view.py -q` (29 passed)
- `pytest tests/test_navigation.py tests/test_auth_logout.py -q` (25 passed)
- `pytest tests/test_navigation.py tests/test_dashboard.py tests/test_interactive_dashboard.py -q` (33 passed)
