### PR TITLE
[codex] Improve indent fulfill feedback on stock shortage

### DIFF
--- a/inventory/services/indent_issue_service.py
+++ b/inventory/services/indent_issue_service.py
@@ -26,6 +26,7 @@ class IssueResult:
     ok: bool
     message: str
     updated_items: int = 0
+    skipped_items: int = 0
 
 
 def _as_decimal(val: Any) -> Decimal:
@@ -71,6 +72,7 @@ def issue_indent(indent_id: int, lines: Iterable[IssueLine], user) -> IssueResul
     }
 
     updated = 0
+    skipped_reasons: list[str] = []
     with transaction.atomic():
         for line in lines:
             qty = _as_decimal(getattr(line, "issue_qty", 0))
@@ -89,7 +91,10 @@ def issue_indent(indent_id: int, lines: Iterable[IssueLine], user) -> IssueResul
             item: Item = ii.item  # type: ignore
             current = _as_decimal(item.current_stock or 0)
             if current < qty:
-                # Not enough stock; skip this line
+                item_name = getattr(item, "name", f"Item {item.item_id}")
+                skipped_reasons.append(
+                    f"{item_name}: requested {qty}, available {current}"
+                )
                 continue
             # Record stock movement (decrease)
             note_parts = [f"Issue for MRN {indent.mrn or indent.indent_id}"]
@@ -136,8 +141,29 @@ def issue_indent(indent_id: int, lines: Iterable[IssueLine], user) -> IssueResul
                 indent.status = "PROCESSING"
                 indent.save(update_fields=["status", "updated_at"])  # type: ignore
 
+    if updated == 0 and skipped_reasons:
+        return IssueResult(
+            ok=False,
+            message="Cannot fulfill due to insufficient stock: "
+            + "; ".join(skipped_reasons),
+            updated_items=0,
+            skipped_items=len(skipped_reasons),
+        )
     if updated == 0:
-        return IssueResult(ok=False, message="No items issued", updated_items=0)
+        return IssueResult(
+            ok=False,
+            message="No items were issued. Enter an issue quantity greater than 0.",
+            updated_items=0,
+            skipped_items=0,
+        )
+    if skipped_reasons:
+        return IssueResult(
+            ok=True,
+            message=f"Issued {updated} line(s). Skipped due to insufficient stock: "
+            + "; ".join(skipped_reasons),
+            updated_items=updated,
+            skipped_items=len(skipped_reasons),
+        )
     return IssueResult(
         ok=True, message=f"Issued {updated} line(s)", updated_items=updated
     )

--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -1131,7 +1131,7 @@ def issue_indent(request, pk: int):
             if result.ok:
                 messages.success(request, result.message, extra_tags="toast")
                 return redirect("indent_detail", pk=indent.pk)
-            messages.info(request, result.message, extra_tags="toast")
+            messages.warning(request, result.message, extra_tags="toast")
             return redirect("indent_detail", pk=indent.pk)
     else:
         Formset = forms.formset_factory(


### PR DESCRIPTION
## What changed
- Improved indent fulfill service messaging when stock is insufficient.
- Added per-item shortage details (requested vs available).
- Differentiated zero-quantity submit vs insufficient-stock failure messages.
- Switched failed fulfill toast severity from info to warning.

## Why
Fulfilling an indent with unavailable quantity gave generic feedback that looked like a broken flow.

## Impact
Users now get clear actionable feedback for insufficient stock instead of ambiguous responses.

## Validation
- `./.venv/Scripts/python.exe -m pytest -k "indent and issue" -q`
- Result: `1 passed`
