### PR TITLE
[codex] phase 10 stabilization and qa hardening

### DIFF
--- a/docs/phase10-release-checklist.md
+++ b/docs/phase10-release-checklist.md
@@ -1,0 +1,82 @@
+# Phase 10 Release Checklist
+
+Use this checklist before merging to the main integration branch and before deploying to Supabase-backed environments.
+
+## 1) Local Quality Gate
+
+- Run system checks:
+  - `.\.venv\Scripts\python.exe manage.py check --settings=inventory_app.settings.test`
+- Run focused regression tests:
+  - `.\.venv\Scripts\python.exe -m pytest tests\test_phase10_smoke.py tests\test_modal_scroll_layout.py tests\test_purchase_order_drawer_partial.py tests\test_navigation.py -q`
+- Run key flow tests:
+  - `.\.venv\Scripts\python.exe -m pytest tests\test_recovery_pages.py tests\test_pos_sales_import.py tests\test_variance_report_view.py tests\test_chef_bulletins_views.py tests\test_recovery_actions_views.py -q`
+- Run lint on changed files:
+  - `.\.venv\Scripts\python.exe -m ruff check inventory/forms/base.py inventory/management/commands/seed_dashboard_data.py tests/test_phase10_smoke.py tests/test_modal_scroll_layout.py tests/test_purchase_order_drawer_partial.py`
+
+## 2) Demo Data Gate
+
+- Seed the app:
+  - `.\.venv\Scripts\python.exe manage.py seed_dashboard_data --days 30 --settings=inventory_app.settings.dev`
+- Confirm generated records exist for:
+  - POS sales (`sales_transactions`)
+  - POS mapping (`pos_menu_item_mappings`)
+  - vendor prices (`vendor_item_prices`)
+  - savings ledger (`savings_ledger`)
+  - chef bulletins (`chef_bulletins`)
+  - recovery actions (`recovery_actions`)
+
+## 3) Manual UI Gate
+
+- Log in as Owner and verify navigation includes:
+  - Insights, Procurement, Stock, Master Data
+- Confirm these pages load and are usable:
+  - `/`, `/items/`, `/suppliers/`, `/recipes/`, `/purchase-orders/`, `/grns/`, `/stock-movements/`, `/savings-ledger/`, `/vendor-prices/`, `/pos-sales/`, `/variance-report/`, `/chef-bulletins/`, `/recovery-actions/`
+- Check modal/drawer behavior:
+  - Drawer forms scroll on smaller screens.
+  - Purchase Order notes field appears as a full-width row below the two-column field grid.
+  - Date fields show native date pickers and also accept manual entry formats handled by the backend.
+
+## 4) Migration Gate (Supabase/Prod)
+
+Run Django migrations from the app deployment path; do not patch tables manually.
+
+- Confirm migration state includes:
+  - `sales_transactions`
+  - `savings_ledger`
+  - `vendor_item_prices`
+  - `chef_bulletins`
+  - `trial_recipe_versions`
+  - `recovery_actions`
+  - `goods_received_notes.grn_number`
+
+Suggested verification SQL (read-only):
+
+```sql
+select table_name
+from information_schema.tables
+where table_schema='public'
+  and table_name in (
+    'sales_transactions',
+    'savings_ledger',
+    'vendor_item_prices',
+    'chef_bulletins',
+    'trial_recipe_versions',
+    'recovery_actions'
+  )
+order by table_name;
+```
+
+```sql
+select column_name
+from information_schema.columns
+where table_schema='public'
+  and table_name='goods_received_notes'
+  and column_name='grn_number';
+```
+
+## 5) Release Sign-off
+
+- CI green (lint + tests).
+- Manual UI gate completed.
+- Migration gate completed in target Supabase environment.
+- Owner dashboard numbers reviewed after seed or production data refresh.

--- a/inventory/forms/base.py
+++ b/inventory/forms/base.py
@@ -9,6 +9,12 @@ DATE_INPUT_FORMATS_FALLBACK = (
     "%m/%d/%Y",
     "%m-%d-%Y",
 )
+DATETIME_INPUT_FORMATS_FALLBACK = (
+    "%Y-%m-%dT%H:%M",
+    "%Y-%m-%d %H:%M",
+    "%d-%m-%Y %H:%M",
+    "%d/%m/%Y %H:%M",
+)
 TIME_INPUT_FORMATS_FALLBACK = ("%H:%M", "%H:%M:%S")
 
 INPUT_CLASS = (
@@ -56,12 +62,28 @@ class StyledFormMixin:
                 widget.attrs["type"] = "time"
                 if not getattr(widget, "format", None):
                     widget.format = "%H:%M"
+            # Some widgets inherited readonly attrs from older templates.
+            # Date/time fields must remain editable for keyboard entry.
+            if isinstance(
+                widget, (forms.DateInput, forms.DateTimeInput, forms.TimeInput)
+            ):
+                if str(widget.attrs.get("readonly", "")).lower() in {
+                    "1",
+                    "true",
+                    "readonly",
+                }:
+                    widget.attrs.pop("readonly", None)
 
             # Accept common manual text formats in addition to native picker values.
             if isinstance(field, forms.DateField):
                 existing = tuple(getattr(field, "input_formats", ()) or ())
                 field.input_formats = tuple(
                     dict.fromkeys((*DATE_INPUT_FORMATS_FALLBACK, *existing))
+                )
+            elif isinstance(field, forms.DateTimeField):
+                existing = tuple(getattr(field, "input_formats", ()) or ())
+                field.input_formats = tuple(
+                    dict.fromkeys((*DATETIME_INPUT_FORMATS_FALLBACK, *existing))
                 )
             elif isinstance(field, forms.TimeField):
                 existing = tuple(getattr(field, "input_formats", ()) or ())

--- a/inventory/management/commands/seed_dashboard_data.py
+++ b/inventory/management/commands/seed_dashboard_data.py
@@ -14,12 +14,20 @@ from django.utils import timezone
 
 from inventory.models import (
     Category,
+    ChefBulletin,
+    GoodsReceivedNote,
+    GRNItem,
     Indent,
     Item,
+    POSMenuItemMapping,
     PurchaseOrder,
+    PurchaseOrderItem,
+    RecoveryAction,
+    SavingsLedger,
     StockTransaction,
     Supplier,
     Unit,
+    VendorItemPrice,
 )
 from inventory.models.enums import IndentStatus, PurchaseOrderStatus
 from inventory.models.recipes import Recipe, RecipeItem, SaleTransaction
@@ -114,8 +122,13 @@ class Command(BaseCommand):
         # Units
         unit_map = {}
         for abbr, name in UNITS:
+            token = abbr.upper()
             unit_map[abbr], _ = Unit.objects.get_or_create(
-                base_unit=abbr, defaults={"unit_name": name}
+                base_unit=token,
+                defaults={
+                    "purchase_unit": token,
+                    "conversion_factor": Decimal("1"),
+                },
             )
 
         # Categories
@@ -126,6 +139,9 @@ class Command(BaseCommand):
         # Supplier
         supplier, _ = Supplier.objects.get_or_create(
             name="Metro Fresh Supplies", defaults={"is_active": True}
+        )
+        alt_supplier, _ = Supplier.objects.get_or_create(
+            name="Harborline Foods", defaults={"is_active": True}
         )
 
         # Items
@@ -169,6 +185,39 @@ class Command(BaseCommand):
                             unit=item.unit.base_unit if item.unit else "kg",
                         )
 
+            POSMenuItemMapping.objects.get_or_create(
+                pos_item_name=spec["name"],
+                defaults={
+                    "recipe": recipe,
+                    "is_active": True,
+                    "notes": "Seed POS mapping",
+                },
+            )
+
+        # Vendor price history for comparison pages
+        for idx, item in enumerate(item_map.values()):
+            base_price = Decimal(str(item.last_purchase_price or 0))
+            if base_price <= 0:
+                continue
+            metro_price = (base_price * Decimal("1.00")).quantize(Decimal("0.01"))
+            harbor_price = (base_price * (Decimal("0.94") if idx % 2 else Decimal("1.06"))).quantize(
+                Decimal("0.01")
+            )
+            VendorItemPrice.objects.get_or_create(
+                vendor=supplier,
+                item=item,
+                unit=item.unit,
+                effective_from=now.date() - timedelta(days=10),
+                defaults={"price": metro_price, "source": "Seed: metro", "is_active": True},
+            )
+            VendorItemPrice.objects.get_or_create(
+                vendor=alt_supplier,
+                item=item,
+                unit=item.unit,
+                effective_from=now.date() - timedelta(days=10),
+                defaults={"price": harbor_price, "source": "Seed: harbor", "is_active": True},
+            )
+
         # Daily transactions
         recipes_list = list(recipe_map.values())
         items_list = list(item_map.values())
@@ -191,9 +240,22 @@ class Command(BaseCommand):
             for _ in range(random.randint(2, 6)):
                 recipe = random.choice(recipes_list)
                 qty = Decimal(str(random.randint(1, 5)))
+                gross = (Decimal(str(recipe.selling_price or 0)) * qty).quantize(
+                    Decimal("0.01")
+                )
+                discount = (gross * Decimal("0.04")).quantize(Decimal("0.01"))
+                net = (gross - discount).quantize(Decimal("0.01"))
+                tax = (net * Decimal("0.05")).quantize(Decimal("0.01"))
                 SaleTransaction.objects.create(
                     recipe=recipe,
                     quantity=qty,
+                    outlet="Main Outlet",
+                    pos_item_name=recipe.name,
+                    gross_sales=gross,
+                    discount=discount,
+                    net_sales=net,
+                    tax=tax,
+                    source=SaleTransaction.Source.POS_CSV,
                     sale_date=day,
                     notes="Seed: sale",
                 )
@@ -237,16 +299,182 @@ class Command(BaseCommand):
             po_number="SEED-PO-DRAFT",
             defaults={
                 "supplier": supplier,
+                "order_date": now.date(),
                 "status": PurchaseOrderStatus.DRAFT,
             },
         )
-        PurchaseOrder.objects.get_or_create(
+        po_sent, _ = PurchaseOrder.objects.get_or_create(
             po_number="SEED-PO-SENT",
             defaults={
                 "supplier": supplier,
+                "order_date": now.date() - timedelta(days=2),
                 "status": PurchaseOrderStatus.SENT,
             },
         )
+
+        sample_items = list(item_map.values())[:3]
+        for line_idx, item in enumerate(sample_items):
+            po_item, _ = PurchaseOrderItem.objects.get_or_create(
+                purchase_order=po_sent,
+                item=item,
+                defaults={
+                    "quantity_ordered": Decimal("10.00") + Decimal(line_idx),
+                    "unit_price": Decimal(str(item.last_purchase_price or 0)),
+                },
+            )
+            po_item.line_total = po_item.quantity_ordered * po_item.unit_price
+            po_item.save(update_fields=["line_total"])
+
+        grn, _ = GoodsReceivedNote.objects.get_or_create(
+            grn_number="SEED-GRN-0001",
+            defaults={
+                "purchase_order": po_sent,
+                "supplier": supplier,
+                "received_date": now.date() - timedelta(days=1),
+                "delivery_note_number": "SEED-DN-1001",
+                "notes": "Seed GRN",
+            },
+        )
+        for po_item in po_sent.purchaseorderitem_set.select_related("item").all():
+            GRNItem.objects.get_or_create(
+                grn=grn,
+                po_item=po_item,
+                defaults={
+                    "quantity_ordered_on_po": po_item.quantity_ordered,
+                    "quantity_received": po_item.quantity_ordered - Decimal("1.00"),
+                    "unit_price_at_receipt": po_item.unit_price,
+                    "item_notes": "Seed receipt",
+                },
+            )
+
+        # Savings ledger entries (estimated / confirmed / lost / verified)
+        ledger_rows = [
+            {
+                "date": now.date() - timedelta(days=4),
+                "item": sample_items[0] if sample_items else None,
+                "saving_type": SavingsLedger.SavingType.VENDOR_SAVING,
+                "source_document_type": "PO",
+                "source_document_id": po_sent.po_number,
+                "baseline_price": Decimal("250.00"),
+                "selected_price": Decimal("235.00"),
+                "invoice_price": Decimal("235.00"),
+                "quantity": Decimal("12.000"),
+                "estimated_saving": Decimal("180.00"),
+                "confirmed_saving": Decimal("180.00"),
+                "lost_saving": Decimal("0.00"),
+                "status": SavingsLedger.Status.CONFIRMED,
+                "notes": "Seed vendor saving",
+            },
+            {
+                "date": now.date() - timedelta(days=3),
+                "item": sample_items[1] if len(sample_items) > 1 else None,
+                "saving_type": SavingsLedger.SavingType.VARIANCE_REDUCTION,
+                "source_document_type": "Variance",
+                "source_document_id": "VR-SEED-01",
+                "baseline_price": Decimal("0.00"),
+                "selected_price": Decimal("0.00"),
+                "invoice_price": Decimal("0.00"),
+                "quantity": Decimal("0.000"),
+                "estimated_saving": Decimal("120.00"),
+                "confirmed_saving": Decimal("0.00"),
+                "lost_saving": Decimal("0.00"),
+                "status": SavingsLedger.Status.ESTIMATED,
+                "notes": "Seed variance opportunity",
+            },
+            {
+                "date": now.date() - timedelta(days=2),
+                "item": sample_items[2] if len(sample_items) > 2 else None,
+                "saving_type": SavingsLedger.SavingType.INVOICE_MISMATCH_CAUGHT,
+                "source_document_type": "GRN",
+                "source_document_id": grn.grn_number,
+                "baseline_price": Decimal("140.00"),
+                "selected_price": Decimal("136.00"),
+                "invoice_price": Decimal("144.00"),
+                "quantity": Decimal("8.000"),
+                "estimated_saving": Decimal("32.00"),
+                "confirmed_saving": Decimal("0.00"),
+                "lost_saving": Decimal("64.00"),
+                "status": SavingsLedger.Status.LOST,
+                "notes": "Seed lost saving",
+            },
+            {
+                "date": now.date() - timedelta(days=1),
+                "item": sample_items[0] if sample_items else None,
+                "saving_type": SavingsLedger.SavingType.WASTE_REDUCTION,
+                "source_document_type": "Action",
+                "source_document_id": "ACT-SEED-01",
+                "baseline_price": Decimal("0.00"),
+                "selected_price": Decimal("0.00"),
+                "invoice_price": Decimal("0.00"),
+                "quantity": Decimal("0.000"),
+                "estimated_saving": Decimal("95.00"),
+                "confirmed_saving": Decimal("95.00"),
+                "lost_saving": Decimal("0.00"),
+                "status": SavingsLedger.Status.VERIFIED,
+                "notes": "Seed verified recovery",
+            },
+        ]
+        created_ledger = []
+        for row in ledger_rows:
+            entry, _ = SavingsLedger.objects.get_or_create(
+                date=row["date"],
+                source_document_type=row["source_document_type"],
+                source_document_id=row["source_document_id"],
+                saving_type=row["saving_type"],
+                defaults=row,
+            )
+            created_ledger.append(entry)
+
+        # Phase 8/9 demo records
+        first_recipe = recipes_list[0] if recipes_list else None
+        bulletin = None
+        if first_recipe:
+            bulletin, _ = ChefBulletin.objects.get_or_create(
+                recipe=first_recipe,
+                period_start=now.date() - timedelta(days=7),
+                period_end=now.date(),
+                alert_type=ChefBulletin.AlertType.FOOD_COST_ABOVE_TARGET,
+                defaults={
+                    "headline": f"{first_recipe.name} cost above target",
+                    "current_food_cost_pct": Decimal("37.50"),
+                    "target_food_cost_pct": Decimal("30.00"),
+                    "monthly_sales": Decimal("78000.00"),
+                    "unrealised_profit": Decimal("5850.00"),
+                    "main_cost_drivers": ["Chicken Breast", "Olive Oil"],
+                    "suggested_change": "Reduce plate portion by 5% and tighten prep controls.",
+                    "expected_saving": Decimal("1200.00"),
+                    "risk_level": ChefBulletin.RiskLevel.MEDIUM,
+                    "is_open": True,
+                },
+            )
+
+        action_verified, _ = RecoveryAction.objects.get_or_create(
+            title="Reduce prep wastage in grill station",
+            leakage_type=RecoveryAction.LeakageType.WASTE_REDUCTION,
+            defaults={
+                "expected_saving": Decimal("1200.00"),
+                "status": RecoveryAction.Status.VERIFIED,
+                "implemented_date": now.date() - timedelta(days=1),
+                "verified_saving": Decimal("950.00"),
+                "linked_item": sample_items[0] if sample_items else None,
+                "linked_chef_bulletin": bulletin,
+                "notes": "Seed verified recovery action",
+            },
+        )
+        action_open, _ = RecoveryAction.objects.get_or_create(
+            title="Switch vendor for salmon procurement",
+            leakage_type=RecoveryAction.LeakageType.VENDOR_PRICE,
+            defaults={
+                "expected_saving": Decimal("2200.00"),
+                "status": RecoveryAction.Status.ASSIGNED,
+                "due_date": now.date() + timedelta(days=5),
+                "linked_item": item_map.get("Salmon Fillet"),
+                "notes": "Seed open opportunity",
+            },
+        )
+        if created_ledger:
+            action_verified.linked_savings_entries.add(created_ledger[-1])
+            action_open.linked_savings_entries.add(created_ledger[0])
 
         # Set 4 items to low stock
         low_stock_names = [
@@ -266,6 +494,8 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.SUCCESS(
                 f"Seeded {days} days of dashboard data with "
-                f"{len(item_map)} items, {len(recipe_map)} recipes."
+                f"{len(item_map)} items, {len(recipe_map)} recipes, "
+                f"{SavingsLedger.objects.count()} savings entries, and "
+                f"{RecoveryAction.objects.count()} recovery actions."
             )
         )

--- a/templates/inventory/purchase_orders/_form_partial.html
+++ b/templates/inventory/purchase_orders/_form_partial.html
@@ -1,11 +1,11 @@
 {% load form_tags %}
-<div class="bg-surface border border-border rounded-2xl shadow-overlay drawer-panel max-w-drawer-xl flex flex-col min-h-0">
+<div class="bg-surface border border-border rounded-2xl shadow-overlay drawer-panel max-w-drawer-xl flex flex-col min-h-0 overflow-hidden max-h-[calc(100vh-2rem)]">
   <div class="px-4 py-3 border-b border-border bg-surfaceSubtle flex items-center justify-between">
     <h3 class="text-base font-semibold text-bodyText">{% if is_edit %}Edit{% else %}New{% endif %} Purchase Order</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
   </div>
   <div class="p-4 flex-1 min-h-0 overflow-y-auto">
-  <form method="post" id="po-drawer-form" class="flex flex-col gap-4" data-drawer="purchase-order" data-formset-prefix="{{ formset.prefix }}" data-modal-form data-requires-line-items action="{% if is_edit %}{% url 'purchase_order_edit_partial' po.pk %}{% else %}{% url 'purchase_order_create_partial' %}{% endif %}">
+  <form method="post" id="po-drawer-form" class="flex flex-col gap-4 flex-1 min-h-0" data-drawer="purchase-order" data-formset-prefix="{{ formset.prefix }}" data-modal-form data-requires-line-items action="{% if is_edit %}{% url 'purchase_order_edit_partial' po.pk %}{% else %}{% url 'purchase_order_create_partial' %}{% endif %}">
       {% csrf_token %}
       {{ item_prices|json_script:"po-item-prices" }}
       {{ item_vendor_hints|json_script:"po-item-vendor-hints" }}

--- a/tests/test_modal_scroll_layout.py
+++ b/tests/test_modal_scroll_layout.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+from bs4 import BeautifulSoup
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def test_modal_root_and_content_are_scrollable(client):
+    response = client.get(reverse("root"))
+    assert response.status_code == 200
+    html = response.content.decode()
+    soup = BeautifulSoup(html, "html.parser")
+
+    modal_root = soup.find(id="modal-root")
+    assert modal_root is not None
+    root_classes = modal_root.get("class", [])
+    assert "overflow-y-auto" in root_classes
+
+    modal_content = soup.find(id="modal-content")
+    assert modal_content is not None
+    content_classes = modal_content.get("class", [])
+    assert "max-h-[calc(100vh-2rem)]" in content_classes
+    assert "overflow-y-auto" in content_classes
+    assert "overscroll-contain" in content_classes

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -69,7 +69,13 @@ def test_role_owner_sees_owner_money_navigation(django_user_model):
     assert "pos_sales_import" in visible_urls
     assert "variance_report" in visible_urls
     assert "chef_bulletins_list" in visible_urls
+    assert "recovery_actions_list" in visible_urls
+    assert "purchase_orders_list" in visible_urls
+    assert "grn_list" in visible_urls
+    assert "stock_movements" in visible_urls
+    assert "stock_take_list" in visible_urls
     assert "indents_list" in visible_urls
+    assert "indents_consolidate_preview" in visible_urls
     assert "items_list" in visible_urls
     assert "recipes_list" in visible_urls
     assert "suppliers_list" in visible_urls

--- a/tests/test_phase10_smoke.py
+++ b/tests/test_phase10_smoke.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from django.contrib.auth.models import Group
+from django.urls import reverse
+
+from inventory.forms.purchase_forms import PurchaseOrderForm
+from inventory.forms.recovery_forms import (
+    RecoveryActionStatusForm,
+    SavingsLedgerForm,
+)
+from inventory.models import PurchaseOrder, Recipe, SaleTransaction, Supplier
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def owner_client(client, django_user_model):
+    owner_group, _ = Group.objects.get_or_create(name="Owner")
+    owner = django_user_model.objects.create_user(
+        username="phase10_owner",
+        password="pw12345",
+        is_staff=True,
+    )
+    owner.groups.add(owner_group)
+    client.force_login(owner)
+    return client
+
+
+@pytest.fixture
+def phase10_base_data(item_factory):
+    supplier = Supplier.objects.create(name="Phase10 Supplier", is_active=True)
+    item = item_factory(name="Phase10 Chicken", current_stock=Decimal("20.00"))
+    recipe = Recipe.objects.create(
+        name="Phase10 Recipe",
+        type=Recipe.Type.FINAL,
+        is_active=True,
+        selling_price=Decimal("280.00"),
+        target_food_cost_pct=Decimal("32.00"),
+    )
+    SaleTransaction.objects.create(
+        recipe=recipe,
+        quantity=Decimal("10.00"),
+        sale_date=date.today(),
+        outlet="Main Outlet",
+        pos_item_name=recipe.name,
+        gross_sales=Decimal("2800.00"),
+        discount=Decimal("140.00"),
+        net_sales=Decimal("2660.00"),
+        tax=Decimal("133.00"),
+        source=SaleTransaction.Source.POS_CSV,
+        notes="Phase10 smoke seed",
+    )
+    PurchaseOrder.objects.create(
+        supplier=supplier,
+        order_date=date.today(),
+        status="DRAFT",
+    )
+    return {"supplier": supplier, "item": item, "recipe": recipe}
+
+
+@pytest.mark.parametrize(
+    "url_name",
+    [
+        "root",
+        "items_list",
+        "suppliers_list",
+        "recipes_list",
+        "indents_list",
+        "purchase_orders_list",
+        "grn_list",
+        "stock_movements",
+        "savings_ledger_list",
+        "vendor_prices_list",
+        "pos_sales_import",
+        "variance_report",
+        "chef_bulletins_list",
+        "recovery_actions_list",
+        "settings",
+    ],
+)
+def test_phase10_owner_pages_render(owner_client, phase10_base_data, url_name):
+    response = owner_client.get(reverse(url_name))
+    assert response.status_code == 200
+
+
+def test_phase10_purchase_order_form_accepts_manual_date(supplier_factory):
+    supplier = supplier_factory(name="Phase10 PO Supplier")
+    form = PurchaseOrderForm(
+        data={
+            "supplier": str(supplier.pk),
+            "order_date": "22/05/2026",
+            "expected_delivery_date": "25/05/2026",
+            "status": "DRAFT",
+            "notes": "manual date entry",
+        }
+    )
+    assert form.is_valid(), form.errors
+
+
+def test_phase10_savings_form_accepts_manual_date(item_factory):
+    item = item_factory(name="Phase10 Ledger Item")
+    form = SavingsLedgerForm(
+        data={
+            "date": "22-05-2026",
+            "item": item.pk,
+            "saving_type": "WASTE_REDUCTION",
+            "source_document_type": "Manual",
+            "source_document_id": "P10-001",
+            "baseline_price": "0",
+            "selected_price": "0",
+            "invoice_price": "0",
+            "quantity": "0",
+            "estimated_saving": "40",
+            "confirmed_saving": "0",
+            "lost_saving": "0",
+            "status": "ESTIMATED",
+            "notes": "manual date entry",
+        }
+    )
+    assert form.is_valid(), form.errors
+
+
+def test_phase10_status_form_accepts_manual_date():
+    form = RecoveryActionStatusForm(
+        data={
+            "status": "IMPLEMENTED",
+            "verified_saving": "",
+            "implemented_date": "22/05/2026",
+            "notes": "implemented",
+        }
+    )
+    assert form.is_valid(), form.errors

--- a/tests/test_purchase_order_drawer_partial.py
+++ b/tests/test_purchase_order_drawer_partial.py
@@ -113,3 +113,19 @@ def test_purchase_order_edit_partial_post_validation_returns_json(
     data = json.loads(resp.content)
     assert data.get("ok") is False
     assert "errors" in data
+
+
+def test_purchase_order_full_form_notes_not_inside_two_column_grid(po_staff_client):
+    resp = po_staff_client.get(reverse("purchase_order_create"))
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.content.decode(), "html.parser")
+
+    notes = soup.find("textarea", attrs={"name": "notes"})
+    assert notes is not None
+
+    grid = soup.find(
+        "div",
+        class_=lambda value: value and "grid-cols-2" in value and "gap-4" in value,
+    )
+    assert grid is not None
+    assert grid.find("textarea", attrs={"name": "notes"}) is None

--- a/tests/test_seed_dashboard_data_phase10.py
+++ b/tests/test_seed_dashboard_data_phase10.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+from django.core.management import call_command
+
+from inventory.models import (
+    ChefBulletin,
+    POSMenuItemMapping,
+    RecoveryAction,
+    SaleTransaction,
+    SavingsLedger,
+    VendorItemPrice,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test_seed_dashboard_data_populates_phase10_surfaces():
+    call_command("seed_dashboard_data", days=7)
+
+    assert SaleTransaction.objects.exists()
+    assert POSMenuItemMapping.objects.exists()
+    assert VendorItemPrice.objects.exists()
+    assert SavingsLedger.objects.exists()
+    assert RecoveryAction.objects.exists()
+    assert ChefBulletin.objects.exists()


### PR DESCRIPTION
﻿## What changed
- Added Phase 10 stabilization coverage and release checklist.
- Hardened shared date/datetime form input parsing to accept manual entries while keeping native picker support.
- Improved purchase order drawer layout constraints for reliable scrolling and full-width notes field.
- Expanded `seed_dashboard_data` to create realistic cross-flow records for POS mapping/sales, vendor prices, PO/GRN, savings ledger, chef bulletins, and recovery actions.
- Added focused tests for owner route smoke coverage, modal scroll layout, seed command output surfaces, and owner navigation/PO form layout assertions.

## Why it changed
- Phase 1-9 features were implemented, but app-level reliability and demo readiness required a hardening pass.
- Date fields and drawer behavior had regressions that affected real-world usage.
- Demo data was not complete enough to validate full recovery workflows end-to-end.

## User/developer impact
- Owner and team can test critical money-first and recovery workflows with realistic seeded data.
- Reduced regressions around date handling and modal/drawer behavior.
- Added a concrete release checklist for CI/manual QA/migration verification before merge/deploy.

## Root cause
- Inconsistent form widget/input format handling and mixed modal/drawer layout constraints caused UX breakage.
- Seed command only populated a subset of entities, leaving later-phase pages without representative data.

## Validation
- `python -m ruff check inventory/forms/base.py inventory/management/commands/seed_dashboard_data.py tests/test_phase10_smoke.py tests/test_modal_scroll_layout.py tests/test_seed_dashboard_data_phase10.py tests/test_navigation.py tests/test_purchase_order_drawer_partial.py`
- `python -m pytest tests/test_phase10_smoke.py tests/test_modal_scroll_layout.py tests/test_seed_dashboard_data_phase10.py tests/test_navigation.py tests/test_purchase_order_drawer_partial.py -q`
- `python -m pytest tests/test_recovery_pages.py tests/test_pos_sales_import.py tests/test_variance_report_view.py tests/test_chef_bulletins_views.py tests/test_recovery_actions_views.py -q`
- `python manage.py check --settings=inventory_app.settings.test`
