### PR TITLE
[codex] implement phase 6 ideal-vs-actual leakage report

### DIFF
--- a/inventory/services/variance_service.py
+++ b/inventory/services/variance_service.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+from django.db.models import Q, Sum
+
+from inventory.models import Item, RecipeItem, SaleTransaction, StockTransaction
+from inventory.services.units_service import UnitsService
+
+ZERO = Decimal("0")
+
+
+def _as_decimal(value) -> Decimal:
+    if value in (None, ""):
+        return ZERO
+    return Decimal(str(value))
+
+
+def _to_base_qty(item: Item, purchase_qty: Decimal) -> Decimal:
+    factor = _as_decimal(getattr(item.unit, "conversion_factor", None))
+    if factor <= 0:
+        factor = Decimal("1")
+    return purchase_qty * factor
+
+
+def _from_base_qty(item: Item, base_qty: Decimal) -> Decimal:
+    factor = _as_decimal(getattr(item.unit, "conversion_factor", None))
+    if factor <= 0:
+        factor = Decimal("1")
+    try:
+        return base_qty / factor
+    except (ArithmeticError, ZeroDivisionError):
+        return ZERO
+
+
+def _effective_item_qty(qty: Decimal, loss_pct: Decimal) -> Decimal:
+    if qty <= 0 or loss_pct <= 0 or loss_pct >= 100:
+        return qty
+    try:
+        return qty / (Decimal("1") - (loss_pct / Decimal("100")))
+    except (ArithmeticError, ZeroDivisionError):
+        return qty
+
+
+def _effective_subrecipe_qty(qty: Decimal, loss_pct: Decimal) -> Decimal:
+    if qty <= 0 or loss_pct <= 0:
+        return qty
+    return qty * (Decimal("1") + (loss_pct / Decimal("100")))
+
+
+def _recipe_lines_with_subrecipes(root_recipe_ids: set[int]) -> dict[int, list[RecipeItem]]:
+    line_map: dict[int, list[RecipeItem]] = {}
+    visited: set[int] = set()
+    queue = set(root_recipe_ids)
+
+    while queue:
+        batch = queue - visited
+        if not batch:
+            break
+        visited.update(batch)
+        rows = list(
+            RecipeItem.objects.filter(recipe_id__in=batch)
+            .select_related("item__unit", "sub_recipe")
+            .order_by("recipe_id", "sort_order", "pk")
+        )
+        for row in rows:
+            line_map.setdefault(row.recipe_id, []).append(row)
+            if row.sub_recipe_id and row.sub_recipe_id not in visited:
+                queue.add(row.sub_recipe_id)
+    return line_map
+
+
+def _expand_recipe_usage(
+    recipe_id: int,
+    multiplier: Decimal,
+    line_map: dict[int, list[RecipeItem]],
+    output: dict[int, Decimal],
+    stack: set[int],
+) -> None:
+    if multiplier <= 0 or recipe_id in stack:
+        return
+    stack_next = set(stack)
+    stack_next.add(recipe_id)
+
+    for line in line_map.get(recipe_id, []):
+        qty = _as_decimal(line.quantity)
+        loss_pct = _as_decimal(line.loss_pct)
+        if line.item_id:
+            per_sale_qty = _effective_item_qty(qty, loss_pct)
+            if per_sale_qty > 0:
+                output[line.item_id] += per_sale_qty * multiplier
+            continue
+        if line.sub_recipe_id:
+            sub_qty = _effective_subrecipe_qty(qty, loss_pct)
+            _expand_recipe_usage(
+                line.sub_recipe_id,
+                sub_qty * multiplier,
+                line_map,
+                output,
+                stack_next,
+            )
+
+
+def _ideal_usage_by_item(start_date: date, end_date: date):
+    sales_rows = (
+        SaleTransaction.objects.filter(
+            sale_date__date__gte=start_date,
+            sale_date__date__lte=end_date,
+            recipe__isnull=False,
+        )
+        .values("recipe_id")
+        .annotate(total_qty=Sum("quantity"))
+    )
+    sales_by_recipe = {
+        row["recipe_id"]: _as_decimal(row["total_qty"])
+        for row in sales_rows
+        if row["recipe_id"] is not None
+    }
+    if not sales_by_recipe:
+        return {}, 0
+
+    line_map = _recipe_lines_with_subrecipes(set(sales_by_recipe.keys()))
+    ideal_by_item: dict[int, Decimal] = defaultdict(lambda: ZERO)
+    for recipe_id, sale_qty in sales_by_recipe.items():
+        _expand_recipe_usage(recipe_id, sale_qty, line_map, ideal_by_item, set())
+    return ideal_by_item, len(sales_by_recipe)
+
+
+def _actual_usage_by_item(start_date: date, end_date: date, candidate_item_ids: set[int]):
+    if not candidate_item_ids:
+        return {}
+    items = {
+        item.pk: item
+        for item in Item.objects.filter(pk__in=candidate_item_ids).select_related("unit")
+    }
+
+    stock_rows = (
+        StockTransaction.objects.filter(
+            item_id__in=candidate_item_ids,
+            transaction_date__date__gte=start_date,
+            transaction_date__date__lte=end_date,
+        )
+        .values("item_id")
+        .annotate(
+            net_qty=Sum("quantity_change"),
+            purchases_qty=Sum(
+                "quantity_change",
+                filter=Q(transaction_type="RECEIVING"),
+            ),
+            wastage_qty=Sum(
+                "quantity_change",
+                filter=Q(transaction_type="WASTAGE"),
+            ),
+        )
+    )
+    stock_map = {row["item_id"]: row for row in stock_rows}
+
+    actual = {}
+    for item_id, item in items.items():
+        row = stock_map.get(item_id) or {}
+        closing_pu = _as_decimal(item.current_stock)
+        net_qty_pu = _as_decimal(row.get("net_qty"))
+        purchases_pu = _as_decimal(row.get("purchases_qty"))
+        wastage_pu = _as_decimal(row.get("wastage_qty"))
+        opening_pu = closing_pu - net_qty_pu
+        actual_pu = opening_pu + purchases_pu - closing_pu
+        actual_base = _to_base_qty(item, actual_pu)
+        wastage_base = abs(_to_base_qty(item, wastage_pu))
+        actual[item_id] = {
+            "item": item,
+            "opening_base": _to_base_qty(item, opening_pu),
+            "purchases_base": _to_base_qty(item, purchases_pu),
+            "closing_base": _to_base_qty(item, closing_pu),
+            "actual_base": actual_base,
+            "wastage_base": wastage_base,
+        }
+    return actual
+
+
+def _likely_reason_and_action(
+    *, ideal_base: Decimal, actual_base: Decimal, variance_base: Decimal, wastage_base: Decimal
+) -> tuple[str, str]:
+    if ideal_base == 0 and actual_base > 0:
+        return (
+            "Usage exists but mapped sales are missing for this item.",
+            "Map missing POS menu items to recipes and verify recipe ingredients.",
+        )
+    if variance_base > 0 and wastage_base > 0:
+        return (
+            "Recorded wastage explains part of over-usage.",
+            "Review wastage reasons and assign a reduction action this week.",
+        )
+    if variance_base > 0:
+        return (
+            "Actual usage is above ideal usage.",
+            "Recheck portioning, receiving quality, and unrecorded waste for this item.",
+        )
+    if variance_base < 0:
+        return (
+            "Actual usage is below ideal usage.",
+            "Validate recipe quantities and sales mapping for this item.",
+        )
+    return (
+        "Usage is aligned with ideal.",
+        "Keep monitoring this item weekly.",
+    )
+
+
+@dataclass
+class VarianceRow:
+    item: Item
+    unit_label: str
+    ideal_usage: Decimal
+    actual_usage: Decimal
+    variance_qty: Decimal
+    variance_value: Decimal
+    likely_reason: str
+    recommended_action: str
+    is_unmapped_candidate: bool
+
+
+def build_variance_report(start_date: date, end_date: date) -> dict:
+    ideal_map, mapped_recipe_count = _ideal_usage_by_item(start_date, end_date)
+    period_item_ids = set(
+        StockTransaction.objects.filter(
+            transaction_date__date__gte=start_date,
+            transaction_date__date__lte=end_date,
+            item__isnull=False,
+        ).values_list("item_id", flat=True)
+    )
+    candidate_item_ids = set(ideal_map.keys()) | period_item_ids
+    actual_map = _actual_usage_by_item(start_date, end_date, candidate_item_ids)
+
+    rows: list[VarianceRow] = []
+    total_positive_leakage = ZERO
+    total_negative_variance_value = ZERO
+
+    item_lookup = {
+        item.pk: item
+        for item in Item.objects.filter(pk__in=(set(ideal_map.keys()) | set(actual_map.keys()))).select_related(
+            "unit"
+        )
+    }
+    for item in sorted(item_lookup.values(), key=lambda row: (row.name or "").lower()):
+        item_id = item.pk
+        state = actual_map.get(item_id)
+        if item is None:
+            continue
+
+        ideal_base = _as_decimal(ideal_map.get(item_id))
+        actual_base = _as_decimal(state["actual_base"] if state else ZERO)
+        variance_base = actual_base - ideal_base
+        cost_per_base = UnitsService.cost_per_base_for_item(item)
+        variance_value = variance_base * _as_decimal(cost_per_base)
+        wastage_base = _as_decimal(state["wastage_base"] if state else ZERO)
+        likely_reason, action = _likely_reason_and_action(
+            ideal_base=ideal_base,
+            actual_base=actual_base,
+            variance_base=variance_base,
+            wastage_base=wastage_base,
+        )
+        is_unmapped_candidate = ideal_base == 0 and actual_base > 0
+
+        if variance_value > 0:
+            total_positive_leakage += variance_value
+        elif variance_value < 0:
+            total_negative_variance_value += abs(variance_value)
+
+        rows.append(
+            VarianceRow(
+                item=item,
+                unit_label=getattr(item.unit, "purchase_unit", "unit"),
+                ideal_usage=_from_base_qty(item, ideal_base),
+                actual_usage=_from_base_qty(item, actual_base),
+                variance_qty=_from_base_qty(item, variance_base),
+                variance_value=variance_value,
+                likely_reason=likely_reason,
+                recommended_action=action,
+                is_unmapped_candidate=is_unmapped_candidate,
+            )
+        )
+
+    rows.sort(key=lambda row: row.variance_value, reverse=True)
+
+    unmapped_sales = SaleTransaction.objects.filter(
+        sale_date__date__gte=start_date,
+        sale_date__date__lte=end_date,
+        recipe__isnull=True,
+    )
+    unmapped_count = unmapped_sales.count()
+
+    return {
+        "rows": rows,
+        "summary": {
+            "total_items": len(rows),
+            "mapped_recipe_count": mapped_recipe_count,
+            "unmapped_sales_count": unmapped_count,
+            "leakage_value": total_positive_leakage,
+            "favourable_value": total_negative_variance_value,
+        },
+    }

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -75,6 +75,7 @@ from .views.recipes import (
 )
 from .views.recovery import savings_ledger_list, vendor_prices_list
 from .views.sales import pos_sales_import
+from .views.variance import variance_report
 from .views.settings import change_password_view, profile_edit_view, settings_view
 from .views.stock import POSearchView, UserSearchView, history_reports, stock_movements
 from .views.stock_take import (
@@ -265,6 +266,7 @@ urlpatterns = [
     path("savings-ledger/", savings_ledger_list, name="savings_ledger_list"),
     path("vendor-prices/", vendor_prices_list, name="vendor_prices_list"),
     path("pos-sales/", pos_sales_import, name="pos_sales_import"),
+    path("variance-report/", variance_report, name="variance_report"),
     path("recipes/", RecipesListView.as_view(), name="recipes_list"),
     path("recipes/table/", RecipesTableView.as_view(), name="recipes_table"),
     path("recipes/food-cost-report/", food_cost_report, name="food_cost_report"),

--- a/inventory/views/variance.py
+++ b/inventory/views/variance.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from django.core.paginator import Paginator
+from django.shortcuts import render
+from django.utils import timezone
+
+from inventory.services.variance_service import build_variance_report
+
+
+def _parse_date(raw_value: str, fallback: date) -> date:
+    raw = (raw_value or "").strip()
+    if not raw:
+        return fallback
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return fallback
+
+
+def variance_report(request):
+    today = timezone.localdate()
+    default_start = today - timedelta(days=6)
+    start_date = _parse_date(request.GET.get("start_date", ""), default_start)
+    end_date = _parse_date(request.GET.get("end_date", ""), today)
+    if start_date > end_date:
+        start_date, end_date = end_date, start_date
+
+    show_mode = (request.GET.get("show") or "all").strip().lower()
+    allowed_modes = {"all", "leakage_only", "unmapped_only"}
+    if show_mode not in allowed_modes:
+        show_mode = "all"
+
+    report = build_variance_report(start_date, end_date)
+    rows = report["rows"]
+    if show_mode == "leakage_only":
+        rows = [row for row in rows if row.variance_value > 0]
+    elif show_mode == "unmapped_only":
+        rows = [row for row in rows if row.is_unmapped_candidate]
+
+    paginator = Paginator(rows, 30)
+    page_obj = paginator.get_page(request.GET.get("page"))
+
+    return render(
+        request,
+        "inventory/recovery/variance_report.html",
+        {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "show_mode": show_mode,
+            "summary": report["summary"],
+            "page_obj": page_obj,
+            "visible_count": len(rows),
+        },
+    )

--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -58,6 +58,11 @@ NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
                 "url_name": "pos_sales_import",
             },
             {
+                "title": "Ideal vs Actual",
+                "description": "Track item-level variance and leakage value by period.",
+                "url_name": "variance_report",
+            },
+            {
                 "title": "History",
                 "description": "Past stock activity and audit trail.",
                 "url_name": "history_reports",
@@ -162,6 +167,7 @@ ROLE_ALLOWED_URLS: Mapping[str, set[str]] = {
         "visualizations",
         "ml_dashboard",
         "pos_sales_import",
+        "variance_report",
         "indents_consolidate_preview",
         "purchase_orders_list",
         "grn_list",
@@ -186,6 +192,7 @@ ROLE_ALLOWED_URLS: Mapping[str, set[str]] = {
         "stock_movements",
         "ml_dashboard",
         "pos_sales_import",
+        "variance_report",
     },
     ROLE_KITCHEN_STAFF: {
         "indents_list",

--- a/templates/inventory/recovery/variance_report.html
+++ b/templates/inventory/recovery/variance_report.html
@@ -1,0 +1,105 @@
+{% extends "components/create_manage_layout.html" %}
+
+{% block page_title %}Ideal vs Actual Variance{% endblock %}
+{% block page_heading %}Ideal vs Actual Variance{% endblock %}
+{% block page_subtitle %}
+  <p class="text-sm text-bodyText/70">
+    Compare recipe-based ideal consumption with stock-based actual usage to find leakage value by item.
+  </p>
+{% endblock %}
+
+{% block filters %}
+  <form method="get" class="bg-surface border border-border rounded-xl p-4 grid gap-3 md:grid-cols-4 md:items-end">
+    <div>
+      <label for="variance-start-date" class="block text-sm font-medium text-bodyText">Start Date</label>
+      <input id="variance-start-date" type="date" name="start_date" value="{{ start_date }}" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+    </div>
+    <div>
+      <label for="variance-end-date" class="block text-sm font-medium text-bodyText">End Date</label>
+      <input id="variance-end-date" type="date" name="end_date" value="{{ end_date }}" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+    </div>
+    <div>
+      <label for="variance-show-mode" class="block text-sm font-medium text-bodyText">Show</label>
+      <select id="variance-show-mode" name="show" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+        <option value="all" {% if show_mode == "all" %}selected{% endif %}>All items</option>
+        <option value="leakage_only" {% if show_mode == "leakage_only" %}selected{% endif %}>Leakage only</option>
+        <option value="unmapped_only" {% if show_mode == "unmapped_only" %}selected{% endif %}>Unmapped sales risk</option>
+      </select>
+    </div>
+    <div class="flex items-center gap-2">
+      <button type="submit" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md bg-primary text-white hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary">
+        Apply
+      </button>
+      <a href="{% url 'variance_report' %}" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md border border-border text-bodyText hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">
+        Reset
+      </a>
+    </div>
+  </form>
+{% endblock %}
+
+{% block kpis %}
+  <div class="grid gap-3 md:grid-cols-4">
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Visible Items</p>
+      <p class="mt-1 text-2xl font-semibold text-bodyText">{{ visible_count }}</p>
+    </div>
+    <div class="bg-danger-soft border border-danger/20 rounded-xl p-4">
+      <p class="text-sm text-danger">Leakage Value</p>
+      <p class="mt-1 text-2xl font-semibold text-danger">Rs. {{ summary.leakage_value|floatformat:2 }}</p>
+    </div>
+    <div class="bg-success-soft border border-success/20 rounded-xl p-4">
+      <p class="text-sm text-success">Favourable Value</p>
+      <p class="mt-1 text-2xl font-semibold text-success">Rs. {{ summary.favourable_value|floatformat:2 }}</p>
+    </div>
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Unmapped Sales Rows</p>
+      <p class="mt-1 text-2xl font-semibold text-warning">{{ summary.unmapped_sales_count }}</p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block data_container %}
+  <div class="overflow-x-auto bg-surface border border-border rounded-xl">
+    <table class="min-w-full divide-y divide-border text-sm">
+      <thead class="bg-surfaceSubtle text-left text-xs font-semibold uppercase tracking-wider text-bodyText/70">
+        <tr>
+          <th class="px-4 py-3">Item</th>
+          <th class="px-4 py-3 text-right">Ideal Usage</th>
+          <th class="px-4 py-3 text-right">Actual Usage</th>
+          <th class="px-4 py-3 text-right">Variance</th>
+          <th class="px-4 py-3 text-right">Variance Value</th>
+          <th class="px-4 py-3">Likely Reason</th>
+          <th class="px-4 py-3">Recommended Action</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-border">
+        {% for row in page_obj %}
+          <tr class="odd:bg-surfaceSubtle/50">
+            <td class="px-4 py-3 font-medium">{{ row.item.name }}</td>
+            <td class="px-4 py-3 text-right tabular-nums">{{ row.ideal_usage|floatformat:3 }} {{ row.unit_label }}</td>
+            <td class="px-4 py-3 text-right tabular-nums">{{ row.actual_usage|floatformat:3 }} {{ row.unit_label }}</td>
+            <td class="px-4 py-3 text-right tabular-nums {% if row.variance_qty > 0 %}text-danger{% elif row.variance_qty < 0 %}text-success{% endif %}">
+              {% if row.variance_qty > 0 %}+{% endif %}{{ row.variance_qty|floatformat:3 }} {{ row.unit_label }}
+            </td>
+            <td class="px-4 py-3 text-right tabular-nums {% if row.variance_value > 0 %}text-danger{% elif row.variance_value < 0 %}text-success{% endif %}">
+              Rs. {{ row.variance_value|floatformat:2 }}
+            </td>
+            <td class="px-4 py-3">{{ row.likely_reason }}</td>
+            <td class="px-4 py-3">{{ row.recommended_action }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="7" class="px-4 py-8 text-center text-bodyText/70">No item variance found for this period.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}
+
+{% block pagination %}
+  <div class="mt-4">
+    {% url 'variance_report' as variance_url %}
+    {% include "components/pagination.html" with page_obj=page_obj base_url=variance_url %}
+  </div>
+{% endblock %}

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -67,6 +67,7 @@ def test_role_owner_sees_owner_money_navigation(django_user_model):
     assert "savings_ledger_list" in visible_urls
     assert "vendor_prices_list" in visible_urls
     assert "pos_sales_import" in visible_urls
+    assert "variance_report" in visible_urls
     assert "indents_list" not in visible_urls
 
 
@@ -114,6 +115,7 @@ def test_role_head_chef_sees_sales_import(django_user_model):
 
     assert role == navigation.ROLE_HEAD_CHEF
     assert "pos_sales_import" in visible_urls
+    assert "variance_report" in visible_urls
 
 
 @pytest.mark.django_db

--- a/tests/test_variance_report_view.py
+++ b/tests/test_variance_report_view.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from inventory.models import Recipe, RecipeItem, SaleTransaction, StockTransaction
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_recipe_with_item(name: str, item, ingredient_qty: Decimal):
+    recipe = Recipe.objects.create(
+        name=name,
+        is_active=True,
+        type=Recipe.Type.FINAL,
+        selling_price=Decimal("250.00"),
+        target_food_cost_pct=Decimal("30.00"),
+    )
+    RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=ingredient_qty,
+        unit="GM",
+        loss_pct=Decimal("0.00"),
+    )
+    return recipe
+
+
+def test_variance_report_page_renders(client, item_factory):
+    item = item_factory(
+        name="Variance Render Item",
+        unit_id=19,
+        current_stock=Decimal("9.00"),
+        last_purchase_price=Decimal("180.00"),
+    )
+    recipe = _create_recipe_with_item("Variance Render Recipe", item, Decimal("100.00"))
+    SaleTransaction.objects.create(
+        recipe=recipe,
+        quantity=Decimal("5.00"),
+        sale_date=timezone.now(),
+    )
+    StockTransaction.objects.create(
+        item=item,
+        quantity_change=Decimal("-1.00"),
+        transaction_type="ISSUE",
+        transaction_date=timezone.now(),
+    )
+
+    response = client.get(reverse("variance_report"))
+
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert "Ideal vs Actual Variance" in html
+    assert "Variance Render Item" in html
+
+
+def test_variance_report_show_mode_filters(client, item_factory):
+    leak_item = item_factory(
+        name="Leakage Chicken",
+        unit_id=19,
+        current_stock=Decimal("11.00"),
+        last_purchase_price=Decimal("200.00"),
+    )
+    good_item = item_factory(
+        name="Favourable Paneer",
+        unit_id=19,
+        current_stock=Decimal("3.50"),
+        last_purchase_price=Decimal("120.00"),
+    )
+    unmapped_item = item_factory(
+        name="Unmapped Mutton",
+        unit_id=19,
+        current_stock=Decimal("7.00"),
+        last_purchase_price=Decimal("220.00"),
+    )
+
+    leak_recipe = _create_recipe_with_item("Leak Recipe", leak_item, Decimal("100.00"))
+    good_recipe = _create_recipe_with_item("Good Recipe", good_item, Decimal("100.00"))
+
+    SaleTransaction.objects.create(
+        recipe=leak_recipe,
+        quantity=Decimal("10.00"),
+        sale_date=timezone.now(),
+    )
+    SaleTransaction.objects.create(
+        recipe=good_recipe,
+        quantity=Decimal("10.00"),
+        sale_date=timezone.now(),
+    )
+    SaleTransaction.objects.create(
+        recipe=None,
+        pos_item_name="Unknown Mutton Curry",
+        quantity=Decimal("3.00"),
+        source=SaleTransaction.Source.POS_CSV,
+        sale_date=timezone.now(),
+    )
+
+    StockTransaction.objects.create(
+        item=leak_item,
+        quantity_change=Decimal("3.00"),
+        transaction_type="RECEIVING",
+        transaction_date=timezone.now(),
+    )
+    StockTransaction.objects.create(
+        item=leak_item,
+        quantity_change=Decimal("-2.00"),
+        transaction_type="ISSUE",
+        transaction_date=timezone.now(),
+    )
+    StockTransaction.objects.create(
+        item=good_item,
+        quantity_change=Decimal("1.00"),
+        transaction_type="RECEIVING",
+        transaction_date=timezone.now(),
+    )
+    StockTransaction.objects.create(
+        item=good_item,
+        quantity_change=Decimal("-0.50"),
+        transaction_type="ISSUE",
+        transaction_date=timezone.now(),
+    )
+    StockTransaction.objects.create(
+        item=unmapped_item,
+        quantity_change=Decimal("-1.00"),
+        transaction_type="ISSUE",
+        transaction_date=timezone.now(),
+    )
+
+    leak_only = client.get(reverse("variance_report"), {"show": "leakage_only"})
+    leak_html = leak_only.content.decode()
+    assert leak_only.status_code == 200
+    assert "Leakage Chicken" in leak_html
+    assert "Favourable Paneer" not in leak_html
+
+    unmapped_only = client.get(reverse("variance_report"), {"show": "unmapped_only"})
+    unmapped_html = unmapped_only.content.decode()
+    assert unmapped_only.status_code == 200
+    assert "Unmapped Mutton" in unmapped_html

--- a/tests/test_variance_service.py
+++ b/tests/test_variance_service.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+
+from inventory.models import Recipe, RecipeItem, SaleTransaction, StockTransaction
+from inventory.services.variance_service import build_variance_report
+
+pytestmark = pytest.mark.django_db
+
+
+def test_build_variance_report_computes_item_leakage(item_factory):
+    item = item_factory(
+        name="Phase6 Chicken",
+        unit_id=19,
+        current_stock=Decimal("11.00"),
+        last_purchase_price=Decimal("200.00"),
+    )
+    recipe = Recipe.objects.create(
+        name="Chicken Bowl Phase6",
+        is_active=True,
+        type=Recipe.Type.FINAL,
+        selling_price=Decimal("300.00"),
+        target_food_cost_pct=Decimal("30.00"),
+    )
+    RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=Decimal("100.00"),
+        unit="GM",
+        loss_pct=Decimal("0.00"),
+    )
+
+    SaleTransaction.objects.create(
+        recipe=recipe,
+        quantity=Decimal("10.00"),
+        source=SaleTransaction.Source.MANUAL,
+        sale_date=timezone.now(),
+    )
+    StockTransaction.objects.create(
+        item=item,
+        quantity_change=Decimal("3.00"),
+        transaction_type="RECEIVING",
+        transaction_date=timezone.now(),
+    )
+    StockTransaction.objects.create(
+        item=item,
+        quantity_change=Decimal("-2.00"),
+        transaction_type="ISSUE",
+        transaction_date=timezone.now(),
+    )
+
+    today = timezone.localdate()
+    report = build_variance_report(today, today)
+    rows = [row for row in report["rows"] if row.item.pk == item.item_id]
+
+    assert rows
+    row = rows[0]
+    assert row.unit_label == "KG"
+    assert row.ideal_usage == Decimal("1.00")
+    assert row.actual_usage == Decimal("2.00")
+    assert row.variance_qty == Decimal("1.00")
+    assert row.variance_value == Decimal("200.00")
+    assert report["summary"]["leakage_value"] == Decimal("200.00")
+
+
+def test_build_variance_report_counts_unmapped_sales_rows(item_factory):
+    item = item_factory(name="Phase6 Paneer", unit_id=19)
+    SaleTransaction.objects.create(
+        recipe=None,
+        pos_item_name="Unmapped Paneer Dish",
+        quantity=Decimal("2.00"),
+        net_sales=Decimal("450.00"),
+        source=SaleTransaction.Source.POS_CSV,
+        sale_date=timezone.now(),
+    )
+    StockTransaction.objects.create(
+        item=item,
+        quantity_change=Decimal("-1.00"),
+        transaction_type="ISSUE",
+        transaction_date=timezone.now(),
+    )
+
+    today = timezone.localdate()
+    report = build_variance_report(today, today)
+    assert report["summary"]["unmapped_sales_count"] == 1


### PR DESCRIPTION
## What changed
- Added Phase 6 ideal-vs-actual variance engine in `inventory/services/variance_service.py`.
- Added new owner/chef report page at `/variance-report/` via `inventory/views/variance.py` and `templates/inventory/recovery/variance_report.html`.
- Wired route and navigation visibility for Owner and Head Chef.
- Added focused tests for service calculations, report filtering, and role navigation.

## Why this changed
Phase 6 requires item-level leakage detection using:
- Ideal usage from recipe-mapped sales.
- Actual usage from stock formula (opening + purchases - closing).
- Variance value in rupees with likely reasons and recommended actions.

## Impact
- Owners and head chefs can now see leakage value by item and filter to high-risk views.
- Existing Phase 1-5 flows remain unchanged; this is an additive reporting workflow.

## Validation
- `python -m pytest tests/test_variance_service.py tests/test_variance_report_view.py tests/test_navigation.py -q`
- `python -m pytest tests/test_dashboard.py tests/test_recovery_pages.py -q`
- `python manage.py check --settings=inventory_app.settings.test`
