### PR TITLE
[codex] implement phase 8 chef bulletins and owner full navigation access

### DIFF
--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 
 from .models import (
     Category,
+    ChefBulletin,
     Department,
     GoodsReceivedNote,
     GRNItem,
@@ -19,6 +20,7 @@ from .models import (
     StockTransaction,
     SubCategory,
     Supplier,
+    TrialRecipeVersion,
     Unit,
     VendorItemPrice,
 )
@@ -39,6 +41,8 @@ for model in [
     GRNItem,
     SavingsLedger,
     VendorItemPrice,
+    ChefBulletin,
+    TrialRecipeVersion,
     Department,
     ItemDepartment,
 ]:

--- a/inventory/migrations/0046_chef_bulletins_trial_recipe_versions.py
+++ b/inventory/migrations/0046_chef_bulletins_trial_recipe_versions.py
@@ -1,0 +1,200 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("inventory", "0045_stocktransaction_wastage_photo"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ChefBulletin",
+            fields=[
+                ("bulletin_id", models.AutoField(primary_key=True, serialize=False)),
+                ("period_start", models.DateField(db_index=True)),
+                ("period_end", models.DateField(db_index=True)),
+                (
+                    "alert_type",
+                    models.CharField(
+                        choices=[
+                            (
+                                "FOOD_COST_ABOVE_TARGET",
+                                "Recipe food cost above target",
+                            ),
+                            (
+                                "INGREDIENT_PRICE_INCREASED",
+                                "Ingredient price increased",
+                            ),
+                            ("RECIPE_COST_CHANGED", "Recipe cost changed"),
+                            ("HIGH_SALES_LOW_MARGIN", "High sales but low margin"),
+                            ("ACTUAL_USAGE_ABOVE_IDEAL", "Actual usage above ideal"),
+                        ],
+                        max_length=40,
+                    ),
+                ),
+                ("headline", models.CharField(blank=True, default="", max_length=255)),
+                (
+                    "current_food_cost_pct",
+                    models.DecimalField(decimal_places=2, default=0, max_digits=6),
+                ),
+                (
+                    "target_food_cost_pct",
+                    models.DecimalField(decimal_places=2, default=0, max_digits=6),
+                ),
+                (
+                    "monthly_sales",
+                    models.DecimalField(decimal_places=2, default=0, max_digits=14),
+                ),
+                (
+                    "unrealised_profit",
+                    models.DecimalField(decimal_places=2, default=0, max_digits=14),
+                ),
+                ("main_cost_drivers", models.JSONField(blank=True, default=list)),
+                ("suggested_change", models.TextField(blank=True, default="")),
+                (
+                    "expected_saving",
+                    models.DecimalField(decimal_places=2, default=0, max_digits=14),
+                ),
+                (
+                    "risk_level",
+                    models.CharField(
+                        choices=[
+                            ("LOW", "Low"),
+                            ("MEDIUM", "Medium"),
+                            ("HIGH", "High"),
+                        ],
+                        default="MEDIUM",
+                        max_length=10,
+                    ),
+                ),
+                (
+                    "chef_decision",
+                    models.CharField(
+                        choices=[
+                            ("PENDING", "Pending"),
+                            ("APPROVE_TRIAL", "Approve trial"),
+                            ("MODIFY", "Modify"),
+                            ("REJECT", "Reject"),
+                            ("SEND_TO_OWNER", "Send to owner"),
+                        ],
+                        default="PENDING",
+                        max_length=20,
+                    ),
+                ),
+                ("decision_notes", models.TextField(blank=True, default="")),
+                ("decided_at", models.DateTimeField(blank=True, null=True)),
+                ("is_open", models.BooleanField(db_index=True, default=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "decided_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "recipe",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="chef_bulletins",
+                        to="inventory.recipe",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "chef_bulletins",
+                "ordering": ["-expected_saving", "-updated_at"],
+            },
+        ),
+        migrations.CreateModel(
+            name="TrialRecipeVersion",
+            fields=[
+                ("trial_id", models.AutoField(primary_key=True, serialize=False)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("DRAFT", "Draft"),
+                            ("UNDER_REVIEW", "Under review"),
+                            ("APPROVED", "Approved"),
+                            ("REJECTED", "Rejected"),
+                        ],
+                        default="DRAFT",
+                        max_length=20,
+                    ),
+                ),
+                ("notes", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "bulletin",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="trial_versions",
+                        to="inventory.chefbulletin",
+                    ),
+                ),
+                (
+                    "created_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "source_recipe",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="trial_versions_source",
+                        to="inventory.recipe",
+                    ),
+                ),
+                (
+                    "trial_recipe",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="trial_versions_generated",
+                        to="inventory.recipe",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "trial_recipe_versions",
+                "ordering": ["-created_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="chefbulletin",
+            index=models.Index(
+                fields=["recipe", "alert_type"], name="chef_bul_recipe_alert_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="chefbulletin",
+            index=models.Index(
+                fields=["is_open", "risk_level"], name="chef_bul_open_risk_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="chefbulletin",
+            index=models.Index(
+                fields=["period_start", "period_end"], name="chef_bul_period_idx"
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="trialrecipeversion",
+            index=models.Index(
+                fields=["bulletin", "status"], name="trial_ver_bulletin_status_idx"
+            ),
+        ),
+    ]

--- a/inventory/models/__init__.py
+++ b/inventory/models/__init__.py
@@ -13,11 +13,13 @@ from .orders import (
     PurchaseOrderItem,
 )
 from .recipes import (
+    ChefBulletin,
     POSMenuItemMapping,
     Recipe,
     RecipeComponent,
     RecipeItem,
     SaleTransaction,
+    TrialRecipeVersion,
 )
 from .recovery import SavingsLedger, VendorItemPrice
 from .site_config import SiteConfig
@@ -50,6 +52,8 @@ __all__ = [
     "RecipeItem",
     "SaleTransaction",
     "POSMenuItemMapping",
+    "ChefBulletin",
+    "TrialRecipeVersion",
     "Department",
     "ItemDepartment",
     "Category",

--- a/inventory/models/recipes.py
+++ b/inventory/models/recipes.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
@@ -356,3 +357,130 @@ class POSMenuItemMapping(models.Model):
         indexes = [
             models.Index(fields=["is_active"], name="idx_pos_map_active"),
         ]
+
+
+class ChefBulletin(models.Model):
+    class AlertType(models.TextChoices):
+        FOOD_COST_ABOVE_TARGET = "FOOD_COST_ABOVE_TARGET", "Recipe food cost above target"
+        INGREDIENT_PRICE_INCREASED = (
+            "INGREDIENT_PRICE_INCREASED",
+            "Ingredient price increased",
+        )
+        RECIPE_COST_CHANGED = "RECIPE_COST_CHANGED", "Recipe cost changed"
+        HIGH_SALES_LOW_MARGIN = "HIGH_SALES_LOW_MARGIN", "High sales but low margin"
+        ACTUAL_USAGE_ABOVE_IDEAL = (
+            "ACTUAL_USAGE_ABOVE_IDEAL",
+            "Actual usage above ideal",
+        )
+
+    class RiskLevel(models.TextChoices):
+        LOW = "LOW", "Low"
+        MEDIUM = "MEDIUM", "Medium"
+        HIGH = "HIGH", "High"
+
+    class ChefDecision(models.TextChoices):
+        PENDING = "PENDING", "Pending"
+        APPROVE_TRIAL = "APPROVE_TRIAL", "Approve trial"
+        MODIFY = "MODIFY", "Modify"
+        REJECT = "REJECT", "Reject"
+        SEND_TO_OWNER = "SEND_TO_OWNER", "Send to owner"
+
+    bulletin_id = models.AutoField(primary_key=True)
+    recipe = models.ForeignKey(
+        Recipe,
+        on_delete=models.CASCADE,
+        related_name="chef_bulletins",
+    )
+    period_start = models.DateField(db_index=True)
+    period_end = models.DateField(db_index=True)
+    alert_type = models.CharField(max_length=40, choices=AlertType.choices)
+    headline = models.CharField(max_length=255, blank=True, default="")
+    current_food_cost_pct = models.DecimalField(max_digits=6, decimal_places=2, default=0)
+    target_food_cost_pct = models.DecimalField(max_digits=6, decimal_places=2, default=0)
+    monthly_sales = models.DecimalField(max_digits=14, decimal_places=2, default=0)
+    unrealised_profit = models.DecimalField(max_digits=14, decimal_places=2, default=0)
+    main_cost_drivers = models.JSONField(default=list, blank=True)
+    suggested_change = models.TextField(blank=True, default="")
+    expected_saving = models.DecimalField(max_digits=14, decimal_places=2, default=0)
+    risk_level = models.CharField(
+        max_length=10,
+        choices=RiskLevel.choices,
+        default=RiskLevel.MEDIUM,
+    )
+    chef_decision = models.CharField(
+        max_length=20,
+        choices=ChefDecision.choices,
+        default=ChefDecision.PENDING,
+    )
+    decision_notes = models.TextField(blank=True, default="")
+    decided_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+    )
+    decided_at = models.DateTimeField(blank=True, null=True)
+    is_open = models.BooleanField(default=True, db_index=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        managed = True
+        db_table = "chef_bulletins"
+        ordering = ["-expected_saving", "-updated_at"]
+        indexes = [
+            models.Index(fields=["recipe", "alert_type"], name="chef_bul_recipe_alert_idx"),
+            models.Index(fields=["is_open", "risk_level"], name="chef_bul_open_risk_idx"),
+            models.Index(fields=["period_start", "period_end"], name="chef_bul_period_idx"),
+        ]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.recipe} - {self.get_alert_type_display()}"
+
+
+class TrialRecipeVersion(models.Model):
+    class Status(models.TextChoices):
+        DRAFT = "DRAFT", "Draft"
+        UNDER_REVIEW = "UNDER_REVIEW", "Under review"
+        APPROVED = "APPROVED", "Approved"
+        REJECTED = "REJECTED", "Rejected"
+
+    trial_id = models.AutoField(primary_key=True)
+    bulletin = models.ForeignKey(
+        ChefBulletin,
+        on_delete=models.CASCADE,
+        related_name="trial_versions",
+    )
+    source_recipe = models.ForeignKey(
+        Recipe,
+        on_delete=models.CASCADE,
+        related_name="trial_versions_source",
+    )
+    trial_recipe = models.ForeignKey(
+        Recipe,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="trial_versions_generated",
+    )
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.DRAFT)
+    notes = models.TextField(blank=True, default="")
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        managed = True
+        db_table = "trial_recipe_versions"
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["bulletin", "status"], name="trial_ver_bulletin_status_idx"),
+        ]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"Trial for {self.source_recipe}"

--- a/inventory/services/chef_bulletins_service.py
+++ b/inventory/services/chef_bulletins_service.py
@@ -20,12 +20,26 @@ from inventory.services.variance_service import build_variance_report
 ZERO = Decimal("0")
 HIGH_SALES_THRESHOLD = Decimal("10000")
 LOW_MARGIN_THRESHOLD = Decimal("60")
+MAX_PCT = Decimal("9999.99")
+MAX_MONEY = Decimal("999999999999.99")
 
 
 def _as_decimal(value) -> Decimal:
     if value in (None, ""):
         return ZERO
     return Decimal(str(value))
+
+
+def _clamp_decimal(
+    value: Decimal,
+    *,
+    min_value: Decimal = ZERO,
+    max_value: Decimal,
+    places: str = "0.01",
+) -> Decimal:
+    quant = Decimal(places)
+    bounded = min(max(value, min_value), max_value)
+    return bounded.quantize(quant)
 
 
 def _month_window(ref_date: date | None = None) -> tuple[date, date]:
@@ -180,32 +194,65 @@ def refresh_chef_bulletins(
         .prefetch_related("items__item", "items__sub_recipe")
         .order_by("name")
     )
+    # Guard against legacy oversize decimal values that can break SQLite conversion.
+    now = timezone.now()
+    ChefBulletin.objects.filter(current_food_cost_pct__gt=MAX_PCT).update(
+        current_food_cost_pct=MAX_PCT,
+        updated_at=now,
+    )
+    ChefBulletin.objects.filter(target_food_cost_pct__gt=MAX_PCT).update(
+        target_food_cost_pct=MAX_PCT,
+        updated_at=now,
+    )
+    ChefBulletin.objects.filter(monthly_sales__gt=MAX_MONEY).update(
+        monthly_sales=MAX_MONEY,
+        updated_at=now,
+    )
+    ChefBulletin.objects.filter(unrealised_profit__gt=MAX_MONEY).update(
+        unrealised_profit=MAX_MONEY,
+        updated_at=now,
+    )
+    ChefBulletin.objects.filter(expected_saving__gt=MAX_MONEY).update(
+        expected_saving=MAX_MONEY,
+        updated_at=now,
+    )
+
     existing_open = {
-        (b.recipe_id, b.alert_type): b
-        for b in ChefBulletin.objects.filter(
+        (row["recipe_id"], row["alert_type"]): row["bulletin_id"]
+        for row in ChefBulletin.objects.filter(
             is_open=True,
             period_start=start_date,
             period_end=end_date,
-        ).select_related("recipe")
+        ).values("bulletin_id", "recipe_id", "alert_type")
     }
     active_keys: set[tuple[int, str]] = set()
 
     for recipe in recipes:
         total_cost = _as_decimal(recipe.get_total_cost())
         current_pct_raw = recipe.compute_food_cost_percentage(total_cost=total_cost)
-        current_pct = _as_decimal(current_pct_raw).quantize(Decimal("0.01"))
-        target_pct = _as_decimal(recipe.target_food_cost_pct or Decimal("30")).quantize(
-            Decimal("0.01")
+        current_pct = _clamp_decimal(
+            _as_decimal(current_pct_raw),
+            max_value=MAX_PCT,
+            places="0.01",
+        )
+        target_pct = _clamp_decimal(
+            _as_decimal(recipe.target_food_cost_pct or Decimal("30")),
+            max_value=MAX_PCT,
+            places="0.01",
         )
         sales_state = sales_map.get(recipe.pk) or {}
-        monthly_sales = _as_decimal(sales_state.get("sales_total")).quantize(
-            Decimal("0.01")
+        monthly_sales = _clamp_decimal(
+            _as_decimal(sales_state.get("sales_total")),
+            max_value=MAX_MONEY,
+            places="0.01",
         )
         sales_qty = _as_decimal(sales_state.get("qty_total"))
         expected_gap_pct = max(current_pct - target_pct, ZERO)
-        unrealised_profit = (
-            monthly_sales * expected_gap_pct / Decimal("100")
-        ).quantize(Decimal("0.01"))
+        unrealised_profit = _clamp_decimal(
+            (monthly_sales * expected_gap_pct / Decimal("100")),
+            max_value=MAX_MONEY,
+            places="0.01",
+        )
         main_cost_drivers = _recipe_cost_drivers(recipe)
         recipe_item_ids = set(
             RecipeItem.objects.filter(recipe=recipe, item__isnull=False).values_list(
@@ -304,9 +351,11 @@ def refresh_chef_bulletins(
                 )
             )
 
-        unexplained_value = sum(
-            _as_decimal(unexplained_by_item.get(item_id)) for item_id in recipe_item_ids
-        ).quantize(Decimal("0.01"))
+        unexplained_value = _clamp_decimal(
+            sum(_as_decimal(unexplained_by_item.get(item_id)) for item_id in recipe_item_ids),
+            max_value=MAX_MONEY,
+            places="0.01",
+        )
         if sales_qty > 0 and unexplained_value > 0:
             alert_payloads.append(
                 (
@@ -329,32 +378,38 @@ def refresh_chef_bulletins(
         for alert_type, payload in alert_payloads:
             key = (recipe.pk, alert_type)
             active_keys.add(key)
-            bulletin = existing_open.get(key)
-            if bulletin is None:
+            bulletin_id = existing_open.get(key)
+            if bulletin_id is None:
                 ChefBulletin.objects.create(
                     recipe=recipe,
                     alert_type=alert_type,
                     **payload,
                 )
                 continue
-            for field, value in payload.items():
-                setattr(bulletin, field, value)
-            bulletin.save()
+            ChefBulletin.objects.filter(pk=bulletin_id).update(
+                **payload,
+                updated_at=timezone.now(),
+            )
 
-    stale = ChefBulletin.objects.filter(
-        is_open=True,
-        period_start=start_date,
-        period_end=end_date,
+    stale_ids = list(
+        ChefBulletin.objects.filter(
+            is_open=True,
+            period_start=start_date,
+            period_end=end_date,
+        ).values_list("bulletin_id", "recipe_id", "alert_type")
     )
-    for bulletin in stale:
-        if (bulletin.recipe_id, bulletin.alert_type) not in active_keys:
-            bulletin.is_open = False
-            bulletin.save(update_fields=["is_open", "updated_at"])
+    for bulletin_id, recipe_id, alert_type in stale_ids:
+        if (recipe_id, alert_type) not in active_keys:
+            ChefBulletin.objects.filter(pk=bulletin_id).update(
+                is_open=False,
+                updated_at=timezone.now(),
+            )
 
     return list(
-        ChefBulletin.objects.select_related("recipe", "decided_by")
-        .filter(period_start=start_date, period_end=end_date)
-        .order_by("-is_open", "-expected_saving", "-updated_at")
+        ChefBulletin.objects.filter(
+            period_start=start_date,
+            period_end=end_date,
+        ).values_list("bulletin_id", flat=True)
     )
 
 

--- a/inventory/services/chef_bulletins_service.py
+++ b/inventory/services/chef_bulletins_service.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+
+from django.db.models import DecimalField, Sum
+from django.db.models.functions import Coalesce
+from django.utils import timezone
+
+from inventory.models import (
+    ChefBulletin,
+    Recipe,
+    RecipeItem,
+    SaleTransaction,
+    TrialRecipeVersion,
+)
+from inventory.services.variance_service import build_variance_report
+
+ZERO = Decimal("0")
+HIGH_SALES_THRESHOLD = Decimal("10000")
+LOW_MARGIN_THRESHOLD = Decimal("60")
+
+
+def _as_decimal(value) -> Decimal:
+    if value in (None, ""):
+        return ZERO
+    return Decimal(str(value))
+
+
+def _month_window(ref_date: date | None = None) -> tuple[date, date]:
+    end = ref_date or timezone.localdate()
+    start = end - timedelta(days=29)
+    return start, end
+
+
+def _suggested_change(alert_type: str) -> str:
+    suggestions = {
+        ChefBulletin.AlertType.FOOD_COST_ABOVE_TARGET: (
+            "Review ingredient yields and portion size. Start with top cost drivers."
+        ),
+        ChefBulletin.AlertType.INGREDIENT_PRICE_INCREASED: (
+            "Renegotiate pricing or approve an alternate vendor for high-impact ingredients."
+        ),
+        ChefBulletin.AlertType.RECIPE_COST_CHANGED: (
+            "Recheck the recipe card and validate latest ingredient prices."
+        ),
+        ChefBulletin.AlertType.HIGH_SALES_LOW_MARGIN: (
+            "Run a trial version with lower-cost swaps while protecting guest experience."
+        ),
+        ChefBulletin.AlertType.ACTUAL_USAGE_ABOVE_IDEAL: (
+            "Audit prep loss and wastage for linked ingredients this week."
+        ),
+    }
+    return suggestions.get(alert_type, "Review this recipe with the kitchen team.")
+
+
+def _headline(alert_type: str, recipe_name: str) -> str:
+    labels = {
+        ChefBulletin.AlertType.FOOD_COST_ABOVE_TARGET: "Food cost above target",
+        ChefBulletin.AlertType.INGREDIENT_PRICE_INCREASED: "Ingredient price increased",
+        ChefBulletin.AlertType.RECIPE_COST_CHANGED: "Recipe cost changed",
+        ChefBulletin.AlertType.HIGH_SALES_LOW_MARGIN: "High sales but low margin",
+        ChefBulletin.AlertType.ACTUAL_USAGE_ABOVE_IDEAL: "Actual usage above ideal",
+    }
+    return f"{labels.get(alert_type, 'Recipe alert')}: {recipe_name}"
+
+
+def _risk_level(expected_saving: Decimal, gap_pct: Decimal) -> str:
+    if expected_saving >= Decimal("10000") or gap_pct >= Decimal("10"):
+        return ChefBulletin.RiskLevel.HIGH
+    if expected_saving >= Decimal("3000") or gap_pct >= Decimal("4"):
+        return ChefBulletin.RiskLevel.MEDIUM
+    return ChefBulletin.RiskLevel.LOW
+
+
+def _recipe_cost_drivers(recipe: Recipe) -> list[str]:
+    drivers: list[tuple[Decimal, str]] = []
+    for row in recipe.items.select_related("item", "sub_recipe").all():
+        line_cost = _as_decimal(row.get_line_cost())
+        if line_cost <= 0:
+            continue
+        if row.item_id:
+            label = row.item.name
+        elif row.sub_recipe_id:
+            label = f"[Sub] {row.sub_recipe.name}"
+        else:
+            continue
+        drivers.append((line_cost, label))
+    drivers.sort(key=lambda entry: entry[0], reverse=True)
+    return [name for _, name in drivers[:3]]
+
+
+def _sales_by_recipe(start_date: date, end_date: date) -> dict[int, dict[str, Decimal]]:
+    sales_rows = (
+        SaleTransaction.objects.filter(
+            sale_date__date__gte=start_date,
+            sale_date__date__lte=end_date,
+            recipe__isnull=False,
+        )
+        .values("recipe_id")
+        .annotate(
+            qty_total=Coalesce(Sum("quantity"), ZERO, output_field=DecimalField()),
+            net_total=Coalesce(
+                Sum("net_sales"),
+                ZERO,
+                output_field=DecimalField(max_digits=14, decimal_places=2),
+            ),
+            gross_total=Coalesce(
+                Sum("gross_sales"),
+                ZERO,
+                output_field=DecimalField(max_digits=14, decimal_places=2),
+            ),
+        )
+    )
+    result: dict[int, dict[str, Decimal]] = {}
+    for row in sales_rows:
+        recipe_id = row.get("recipe_id")
+        if recipe_id is None:
+            continue
+        net_total = _as_decimal(row.get("net_total"))
+        gross_total = _as_decimal(row.get("gross_total"))
+        qty_total = _as_decimal(row.get("qty_total"))
+        result[recipe_id] = {
+            "qty_total": qty_total,
+            "sales_total": net_total
+            if net_total > 0
+            else (gross_total if gross_total > 0 else ZERO),
+        }
+    return result
+
+
+def _build_alert_payload(
+    *,
+    recipe: Recipe,
+    alert_type: str,
+    start_date: date,
+    end_date: date,
+    monthly_sales: Decimal,
+    current_food_cost_pct: Decimal,
+    target_food_cost_pct: Decimal,
+    expected_saving: Decimal,
+    unrealised_profit: Decimal,
+    main_cost_drivers: list[str],
+) -> dict:
+    gap_pct = max(current_food_cost_pct - target_food_cost_pct, ZERO)
+    return {
+        "period_start": start_date,
+        "period_end": end_date,
+        "headline": _headline(alert_type, recipe.name),
+        "current_food_cost_pct": current_food_cost_pct,
+        "target_food_cost_pct": target_food_cost_pct,
+        "monthly_sales": monthly_sales,
+        "unrealised_profit": unrealised_profit,
+        "main_cost_drivers": main_cost_drivers,
+        "suggested_change": _suggested_change(alert_type),
+        "expected_saving": expected_saving,
+        "risk_level": _risk_level(expected_saving, gap_pct),
+    }
+
+
+def refresh_chef_bulletins(
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> list[ChefBulletin]:
+    if start_date is None or end_date is None:
+        start_date, end_date = _month_window(end_date)
+    if start_date > end_date:
+        start_date, end_date = end_date, start_date
+
+    sales_map = _sales_by_recipe(start_date, end_date)
+    variance = build_variance_report(start_date, end_date)
+    unexplained_by_item: dict[int, Decimal] = {}
+    for row in variance["rows"]:
+        if row.unexplained_variance_value > 0:
+            unexplained_by_item[row.item.pk] = _as_decimal(row.unexplained_variance_value)
+
+    recipes = list(
+        Recipe.objects.filter(type=Recipe.Type.FINAL, is_active=True)
+        .prefetch_related("items__item", "items__sub_recipe")
+        .order_by("name")
+    )
+    existing_open = {
+        (b.recipe_id, b.alert_type): b
+        for b in ChefBulletin.objects.filter(
+            is_open=True,
+            period_start=start_date,
+            period_end=end_date,
+        ).select_related("recipe")
+    }
+    active_keys: set[tuple[int, str]] = set()
+
+    for recipe in recipes:
+        total_cost = _as_decimal(recipe.get_total_cost())
+        current_pct_raw = recipe.compute_food_cost_percentage(total_cost=total_cost)
+        current_pct = _as_decimal(current_pct_raw).quantize(Decimal("0.01"))
+        target_pct = _as_decimal(recipe.target_food_cost_pct or Decimal("30")).quantize(
+            Decimal("0.01")
+        )
+        sales_state = sales_map.get(recipe.pk) or {}
+        monthly_sales = _as_decimal(sales_state.get("sales_total")).quantize(
+            Decimal("0.01")
+        )
+        sales_qty = _as_decimal(sales_state.get("qty_total"))
+        expected_gap_pct = max(current_pct - target_pct, ZERO)
+        unrealised_profit = (
+            monthly_sales * expected_gap_pct / Decimal("100")
+        ).quantize(Decimal("0.01"))
+        main_cost_drivers = _recipe_cost_drivers(recipe)
+        recipe_item_ids = set(
+            RecipeItem.objects.filter(recipe=recipe, item__isnull=False).values_list(
+                "item_id", flat=True
+            )
+        )
+
+        alert_payloads: list[tuple[str, dict]] = []
+        if current_pct > target_pct:
+            alert_payloads.append(
+                (
+                    ChefBulletin.AlertType.FOOD_COST_ABOVE_TARGET,
+                    _build_alert_payload(
+                        recipe=recipe,
+                        alert_type=ChefBulletin.AlertType.FOOD_COST_ABOVE_TARGET,
+                        start_date=start_date,
+                        end_date=end_date,
+                        monthly_sales=monthly_sales,
+                        current_food_cost_pct=current_pct,
+                        target_food_cost_pct=target_pct,
+                        expected_saving=unrealised_profit,
+                        unrealised_profit=unrealised_profit,
+                        main_cost_drivers=main_cost_drivers,
+                    ),
+                )
+            )
+
+        has_price_increase = False
+        has_cost_change = False
+        for row in recipe.items.select_related("item").all():
+            item = row.item
+            if not item:
+                continue
+            current_price = _as_decimal(item.last_purchase_price)
+            initial_price = _as_decimal(item.initial_purchase_price)
+            if initial_price > 0 and current_price > initial_price:
+                has_price_increase = True
+            if initial_price > 0 and current_price != initial_price:
+                has_cost_change = True
+
+        if has_price_increase:
+            alert_payloads.append(
+                (
+                    ChefBulletin.AlertType.INGREDIENT_PRICE_INCREASED,
+                    _build_alert_payload(
+                        recipe=recipe,
+                        alert_type=ChefBulletin.AlertType.INGREDIENT_PRICE_INCREASED,
+                        start_date=start_date,
+                        end_date=end_date,
+                        monthly_sales=monthly_sales,
+                        current_food_cost_pct=current_pct,
+                        target_food_cost_pct=target_pct,
+                        expected_saving=unrealised_profit,
+                        unrealised_profit=unrealised_profit,
+                        main_cost_drivers=main_cost_drivers,
+                    ),
+                )
+            )
+
+        if has_cost_change:
+            alert_payloads.append(
+                (
+                    ChefBulletin.AlertType.RECIPE_COST_CHANGED,
+                    _build_alert_payload(
+                        recipe=recipe,
+                        alert_type=ChefBulletin.AlertType.RECIPE_COST_CHANGED,
+                        start_date=start_date,
+                        end_date=end_date,
+                        monthly_sales=monthly_sales,
+                        current_food_cost_pct=current_pct,
+                        target_food_cost_pct=target_pct,
+                        expected_saving=unrealised_profit,
+                        unrealised_profit=unrealised_profit,
+                        main_cost_drivers=main_cost_drivers,
+                    ),
+                )
+            )
+
+        gross_margin_pct = Decimal("100") - current_pct
+        if monthly_sales >= HIGH_SALES_THRESHOLD and gross_margin_pct < LOW_MARGIN_THRESHOLD:
+            alert_payloads.append(
+                (
+                    ChefBulletin.AlertType.HIGH_SALES_LOW_MARGIN,
+                    _build_alert_payload(
+                        recipe=recipe,
+                        alert_type=ChefBulletin.AlertType.HIGH_SALES_LOW_MARGIN,
+                        start_date=start_date,
+                        end_date=end_date,
+                        monthly_sales=monthly_sales,
+                        current_food_cost_pct=current_pct,
+                        target_food_cost_pct=target_pct,
+                        expected_saving=unrealised_profit,
+                        unrealised_profit=unrealised_profit,
+                        main_cost_drivers=main_cost_drivers,
+                    ),
+                )
+            )
+
+        unexplained_value = sum(
+            _as_decimal(unexplained_by_item.get(item_id)) for item_id in recipe_item_ids
+        ).quantize(Decimal("0.01"))
+        if sales_qty > 0 and unexplained_value > 0:
+            alert_payloads.append(
+                (
+                    ChefBulletin.AlertType.ACTUAL_USAGE_ABOVE_IDEAL,
+                    _build_alert_payload(
+                        recipe=recipe,
+                        alert_type=ChefBulletin.AlertType.ACTUAL_USAGE_ABOVE_IDEAL,
+                        start_date=start_date,
+                        end_date=end_date,
+                        monthly_sales=monthly_sales,
+                        current_food_cost_pct=current_pct,
+                        target_food_cost_pct=target_pct,
+                        expected_saving=unexplained_value,
+                        unrealised_profit=unrealised_profit,
+                        main_cost_drivers=main_cost_drivers,
+                    ),
+                )
+            )
+
+        for alert_type, payload in alert_payloads:
+            key = (recipe.pk, alert_type)
+            active_keys.add(key)
+            bulletin = existing_open.get(key)
+            if bulletin is None:
+                ChefBulletin.objects.create(
+                    recipe=recipe,
+                    alert_type=alert_type,
+                    **payload,
+                )
+                continue
+            for field, value in payload.items():
+                setattr(bulletin, field, value)
+            bulletin.save()
+
+    stale = ChefBulletin.objects.filter(
+        is_open=True,
+        period_start=start_date,
+        period_end=end_date,
+    )
+    for bulletin in stale:
+        if (bulletin.recipe_id, bulletin.alert_type) not in active_keys:
+            bulletin.is_open = False
+            bulletin.save(update_fields=["is_open", "updated_at"])
+
+    return list(
+        ChefBulletin.objects.select_related("recipe", "decided_by")
+        .filter(period_start=start_date, period_end=end_date)
+        .order_by("-is_open", "-expected_saving", "-updated_at")
+    )
+
+
+@dataclass
+class BulletinDecisionResult:
+    bulletin: ChefBulletin
+    trial_version: TrialRecipeVersion | None
+
+
+def _next_trial_recipe_name(source_recipe: Recipe) -> str:
+    suffix = timezone.now().strftime("%Y%m%d%H%M%S")
+    return f"{source_recipe.name} (Trial {suffix})"
+
+
+def _clone_trial_recipe(
+    *,
+    bulletin: ChefBulletin,
+    user,
+    notes: str,
+) -> TrialRecipeVersion:
+    existing = (
+        TrialRecipeVersion.objects.filter(bulletin=bulletin)
+        .select_related("trial_recipe")
+        .first()
+    )
+    if existing:
+        return existing
+
+    source = bulletin.recipe
+    trial_recipe = Recipe.objects.create(
+        name=_next_trial_recipe_name(source),
+        description=source.description,
+        is_active=False,
+        type=source.type,
+        default_yield_qty=source.default_yield_qty,
+        default_yield_unit=source.default_yield_unit,
+        plating_notes=source.plating_notes,
+        tags=source.tags,
+        version=(source.version or 1) + 1,
+        selling_price=source.selling_price,
+        target_food_cost_pct=source.target_food_cost_pct,
+    )
+    source_rows = RecipeItem.objects.filter(recipe=source).order_by("sort_order", "pk")
+    for row in source_rows:
+        RecipeItem.objects.create(
+            recipe=trial_recipe,
+            item=row.item,
+            sub_recipe=row.sub_recipe,
+            quantity=row.quantity,
+            unit=row.unit,
+            loss_pct=row.loss_pct,
+            sort_order=row.sort_order,
+            notes=row.notes,
+        )
+
+    return TrialRecipeVersion.objects.create(
+        bulletin=bulletin,
+        source_recipe=source,
+        trial_recipe=trial_recipe,
+        status=TrialRecipeVersion.Status.DRAFT,
+        notes=notes or "Trial recipe generated from chef bulletin.",
+        created_by=user if user and user.is_authenticated else None,
+    )
+
+
+def apply_chef_decision(
+    *,
+    bulletin: ChefBulletin,
+    decision: str,
+    user,
+    notes: str = "",
+) -> BulletinDecisionResult:
+    decision = (decision or "").strip().upper()
+    valid_decisions = {choice[0] for choice in ChefBulletin.ChefDecision.choices}
+    if decision not in valid_decisions:
+        raise ValueError("Invalid chef decision.")
+
+    trial_version: TrialRecipeVersion | None = None
+    bulletin.chef_decision = decision
+    bulletin.decision_notes = notes or ""
+    bulletin.decided_at = timezone.now()
+    bulletin.decided_by = user if user and user.is_authenticated else None
+
+    if decision == ChefBulletin.ChefDecision.APPROVE_TRIAL:
+        trial_version = _clone_trial_recipe(bulletin=bulletin, user=user, notes=notes)
+        bulletin.is_open = False
+    elif decision in {
+        ChefBulletin.ChefDecision.REJECT,
+        ChefBulletin.ChefDecision.SEND_TO_OWNER,
+    }:
+        bulletin.is_open = False
+    else:
+        bulletin.is_open = True
+
+    bulletin.save()
+    return BulletinDecisionResult(bulletin=bulletin, trial_version=trial_version)

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
 from django.views.generic import RedirectView
 
+from .views.chef_bulletins import (
+    chef_bulletin_decision,
+    chef_bulletin_detail,
+    chef_bulletins_list,
+)
 from .views.goods_received import (
     GRNCreateView,
     GRNDetailView,
@@ -75,7 +80,6 @@ from .views.recipes import (
 )
 from .views.recovery import savings_ledger_list, vendor_prices_list
 from .views.sales import pos_sales_import
-from .views.variance import variance_report
 from .views.settings import change_password_view, profile_edit_view, settings_view
 from .views.stock import POSearchView, UserSearchView, history_reports, stock_movements
 from .views.stock_take import (
@@ -98,6 +102,7 @@ from .views.suppliers import (
     SuppliersTableView,
     SupplierToggleActiveView,
 )
+from .views.variance import variance_report
 from .views.visualizations import visualizations
 
 urlpatterns = [
@@ -267,6 +272,17 @@ urlpatterns = [
     path("vendor-prices/", vendor_prices_list, name="vendor_prices_list"),
     path("pos-sales/", pos_sales_import, name="pos_sales_import"),
     path("variance-report/", variance_report, name="variance_report"),
+    path("chef-bulletins/", chef_bulletins_list, name="chef_bulletins_list"),
+    path(
+        "chef-bulletins/<int:bulletin_id>/",
+        chef_bulletin_detail,
+        name="chef_bulletin_detail",
+    ),
+    path(
+        "chef-bulletins/<int:bulletin_id>/decision/",
+        chef_bulletin_decision,
+        name="chef_bulletin_decision",
+    ),
     path("recipes/", RecipesListView.as_view(), name="recipes_list"),
     path("recipes/table/", RecipesTableView.as_view(), name="recipes_table"),
     path("recipes/food-cost-report/", food_cost_report, name="food_cost_report"),

--- a/inventory/views/chef_bulletins.py
+++ b/inventory/views/chef_bulletins.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from django.contrib import messages
+from django.core.paginator import Paginator
+from django.shortcuts import get_object_or_404, redirect, render
+from django.utils import timezone
+from django.views.decorators.http import require_POST
+
+from inventory.models import ChefBulletin
+from inventory.services.chef_bulletins_service import (
+    apply_chef_decision,
+    refresh_chef_bulletins,
+)
+
+
+def _parse_date(raw: str, fallback: date) -> date:
+    value = (raw or "").strip()
+    if not value:
+        return fallback
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return fallback
+
+
+def chef_bulletins_list(request):
+    today = timezone.localdate()
+    default_start = today - timedelta(days=29)
+    start_date = _parse_date(request.GET.get("start_date", ""), default_start)
+    end_date = _parse_date(request.GET.get("end_date", ""), today)
+    if start_date > end_date:
+        start_date, end_date = end_date, start_date
+
+    alert_type = (request.GET.get("alert_type") or "").strip()
+    risk = (request.GET.get("risk") or "").strip()
+    state = (request.GET.get("state") or "open").strip().lower()
+
+    refresh_chef_bulletins(start_date, end_date)
+    qs = ChefBulletin.objects.select_related("recipe", "decided_by").filter(
+        period_start=start_date,
+        period_end=end_date,
+    )
+    if alert_type:
+        qs = qs.filter(alert_type=alert_type)
+    if risk:
+        qs = qs.filter(risk_level=risk)
+    if state == "open":
+        qs = qs.filter(is_open=True)
+    elif state == "closed":
+        qs = qs.filter(is_open=False)
+
+    qs = qs.order_by("-is_open", "-expected_saving", "-updated_at")
+    paginator = Paginator(qs, 30)
+    page_obj = paginator.get_page(request.GET.get("page"))
+
+    summary = {
+        "open_count": qs.filter(is_open=True).count(),
+        "closed_count": qs.filter(is_open=False).count(),
+        "high_risk_count": qs.filter(risk_level=ChefBulletin.RiskLevel.HIGH).count(),
+    }
+
+    return render(
+        request,
+        "inventory/chef_bulletins/list.html",
+        {
+            "page_obj": page_obj,
+            "summary": summary,
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "alert_type": alert_type,
+            "risk": risk,
+            "state": state,
+            "alert_type_choices": ChefBulletin.AlertType.choices,
+            "risk_choices": ChefBulletin.RiskLevel.choices,
+        },
+    )
+
+
+def chef_bulletin_detail(request, bulletin_id: int):
+    bulletin = get_object_or_404(
+        ChefBulletin.objects.select_related("recipe", "decided_by"),
+        pk=bulletin_id,
+    )
+    return render(
+        request,
+        "inventory/chef_bulletins/detail.html",
+        {
+            "bulletin": bulletin,
+            "decision_choices": ChefBulletin.ChefDecision.choices,
+        },
+    )
+
+
+@require_POST
+def chef_bulletin_decision(request, bulletin_id: int):
+    bulletin = get_object_or_404(ChefBulletin, pk=bulletin_id)
+    decision = request.POST.get("decision", "")
+    notes = request.POST.get("decision_notes", "")
+    try:
+        result = apply_chef_decision(
+            bulletin=bulletin,
+            decision=decision,
+            user=request.user,
+            notes=notes,
+        )
+    except ValueError as exc:
+        messages.error(request, str(exc), extra_tags="toast")
+        return redirect("chef_bulletin_detail", bulletin_id=bulletin_id)
+
+    if result.trial_version and result.trial_version.trial_recipe:
+        messages.success(
+            request,
+            (
+                f"Decision saved. Trial recipe created: "
+                f"{result.trial_version.trial_recipe.name}"
+            ),
+            extra_tags="toast",
+        )
+    else:
+        messages.success(request, "Chef decision saved.", extra_tags="toast")
+    return redirect("chef_bulletin_detail", bulletin_id=bulletin_id)

--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -63,6 +63,11 @@ NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
                 "url_name": "variance_report",
             },
             {
+                "title": "Chef Bulletins",
+                "description": "Recipe alerts, trials, and chef decisions.",
+                "url_name": "chef_bulletins_list",
+            },
+            {
                 "title": "History",
                 "description": "Past stock activity and audit trail.",
                 "url_name": "history_reports",
@@ -168,6 +173,7 @@ ROLE_ALLOWED_URLS: Mapping[str, set[str]] = {
         "ml_dashboard",
         "pos_sales_import",
         "variance_report",
+        "chef_bulletins_list",
         "indents_consolidate_preview",
         "purchase_orders_list",
         "grn_list",
@@ -193,6 +199,7 @@ ROLE_ALLOWED_URLS: Mapping[str, set[str]] = {
         "ml_dashboard",
         "pos_sales_import",
         "variance_report",
+        "chef_bulletins_list",
     },
     ROLE_KITCHEN_STAFF: {
         "indents_list",
@@ -284,6 +291,8 @@ def get_primary_role(user) -> str | None:
 
 def get_navigation_groups_for_role(role: str | None) -> List[dict]:
     """Return navigation groups filtered by role, or full groups if no role."""
+    if role == ROLE_OWNER:
+        return get_navigation_groups()
     allowed_urls = ROLE_ALLOWED_URLS.get(role)
     if not allowed_urls:
         return get_navigation_groups()

--- a/templates/inventory/chef_bulletins/detail.html
+++ b/templates/inventory/chef_bulletins/detail.html
@@ -1,0 +1,107 @@
+{% extends "components/create_manage_layout.html" %}
+
+{% block page_title %}Chef Bulletin{% endblock %}
+{% block page_heading %}{{ bulletin.recipe.name }}{% endblock %}
+{% block page_subtitle %}
+  <p class="text-sm text-bodyText/70">{{ bulletin.get_alert_type_display }} for {{ bulletin.period_start|date:"d M Y" }} to {{ bulletin.period_end|date:"d M Y" }}.</p>
+{% endblock %}
+
+{% block primary_actions %}
+  <a href="{% url 'chef_bulletins_list' %}" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md border border-border text-bodyText hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Back to Bulletins</a>
+{% endblock %}
+
+{% block kpis %}
+  <div class="grid gap-3 md:grid-cols-4">
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Current FC%</p>
+      <p class="mt-1 text-2xl font-semibold text-bodyText">{{ bulletin.current_food_cost_pct|floatformat:2 }}</p>
+    </div>
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Target FC%</p>
+      <p class="mt-1 text-2xl font-semibold text-bodyText">{{ bulletin.target_food_cost_pct|floatformat:2 }}</p>
+    </div>
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Monthly Sales</p>
+      <p class="mt-1 text-2xl font-semibold text-bodyText">Rs. {{ bulletin.monthly_sales|floatformat:2 }}</p>
+    </div>
+    <div class="bg-success-soft border border-success/20 rounded-xl p-4">
+      <p class="text-sm text-success">Expected Saving</p>
+      <p class="mt-1 text-2xl font-semibold text-success">Rs. {{ bulletin.expected_saving|floatformat:2 }}</p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block extra_top %}
+  <section class="bg-surface border border-border rounded-xl p-4 space-y-4">
+    <div>
+      <h2 class="text-lg font-semibold text-bodyText">Bulletin Summary</h2>
+      <p class="mt-1 text-sm text-bodyText/70">{{ bulletin.headline }}</p>
+    </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      <div>
+        <h3 class="text-sm font-semibold text-bodyText">Main Cost Drivers</h3>
+        <ul class="mt-2 space-y-1 text-sm text-bodyText/80">
+          {% for driver in bulletin.main_cost_drivers %}
+            <li>{{ driver }}</li>
+          {% empty %}
+            <li>No cost drivers recorded.</li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div>
+        <h3 class="text-sm font-semibold text-bodyText">Suggested Change</h3>
+        <p class="mt-2 text-sm text-bodyText/80">{{ bulletin.suggested_change }}</p>
+      </div>
+    </div>
+    <div class="grid gap-4 md:grid-cols-2">
+      <div>
+        <p class="text-sm text-bodyText/70">Risk Level</p>
+        <p class="text-base font-semibold text-bodyText">{{ bulletin.get_risk_level_display }}</p>
+      </div>
+      <div>
+        <p class="text-sm text-bodyText/70">Current Decision</p>
+        <p class="text-base font-semibold text-bodyText">{{ bulletin.get_chef_decision_display }}</p>
+      </div>
+      {% if bulletin.decided_by %}
+        <div>
+          <p class="text-sm text-bodyText/70">Decided By</p>
+          <p class="text-base font-semibold text-bodyText">{{ bulletin.decided_by.username }}</p>
+        </div>
+      {% endif %}
+      {% if bulletin.decided_at %}
+        <div>
+          <p class="text-sm text-bodyText/70">Decided At</p>
+          <p class="text-base font-semibold text-bodyText">{{ bulletin.decided_at|date:"d M Y H:i" }}</p>
+        </div>
+      {% endif %}
+    </div>
+    {% if bulletin.decision_notes %}
+      <div>
+        <h3 class="text-sm font-semibold text-bodyText">Decision Notes</h3>
+        <p class="mt-2 text-sm text-bodyText/80">{{ bulletin.decision_notes }}</p>
+      </div>
+    {% endif %}
+  </section>
+
+  <section class="bg-surface border border-border rounded-xl p-4">
+    <h2 class="text-lg font-semibold text-bodyText">Chef Decision</h2>
+    <form method="post" action="{% url 'chef_bulletin_decision' bulletin_id=bulletin.bulletin_id %}" class="mt-4 grid gap-4 md:grid-cols-3">
+      {% csrf_token %}
+      <div class="md:col-span-1">
+        <label for="bulletin-decision" class="block text-sm font-medium text-bodyText">Decision</label>
+        <select id="bulletin-decision" name="decision" class="mt-1 block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+          {% for value, label in decision_choices %}
+            <option value="{{ value }}" {% if bulletin.chef_decision == value %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="md:col-span-2">
+        <label for="bulletin-notes" class="block text-sm font-medium text-bodyText">Notes</label>
+        <textarea id="bulletin-notes" name="decision_notes" rows="2" class="mt-1 block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">{{ bulletin.decision_notes }}</textarea>
+      </div>
+      <div class="md:col-span-3">
+        <button type="submit" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md bg-primary text-white hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary">Save Decision</button>
+      </div>
+    </form>
+  </section>
+{% endblock %}

--- a/templates/inventory/chef_bulletins/list.html
+++ b/templates/inventory/chef_bulletins/list.html
@@ -1,0 +1,123 @@
+{% extends "components/create_manage_layout.html" %}
+
+{% block page_title %}Chef Bulletins{% endblock %}
+{% block page_heading %}Chef Bulletins{% endblock %}
+{% block page_subtitle %}
+  <p class="text-sm text-bodyText/70">Rule-based recipe cost alerts with chef decisions and trial recipe control.</p>
+{% endblock %}
+
+{% block filters %}
+  <form method="get" class="bg-surface border border-border rounded-xl p-4 grid gap-3 md:grid-cols-6 md:items-end">
+    <div>
+      <label for="bulletin-start-date" class="block text-sm font-medium text-bodyText">Start Date</label>
+      <input id="bulletin-start-date" type="date" name="start_date" value="{{ start_date }}" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+    </div>
+    <div>
+      <label for="bulletin-end-date" class="block text-sm font-medium text-bodyText">End Date</label>
+      <input id="bulletin-end-date" type="date" name="end_date" value="{{ end_date }}" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+    </div>
+    <div>
+      <label for="bulletin-alert-type" class="block text-sm font-medium text-bodyText">Alert Type</label>
+      <select id="bulletin-alert-type" name="alert_type" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+        <option value="">All alerts</option>
+        {% for value, label in alert_type_choices %}
+          <option value="{{ value }}" {% if alert_type == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label for="bulletin-risk" class="block text-sm font-medium text-bodyText">Risk</label>
+      <select id="bulletin-risk" name="risk" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+        <option value="">All risk levels</option>
+        {% for value, label in risk_choices %}
+          <option value="{{ value }}" {% if risk == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label for="bulletin-state" class="block text-sm font-medium text-bodyText">State</label>
+      <select id="bulletin-state" name="state" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+        <option value="open" {% if state == "open" %}selected{% endif %}>Open</option>
+        <option value="closed" {% if state == "closed" %}selected{% endif %}>Closed</option>
+        <option value="all" {% if state == "all" %}selected{% endif %}>All</option>
+      </select>
+    </div>
+    <div class="flex gap-2">
+      <button type="submit" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md bg-primary text-white hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary">Apply</button>
+      <a href="{% url 'chef_bulletins_list' %}" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md border border-border text-bodyText hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Reset</a>
+    </div>
+  </form>
+{% endblock %}
+
+{% block kpis %}
+  <div class="grid gap-3 md:grid-cols-3">
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Open Bulletins</p>
+      <p class="mt-1 text-2xl font-semibold text-bodyText">{{ summary.open_count }}</p>
+    </div>
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Closed Bulletins</p>
+      <p class="mt-1 text-2xl font-semibold text-bodyText">{{ summary.closed_count }}</p>
+    </div>
+    <div class="bg-danger-soft border border-danger/20 rounded-xl p-4">
+      <p class="text-sm text-danger">High Risk</p>
+      <p class="mt-1 text-2xl font-semibold text-danger">{{ summary.high_risk_count }}</p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block data_container %}
+  <div class="overflow-x-auto bg-surface border border-border rounded-xl">
+    <table class="min-w-full divide-y divide-border text-sm">
+      <thead class="bg-surfaceSubtle text-left text-xs font-semibold uppercase tracking-wider text-bodyText/70">
+        <tr>
+          <th class="px-4 py-3">Recipe</th>
+          <th class="px-4 py-3">Alert</th>
+          <th class="px-4 py-3">Risk</th>
+          <th class="px-4 py-3 text-right">Current FC%</th>
+          <th class="px-4 py-3 text-right">Target FC%</th>
+          <th class="px-4 py-3 text-right">Monthly Sales</th>
+          <th class="px-4 py-3 text-right">Expected Saving</th>
+          <th class="px-4 py-3">Decision</th>
+          <th class="px-4 py-3">State</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-border">
+        {% for bulletin in page_obj %}
+          <tr class="odd:bg-surfaceSubtle/50">
+            <td class="px-4 py-3">
+              <a href="{% url 'chef_bulletin_detail' bulletin_id=bulletin.bulletin_id %}" class="font-semibold text-primary hover:underline">
+                {{ bulletin.recipe.name }}
+              </a>
+            </td>
+            <td class="px-4 py-3">{{ bulletin.get_alert_type_display }}</td>
+            <td class="px-4 py-3">{{ bulletin.get_risk_level_display }}</td>
+            <td class="px-4 py-3 text-right tabular-nums">{{ bulletin.current_food_cost_pct|floatformat:2 }}</td>
+            <td class="px-4 py-3 text-right tabular-nums">{{ bulletin.target_food_cost_pct|floatformat:2 }}</td>
+            <td class="px-4 py-3 text-right tabular-nums">Rs. {{ bulletin.monthly_sales|floatformat:2 }}</td>
+            <td class="px-4 py-3 text-right tabular-nums text-success">Rs. {{ bulletin.expected_saving|floatformat:2 }}</td>
+            <td class="px-4 py-3">{{ bulletin.get_chef_decision_display }}</td>
+            <td class="px-4 py-3">
+              {% if bulletin.is_open %}
+                <span class="inline-flex items-center rounded-full bg-warning-soft px-2 py-1 text-xs font-semibold text-warning">Open</span>
+              {% else %}
+                <span class="inline-flex items-center rounded-full bg-success-soft px-2 py-1 text-xs font-semibold text-success">Closed</span>
+              {% endif %}
+            </td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="9" class="px-4 py-8 text-center text-bodyText/70">No chef bulletins for this period.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}
+
+{% block pagination %}
+  <div class="mt-4">
+    {% url 'chef_bulletins_list' as bulletins_url %}
+    {% include "components/pagination.html" with page_obj=page_obj base_url=bulletins_url %}
+  </div>
+{% endblock %}

--- a/tests/test_chef_bulletins_service.py
+++ b/tests/test_chef_bulletins_service.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from inventory.models import (
+    ChefBulletin,
+    Recipe,
+    RecipeItem,
+    SaleTransaction,
+    TrialRecipeVersion,
+)
+from inventory.services.chef_bulletins_service import (
+    apply_chef_decision,
+    refresh_chef_bulletins,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_recipe(item, *, name: str) -> Recipe:
+    recipe = Recipe.objects.create(
+        name=name,
+        is_active=True,
+        type=Recipe.Type.FINAL,
+        selling_price=Decimal("100.00"),
+        target_food_cost_pct=Decimal("30.00"),
+    )
+    RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=Decimal("1000.00"),
+        unit="GM",
+        loss_pct=Decimal("0.00"),
+    )
+    return recipe
+
+
+def test_refresh_chef_bulletins_creates_rule_based_alerts(item_factory):
+    item = item_factory(
+        name="Bulletin Chicken",
+        unit_id=19,
+        initial_purchase_price=Decimal("50.00"),
+        last_purchase_price=Decimal("70.00"),
+    )
+    recipe = _make_recipe(item, name="Bulletin Chicken Curry")
+    SaleTransaction.objects.create(
+        recipe=recipe,
+        quantity=Decimal("180.00"),
+        net_sales=Decimal("18000.00"),
+        source=SaleTransaction.Source.MANUAL,
+        sale_date=timezone.now(),
+    )
+
+    today = timezone.localdate()
+    refresh_chef_bulletins(today, today)
+
+    alerts = set(
+        ChefBulletin.objects.filter(recipe=recipe, period_start=today, period_end=today)
+        .values_list("alert_type", flat=True)
+    )
+    assert ChefBulletin.AlertType.FOOD_COST_ABOVE_TARGET in alerts
+    assert ChefBulletin.AlertType.HIGH_SALES_LOW_MARGIN in alerts
+    assert ChefBulletin.AlertType.INGREDIENT_PRICE_INCREASED in alerts
+    assert ChefBulletin.AlertType.RECIPE_COST_CHANGED in alerts
+
+
+def test_apply_chef_decision_approve_trial_creates_trial_recipe(item_factory):
+    item = item_factory(
+        name="Trial Paneer",
+        unit_id=19,
+        initial_purchase_price=Decimal("120.00"),
+        last_purchase_price=Decimal("140.00"),
+    )
+    recipe = _make_recipe(item, name="Trial Paneer Tikka")
+    bulletin = ChefBulletin.objects.create(
+        recipe=recipe,
+        period_start=timezone.localdate(),
+        period_end=timezone.localdate(),
+        alert_type=ChefBulletin.AlertType.FOOD_COST_ABOVE_TARGET,
+        current_food_cost_pct=Decimal("45.00"),
+        target_food_cost_pct=Decimal("30.00"),
+        monthly_sales=Decimal("12000.00"),
+        unrealised_profit=Decimal("1800.00"),
+        expected_saving=Decimal("1800.00"),
+        risk_level=ChefBulletin.RiskLevel.MEDIUM,
+    )
+    user_model = get_user_model()
+    user = user_model.objects.create_user(username="chef_decider", password="pw")
+
+    result = apply_chef_decision(
+        bulletin=bulletin,
+        decision=ChefBulletin.ChefDecision.APPROVE_TRIAL,
+        user=user,
+        notes="Run trial with alternate marinade.",
+    )
+
+    bulletin.refresh_from_db()
+    assert bulletin.chef_decision == ChefBulletin.ChefDecision.APPROVE_TRIAL
+    assert bulletin.is_open is False
+    assert result.trial_version is not None
+    trial_version = result.trial_version
+    assert TrialRecipeVersion.objects.filter(pk=trial_version.pk).exists()
+    assert trial_version.trial_recipe is not None
+    assert trial_version.trial_recipe.is_active is False
+    assert RecipeItem.objects.filter(recipe=trial_version.trial_recipe).count() == RecipeItem.objects.filter(
+        recipe=recipe
+    ).count()

--- a/tests/test_chef_bulletins_views.py
+++ b/tests/test_chef_bulletins_views.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from inventory.models import ChefBulletin, Recipe, RecipeItem, SaleTransaction
+
+pytestmark = pytest.mark.django_db
+
+
+def _recipe_for_bulletin(item, *, name: str) -> Recipe:
+    recipe = Recipe.objects.create(
+        name=name,
+        is_active=True,
+        type=Recipe.Type.FINAL,
+        selling_price=Decimal("100.00"),
+        target_food_cost_pct=Decimal("30.00"),
+    )
+    RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=Decimal("1000.00"),
+        unit="GM",
+        loss_pct=Decimal("0.00"),
+    )
+    return recipe
+
+
+def test_chef_bulletins_list_page_renders(client, item_factory):
+    item = item_factory(
+        name="Chef List Chicken",
+        unit_id=19,
+        initial_purchase_price=Decimal("50.00"),
+        last_purchase_price=Decimal("70.00"),
+    )
+    recipe = _recipe_for_bulletin(item, name="Chef List Curry")
+    SaleTransaction.objects.create(
+        recipe=recipe,
+        quantity=Decimal("100.00"),
+        net_sales=Decimal("12000.00"),
+        sale_date=timezone.now(),
+    )
+    today = timezone.localdate()
+
+    response = client.get(
+        reverse("chef_bulletins_list"),
+        {
+            "start_date": today.isoformat(),
+            "end_date": today.isoformat(),
+            "state": "all",
+        },
+    )
+
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert "Chef Bulletins" in html
+    assert "Chef List Curry" in html
+
+
+def test_chef_bulletin_detail_and_decision_updates_status(client, item_factory):
+    item = item_factory(name="Chef Detail Paneer", unit_id=19)
+    recipe = _recipe_for_bulletin(item, name="Chef Detail Dish")
+    bulletin = ChefBulletin.objects.create(
+        recipe=recipe,
+        period_start=timezone.localdate(),
+        period_end=timezone.localdate(),
+        alert_type=ChefBulletin.AlertType.RECIPE_COST_CHANGED,
+        current_food_cost_pct=Decimal("34.00"),
+        target_food_cost_pct=Decimal("30.00"),
+        monthly_sales=Decimal("5000.00"),
+        expected_saving=Decimal("200.00"),
+    )
+
+    detail_response = client.get(
+        reverse("chef_bulletin_detail", kwargs={"bulletin_id": bulletin.pk})
+    )
+    assert detail_response.status_code == 200
+    assert "Chef Detail Dish" in detail_response.content.decode()
+
+    post_response = client.post(
+        reverse("chef_bulletin_decision", kwargs={"bulletin_id": bulletin.pk}),
+        {
+            "decision": ChefBulletin.ChefDecision.REJECT,
+            "decision_notes": "Not feasible this cycle.",
+        },
+    )
+
+    assert post_response.status_code == 302
+    bulletin.refresh_from_db()
+    assert bulletin.chef_decision == ChefBulletin.ChefDecision.REJECT
+    assert bulletin.is_open is False

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -68,7 +68,11 @@ def test_role_owner_sees_owner_money_navigation(django_user_model):
     assert "vendor_prices_list" in visible_urls
     assert "pos_sales_import" in visible_urls
     assert "variance_report" in visible_urls
-    assert "indents_list" not in visible_urls
+    assert "chef_bulletins_list" in visible_urls
+    assert "indents_list" in visible_urls
+    assert "items_list" in visible_urls
+    assert "recipes_list" in visible_urls
+    assert "suppliers_list" in visible_urls
 
 
 @pytest.mark.django_db
@@ -116,6 +120,7 @@ def test_role_head_chef_sees_sales_import(django_user_model):
     assert role == navigation.ROLE_HEAD_CHEF
     assert "pos_sales_import" in visible_urls
     assert "variance_report" in visible_urls
+    assert "chef_bulletins_list" in visible_urls
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What changed
- Implemented Phase 8 recipe cost alerts and chef bulletin workflow.
- Added new data models: `ChefBulletin` and `TrialRecipeVersion` with migration `0046`.
- Added bulletin service rules for:
  - food cost above target
  - ingredient price increased
  - recipe cost changed
  - high sales with low margin
  - actual usage above ideal (variance-linked)
- Added owner/head-chef UI flow:
  - `/chef-bulletins/` list
  - `/chef-bulletins/<id>/` detail
  - decision endpoint to approve trial/modify/reject/send-to-owner
- Added trial recipe creation on `APPROVE_TRIAL` (inactive copy, no automatic live recipe mutation).
- Updated role navigation so Owner has full access to all navigation sections (including masters).

## Why it changed
- This is Phase 8 of the food-cost recovery pivot: surface actionable recipe leakage alerts, route decisions to chefs, and preserve controlled trial workflow.
- Owner full-access correction restores expected control visibility across the app.

## Impact
- Head Chef and Owner now have a dedicated bulletin workflow for recipe-cost interventions.
- Trial recipes can be generated from bulletin decisions without affecting active recipes.
- Owners can access all sections from navigation again.

## Validation
- `python -m pytest tests/test_chef_bulletins_service.py tests/test_chef_bulletins_views.py tests/test_navigation.py -q`
  - Result: `32 passed`
- `python manage.py check --settings=inventory_app.settings.test`
  - Result: no issues
- `ruff check` on changed files passed.
