### PR TITLE
[codex] Improve indent fulfillment shortage flow

### DIFF
--- a/inventory/forms/indent_issue_forms.py
+++ b/inventory/forms/indent_issue_forms.py
@@ -7,19 +7,31 @@ from django import forms
 from ..models import IndentItem
 from .base import INPUT_CLASS, StyledFormMixin
 
+SOURCE_LOCATION_CHOICES = [
+    ("", "Select source..."),
+    ("Main Store", "Main Store"),
+    ("Kitchen - Indiqube", "Kitchen - Indiqube"),
+    ("Kitchen - Bagmane", "Kitchen - Bagmane"),
+    ("Bar - Indiqube", "Bar - Indiqube"),
+    ("Bar - Bagmane", "Bar - Bagmane"),
+]
+
 
 class IndentItemIssueForm(StyledFormMixin, forms.Form):
     indent_item_id = forms.IntegerField(widget=forms.HiddenInput())
     issue_qty = forms.DecimalField(min_value=Decimal("0.00"), required=False)
-    source_location = forms.CharField(required=False)
+    source_location = forms.ChoiceField(
+        choices=SOURCE_LOCATION_CHOICES,
+        required=False,
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["issue_qty"].widget = forms.NumberInput(
             attrs={"step": "0.01", "class": INPUT_CLASS}
         )
-        self.fields["source_location"].widget = forms.TextInput(
-            attrs={"placeholder": "Store/Freezer/Bin...", "class": INPUT_CLASS}
+        self.fields["source_location"].widget = forms.Select(
+            choices=SOURCE_LOCATION_CHOICES, attrs={"class": INPUT_CLASS}
         )
         self.apply_styling()
 
@@ -41,6 +53,23 @@ class IndentIssueFormset(forms.BaseFormSet):
             IndentItem.objects.select_related("item")
             .filter(indent_id=indent_id)
             .order_by("indent_item_id")
-            .values("indent_item_id")
+            .values(
+                "indent_item_id",
+                "requested_qty",
+                "issued_qty",
+                "item__current_stock",
+            )
         )
-        return [{"indent_item_id": r["indent_item_id"]} for r in rows]
+        initial = []
+        for row in rows:
+            requested = row["requested_qty"] or Decimal("0")
+            issued = row["issued_qty"] or Decimal("0")
+            available = row["item__current_stock"] or Decimal("0")
+            pending = max(Decimal("0"), requested - issued)
+            initial.append(
+                {
+                    "indent_item_id": row["indent_item_id"],
+                    "issue_qty": min(pending, available),
+                }
+            )
+        return initial

--- a/inventory/services/indent_issue_service.py
+++ b/inventory/services/indent_issue_service.py
@@ -27,6 +27,7 @@ class IssueResult:
     message: str
     updated_items: int = 0
     skipped_items: int = 0
+    shortage_items: int = 0
 
 
 def _as_decimal(val: Any) -> Decimal:
@@ -92,10 +93,13 @@ def issue_indent(indent_id: int, lines: Iterable[IssueLine], user) -> IssueResul
             current = _as_decimal(item.current_stock or 0)
             if current < qty:
                 item_name = getattr(item, "name", f"Item {item.item_id}")
+                shortage_qty = qty - current
                 skipped_reasons.append(
-                    f"{item_name}: requested {qty}, available {current}"
+                    f"{item_name}: requested {qty}, available {current}, shortage {shortage_qty}"
                 )
-                continue
+                if current <= 0:
+                    continue
+                qty = min(current, pending)
             # Record stock movement (decrease)
             note_parts = [f"Issue for MRN {indent.mrn or indent.indent_id}"]
             loc = (getattr(line, "source_location", "") or "").strip()
@@ -148,6 +152,7 @@ def issue_indent(indent_id: int, lines: Iterable[IssueLine], user) -> IssueResul
             + "; ".join(skipped_reasons),
             updated_items=0,
             skipped_items=len(skipped_reasons),
+            shortage_items=len(skipped_reasons),
         )
     if updated == 0:
         return IssueResult(
@@ -155,6 +160,7 @@ def issue_indent(indent_id: int, lines: Iterable[IssueLine], user) -> IssueResul
             message="No items were issued. Enter an issue quantity greater than 0.",
             updated_items=0,
             skipped_items=0,
+            shortage_items=0,
         )
     if skipped_reasons:
         return IssueResult(
@@ -163,6 +169,7 @@ def issue_indent(indent_id: int, lines: Iterable[IssueLine], user) -> IssueResul
             + "; ".join(skipped_reasons),
             updated_items=updated,
             skipped_items=len(skipped_reasons),
+            shortage_items=len(skipped_reasons),
         )
     return IssueResult(
         ok=True, message=f"Issued {updated} line(s)", updated_items=updated

--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from decimal import Decimal
 
 from django import forms
 from django.contrib import messages
@@ -20,9 +21,8 @@ from django.views.generic import TemplateView
 from ..forms.indent_forms import IndentForm, IndentItemFormSet
 from ..forms.indent_issue_forms import IndentIssueFormset, IndentItemIssueForm
 from ..indent_pdf import generate_indent_pdf
-from ..models import Department, Indent
+from ..models import Department, Indent, Item
 from ..models import IndentItem as IndentItemModel
-from ..models import Item
 from ..models import Supplier as SupplierModel
 from ..services import indent_consolidation_service, indent_issue_service, list_utils
 
@@ -1108,6 +1108,15 @@ def issue_indent(request, pk: int):
     items = list(
         indent.indentitem_set.select_related("item").order_by("indent_item_id").all()
     )
+    shortage_rows = [
+        item
+        for item in items
+        if max(
+            Decimal("0"),
+            Decimal(str(item.requested_qty or 0)) - Decimal(str(item.issued_qty or 0)),
+        )
+        > Decimal(str(getattr(item.item, "current_stock", 0) or 0))
+    ]
     # Build formset for all items in this indent
     if request.method == "POST":
         Formset = forms.formset_factory(
@@ -1129,7 +1138,15 @@ def issue_indent(request, pk: int):
                 indent.indent_id, lines, request.user
             )
             if result.ok:
-                messages.success(request, result.message, extra_tags="toast")
+                if result.shortage_items:
+                    messages.warning(
+                        request,
+                        result.message
+                        + " Create a PO for the remaining shortage from the indent page.",
+                        extra_tags="toast",
+                    )
+                else:
+                    messages.success(request, result.message, extra_tags="toast")
                 return redirect("indent_detail", pk=indent.pk)
             messages.warning(request, result.message, extra_tags="toast")
             return redirect("indent_detail", pk=indent.pk)
@@ -1150,6 +1167,7 @@ def issue_indent(request, pk: int):
             "items": items,
             "formset": formset,
             "pairs": pairs,
+            "shortage_rows": shortage_rows,
         },
     )
 

--- a/templates/inventory/indent_issue_form.html
+++ b/templates/inventory/indent_issue_form.html
@@ -8,6 +8,13 @@
   <form method="post" class="space-y-4">
     {% csrf_token %}
     {{ formset.management_form }}
+    {% if shortage_rows %}
+      <div class="rounded-lg border border-warning-strong bg-warning-soft px-4 py-3 text-sm text-warning">
+        <p class="font-medium text-bodyText">Available stock is short for this indent.</p>
+        <p class="mt-1">Issue available quantities now, then create a PO for the remaining shortage.</p>
+        <a href="{% url 'indents_consolidate_preview' %}?ids={{ indent.indent_id }}" class="inline-flex mt-2 text-primary font-medium hover:underline">Create PO for shortage</a>
+      </div>
+    {% endif %}
     <div class="bg-surface border border-border rounded-xl shadow-card">
       <table class="min-w-full divide-y divide-border">
         <thead class="bg-surfaceSubtle text-left text-xs font-semibold uppercase tracking-wider text-gray-600">
@@ -16,6 +23,7 @@
             <th class="px-3 py-2 text-right">Requested</th>
             <th class="px-3 py-2 text-right">Issued</th>
             <th class="px-3 py-2 text-right">Pending</th>
+            <th class="px-3 py-2 text-right">Available</th>
             <th class="px-3 py-2 text-right">Issue Now</th>
             <th class="px-3 py-2">Source</th>
           </tr>
@@ -27,6 +35,7 @@
               <td class="px-3 py-2 text-right align-top">{{ row.requested_qty }}</td>
               <td class="px-3 py-2 text-right align-top">{{ row.issued_qty|default:0 }}</td>
               <td class="px-3 py-2 text-right align-top">{{ row.remaining_qty }}</td>
+              <td class="px-3 py-2 text-right align-top" data-testid="available-stock">{{ row.item.current_stock|default:0 }}</td>
               <td class="px-3 py-2 text-right align-top">{{ form.issue_qty }}{{ form.indent_item_id }}</td>
               <td class="px-3 py-2 align-top">{{ form.source_location }}</td>
             </tr>

--- a/tests/test_indent_issue_flow.py
+++ b/tests/test_indent_issue_flow.py
@@ -1,0 +1,88 @@
+from decimal import Decimal
+
+import pytest
+from bs4 import BeautifulSoup
+from django.urls import reverse
+
+from inventory.models import Indent, IndentItem, StockTransaction
+from inventory.models.enums import IndentStatus
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_indent_line(item, requested=Decimal("100.00"), issued=Decimal("0.00")):
+    indent = Indent.objects.create(
+        mrn="MRN-ISSUE-001",
+        requested_by="Kitchen",
+        status=IndentStatus.APPROVED,
+    )
+    line = IndentItem.objects.create(
+        indent=indent,
+        item=item,
+        requested_qty=requested,
+        issued_qty=issued,
+    )
+    return indent, line
+
+
+def test_issue_indent_page_shows_available_stock_and_location_select(
+    client, item_factory
+):
+    item = item_factory(name="Issue Stock Item", current_stock=Decimal("20.00"))
+    indent, _line = _create_indent_line(item)
+
+    resp = client.get(reverse("issue_indent", kwargs={"pk": indent.pk}))
+
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.content.decode(), "html.parser")
+    assert soup.find(string="Available") is not None
+    assert (
+        soup.find("td", attrs={"data-testid": "available-stock"}).get_text(strip=True)
+        == "20.00"
+    )
+    source = soup.find("select", attrs={"name": "form-0-source_location"})
+    assert source is not None
+    options = [option["value"] for option in source.find_all("option")]
+    assert options == [
+        "",
+        "Main Store",
+        "Kitchen - Indiqube",
+        "Kitchen - Bagmane",
+        "Bar - Indiqube",
+        "Bar - Bagmane",
+    ]
+    assert "Freezer" not in options
+    issue_qty = soup.find("input", attrs={"name": "form-0-issue_qty"})
+    assert issue_qty["value"] == "20.00"
+    assert "Create PO for shortage" in resp.content.decode()
+
+
+def test_issue_indent_post_issues_available_qty_and_leaves_shortage(
+    client, item_factory
+):
+    item = item_factory(name="Short Issue Item", current_stock=Decimal("20.00"))
+    indent, line = _create_indent_line(item)
+
+    resp = client.post(
+        reverse("issue_indent", kwargs={"pk": indent.pk}),
+        {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-indent_item_id": str(line.pk),
+            "form-0-issue_qty": "100.00",
+            "form-0-source_location": "Main Store",
+        },
+    )
+
+    assert resp.status_code == 302
+    item.refresh_from_db()
+    line.refresh_from_db()
+    assert item.current_stock == Decimal("0.00")
+    assert line.issued_qty == Decimal("20.00")
+    assert StockTransaction.objects.filter(
+        item=item,
+        transaction_type="ISSUE",
+        quantity_change=Decimal("-20.00"),
+    ).exists()


### PR DESCRIPTION
## What changed
- Added available-stock visibility to the indent fulfillment screen.
- Replaced free-text source entry with controlled physical stock locations:
  - Main Store
  - Kitchen - Indiqube
  - Kitchen - Bagmane
  - Bar - Indiqube
  - Bar - Bagmane
- Defaulted issue quantity to the lesser of pending quantity and available stock.
- Changed shortage handling so available quantity is issued and remaining shortage is reported.
- Added a shortage callout with a Create PO for shortage action.
- Added regression coverage for the screen and partial-issue behavior.

## Why
The fulfillment screen allowed impossible issue quantities, did not show stock availability, and used an open text source field even though physical stock will be counted by defined store locations.

## Validation
- `./.venv/Scripts/python.exe -m pytest tests/test_indent_issue_flow.py tests/test_indent_forms.py tests/test_indents_table.py tests/test_low_stock_indent_flow.py -q`
- Result: `10 passed`
- `./.venv/Scripts/python.exe -m pytest tests/test_ui_authenticated_smoke.py::test_ui_url_get_smoke --override-ini addopts="" -q`
- Result: `79 passed, 11 skipped`
- `./.venv/Scripts/python.exe -m ruff check inventory/forms/indent_issue_forms.py inventory/services/indent_issue_service.py inventory/views/indents.py tests/test_indent_issue_flow.py`
- Result: passed
- `git diff --check`
- Result: passed
