### PR TITLE
[codex] implement phase 9 recovery actions and verified recovery

### DIFF
--- a/core/templates/core/_kpi_cards.html
+++ b/core/templates/core/_kpi_cards.html
@@ -71,5 +71,23 @@
       <p class="text-2xl font-semibold text-warning-text leading-tight">&#8377;{{ remaining_opportunity|floatformat:0 }}</p>
       <p class="text-[11px] text-gray-400">Money still leaking</p>
     </div>
+
+    <div class="bg-surface border border-border rounded-xl px-4 py-4 flex flex-col gap-1">
+      <p class="text-[11px] font-medium uppercase tracking-wide text-gray-400">Open Opportunity</p>
+      <p class="text-2xl font-semibold text-warning-text leading-tight">&#8377;{{ open_opportunity|floatformat:0 }}</p>
+      <p class="text-[11px] text-gray-400">Expected saving in open actions</p>
+    </div>
+
+    <div class="bg-surface border border-border rounded-xl px-4 py-4 flex flex-col gap-1">
+      <p class="text-[11px] font-medium uppercase tracking-wide text-gray-400">Expected Recovery</p>
+      <p class="text-2xl font-semibold text-bodyText leading-tight">&#8377;{{ expected_recovery|floatformat:0 }}</p>
+      <p class="text-[11px] text-gray-400">Assigned, in-progress, and implemented actions</p>
+    </div>
+
+    <div class="bg-surface border border-border rounded-xl px-4 py-4 flex flex-col gap-1">
+      <p class="text-[11px] font-medium uppercase tracking-wide text-gray-400">Verified Recovered Profit</p>
+      <p class="text-2xl font-semibold text-success leading-tight">&#8377;{{ verified_recovered_profit|floatformat:0 }}</p>
+      <p class="text-[11px] text-gray-400">Recovered profit proven through verified actions</p>
+    </div>
   </div>
 </div>

--- a/inventory/admin.py
+++ b/inventory/admin.py
@@ -15,6 +15,7 @@ from .models import (
     PurchaseOrderItem,
     Recipe,
     RecipeItem,
+    RecoveryAction,
     SaleTransaction,
     SavingsLedger,
     StockTransaction,
@@ -43,6 +44,7 @@ for model in [
     VendorItemPrice,
     ChefBulletin,
     TrialRecipeVersion,
+    RecoveryAction,
     Department,
     ItemDepartment,
 ]:

--- a/inventory/forms/recovery_forms.py
+++ b/inventory/forms/recovery_forms.py
@@ -1,6 +1,16 @@
-from django import forms
+from decimal import Decimal
 
-from ..models import Item, SavingsLedger, Supplier, VendorItemPrice
+from django import forms
+from django.contrib.auth import get_user_model
+
+from ..models import (
+    ChefBulletin,
+    Item,
+    RecoveryAction,
+    SavingsLedger,
+    Supplier,
+    VendorItemPrice,
+)
 from .base import StyledFormMixin
 
 
@@ -62,3 +72,69 @@ class VendorItemPriceForm(StyledFormMixin, forms.ModelForm):
             "name"
         )
         self.fields["unit"].required = False
+
+
+class RecoveryActionForm(StyledFormMixin, forms.ModelForm):
+    class Meta:
+        model = RecoveryAction
+        fields = [
+            "title",
+            "leakage_type",
+            "expected_saving",
+            "assigned_to",
+            "due_date",
+            "linked_item",
+            "linked_chef_bulletin",
+            "notes",
+        ]
+        widgets = {
+            "due_date": forms.DateInput(attrs={"type": "date"}),
+            "notes": forms.Textarea(attrs={"rows": 2}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        user_model = get_user_model()
+        self.fields["assigned_to"].queryset = user_model.objects.filter(
+            is_active=True
+        ).order_by("username")
+        self.fields["linked_item"].queryset = Item.objects.filter(is_active=True).order_by(
+            "name"
+        )
+        self.fields["linked_item"].required = False
+        self.fields["linked_chef_bulletin"].queryset = ChefBulletin.objects.select_related(
+            "recipe"
+        ).filter(is_open=True)
+        self.fields["linked_chef_bulletin"].required = False
+
+
+class RecoveryActionStatusForm(StyledFormMixin, forms.Form):
+    status = forms.ChoiceField(choices=RecoveryAction.Status.choices)
+    verified_saving = forms.DecimalField(
+        required=False,
+        max_digits=14,
+        decimal_places=2,
+        min_value=Decimal("0.00"),
+    )
+    implemented_date = forms.DateField(
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+    notes = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 2}),
+    )
+
+    def clean(self):
+        cleaned = super().clean()
+        status = cleaned.get("status")
+        verified_saving = cleaned.get("verified_saving")
+        if (
+            status == RecoveryAction.Status.VERIFIED
+            and (verified_saving is None or verified_saving <= 0)
+        ):
+            self.add_error(
+                "verified_saving",
+                "Verified saving must be greater than zero for verified actions.",
+            )
+        return cleaned

--- a/inventory/migrations/0047_recoveryaction.py
+++ b/inventory/migrations/0047_recoveryaction.py
@@ -1,0 +1,111 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("inventory", "0046_chef_bulletins_trial_recipe_versions"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="RecoveryAction",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("title", models.CharField(max_length=255)),
+                (
+                    "leakage_type",
+                    models.CharField(
+                        choices=[
+                            ("FOOD_COST_GAP", "Food cost gap"),
+                            ("VENDOR_PRICE", "Vendor price"),
+                            ("INVOICE_MISMATCH", "Invoice mismatch"),
+                            ("RECIPE_OPTIMISATION", "Recipe optimisation"),
+                            ("WASTE_REDUCTION", "Waste reduction"),
+                            ("VARIANCE_REDUCTION", "Variance reduction"),
+                            ("MENU_PRICE_CORRECTION", "Menu price correction"),
+                        ],
+                        max_length=40,
+                    ),
+                ),
+                ("expected_saving", models.DecimalField(decimal_places=2, default=0, max_digits=14)),
+                ("due_date", models.DateField(blank=True, null=True)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("SUGGESTED", "Suggested"),
+                            ("ASSIGNED", "Assigned"),
+                            ("IN_PROGRESS", "In progress"),
+                            ("IMPLEMENTED", "Implemented"),
+                            ("VERIFIED", "Verified"),
+                            ("REJECTED", "Rejected"),
+                        ],
+                        default="SUGGESTED",
+                        max_length=16,
+                    ),
+                ),
+                ("implemented_date", models.DateField(blank=True, null=True)),
+                ("verified_saving", models.DecimalField(decimal_places=2, default=0, max_digits=14)),
+                ("notes", models.TextField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "assigned_to",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="recovery_actions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "linked_chef_bulletin",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="recovery_actions",
+                        to="inventory.chefbulletin",
+                    ),
+                ),
+                (
+                    "linked_item",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="recovery_actions",
+                        to="inventory.item",
+                    ),
+                ),
+                (
+                    "linked_savings_entries",
+                    models.ManyToManyField(blank=True, related_name="recovery_actions", to="inventory.savingsledger"),
+                ),
+            ],
+            options={
+                "db_table": "recovery_actions",
+                "ordering": ["-created_at", "-id"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="recoveryaction",
+            index=models.Index(fields=["status"], name="rec_action_status_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="recoveryaction",
+            index=models.Index(fields=["leakage_type"], name="rec_action_type_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="recoveryaction",
+            index=models.Index(fields=["due_date"], name="rec_action_due_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="recoveryaction",
+            index=models.Index(fields=["assigned_to", "status"], name="rec_action_assign_status_idx"),
+        ),
+    ]

--- a/inventory/models/__init__.py
+++ b/inventory/models/__init__.py
@@ -21,7 +21,7 @@ from .recipes import (
     SaleTransaction,
     TrialRecipeVersion,
 )
-from .recovery import SavingsLedger, VendorItemPrice
+from .recovery import RecoveryAction, SavingsLedger, VendorItemPrice
 from .site_config import SiteConfig
 from .stock_take import StockTake, StockTakeItem
 from .subcategory import SubCategory
@@ -44,6 +44,7 @@ __all__ = [
     "GRNItem",
     "SavingsLedger",
     "VendorItemPrice",
+    "RecoveryAction",
     "IndentStatus",
     "ItemStatus",
     "PurchaseOrderStatus",

--- a/inventory/models/recovery.py
+++ b/inventory/models/recovery.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import models
 
 
@@ -78,3 +79,72 @@ class VendorItemPrice(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"{self.vendor} - {self.item} @ {self.price}"
+
+
+class RecoveryAction(models.Model):
+    class LeakageType(models.TextChoices):
+        FOOD_COST_GAP = "FOOD_COST_GAP", "Food cost gap"
+        VENDOR_PRICE = "VENDOR_PRICE", "Vendor price"
+        INVOICE_MISMATCH = "INVOICE_MISMATCH", "Invoice mismatch"
+        RECIPE_OPTIMISATION = "RECIPE_OPTIMISATION", "Recipe optimisation"
+        WASTE_REDUCTION = "WASTE_REDUCTION", "Waste reduction"
+        VARIANCE_REDUCTION = "VARIANCE_REDUCTION", "Variance reduction"
+        MENU_PRICE_CORRECTION = "MENU_PRICE_CORRECTION", "Menu price correction"
+
+    class Status(models.TextChoices):
+        SUGGESTED = "SUGGESTED", "Suggested"
+        ASSIGNED = "ASSIGNED", "Assigned"
+        IN_PROGRESS = "IN_PROGRESS", "In progress"
+        IMPLEMENTED = "IMPLEMENTED", "Implemented"
+        VERIFIED = "VERIFIED", "Verified"
+        REJECTED = "REJECTED", "Rejected"
+
+    title = models.CharField(max_length=255)
+    leakage_type = models.CharField(max_length=40, choices=LeakageType.choices)
+    expected_saving = models.DecimalField(max_digits=14, decimal_places=2, default=0)
+    assigned_to = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="recovery_actions",
+    )
+    due_date = models.DateField(null=True, blank=True)
+    status = models.CharField(max_length=16, choices=Status.choices, default=Status.SUGGESTED)
+    implemented_date = models.DateField(null=True, blank=True)
+    verified_saving = models.DecimalField(max_digits=14, decimal_places=2, default=0)
+    linked_savings_entries = models.ManyToManyField(
+        "inventory.SavingsLedger",
+        blank=True,
+        related_name="recovery_actions",
+    )
+    linked_chef_bulletin = models.ForeignKey(
+        "inventory.ChefBulletin",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="recovery_actions",
+    )
+    linked_item = models.ForeignKey(
+        "inventory.Item",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="recovery_actions",
+    )
+    notes = models.TextField(blank=True, default="")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "recovery_actions"
+        ordering = ["-created_at", "-id"]
+        indexes = [
+            models.Index(fields=["status"], name="rec_action_status_idx"),
+            models.Index(fields=["leakage_type"], name="rec_action_type_idx"),
+            models.Index(fields=["due_date"], name="rec_action_due_idx"),
+            models.Index(fields=["assigned_to", "status"], name="rec_action_assign_status_idx"),
+        ]
+
+    def __str__(self) -> str:  # pragma: no cover - simple representation
+        return f"{self.title} ({self.get_status_display()})"

--- a/inventory/services/chef_bulletins_service.py
+++ b/inventory/services/chef_bulletins_service.py
@@ -351,8 +351,12 @@ def refresh_chef_bulletins(
                 )
             )
 
+        unexplained_total = sum(
+            (_as_decimal(unexplained_by_item.get(item_id)) for item_id in recipe_item_ids),
+            ZERO,
+        )
         unexplained_value = _clamp_decimal(
-            sum(_as_decimal(unexplained_by_item.get(item_id)) for item_id in recipe_item_ids),
+            _as_decimal(unexplained_total),
             max_value=MAX_MONEY,
             places="0.01",
         )

--- a/inventory/services/recovery_actions_service.py
+++ b/inventory/services/recovery_actions_service.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any
+
+from django.db.models import DecimalField, Sum
+from django.db.models.functions import Coalesce
+from django.urls import reverse
+from django.utils import timezone
+
+from inventory.models import ChefBulletin, RecoveryAction, SavingsLedger
+from inventory.services.chef_bulletins_service import refresh_chef_bulletins
+from inventory.services.variance_service import build_variance_report
+
+ZERO = Decimal("0.00")
+OPEN_STATUSES = {
+    RecoveryAction.Status.SUGGESTED,
+    RecoveryAction.Status.ASSIGNED,
+    RecoveryAction.Status.IN_PROGRESS,
+    RecoveryAction.Status.IMPLEMENTED,
+}
+IN_PROGRESS_STATUSES = {
+    RecoveryAction.Status.ASSIGNED,
+    RecoveryAction.Status.IN_PROGRESS,
+    RecoveryAction.Status.IMPLEMENTED,
+}
+
+ALERT_TO_LEAKAGE = {
+    ChefBulletin.AlertType.FOOD_COST_ABOVE_TARGET: RecoveryAction.LeakageType.FOOD_COST_GAP,
+    ChefBulletin.AlertType.INGREDIENT_PRICE_INCREASED: RecoveryAction.LeakageType.VENDOR_PRICE,
+    ChefBulletin.AlertType.RECIPE_COST_CHANGED: RecoveryAction.LeakageType.RECIPE_OPTIMISATION,
+    ChefBulletin.AlertType.HIGH_SALES_LOW_MARGIN: RecoveryAction.LeakageType.MENU_PRICE_CORRECTION,
+    ChefBulletin.AlertType.ACTUAL_USAGE_ABOVE_IDEAL: RecoveryAction.LeakageType.VARIANCE_REDUCTION,
+}
+
+LEAKAGE_TO_SAVING = {
+    RecoveryAction.LeakageType.FOOD_COST_GAP: SavingsLedger.SavingType.RECIPE_OPTIMISATION,
+    RecoveryAction.LeakageType.VENDOR_PRICE: SavingsLedger.SavingType.VENDOR_SAVING,
+    RecoveryAction.LeakageType.INVOICE_MISMATCH: SavingsLedger.SavingType.INVOICE_MISMATCH_CAUGHT,
+    RecoveryAction.LeakageType.RECIPE_OPTIMISATION: SavingsLedger.SavingType.RECIPE_OPTIMISATION,
+    RecoveryAction.LeakageType.WASTE_REDUCTION: SavingsLedger.SavingType.WASTE_REDUCTION,
+    RecoveryAction.LeakageType.VARIANCE_REDUCTION: SavingsLedger.SavingType.VARIANCE_REDUCTION,
+    RecoveryAction.LeakageType.MENU_PRICE_CORRECTION: SavingsLedger.SavingType.MENU_PRICE_CORRECTION,
+}
+
+CHEF_LEAKAGE_TYPES = {
+    RecoveryAction.LeakageType.FOOD_COST_GAP,
+    RecoveryAction.LeakageType.RECIPE_OPTIMISATION,
+    RecoveryAction.LeakageType.WASTE_REDUCTION,
+    RecoveryAction.LeakageType.VARIANCE_REDUCTION,
+    RecoveryAction.LeakageType.MENU_PRICE_CORRECTION,
+}
+PURCHASE_LEAKAGE_TYPES = {
+    RecoveryAction.LeakageType.VENDOR_PRICE,
+    RecoveryAction.LeakageType.INVOICE_MISMATCH,
+}
+
+
+def _as_decimal(value: Any) -> Decimal:
+    if value in (None, ""):
+        return ZERO
+    return Decimal(str(value)).quantize(Decimal("0.01"))
+
+
+def _money_sum(queryset, field_name: str) -> Decimal:
+    value = queryset.aggregate(
+        total=Coalesce(
+            Sum(field_name),
+            Decimal("0"),
+            output_field=DecimalField(max_digits=14, decimal_places=2),
+        )
+    )["total"]
+    return _as_decimal(value)
+
+
+def _default_window(
+    start_date: date | None,
+    end_date: date | None,
+) -> tuple[date, date]:
+    end = end_date or timezone.localdate()
+    start = start_date or (end - timedelta(days=29))
+    if start > end:
+        return end, start
+    return start, end
+
+
+def _action_title_for_bulletin(bulletin: ChefBulletin) -> str:
+    return f"Recover {bulletin.recipe.name}: {bulletin.get_alert_type_display()}"
+
+
+def _create_suggestions_from_bulletins(
+    *,
+    start_date: date,
+    end_date: date,
+) -> int:
+    created = 0
+    bulletins = ChefBulletin.objects.select_related("recipe").filter(
+        is_open=True,
+        period_start=start_date,
+        period_end=end_date,
+    )
+    for bulletin in bulletins:
+        exists = RecoveryAction.objects.filter(
+            linked_chef_bulletin=bulletin,
+            status__in=OPEN_STATUSES,
+        ).exists()
+        if exists:
+            continue
+        RecoveryAction.objects.create(
+            title=_action_title_for_bulletin(bulletin),
+            leakage_type=ALERT_TO_LEAKAGE.get(
+                bulletin.alert_type,
+                RecoveryAction.LeakageType.RECIPE_OPTIMISATION,
+            ),
+            expected_saving=_as_decimal(bulletin.expected_saving),
+            due_date=end_date + timedelta(days=7),
+            linked_chef_bulletin=bulletin,
+            notes=bulletin.suggested_change or "",
+        )
+        created += 1
+    return created
+
+
+def _create_suggestions_from_variance(
+    *,
+    start_date: date,
+    end_date: date,
+) -> int:
+    created = 0
+    report = build_variance_report(start_date, end_date)
+    for row in report["rows"]:
+        unexplained = _as_decimal(row.unexplained_variance_value)
+        if unexplained <= ZERO:
+            continue
+        exists = RecoveryAction.objects.filter(
+            leakage_type=RecoveryAction.LeakageType.VARIANCE_REDUCTION,
+            linked_item=row.item,
+            linked_chef_bulletin__isnull=True,
+            status__in=OPEN_STATUSES,
+        ).exists()
+        if exists:
+            continue
+        RecoveryAction.objects.create(
+            title=f"Reduce unexplained variance: {row.item.name}",
+            leakage_type=RecoveryAction.LeakageType.VARIANCE_REDUCTION,
+            expected_saving=unexplained,
+            due_date=end_date + timedelta(days=7),
+            linked_item=row.item,
+            notes=row.recommended_action,
+        )
+        created += 1
+    return created
+
+
+def refresh_recovery_actions(
+    start_date: date | None = None,
+    end_date: date | None = None,
+) -> dict[str, int]:
+    start_date, end_date = _default_window(start_date, end_date)
+    refresh_chef_bulletins(start_date, end_date)
+    from_bulletins = _create_suggestions_from_bulletins(
+        start_date=start_date,
+        end_date=end_date,
+    )
+    from_variance = _create_suggestions_from_variance(
+        start_date=start_date,
+        end_date=end_date,
+    )
+    return {
+        "created_from_bulletins": from_bulletins,
+        "created_from_variance": from_variance,
+    }
+
+
+def summarize_recovery_actions() -> dict[str, Decimal]:
+    qs = RecoveryAction.objects.all()
+    open_opportunity = _money_sum(
+        qs.filter(status__in=OPEN_STATUSES),
+        "expected_saving",
+    )
+    expected_recovery = _money_sum(
+        qs.filter(status__in=IN_PROGRESS_STATUSES),
+        "expected_saving",
+    )
+    verified_recovered_profit = _money_sum(
+        qs.filter(status=RecoveryAction.Status.VERIFIED),
+        "verified_saving",
+    )
+    return {
+        "open_opportunity": open_opportunity,
+        "expected_recovery": expected_recovery,
+        "verified_recovered_profit": verified_recovered_profit,
+    }
+
+
+def weekly_action_plan_from_actions(limit: int = 3) -> list[dict[str, Any]]:
+    actions = (
+        RecoveryAction.objects.select_related("assigned_to")
+        .filter(status__in=OPEN_STATUSES)
+        .order_by("due_date", "-expected_saving", "-created_at")[:limit]
+    )
+    plan: list[dict[str, Any]] = []
+    for action in actions:
+        assigned = action.assigned_to.username if action.assigned_to else "Unassigned"
+        due = action.due_date.strftime("%d %b") if action.due_date else "No due date"
+        plan.append(
+            {
+                "title": action.title,
+                "detail": f"{action.get_status_display()} | {assigned} | Due {due}",
+                "url": reverse("recovery_action_detail", kwargs={"action_id": action.pk}),
+            }
+        )
+    return plan
+
+
+def apply_recovery_action_status(
+    *,
+    action: RecoveryAction,
+    status: str,
+    notes: str = "",
+    verified_saving: Decimal | None = None,
+    implemented_date: date | None = None,
+) -> SavingsLedger | None:
+    valid_statuses = {choice[0] for choice in RecoveryAction.Status.choices}
+    if status not in valid_statuses:
+        raise ValueError("Invalid recovery action status.")
+
+    action.status = status
+    if notes:
+        action.notes = notes
+
+    if status == RecoveryAction.Status.IMPLEMENTED:
+        action.implemented_date = implemented_date or timezone.localdate()
+        action.save()
+        return None
+
+    if status != RecoveryAction.Status.VERIFIED:
+        action.save()
+        return None
+
+    value = _as_decimal(verified_saving or 0)
+    if value <= ZERO:
+        raise ValueError("Verified saving must be greater than zero.")
+
+    action.verified_saving = value
+    action.implemented_date = implemented_date or action.implemented_date or timezone.localdate()
+    action.save()
+
+    ledger_defaults = {
+        "saving_type": LEAKAGE_TO_SAVING.get(
+            action.leakage_type,
+            SavingsLedger.SavingType.RECIPE_OPTIMISATION,
+        ),
+        "status": SavingsLedger.Status.VERIFIED,
+        "item": action.linked_item,
+        "estimated_saving": _as_decimal(action.expected_saving),
+        "confirmed_saving": value,
+        "lost_saving": ZERO,
+        "notes": f"Recovery action #{action.pk}: {action.title}",
+    }
+    ledger, _ = SavingsLedger.objects.update_or_create(
+        source_document_type="RecoveryAction",
+        source_document_id=str(action.pk),
+        defaults={
+            "date": action.implemented_date or timezone.localdate(),
+            "baseline_price": ZERO,
+            "selected_price": ZERO,
+            "invoice_price": ZERO,
+            "quantity": Decimal("0.000"),
+            **ledger_defaults,
+        },
+    )
+    action.linked_savings_entries.add(ledger)
+    return ledger

--- a/inventory/services/recovery_dashboard_service.py
+++ b/inventory/services/recovery_dashboard_service.py
@@ -11,6 +11,10 @@ from django.urls import reverse
 
 from inventory.models import SavingsLedger
 from inventory.services import dashboard_kpis as dkpis
+from inventory.services.recovery_actions_service import (
+    summarize_recovery_actions,
+    weekly_action_plan_from_actions,
+)
 from inventory.services.variance_service import build_variance_report
 
 MONEY_PLACES = Decimal("0.01")
@@ -106,7 +110,7 @@ def _leakage_areas(
     return areas[:3]
 
 
-def _weekly_action_plan(
+def _weekly_action_plan_fallback(
     *,
     food_cost_gap_pct: Decimal | None,
     target_food_cost_pct: Decimal | None,
@@ -232,6 +236,14 @@ def build_owner_money_dashboard(
     )
     variance_summary = build_variance_report(start, end)["summary"]
     unexplained_leakage = _money(variance_summary.get("unexplained_leakage_value", 0))
+    recovery_summary = summarize_recovery_actions()
+    action_plan = weekly_action_plan_from_actions(limit=3)
+    if not action_plan:
+        action_plan = _weekly_action_plan_fallback(
+            food_cost_gap_pct=food_cost_gap_pct,
+            target_food_cost_pct=target_food_cost_pct,
+            wastage=wastage,
+        )
 
     return {
         "opening_stock": opening_stock,
@@ -245,6 +257,11 @@ def build_owner_money_dashboard(
         "unrealised_profit": unrealised_profit,
         "recovered_profit_this_month": recovered_profit_this_month,
         "remaining_opportunity": remaining_opportunity,
+        "open_opportunity": _money(recovery_summary["open_opportunity"]),
+        "expected_recovery": _money(recovery_summary["expected_recovery"]),
+        "verified_recovered_profit": _money(
+            recovery_summary["verified_recovered_profit"]
+        ),
         "wastage": wastage,
         "unexplained_leakage": unexplained_leakage,
         "top_leakage_areas": _leakage_areas(
@@ -253,9 +270,5 @@ def build_owner_money_dashboard(
             wastage=wastage,
             unexplained_leakage=unexplained_leakage,
         ),
-        "weekly_action_plan": _weekly_action_plan(
-            food_cost_gap_pct=food_cost_gap_pct,
-            target_food_cost_pct=target_food_cost_pct,
-            wastage=wastage,
-        ),
+        "weekly_action_plan": action_plan,
     }

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -78,7 +78,13 @@ from .views.recipes import (
     recipe_detail,
     recipe_meta,
 )
-from .views.recovery import savings_ledger_list, vendor_prices_list
+from .views.recovery import (
+    recovery_action_detail,
+    recovery_action_status,
+    recovery_actions_list,
+    savings_ledger_list,
+    vendor_prices_list,
+)
 from .views.sales import pos_sales_import
 from .views.settings import change_password_view, profile_edit_view, settings_view
 from .views.stock import POSearchView, UserSearchView, history_reports, stock_movements
@@ -270,6 +276,17 @@ urlpatterns = [
     path("grns/<int:pk>/", GRNDetailView.as_view(), name="grn_detail"),
     path("savings-ledger/", savings_ledger_list, name="savings_ledger_list"),
     path("vendor-prices/", vendor_prices_list, name="vendor_prices_list"),
+    path("recovery-actions/", recovery_actions_list, name="recovery_actions_list"),
+    path(
+        "recovery-actions/<int:action_id>/",
+        recovery_action_detail,
+        name="recovery_action_detail",
+    ),
+    path(
+        "recovery-actions/<int:action_id>/status/",
+        recovery_action_status,
+        name="recovery_action_status",
+    ),
     path("pos-sales/", pos_sales_import, name="pos_sales_import"),
     path("variance-report/", variance_report, name="variance_report"),
     path("chef-bulletins/", chef_bulletins_list, name="chef_bulletins_list"),

--- a/inventory/views/recovery.py
+++ b/inventory/views/recovery.py
@@ -1,20 +1,47 @@
 from __future__ import annotations
 
+from datetime import date, timedelta
 from decimal import Decimal
 
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.core.paginator import Paginator
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
+from django.views.decorators.http import require_POST
 
-from ..forms.recovery_forms import SavingsLedgerForm, VendorItemPriceForm
-from ..models import SavingsLedger, VendorItemPrice
+from inventory_app.navigation import ROLE_HEAD_CHEF, ROLE_PURCHASE, get_primary_role
+
+from ..forms.recovery_forms import (
+    RecoveryActionForm,
+    RecoveryActionStatusForm,
+    SavingsLedgerForm,
+    VendorItemPriceForm,
+)
+from ..models import RecoveryAction, SavingsLedger, VendorItemPrice
+from ..services.recovery_actions_service import (
+    CHEF_LEAKAGE_TYPES,
+    PURCHASE_LEAKAGE_TYPES,
+    apply_recovery_action_status,
+    refresh_recovery_actions,
+    summarize_recovery_actions,
+)
 
 
 def _money_total(field_name: str):
     return Coalesce(Sum(field_name), Decimal("0.00"))
+
+
+def _parse_date(raw_value: str):
+    value = (raw_value or "").strip()
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
 
 
 def savings_ledger_list(request):
@@ -97,3 +124,135 @@ def vendor_prices_list(request):
             "inactive_count": VendorItemPrice.objects.filter(is_active=False).count(),
         },
     )
+
+
+def _role_scoped_actions_queryset(request, qs):
+    role = get_primary_role(getattr(request, "user", None))
+    if role == ROLE_PURCHASE:
+        return qs.filter(leakage_type__in=PURCHASE_LEAKAGE_TYPES)
+    if role == ROLE_HEAD_CHEF:
+        return qs.filter(leakage_type__in=CHEF_LEAKAGE_TYPES)
+    return qs
+
+
+def recovery_actions_list(request):
+    start_date = _parse_date(request.GET.get("start_date", "")) or (
+        timezone.localdate() - timedelta(days=29)
+    )
+    end_date = _parse_date(request.GET.get("end_date", "")) or timezone.localdate()
+    if start_date > end_date:
+        start_date, end_date = end_date, start_date
+
+    refresh_recovery_actions(start_date, end_date)
+
+    status = (request.GET.get("status") or "").strip()
+    leakage_type = (request.GET.get("leakage_type") or "").strip()
+    assigned_to = (request.GET.get("assigned_to") or "").strip()
+
+    qs = RecoveryAction.objects.select_related(
+        "assigned_to",
+        "linked_item",
+        "linked_chef_bulletin__recipe",
+    ).prefetch_related("linked_savings_entries")
+    qs = _role_scoped_actions_queryset(request, qs)
+
+    if status:
+        qs = qs.filter(status=status)
+    if leakage_type:
+        qs = qs.filter(leakage_type=leakage_type)
+    if assigned_to.isdigit():
+        qs = qs.filter(assigned_to_id=int(assigned_to))
+
+    if request.method == "POST":
+        form = RecoveryActionForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Recovery action saved", extra_tags="toast")
+            return redirect("recovery_actions_list")
+    else:
+        form = RecoveryActionForm()
+
+    paginator = Paginator(qs.order_by("due_date", "-expected_saving", "-created_at"), 25)
+    page_obj = paginator.get_page(request.GET.get("page"))
+    summary = summarize_recovery_actions()
+
+    return render(
+        request,
+        "inventory/recovery/recovery_actions_list.html",
+        {
+            "form": form,
+            "page_obj": page_obj,
+            "summary": summary,
+            "status": status,
+            "leakage_type": leakage_type,
+            "assigned_to": assigned_to,
+            "status_choices": RecoveryAction.Status.choices,
+            "leakage_type_choices": RecoveryAction.LeakageType.choices,
+            "assigned_user_choices": get_user_model()
+            .objects.filter(is_active=True)
+            .order_by("username"),
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+        },
+    )
+
+
+def recovery_action_detail(request, action_id: int):
+    action = get_object_or_404(
+        RecoveryAction.objects.select_related(
+            "assigned_to",
+            "linked_item",
+            "linked_chef_bulletin__recipe",
+        ).prefetch_related("linked_savings_entries"),
+        pk=action_id,
+    )
+    status_form = RecoveryActionStatusForm(
+        initial={
+            "status": action.status,
+            "verified_saving": action.verified_saving,
+            "implemented_date": action.implemented_date,
+            "notes": action.notes,
+        }
+    )
+    return render(
+        request,
+        "inventory/recovery/recovery_action_detail.html",
+        {
+            "action": action,
+            "status_form": status_form,
+        },
+    )
+
+
+@require_POST
+def recovery_action_status(request, action_id: int):
+    action = get_object_or_404(RecoveryAction, pk=action_id)
+    form = RecoveryActionStatusForm(request.POST)
+    if not form.is_valid():
+        for field_errors in form.errors.values():
+            for error in field_errors:
+                messages.error(request, error, extra_tags="toast")
+        return redirect("recovery_action_detail", action_id=action_id)
+
+    cleaned = form.cleaned_data
+    try:
+        ledger = apply_recovery_action_status(
+            action=action,
+            status=cleaned["status"],
+            notes=cleaned.get("notes") or "",
+            verified_saving=cleaned.get("verified_saving"),
+            implemented_date=cleaned.get("implemented_date"),
+        )
+    except ValueError as exc:
+        messages.error(request, str(exc), extra_tags="toast")
+        return redirect("recovery_action_detail", action_id=action_id)
+
+    if ledger is not None:
+        messages.success(
+            request,
+            "Action verified and linked to savings ledger.",
+            extra_tags="toast",
+        )
+    else:
+        messages.success(request, "Action status updated.", extra_tags="toast")
+    return redirect("recovery_action_detail", action_id=action_id)

--- a/inventory_app/navigation.py
+++ b/inventory_app/navigation.py
@@ -53,6 +53,11 @@ NAVIGATION_GROUPS: List[tuple[str, List[Mapping[str, str]]]] = [
                 "url_name": "savings_ledger_list",
             },
             {
+                "title": "Recovery Actions",
+                "description": "Track assigned actions and verified recovery.",
+                "url_name": "recovery_actions_list",
+            },
+            {
                 "title": "Sales Import",
                 "description": "Import POS sales and map menu items to recipes.",
                 "url_name": "pos_sales_import",
@@ -178,6 +183,7 @@ ROLE_ALLOWED_URLS: Mapping[str, set[str]] = {
         "purchase_orders_list",
         "grn_list",
         "vendor_prices_list",
+        "recovery_actions_list",
     },
     ROLE_PURCHASE: {
         "indents_consolidate_preview",
@@ -185,6 +191,7 @@ ROLE_ALLOWED_URLS: Mapping[str, set[str]] = {
         "purchase_orders_list",
         "grn_list",
         "savings_ledger_list",
+        "recovery_actions_list",
     },
     ROLE_STOREKEEPER: {
         "grn_list",
@@ -200,6 +207,7 @@ ROLE_ALLOWED_URLS: Mapping[str, set[str]] = {
         "pos_sales_import",
         "variance_report",
         "chef_bulletins_list",
+        "recovery_actions_list",
     },
     ROLE_KITCHEN_STAFF: {
         "indents_list",

--- a/templates/components/top_nav.html
+++ b/templates/components/top_nav.html
@@ -40,6 +40,7 @@
                       {% elif link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-primary' aria_label='' %}
                       {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-primary' aria_label='' %}
                       {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-primary' aria_label='' %}
+                      {% elif link.url_name == 'recovery_actions_list' %}{% icon 'clipboard-document-check' 'h-4 w-4 text-primary' aria_label='' %}
                       {% elif link.url_name == 'ml_dashboard' %}{% icon 'sparkles' 'h-4 w-4 text-primary' aria_label='' %}
                       {% elif link.url_name == 'indents_list' %}{% icon 'clipboard-document-list' 'h-4 w-4 text-primary' aria_label='' %}
                       {% elif link.url_name == 'indents_consolidate_preview' %}{% icon 'queue-list' 'h-4 w-4 text-primary' aria_label='' %}
@@ -65,6 +66,7 @@
                       {% elif link.url_name == 'visualizations' %}{% icon 'presentation-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'food_cost_report' %}{% icon 'calculator' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'history_reports' %}{% icon 'document-chart-bar' 'h-4 w-4 text-gray-500' aria_label='' %}
+                      {% elif link.url_name == 'recovery_actions_list' %}{% icon 'clipboard-document-check' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'ml_dashboard' %}{% icon 'sparkles' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'indents_list' %}{% icon 'clipboard-document-list' 'h-4 w-4 text-gray-500' aria_label='' %}
                       {% elif link.url_name == 'indents_consolidate_preview' %}{% icon 'queue-list' 'h-4 w-4 text-gray-500' aria_label='' %}

--- a/templates/inventory/recovery/recovery_action_detail.html
+++ b/templates/inventory/recovery/recovery_action_detail.html
@@ -1,0 +1,112 @@
+{% extends "components/create_manage_layout.html" %}
+
+{% block page_title %}Recovery Action{% endblock %}
+{% block page_heading %}{{ action.title }}{% endblock %}
+{% block page_subtitle %}
+  <p class="text-sm text-bodyText/70">{{ action.get_leakage_type_display }} action created {{ action.created_at|date:"d M Y" }}.</p>
+{% endblock %}
+
+{% block primary_actions %}
+  <a href="{% url 'recovery_actions_list' %}" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md border border-border text-bodyText hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Back to Actions</a>
+{% endblock %}
+
+{% block kpis %}
+  <div class="grid gap-3 md:grid-cols-4">
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Status</p>
+      <p class="mt-1 text-lg font-semibold text-bodyText">{{ action.get_status_display }}</p>
+    </div>
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Expected Saving</p>
+      <p class="mt-1 text-lg font-semibold text-bodyText">Rs. {{ action.expected_saving|floatformat:2 }}</p>
+    </div>
+    <div class="bg-success-soft border border-success/20 rounded-xl p-4">
+      <p class="text-sm text-success">Verified Saving</p>
+      <p class="mt-1 text-lg font-semibold text-success">Rs. {{ action.verified_saving|floatformat:2 }}</p>
+    </div>
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Assigned To</p>
+      <p class="mt-1 text-lg font-semibold text-bodyText">{{ action.assigned_to.username|default:"Unassigned" }}</p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block extra_top %}
+  <section class="bg-surface border border-border rounded-xl p-4 space-y-4">
+    <h2 class="text-lg font-semibold text-bodyText">Action Details</h2>
+    <div class="grid gap-3 md:grid-cols-3 text-sm">
+      <div>
+        <p class="text-bodyText/70">Due Date</p>
+        <p class="font-medium text-bodyText">{{ action.due_date|date:"d M Y"|default:"-" }}</p>
+      </div>
+      <div>
+        <p class="text-bodyText/70">Implemented Date</p>
+        <p class="font-medium text-bodyText">{{ action.implemented_date|date:"d M Y"|default:"-" }}</p>
+      </div>
+      <div>
+        <p class="text-bodyText/70">Linked Item</p>
+        <p class="font-medium text-bodyText">{{ action.linked_item|default:"-" }}</p>
+      </div>
+    </div>
+    {% if action.linked_chef_bulletin %}
+      <div class="text-sm">
+        <p class="text-bodyText/70">Linked Chef Bulletin</p>
+        <a href="{% url 'chef_bulletin_detail' bulletin_id=action.linked_chef_bulletin_id %}" class="font-medium text-primary hover:underline">
+          {{ action.linked_chef_bulletin.headline }}
+        </a>
+      </div>
+    {% endif %}
+    {% if action.notes %}
+      <div class="text-sm">
+        <p class="text-bodyText/70">Notes</p>
+        <p class="font-medium text-bodyText whitespace-pre-line">{{ action.notes }}</p>
+      </div>
+    {% endif %}
+  </section>
+
+  <section class="bg-surface border border-border rounded-xl p-4">
+    <h2 class="text-lg font-semibold text-bodyText">Update Status</h2>
+    <form method="post" action="{% url 'recovery_action_status' action_id=action.pk %}" class="mt-4 grid gap-4 md:grid-cols-2">
+      {% csrf_token %}
+      {% include "components/form_field.html" with field=status_form.status %}
+      {% include "components/form_field.html" with field=status_form.implemented_date %}
+      {% include "components/form_field.html" with field=status_form.verified_saving %}
+      <div class="md:col-span-2">
+        {% include "components/form_field.html" with field=status_form.notes %}
+      </div>
+      <div class="md:col-span-2">
+        <button type="submit" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md bg-primary text-white hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary">Save Status</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="bg-surface border border-border rounded-xl p-4">
+    <h2 class="text-lg font-semibold text-bodyText">Linked Savings Ledger Entries</h2>
+    <div class="overflow-x-auto mt-3">
+      <table class="min-w-full divide-y divide-border text-sm">
+        <thead class="bg-surfaceSubtle text-left text-xs font-semibold uppercase tracking-wider text-bodyText/70">
+          <tr>
+            <th class="px-4 py-3">Date</th>
+            <th class="px-4 py-3">Type</th>
+            <th class="px-4 py-3">Status</th>
+            <th class="px-4 py-3 text-right">Confirmed</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-border">
+          {% for entry in action.linked_savings_entries.all %}
+            <tr class="odd:bg-surfaceSubtle/50">
+              <td class="px-4 py-3">{{ entry.date|date:"d M Y" }}</td>
+              <td class="px-4 py-3">{{ entry.get_saving_type_display }}</td>
+              <td class="px-4 py-3">{{ entry.get_status_display }}</td>
+              <td class="px-4 py-3 text-right tabular-nums text-success">Rs. {{ entry.confirmed_saving|floatformat:2 }}</td>
+            </tr>
+          {% empty %}
+            <tr>
+              <td colspan="4" class="px-4 py-6 text-center text-bodyText/70">No linked ledger entries yet.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+{% endblock %}

--- a/templates/inventory/recovery/recovery_actions_list.html
+++ b/templates/inventory/recovery/recovery_actions_list.html
@@ -1,0 +1,136 @@
+{% extends "components/create_manage_layout.html" %}
+
+{% block page_title %}Recovery Actions{% endblock %}
+{% block page_heading %}Recovery Actions{% endblock %}
+{% block page_subtitle %}
+  <p class="text-sm text-bodyText/70">Track leakage recovery tasks from suggestion through verified savings.</p>
+{% endblock %}
+
+{% block filters %}
+  <form method="get" class="bg-surface border border-border rounded-xl p-4 grid gap-3 md:grid-cols-6 md:items-end">
+    <div>
+      <label for="recovery-start-date" class="block text-sm font-medium text-bodyText">Start Date</label>
+      <input id="recovery-start-date" type="date" name="start_date" value="{{ start_date }}" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+    </div>
+    <div>
+      <label for="recovery-end-date" class="block text-sm font-medium text-bodyText">End Date</label>
+      <input id="recovery-end-date" type="date" name="end_date" value="{{ end_date }}" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+    </div>
+    <div>
+      <label for="recovery-status" class="block text-sm font-medium text-bodyText">Status</label>
+      <select id="recovery-status" name="status" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+        <option value="">All statuses</option>
+        {% for value, label in status_choices %}
+          <option value="{{ value }}" {% if status == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label for="recovery-leakage-type" class="block text-sm font-medium text-bodyText">Leakage Type</label>
+      <select id="recovery-leakage-type" name="leakage_type" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+        <option value="">All types</option>
+        {% for value, label in leakage_type_choices %}
+          <option value="{{ value }}" {% if leakage_type == value %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div>
+      <label for="recovery-assigned-to" class="block text-sm font-medium text-bodyText">Assigned To</label>
+      <select id="recovery-assigned-to" name="assigned_to" class="block w-full p-2 border border-form-border rounded-md bg-form-bg text-form-text focus:outline-none focus:ring-2 focus:ring-primary">
+        <option value="">All users</option>
+        {% for user in assigned_user_choices %}
+          <option value="{{ user.pk }}" {% if assigned_to == user.pk|stringformat:'s' %}selected{% endif %}>{{ user.username }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="flex gap-2">
+      <button type="submit" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md bg-primary text-white hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary">Apply</button>
+      <a href="{% url 'recovery_actions_list' %}" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md border border-border text-bodyText hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Reset</a>
+    </div>
+  </form>
+{% endblock %}
+
+{% block kpis %}
+  <div class="grid gap-3 md:grid-cols-3">
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Open Opportunity</p>
+      <p class="mt-1 text-2xl font-semibold text-warning-text">Rs. {{ summary.open_opportunity|floatformat:2 }}</p>
+    </div>
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <p class="text-sm text-bodyText/70">Expected Recovery</p>
+      <p class="mt-1 text-2xl font-semibold text-bodyText">Rs. {{ summary.expected_recovery|floatformat:2 }}</p>
+    </div>
+    <div class="bg-success-soft border border-success/20 rounded-xl p-4">
+      <p class="text-sm text-success">Verified Recovered</p>
+      <p class="mt-1 text-2xl font-semibold text-success">Rs. {{ summary.verified_recovered_profit|floatformat:2 }}</p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block extra_top %}
+  <section class="bg-surface border border-border rounded-xl p-4">
+    <h2 class="text-lg font-semibold text-bodyText">Add Recovery Action</h2>
+    <form method="post" class="mt-4 grid gap-4 md:grid-cols-3">
+      {% csrf_token %}
+      {% include "components/form_field.html" with field=form.title %}
+      {% include "components/form_field.html" with field=form.leakage_type %}
+      {% include "components/form_field.html" with field=form.expected_saving %}
+      {% include "components/form_field.html" with field=form.assigned_to %}
+      {% include "components/form_field.html" with field=form.due_date %}
+      {% include "components/form_field.html" with field=form.linked_item %}
+      <div class="md:col-span-3">
+        {% include "components/form_field.html" with field=form.linked_chef_bulletin %}
+      </div>
+      <div class="md:col-span-3">
+        {% include "components/form_field.html" with field=form.notes %}
+      </div>
+      <div class="md:col-span-3">
+        <button type="submit" class="inline-flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-md bg-primary text-white hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-primary">Save Action</button>
+      </div>
+    </form>
+  </section>
+{% endblock %}
+
+{% block data_container %}
+  <div class="overflow-x-auto bg-surface border border-border rounded-xl">
+    <table class="min-w-full divide-y divide-border text-sm">
+      <thead class="bg-surfaceSubtle text-left text-xs font-semibold uppercase tracking-wider text-bodyText/70">
+        <tr>
+          <th class="px-4 py-3">Title</th>
+          <th class="px-4 py-3">Type</th>
+          <th class="px-4 py-3">Status</th>
+          <th class="px-4 py-3">Assigned</th>
+          <th class="px-4 py-3">Due</th>
+          <th class="px-4 py-3 text-right">Expected</th>
+          <th class="px-4 py-3 text-right">Verified</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-border">
+        {% for action in page_obj %}
+          <tr class="odd:bg-surfaceSubtle/50">
+            <td class="px-4 py-3">
+              <a href="{% url 'recovery_action_detail' action_id=action.pk %}" class="font-semibold text-primary hover:underline">{{ action.title }}</a>
+            </td>
+            <td class="px-4 py-3">{{ action.get_leakage_type_display }}</td>
+            <td class="px-4 py-3">{{ action.get_status_display }}</td>
+            <td class="px-4 py-3">{{ action.assigned_to.username|default:"Unassigned" }}</td>
+            <td class="px-4 py-3">{{ action.due_date|date:"d M Y"|default:"-" }}</td>
+            <td class="px-4 py-3 text-right tabular-nums">Rs. {{ action.expected_saving|floatformat:2 }}</td>
+            <td class="px-4 py-3 text-right tabular-nums text-success">Rs. {{ action.verified_saving|floatformat:2 }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="7" class="px-4 py-8 text-center text-bodyText/70">No recovery actions yet.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}
+
+{% block pagination %}
+  <div class="mt-4">
+    {% url 'recovery_actions_list' as base_url %}
+    {% include "components/pagination.html" with page_obj=page_obj base_url=base_url %}
+  </div>
+{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -10,6 +10,7 @@ from core.viewmodels import DashboardContext
 from inventory.models import (
     Recipe,
     RecipeItem,
+    RecoveryAction,
     SaleTransaction,
     SavingsLedger,
     StockTransaction,
@@ -104,6 +105,9 @@ def test_dashboard_renders_owner_money_recovery_cards(client, django_user_model)
     assert "Unrealised Profit" in html
     assert "Recovered Profit This Month" in html
     assert "Remaining Opportunity" in html
+    assert "Open Opportunity" in html
+    assert "Expected Recovery" in html
+    assert "Verified Recovered Profit" in html
     assert "Top leakage areas" in html
     assert "Weekly action plan" in html
 
@@ -200,3 +204,22 @@ def test_dashboard_surfaces_unexplained_variance_area(
     assert resp.status_code == 200
     html = resp.content.decode()
     assert "Unexplained variance" in html
+
+
+@pytest.mark.django_db
+def test_dashboard_uses_recovery_actions_for_weekly_action_plan(
+    client, django_user_model
+):
+    user = django_user_model.objects.create_user(username="owner-weekly", password="pw")
+    client.force_login(user)
+    RecoveryAction.objects.create(
+        title="Close chicken variance leakage",
+        leakage_type=RecoveryAction.LeakageType.VARIANCE_REDUCTION,
+        expected_saving=Decimal("300.00"),
+        status=RecoveryAction.Status.SUGGESTED,
+    )
+
+    resp = client.get(reverse("root"))
+    assert resp.status_code == 200
+    html = resp.content.decode()
+    assert "Close chicken variance leakage" in html

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -89,6 +89,7 @@ def test_role_purchase_sees_procurement_only_navigation(django_user_model):
     assert "purchase_orders_list" in visible_urls
     assert "grn_list" in visible_urls
     assert "vendor_prices_list" in visible_urls
+    assert "recovery_actions_list" in visible_urls
     assert "items_list" not in visible_urls
     assert "recipes_list" not in visible_urls
 
@@ -121,6 +122,7 @@ def test_role_head_chef_sees_sales_import(django_user_model):
     assert "pos_sales_import" in visible_urls
     assert "variance_report" in visible_urls
     assert "chef_bulletins_list" in visible_urls
+    assert "recovery_actions_list" in visible_urls
 
 
 @pytest.mark.django_db

--- a/tests/test_recovery_actions_service.py
+++ b/tests/test_recovery_actions_service.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+
+from inventory.models import (
+    Recipe,
+    RecipeItem,
+    RecoveryAction,
+    SaleTransaction,
+    SavingsLedger,
+)
+from inventory.services.recovery_actions_service import (
+    apply_recovery_action_status,
+    refresh_recovery_actions,
+    summarize_recovery_actions,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_recipe(name: str) -> Recipe:
+    return Recipe.objects.create(
+        name=name,
+        is_active=True,
+        type=Recipe.Type.FINAL,
+        selling_price=Decimal("250.00"),
+        target_food_cost_pct=Decimal("30.00"),
+    )
+
+
+def test_refresh_recovery_actions_creates_and_deduplicates_bulletin_actions(item_factory):
+    today = date.today()
+    item = item_factory(
+        name="Recovery Action Ingredient",
+        unit_id=19,
+        initial_purchase_price=Decimal("50.00"),
+        last_purchase_price=Decimal("80.00"),
+    )
+    recipe = _create_recipe("Recovery Chicken Curry")
+    RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=Decimal("1000.00"),
+        unit="GM",
+        loss_pct=Decimal("0.00"),
+    )
+    SaleTransaction.objects.create(
+        recipe=recipe,
+        quantity=Decimal("50.00"),
+        net_sales=Decimal("10000.00"),
+        sale_date=timezone.now(),
+    )
+    first = refresh_recovery_actions(today, today)
+    second = refresh_recovery_actions(today, today)
+
+    assert first["created_from_bulletins"] >= 1
+    assert second["created_from_bulletins"] == 0
+    actions = RecoveryAction.objects.filter(linked_chef_bulletin__isnull=False)
+    assert actions.exists()
+    assert actions.filter(status=RecoveryAction.Status.SUGGESTED).exists()
+
+
+def test_apply_recovery_action_status_verified_creates_and_links_ledger(item_factory):
+    item = item_factory(name="Recovery Item")
+    action = RecoveryAction.objects.create(
+        title="Reduce wastage in prep",
+        leakage_type=RecoveryAction.LeakageType.WASTE_REDUCTION,
+        expected_saving=Decimal("450.00"),
+        linked_item=item,
+    )
+
+    ledger = apply_recovery_action_status(
+        action=action,
+        status=RecoveryAction.Status.VERIFIED,
+        verified_saving=Decimal("425.00"),
+        notes="Verified in weekly review.",
+    )
+
+    action.refresh_from_db()
+    assert action.status == RecoveryAction.Status.VERIFIED
+    assert action.verified_saving == Decimal("425.00")
+    assert ledger is not None
+    assert ledger.status == SavingsLedger.Status.VERIFIED
+    assert ledger.confirmed_saving == Decimal("425.00")
+    assert ledger in action.linked_savings_entries.all()
+
+
+def test_summarize_recovery_actions_rolls_up_expected_and_verified():
+    RecoveryAction.objects.create(
+        title="Action Suggested",
+        leakage_type=RecoveryAction.LeakageType.FOOD_COST_GAP,
+        expected_saving=Decimal("100.00"),
+        status=RecoveryAction.Status.SUGGESTED,
+    )
+    RecoveryAction.objects.create(
+        title="Action In Progress",
+        leakage_type=RecoveryAction.LeakageType.VENDOR_PRICE,
+        expected_saving=Decimal("250.00"),
+        status=RecoveryAction.Status.IN_PROGRESS,
+    )
+    RecoveryAction.objects.create(
+        title="Action Verified",
+        leakage_type=RecoveryAction.LeakageType.WASTE_REDUCTION,
+        expected_saving=Decimal("120.00"),
+        verified_saving=Decimal("95.00"),
+        status=RecoveryAction.Status.VERIFIED,
+    )
+
+    summary = summarize_recovery_actions()
+
+    assert summary["open_opportunity"] == Decimal("350.00")
+    assert summary["expected_recovery"] == Decimal("250.00")
+    assert summary["verified_recovered_profit"] == Decimal("95.00")

--- a/tests/test_recovery_actions_views.py
+++ b/tests/test_recovery_actions_views.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+
+from inventory.models import RecoveryAction
+
+pytestmark = pytest.mark.django_db
+
+
+def test_recovery_actions_list_page_lists_and_creates(client, django_user_model):
+    user = django_user_model.objects.create_user(username="owner_action", password="pw")
+    client.force_login(user)
+    RecoveryAction.objects.create(
+        title="Existing action",
+        leakage_type=RecoveryAction.LeakageType.FOOD_COST_GAP,
+        expected_saving=Decimal("150.00"),
+    )
+
+    response = client.get(reverse("recovery_actions_list"))
+
+    assert response.status_code == 200
+    assert b"Recovery Actions" in response.content
+    assert b"Existing action" in response.content
+
+    post_response = client.post(
+        reverse("recovery_actions_list"),
+        {
+            "title": "New action",
+            "leakage_type": RecoveryAction.LeakageType.WASTE_REDUCTION,
+            "expected_saving": "200.00",
+            "due_date": date.today().isoformat(),
+            "notes": "Created in test",
+        },
+    )
+
+    assert post_response.status_code == 302
+    assert RecoveryAction.objects.filter(title="New action").exists()
+
+
+def test_recovery_action_detail_status_update_verifies_and_links_ledger(
+    client, django_user_model
+):
+    user = django_user_model.objects.create_user(username="manager_action", password="pw")
+    client.force_login(user)
+    action = RecoveryAction.objects.create(
+        title="Verify this action",
+        leakage_type=RecoveryAction.LeakageType.VENDOR_PRICE,
+        expected_saving=Decimal("500.00"),
+        status=RecoveryAction.Status.ASSIGNED,
+    )
+
+    detail = client.get(reverse("recovery_action_detail", kwargs={"action_id": action.pk}))
+    assert detail.status_code == 200
+    assert b"Verify this action" in detail.content
+
+    status_response = client.post(
+        reverse("recovery_action_status", kwargs={"action_id": action.pk}),
+        {
+            "status": RecoveryAction.Status.VERIFIED,
+            "verified_saving": "420.00",
+            "implemented_date": date.today().isoformat(),
+            "notes": "Verified by manager",
+        },
+    )
+
+    assert status_response.status_code == 302
+    action.refresh_from_db()
+    assert action.status == RecoveryAction.Status.VERIFIED
+    assert action.verified_saving == Decimal("420.00")
+    assert action.linked_savings_entries.count() == 1
+
+
+def test_recovery_actions_list_is_role_scoped_for_purchase(client, django_user_model):
+    purchase_group, _ = Group.objects.get_or_create(name="Purchase")
+    user = django_user_model.objects.create_user(username="purchase_u", password="pw")
+    user.groups.add(purchase_group)
+    client.force_login(user)
+
+    RecoveryAction.objects.create(
+        title="Vendor saving action",
+        leakage_type=RecoveryAction.LeakageType.VENDOR_PRICE,
+        expected_saving=Decimal("120.00"),
+    )
+    RecoveryAction.objects.create(
+        title="Recipe action",
+        leakage_type=RecoveryAction.LeakageType.RECIPE_OPTIMISATION,
+        expected_saving=Decimal("140.00"),
+    )
+
+    response = client.get(reverse("recovery_actions_list"))
+
+    assert response.status_code == 200
+    html = response.content.decode()
+    assert "Vendor saving action" in html
+    assert "Recipe action" not in html

--- a/tests/test_ui_authenticated_smoke.py
+++ b/tests/test_ui_authenticated_smoke.py
@@ -23,6 +23,7 @@ from inventory.models import (
     PurchaseOrder,
     PurchaseOrderItem,
     Recipe,
+    RecoveryAction,
     SavingsLedger,
     StockTake,
     StockTakeItem,
@@ -46,6 +47,7 @@ _POST_ONLY_GET_SKIP = frozenset(
         "supplier_delete",
         "suppliers_bulk_delete",
         "recipe_create_indent",
+        "recovery_action_status",
     }
 )
 
@@ -107,6 +109,11 @@ def smoke_entities(item_factory, django_user_model):
         item=item,
         system_qty=Decimal("0"),
     )
+    recovery_action = RecoveryAction.objects.create(
+        title=f"SmokeAction-{uuid.uuid4().hex[:6]}",
+        leakage_type=RecoveryAction.LeakageType.VENDOR_PRICE,
+        expected_saving=Decimal("15.00"),
+    )
     return {
         "item": item,
         "supplier": supplier,
@@ -115,6 +122,7 @@ def smoke_entities(item_factory, django_user_model):
         "po": po,
         "grn": grn,
         "stock_take": stock_take,
+        "recovery_action": recovery_action,
     }
 
 
@@ -127,6 +135,7 @@ def _kwargs_for_url_name(name: str, ctx: dict) -> dict | None:
     po = ctx["po"]
     grn = ctx["grn"]
     stock_take = ctx["stock_take"]
+    recovery_action = ctx["recovery_action"]
 
     pk_urls = {
         "item_edit": {"pk": item.pk},
@@ -158,6 +167,8 @@ def _kwargs_for_url_name(name: str, ctx: dict) -> dict | None:
         "recipe_delete": {"pk": recipe.pk},
         "recipe_detail": {"pk": recipe.pk},
         "recipe_create_indent": {"pk": recipe.pk},
+        "recovery_action_detail": {"action_id": recovery_action.pk},
+        "recovery_action_status": {"action_id": recovery_action.pk},
     }
     if name in pk_urls:
         return pk_urls[name]
@@ -253,6 +264,9 @@ _UI_URL_NAMES: tuple[str, ...] = (
     "grn_detail",
     "savings_ledger_list",
     "vendor_prices_list",
+    "recovery_actions_list",
+    "recovery_action_detail",
+    "recovery_action_status",
     "recipes_list",
     "recipes_table",
     "food_cost_report",


### PR DESCRIPTION
## What changed
- Implemented Phase 9 recovery actions workflow.
- Added `RecoveryAction` model and migration (`0047_recoveryaction`) with status lifecycle and links to savings ledger, chef bulletin, assignee, and item.
- Added `recovery_actions_service` to:
  - generate suggested actions from open chef bulletins and unexplained variance
  - roll up owner metrics (`open_opportunity`, `expected_recovery`, `verified_recovered_profit`)
  - enforce verified action flow and write linked verified `SavingsLedger` entries
- Added UI pages and routes:
  - `/recovery-actions/`
  - `/recovery-actions/<id>/`
  - `/recovery-actions/<id>/status/`
- Updated owner dashboard cards and weekly action plan to use live recovery actions.
- Updated role navigation and top-nav icons to expose Recovery Actions for Owner/Purchase/Head Chef.
- Added service/view/dashboard/navigation/smoke tests for new behavior.

## Why it changed
- Phase 9 requires the final loop from leakage detection to assigned action tracking and verified recovery, with owner-facing rollups.

## Impact
- Owner can now see open opportunity, expected recovery, and verified recovered profit directly on dashboard.
- Teams can track recovery actions through execution states and capture verified savings in the ledger.
- Recovery workflow is now auditable and linked across bulletins/actions/ledger.

## Validation
- `python -m ruff check ...` on changed files passed
- `python -m pytest tests/test_recovery_actions_service.py tests/test_recovery_actions_views.py tests/test_dashboard.py tests/test_navigation.py tests/test_recovery_pages.py tests/test_ui_authenticated_smoke.py -q`
  - Result: `126 passed, 11 skipped`
- `python manage.py check --settings=inventory_app.settings.test`
  - Result: no issues
- Local migration check:
  - `python manage.py migrate inventory 0047 --settings=inventory_app.settings.dev` applied successfully
