### PR TITLE
[codex] Fix PO edit workflow and lead-time delivery date

### DIFF
--- a/inventory/forms/purchase_forms.py
+++ b/inventory/forms/purchase_forms.py
@@ -216,6 +216,14 @@ PurchaseOrderItemFormSet = forms.inlineformset_factory(
     can_delete=True,
 )
 
+PurchaseOrderItemEditFormSet = forms.inlineformset_factory(
+    PurchaseOrder,
+    PurchaseOrderItem,
+    form=PurchaseOrderItemForm,
+    extra=0,
+    can_delete=True,
+)
+
 
 class GRNForm(StyledFormMixin, forms.ModelForm):
     notes = forms.CharField(

--- a/inventory/services/purchase_order_service.py
+++ b/inventory/services/purchase_order_service.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
@@ -50,11 +51,41 @@ def _po_line_items_from_formset_cleaned(cleaned_rows: list) -> List[Dict[str, An
     return items_data
 
 
+def _expected_delivery_from_lead_times(order_date, cleaned_rows: list):
+    if not order_date:
+        return None
+    lead_days = [
+        row["item"].lead_time_days
+        for row in cleaned_rows
+        if row
+        and not row.get("DELETE", False)
+        and row.get("item")
+        and row["item"].lead_time_days is not None
+    ]
+    if not lead_days:
+        return None
+    return order_date + timedelta(days=max(lead_days))
+
+
+def _apply_expected_delivery_fallback(form: PurchaseOrderForm, formset) -> None:
+    if form.cleaned_data.get("expected_delivery_date"):
+        return
+    calculated = _expected_delivery_from_lead_times(
+        form.cleaned_data.get("order_date"),
+        formset.cleaned_data,
+    )
+    if calculated:
+        form.instance.expected_delivery_date = calculated
+        form.cleaned_data["expected_delivery_date"] = calculated
+
+
 def save_purchase_order_from_forms(
     form: PurchaseOrderForm,
     formset: PurchaseOrderItemFormSet,
 ) -> PurchaseOrder:
     """Persist header and lines. Call only when ``form`` and ``formset`` are valid."""
+
+    _apply_expected_delivery_fallback(form, formset)
 
     if form.instance.pk:
         po = form.save()

--- a/inventory/views/purchase_orders.py
+++ b/inventory/views/purchase_orders.py
@@ -15,7 +15,12 @@ from django.views import View
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
 
-from ..forms.purchase_forms import GRNForm, PurchaseOrderForm, PurchaseOrderItemFormSet
+from ..forms.purchase_forms import (
+    GRNForm,
+    PurchaseOrderForm,
+    PurchaseOrderItemEditFormSet,
+    PurchaseOrderItemFormSet,
+)
 from ..models import Item, PurchaseOrder, SavingsLedger, Supplier, VendorItemPrice
 from ..services import (
     goods_receiving_service,
@@ -78,6 +83,15 @@ def _build_item_vendor_hints_dict() -> dict[str, dict[str, float]]:
             ),
         }
     return hints
+
+
+def _build_item_lead_times_dict() -> dict[str, int]:
+    return {
+        str(item.pk): int(item.lead_time_days)
+        for item in Item.objects.filter(
+            is_active=True, lead_time_days__isnull=False
+        ).only("item_id", "lead_time_days")
+    }
 
 
 def _is_partial_post(request) -> bool:
@@ -486,6 +500,7 @@ class PurchaseOrderCreatePartialView(View):
                 "is_edit": False,
                 "item_prices": _build_item_prices_dict(),
                 "item_vendor_hints": _build_item_vendor_hints_dict(),
+                "item_lead_times": _build_item_lead_times_dict(),
             },
         )
 
@@ -516,6 +531,7 @@ class PurchaseOrderCreatePartialView(View):
             "is_edit": False,
             "item_prices": _build_item_prices_dict(),
             "item_vendor_hints": _build_item_vendor_hints_dict(),
+            "item_lead_times": _build_item_lead_times_dict(),
         }
         if _is_partial_post(request):
             return JsonResponse(build_form_error_payload(form, formset), status=400)
@@ -545,6 +561,7 @@ def purchase_order_create(request):
             "is_edit": False,
             "item_prices": _build_item_prices_dict(),
             "item_vendor_hints": _build_item_vendor_hints_dict(),
+            "item_lead_times": _build_item_lead_times_dict(),
         },
     )
 
@@ -556,13 +573,15 @@ def purchase_order_edit(request, pk: int):
         form = PurchaseOrderForm(
             request.POST, instance=po, supplier_suggest_url=supplier_url
         )
-        formset = PurchaseOrderItemFormSet(request.POST, instance=po, prefix="items")
+        formset = PurchaseOrderItemEditFormSet(
+            request.POST, instance=po, prefix="items"
+        )
         if form.is_valid() and formset.is_valid():
             purchase_order_service.save_purchase_order_from_forms(form, formset)
             return redirect("purchase_order_detail", pk=pk)
     else:
         form = PurchaseOrderForm(instance=po, supplier_suggest_url=supplier_url)
-        formset = PurchaseOrderItemFormSet(instance=po, prefix="items")
+        formset = PurchaseOrderItemEditFormSet(instance=po, prefix="items")
     return render(
         request,
         "inventory/purchase_orders/form.html",
@@ -573,6 +592,7 @@ def purchase_order_edit(request, pk: int):
             "po": po,
             "item_prices": _build_item_prices_dict(),
             "item_vendor_hints": _build_item_vendor_hints_dict(),
+            "item_lead_times": _build_item_lead_times_dict(),
         },
     )
 
@@ -586,7 +606,7 @@ class PurchaseOrderEditPartialView(View):
         po = get_object_or_404(PurchaseOrder, pk=pk)
         supplier_url = reverse("supplier_search")
         form = PurchaseOrderForm(instance=po, supplier_suggest_url=supplier_url)
-        formset = PurchaseOrderItemFormSet(instance=po, prefix="items")
+        formset = PurchaseOrderItemEditFormSet(instance=po, prefix="items")
         return render(
             request,
             self.template_name,
@@ -597,6 +617,7 @@ class PurchaseOrderEditPartialView(View):
                 "po": po,
                 "item_prices": _build_item_prices_dict(),
                 "item_vendor_hints": _build_item_vendor_hints_dict(),
+                "item_lead_times": _build_item_lead_times_dict(),
             },
         )
 
@@ -606,7 +627,9 @@ class PurchaseOrderEditPartialView(View):
         form = PurchaseOrderForm(
             request.POST, instance=po, supplier_suggest_url=supplier_url
         )
-        formset = PurchaseOrderItemFormSet(request.POST, instance=po, prefix="items")
+        formset = PurchaseOrderItemEditFormSet(
+            request.POST, instance=po, prefix="items"
+        )
         if form.is_valid() and formset.is_valid():
             purchase_order_service.save_purchase_order_from_forms(form, formset)
             return JsonResponse(
@@ -623,6 +646,8 @@ class PurchaseOrderEditPartialView(View):
             "is_edit": True,
             "po": po,
             "item_prices": _build_item_prices_dict(),
+            "item_vendor_hints": _build_item_vendor_hints_dict(),
+            "item_lead_times": _build_item_lead_times_dict(),
         }
         if _is_partial_post(request):
             return JsonResponse(build_form_error_payload(form, formset), status=400)

--- a/static/js/purchase-order-drawer.js
+++ b/static/js/purchase-order-drawer.js
@@ -68,6 +68,76 @@
     }
   }
 
+  function readItemLeadTimes(form) {
+    const el = form.querySelector("#po-item-lead-times");
+    if (!el || !el.textContent) return {};
+    try {
+      return JSON.parse(el.textContent);
+    } catch (_) {
+      return {};
+    }
+  }
+
+  function parseOrderDate(value) {
+    const raw = String(value || "").trim();
+    let match = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (match) {
+      return {
+        date: new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3])),
+        format: "iso",
+      };
+    }
+    match = raw.match(/^(\d{2})-(\d{2})-(\d{4})$/);
+    if (match) {
+      return {
+        date: new Date(Number(match[3]), Number(match[2]) - 1, Number(match[1])),
+        format: "dmy",
+      };
+    }
+    return null;
+  }
+
+  function pad2(value) {
+    return String(value).padStart(2, "0");
+  }
+
+  function formatDate(date, format) {
+    const year = date.getFullYear();
+    const month = pad2(date.getMonth() + 1);
+    const day = pad2(date.getDate());
+    if (format === "dmy") return `${day}-${month}-${year}`;
+    return `${year}-${month}-${day}`;
+  }
+
+  function updateExpectedDeliveryDate(form, formsetEl, itemLeadTimes) {
+    const orderInput = form.querySelector('[name="order_date"]');
+    const expectedInput = form.querySelector('[name="expected_delivery_date"]');
+    if (!orderInput || !expectedInput) return;
+
+    const parsed = parseOrderDate(orderInput.value);
+    if (!parsed) return;
+
+    let maxLeadDays = null;
+    formsetEl.querySelectorAll(".item-form").forEach(function (row) {
+      if (row.style.display === "none") return;
+      const deleted = row.querySelector('input[type="checkbox"][name$="-DELETE"]');
+      if (deleted && deleted.checked) return;
+      const itemSelect = row.querySelector("select.item-select");
+      if (!itemSelect || !itemSelect.value) return;
+      const leadDays = Number(itemLeadTimes[itemSelect.value]);
+      if (!Number.isFinite(leadDays)) return;
+      maxLeadDays = maxLeadDays === null ? leadDays : Math.max(maxLeadDays, leadDays);
+    });
+
+    if (maxLeadDays === null) return;
+    if (expectedInput.value && expectedInput.dataset.poAutoDate !== "1") return;
+
+    const expected = new Date(parsed.date);
+    expected.setDate(expected.getDate() + maxLeadDays);
+    expectedInput.value = formatDate(expected, parsed.format);
+    expectedInput.dataset.poAutoDate = "1";
+  }
+
   function applyHints(row, itemId, hints) {
     const suggestedEl = row.querySelector("[data-suggested-qty]");
     const priceHintEl = row.querySelector("[data-price-hint]");
@@ -101,6 +171,7 @@
 
     const itemPrices = readItemPrices(form);
     const itemVendorHints = readItemVendorHints(form);
+    const itemLeadTimes = readItemLeadTimes(form);
     const prefix = form.getAttribute("data-formset-prefix") || "items";
 
     if (!formsetEl._poDelegationBound) {
@@ -121,12 +192,15 @@
           if (!rowPk || !String(rowPk.value || "").trim()) {
             row.remove();
             renumberFormsetRows(form, formsetEl, prefix);
+            updateExpectedDeliveryDate(form, formsetEl, itemLeadTimes);
             return;
           }
           row.style.display = "none";
+          updateExpectedDeliveryDate(form, formsetEl, itemLeadTimes);
         } else {
           row.remove();
           renumberFormsetRows(form, formsetEl, prefix);
+          updateExpectedDeliveryDate(form, formsetEl, itemLeadTimes);
         }
       });
 
@@ -144,6 +218,22 @@
           priceInput.value = parseFloat(itemPrices[t.value]).toFixed(2);
         }
         applyHints(row, t.value, itemVendorHints);
+        updateExpectedDeliveryDate(form, formsetEl, itemLeadTimes);
+      });
+    }
+
+    const orderInput = form.querySelector('[name="order_date"]');
+    const expectedInput = form.querySelector('[name="expected_delivery_date"]');
+    if (orderInput && !orderInput._poLeadTimeBound) {
+      orderInput._poLeadTimeBound = true;
+      orderInput.addEventListener("change", function () {
+        updateExpectedDeliveryDate(form, formsetEl, itemLeadTimes);
+      });
+    }
+    if (expectedInput && !expectedInput._poLeadTimeBound) {
+      expectedInput._poLeadTimeBound = true;
+      expectedInput.addEventListener("input", function () {
+        expectedInput.dataset.poAutoDate = "0";
       });
     }
 
@@ -167,6 +257,7 @@
         applyHints(row, sel.value, itemVendorHints);
       }
     });
+    updateExpectedDeliveryDate(form, formsetEl, itemLeadTimes);
 
     if (form.id === "po-form" && !form._poNativeValidityBound) {
       form._poNativeValidityBound = true;

--- a/templates/inventory/purchase_orders/_form_partial.html
+++ b/templates/inventory/purchase_orders/_form_partial.html
@@ -9,6 +9,7 @@
       {% csrf_token %}
       {{ item_prices|json_script:"po-item-prices" }}
       {{ item_vendor_hints|json_script:"po-item-vendor-hints" }}
+      {{ item_lead_times|json_script:"po-item-lead-times" }}
       <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
         {% for field in form %}
           {% if field.name != "notes" %}

--- a/templates/inventory/purchase_orders/_po_line_items.html
+++ b/templates/inventory/purchase_orders/_po_line_items.html
@@ -22,7 +22,9 @@
         {% for f in formset %}
         <tr class="item-form align-top border-b border-border last:border-0">
           <td class="px-3 py-2 align-top">
-            <div class="hidden">{{ f.id }}</div>
+            {% for hidden in f.hidden_fields %}
+              <div class="hidden">{{ hidden }}</div>
+            {% endfor %}
             {% if f.non_field_errors %}
             <ul class="text-danger list-disc pl-5 mb-2 text-xs">
               {% for error in f.non_field_errors %}<li>{{ error }}</li>{% endfor %}
@@ -51,10 +53,11 @@
 <template id="item-empty-form">
   <tr class="item-form align-top border-b border-border">
     <td class="px-3 py-2 align-top">
+      {% for hidden in formset.empty_form.hidden_fields %}
+        <div class="hidden">{{ hidden }}</div>
+      {% endfor %}
       {% for field in formset.empty_form %}
-        {% if field.name == 'id' %}
-          <div class="hidden">{{ field }}</div>
-        {% elif field.name == 'item' %}
+        {% if field.name == 'item' %}
           {% include "components/form_field.html" with field=field %}
           <p class="mt-1 text-xs text-gray-500" data-suggested-qty></p>
         {% endif %}

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -1,5 +1,14 @@
 {% extends "components/detail_layout.html" %}
 {% block title %}{{ po.po_number }} – {{ po.supplier.name }} – Inventory Pro{% endblock %}
+{% block breadcrumbs %}
+  <nav class="mb-4 text-sm text-gray-600" aria-label="Breadcrumb">
+    <ol class="flex flex-wrap items-center gap-2">
+      <li><a href="{% url 'purchase_orders_list' %}" class="text-primary hover:underline">Purchase Orders</a></li>
+      <li aria-hidden="true">/</li>
+      <li class="text-bodyText">{{ po.po_number }}</li>
+    </ol>
+  </nav>
+{% endblock %}
 {% block heading %}{{ po.po_number }}{% endblock %}
 {% block status_badge %}
   <span class="inline-flex items-center gap-1 px-3 py-1 text-xs font-semibold rounded-full border border-border bg-surfaceSubtle text-bodyText">
@@ -29,7 +38,16 @@
   </div>
 {% endblock %}
 {% block actions %}
-  <a href="{% url 'purchase_order_receive' po.pk %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Receive Goods</a>
+  {% if po.status == 'DRAFT' %}
+    <form action="{% url 'purchase_order_mark_ordered' po.pk %}" method="post">
+      {% csrf_token %}
+      <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Send to Supplier</button>
+    </form>
+  {% elif po.status == 'SENT' %}
+    <a href="{% url 'purchase_order_receive' po.pk %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Receive Goods</a>
+  {% elif po.status == 'RECEIVED' %}
+    <a href="{% url 'grn_list' %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">View GRNs</a>
+  {% endif %}
   <!-- More actions dropdown -->
   <div class="relative" x-data="{ open: false }" @keydown.escape="open = false" @click.outside="open = false">
     <button type="button" @click="open = !open" :aria-expanded="open.toString()" class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">
@@ -39,10 +57,12 @@
     <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95" class="absolute right-0 mt-1 w-44 rounded-lg bg-surface border border-border shadow-card z-30 py-1" role="menu">
       <a href="{% url 'purchase_order_edit' po.pk %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Edit</a>
       {% if po.status == 'DRAFT' %}
-      <form action="{% url 'purchase_order_mark_ordered' po.pk %}" method="post">
-        {% csrf_token %}
-        <button type="submit" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Send to Supplier</button>
-      </form>
+        <form action="{% url 'purchase_order_mark_ordered' po.pk %}" method="post">
+          {% csrf_token %}
+          <button type="submit" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Send to Supplier</button>
+        </form>
+      {% elif po.status == 'SENT' %}
+        <a href="{% url 'purchase_order_receive' po.pk %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Receive Goods</a>
       {% endif %}
       <div class="border-t border-border my-1"></div>
       <a href="{% url 'grn_list' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">View GRNs</a>

--- a/templates/inventory/purchase_orders/form.html
+++ b/templates/inventory/purchase_orders/form.html
@@ -9,6 +9,7 @@
 {% block fields %}
   {{ item_prices|json_script:"po-item-prices" }}
   {{ item_vendor_hints|json_script:"po-item-vendor-hints" }}
+  {{ item_lead_times|json_script:"po-item-lead-times" }}
   <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
     {% for field in form %}
       {% if field.name != "notes" %}

--- a/tests/test_purchase_order_drawer_partial.py
+++ b/tests/test_purchase_order_drawer_partial.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 from datetime import date
+from decimal import Decimal
 
 import pytest
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
-from inventory.models import PurchaseOrder, Supplier
+from inventory.models import PurchaseOrder, PurchaseOrderItem, Supplier
 
 pytestmark = pytest.mark.django_db
 
@@ -113,6 +114,35 @@ def test_purchase_order_edit_partial_post_validation_returns_json(
     data = json.loads(resp.content)
     assert data.get("ok") is False
     assert "errors" in data
+
+
+def test_purchase_order_edit_partial_renders_existing_line_pk_without_blank_extra(
+    po_staff_client, item_factory
+):
+    supplier = Supplier.objects.create(name="Edit Drawer Hidden PK Supplier")
+    item = item_factory(name="Edit Drawer Hidden PK Item")
+    po = PurchaseOrder.objects.create(
+        supplier=supplier,
+        order_date=date.today(),
+        status="DRAFT",
+    )
+    poi = PurchaseOrderItem.objects.create(
+        purchase_order=po,
+        item=item,
+        quantity_ordered=Decimal("2.00"),
+        unit_price=Decimal("3.00"),
+    )
+
+    resp = po_staff_client.get(
+        reverse("purchase_order_edit_partial", kwargs={"pk": po.pk})
+    )
+
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.content.decode(), "html.parser")
+    assert soup.find("input", attrs={"name": "items-0-po_item_id"})["value"] == str(
+        poi.pk
+    )
+    assert soup.find("select", attrs={"name": "items-1-item"}) is None
 
 
 def test_purchase_order_full_form_notes_not_inside_two_column_grid(po_staff_client):

--- a/tests/test_purchase_order_service_django.py
+++ b/tests/test_purchase_order_service_django.py
@@ -50,6 +50,46 @@ def test_save_purchase_order_from_forms_creates(item_factory):
 
 
 @pytest.mark.django_db
+def test_save_purchase_order_from_forms_sets_expected_date_from_longest_item_lead_time(
+    item_factory,
+):
+    supplier = Supplier.objects.create(name="Lead Time Vendor", is_active=True)
+    short_lead = item_factory(name="Short Lead Item", lead_time_days=2)
+    long_lead = item_factory(name="Long Lead Item", lead_time_days=7)
+    order_date = date(2026, 5, 25)
+    form = PurchaseOrderForm(
+        {
+            "supplier": str(supplier.pk),
+            "order_date": str(order_date),
+            "expected_delivery_date": "",
+            "status": "DRAFT",
+            "notes": "",
+        }
+    )
+    formset = PurchaseOrderItemFormSet(
+        {
+            "items-TOTAL_FORMS": "2",
+            "items-INITIAL_FORMS": "0",
+            "items-MIN_NUM_FORMS": "0",
+            "items-MAX_NUM_FORMS": "1000",
+            "items-0-item": str(short_lead.pk),
+            "items-0-quantity_ordered": "2",
+            "items-0-unit_price": "3.00",
+            "items-1-item": str(long_lead.pk),
+            "items-1-quantity_ordered": "1",
+            "items-1-unit_price": "4.00",
+        },
+        prefix="items",
+    )
+
+    assert form.is_valid(), form.errors
+    assert formset.is_valid(), formset.errors
+    po = purchase_order_service.save_purchase_order_from_forms(form, formset)
+
+    assert po.expected_delivery_date == date(2026, 6, 1)
+
+
+@pytest.mark.django_db
 def test_create_po_and_get_po(item_factory):
     supplier = Supplier.objects.create(name="Vendor")
     item = item_factory(name="Widget")


### PR DESCRIPTION
## What changed
- Fixed PO edit formset rendering so existing line items submit their hidden `po_item_id`.
- Added an edit-specific PO line-item formset with no blank extra row by default.
- Added expected delivery auto-calculation from the longest selected item lead time.
- Added server-side expected delivery fallback when the date is blank.
- Added PO detail breadcrumbs and status-aware primary next actions.

## Why
Editing a PO could fail with `po_item_id` required because the hidden primary-key field was not rendered. Expected delivery also needed to derive from item lead time, and the saved PO page needed clearer next-step actions.

## Validation
- `./.venv/Scripts/python.exe -m pytest tests/test_purchase_order_drawer_partial.py tests/test_purchase_order_service_django.py tests/test_purchase_forms.py tests/test_phase10_smoke.py::test_phase10_purchase_order_form_accepts_manual_date -q`
- Result: `15 passed`
- `./.venv/Scripts/python.exe -m ruff check inventory/forms/purchase_forms.py inventory/services/purchase_order_service.py inventory/views/purchase_orders.py tests/test_purchase_order_drawer_partial.py tests/test_purchase_order_service_django.py`
- Result: passed
- `git diff --check`
- Result: passed
