### PR TITLE
[codex] Fix purchase order modal transactions

### DIFF
--- a/inventory/forms/purchase_forms.py
+++ b/inventory/forms/purchase_forms.py
@@ -75,10 +75,11 @@ class PurchaseOrderForm(StyledFormMixin, forms.ModelForm):
         try:
             status_field = self.fields.get("status")
             if status_field and getattr(status_field, "choices", None):
+                current_status = str(getattr(self.instance, "status", "") or "").upper()
                 filtered = [
                     (v, lbl)
                     for v, lbl in status_field.choices
-                    if str(v).upper() != "SENT"
+                    if str(v).upper() != "SENT" or current_status == "SENT"
                 ]
                 status_field.choices = filtered
         except Exception:

--- a/inventory/services/goods_receiving_service.py
+++ b/inventory/services/goods_receiving_service.py
@@ -19,6 +19,7 @@ from .exceptions import StockServiceError
 from .vendor_savings_service import apply_grn_realization
 
 logger = logging.getLogger(__name__)
+RECEIVABLE_STATUSES = {"SENT", "RECEIVED"}
 
 
 def generate_grn_number() -> str:
@@ -43,10 +44,12 @@ def _create_grn_header(
 ) -> Tuple[GoodsReceivedNote, Optional[PurchaseOrder]]:
     supplier = Supplier.objects.get(pk=grn_data["supplier_id"])
     po = (
-        PurchaseOrder.objects.get(pk=grn_data.get("po_id"))
+        PurchaseOrder.objects.select_for_update().get(pk=grn_data.get("po_id"))
         if grn_data.get("po_id")
         else None
     )
+    if po and po.status not in RECEIVABLE_STATUSES:
+        raise ValueError("Only sent purchase orders can receive goods.")
     grn = GoodsReceivedNote.objects.create(
         grn_number=generate_grn_number(),
         purchase_order=po,
@@ -68,7 +71,13 @@ def _process_items(
     item_ids = {d["item_id"] for d in items_received_data}
     po_item_ids = {d["po_item_id"] for d in items_received_data}
     items = Item.objects.in_bulk(item_ids)
-    po_items = PurchaseOrderItem.objects.in_bulk(po_item_ids)
+    po_items = PurchaseOrderItem.objects.select_for_update().in_bulk(po_item_ids)
+    remaining_by_po_item: dict[int, Decimal] = {}
+    for po_item_id, po_item in po_items.items():
+        remaining_by_po_item[po_item_id] = max(
+            Decimal("0"),
+            (po_item.quantity_ordered or Decimal("0")) - po_item.received_total,
+        )
 
     grn_items: List[GRNItem] = []
     for item_d in items_received_data:
@@ -80,7 +89,19 @@ def _process_items(
             raise PurchaseOrderItem.DoesNotExist(
                 f"PurchaseOrderItem {item_d['po_item_id']} not found"
             )
+        if po and po_item.purchase_order_id != po.pk:
+            raise ValueError("Received line does not belong to this purchase order.")
+        if po_item.item_id != item.item_id:
+            raise ValueError("Received line item does not match the purchase order.")
         qty = Decimal(str(item_d["quantity_received"]))
+        if qty <= 0:
+            raise ValueError(f"Received quantity for {item.name} must be positive.")
+        remaining = remaining_by_po_item.get(po_item.pk, Decimal("0"))
+        if qty > remaining:
+            raise ValueError(
+                f"Received quantity for {item.name} exceeds remaining quantity."
+            )
+        remaining_by_po_item[po_item.pk] = remaining - qty
         grn_items.append(
             GRNItem(
                 grn=grn,
@@ -158,6 +179,8 @@ def create_grn(
         StockServiceError,
     ) as exc:
         return False, f"Invalid reference: {exc}", None
+    except ValueError as exc:
+        return False, str(exc), None
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("Error creating GRN: %s", exc)
         return False, "Database error creating GRN.", None

--- a/inventory/services/purchase_order_service.py
+++ b/inventory/services/purchase_order_service.py
@@ -57,14 +57,43 @@ def save_purchase_order_from_forms(
     """Persist header and lines. Call only when ``form`` and ``formset`` are valid."""
 
     if form.instance.pk:
-        po = form.save()
-        formset.save()
+        with transaction.atomic():
+            _validate_po_update_formset(formset)
+            po = form.save()
+            formset.save()
         return po
 
     po_data = _po_header_dict_from_cleaned_form(form)
     items_data = _po_line_items_from_formset_cleaned(formset.cleaned_data)
     po_id = create_po(po_data, items_data)
     return PurchaseOrder.objects.get(pk=po_id)
+
+
+def _validate_po_update_formset(formset: PurchaseOrderItemFormSet) -> None:
+    """Prevent edits that would detach or invalidate existing receipt history."""
+
+    for item_form in formset.forms:
+        if not getattr(item_form, "cleaned_data", None):
+            continue
+        po_item = item_form.instance
+        if not po_item.pk:
+            continue
+        received_total = po_item.received_total
+        if not received_total:
+            continue
+        item_name = getattr(getattr(po_item, "item", None), "name", "this item")
+        if item_form.cleaned_data.get("DELETE"):
+            raise PurchaseOrderServiceError(
+                f"Cannot delete {item_name}; goods have already been received."
+            )
+        ordered_qty = item_form.cleaned_data.get("quantity_ordered")
+        if ordered_qty is not None and ordered_qty < received_total:
+            raise PurchaseOrderServiceError(
+                (
+                    f"Cannot reduce {item_name} below the already received "
+                    f"quantity ({received_total})."
+                )
+            )
 
 
 def create_po(po_data: Dict[str, Any], items_data: List[Dict[str, Any]]) -> int:

--- a/inventory/views/form_errors.py
+++ b/inventory/views/form_errors.py
@@ -8,11 +8,13 @@ def get_field_label(form_like, field_name: str) -> str:
     return field_name.replace("_", " ").capitalize()
 
 
-def build_form_error_payload(form, formset) -> dict:
+def build_form_error_payload(form, formset=None) -> dict:
     """Collect validation errors into a JSON-serializable dict for JsonResponse."""
 
     form_non_field_errors = [str(error) for error in form.non_field_errors()]
-    formset_non_form_errors = [str(error) for error in formset.non_form_errors()]
+    formset_non_form_errors = (
+        [str(error) for error in formset.non_form_errors()] if formset else []
+    )
 
     form_errors: dict[str, list[str]] = {}
     first_form_field_error = None
@@ -27,7 +29,7 @@ def build_form_error_payload(form, formset) -> dict:
 
     formset_errors: list[dict] = []
     first_formset_field_error = None
-    forms = list(formset.forms)
+    forms = list(formset.forms) if formset else []
     total_forms = len(forms)
     for index, form_instance in enumerate(forms):
         child_errors: dict[str, list[str]] = {}

--- a/inventory/views/purchase_orders.py
+++ b/inventory/views/purchase_orders.py
@@ -97,6 +97,86 @@ def _annotate_total_value(qs):
     )
 
 
+def _build_po_initial_from_request(
+    request,
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Prefill a new PO drawer when launched from item/low-stock contexts."""
+
+    item_pk = request.GET.get("item")
+    if not item_pk or not str(item_pk).isdigit():
+        return {}, []
+    item = (
+        Item.objects.filter(pk=int(item_pk), is_active=True)
+        .select_related("preferred_supplier")
+        .first()
+    )
+    if not item:
+        return {}, []
+    reorder = Decimal(str(item.reorder_point or 0))
+    stock = Decimal(str(item.current_stock or 0))
+    suggested_qty = reorder - stock
+    if suggested_qty <= 0:
+        suggested_qty = item.minimum_order_qty or Decimal("1")
+    unit_price = item.last_purchase_price or item.initial_purchase_price or Decimal("0")
+    form_initial: dict[str, Any] = {}
+    if item.preferred_supplier_id and item.preferred_supplier:
+        form_initial["supplier"] = item.preferred_supplier.name
+    line_initial = [
+        {
+            "item": item.pk,
+            "quantity_ordered": suggested_qty,
+            "unit_price": unit_price,
+        }
+    ]
+    return form_initial, line_initial
+
+
+def _get_receive_items(po: PurchaseOrder):
+    return (
+        po.purchaseorderitem_set.select_related("item")
+        .annotate(_received_total=Sum("grnitem__quantity_received"))
+        .all()
+    )
+
+
+def _build_receive_items_data(request, form: GRNForm, items) -> list[dict[str, Any]]:
+    any_received = False
+    items_data: list[dict[str, Any]] = []
+    for item in items:
+        qty_field = f"item_{item.pk}"
+        try:
+            qty = Decimal(request.POST.get(qty_field, 0) or 0)
+        except Exception:
+            qty = Decimal("0")
+        if qty < 0:
+            form.add_error(
+                None,
+                f"Received quantity for {item.item.name} cannot be negative.",
+            )
+            continue
+        if qty:
+            any_received = True
+            remaining = item.quantity_ordered - item.received_total
+            if qty > remaining:
+                form.add_error(
+                    None,
+                    f"Received quantity for {item.item.name} exceeds remaining.",
+                )
+                continue
+            items_data.append(
+                {
+                    "item_id": item.item_id,
+                    "po_item_id": item.pk,
+                    "quantity_ordered_on_po": item.quantity_ordered,
+                    "quantity_received": qty,
+                    "unit_price_at_receipt": item.unit_price,
+                }
+            )
+    if not any_received:
+        form.add_error(None, "No quantities received.")
+    return items_data
+
+
 class PurchaseOrdersListView(TemplateView):
     """Display purchase orders list and filters."""
 
@@ -475,8 +555,11 @@ class PurchaseOrderCreatePartialView(View):
 
     def get(self, request):
         supplier_url = reverse("supplier_search")
-        form = PurchaseOrderForm(supplier_suggest_url=supplier_url)
-        formset = PurchaseOrderItemFormSet(prefix="items")
+        form_initial, line_initial = _build_po_initial_from_request(request)
+        form = PurchaseOrderForm(
+            initial=form_initial, supplier_suggest_url=supplier_url
+        )
+        formset = PurchaseOrderItemFormSet(prefix="items", initial=line_initial)
         return render(
             request,
             self.template_name,
@@ -534,8 +617,11 @@ def purchase_order_create(request):
             except PurchaseOrderServiceError as exc:
                 messages.error(request, str(exc), extra_tags="toast")
     else:
-        form = PurchaseOrderForm(supplier_suggest_url=supplier_url)
-        formset = PurchaseOrderItemFormSet(prefix="items")
+        form_initial, line_initial = _build_po_initial_from_request(request)
+        form = PurchaseOrderForm(
+            initial=form_initial, supplier_suggest_url=supplier_url
+        )
+        formset = PurchaseOrderItemFormSet(prefix="items", initial=line_initial)
     return render(
         request,
         "inventory/purchase_orders/form.html",
@@ -558,8 +644,11 @@ def purchase_order_edit(request, pk: int):
         )
         formset = PurchaseOrderItemFormSet(request.POST, instance=po, prefix="items")
         if form.is_valid() and formset.is_valid():
-            purchase_order_service.save_purchase_order_from_forms(form, formset)
-            return redirect("purchase_order_detail", pk=pk)
+            try:
+                purchase_order_service.save_purchase_order_from_forms(form, formset)
+                return redirect("purchase_order_detail", pk=pk)
+            except PurchaseOrderServiceError as exc:
+                messages.error(request, str(exc), extra_tags="toast")
     else:
         form = PurchaseOrderForm(instance=po, supplier_suggest_url=supplier_url)
         formset = PurchaseOrderItemFormSet(instance=po, prefix="items")
@@ -608,21 +697,27 @@ class PurchaseOrderEditPartialView(View):
         )
         formset = PurchaseOrderItemFormSet(request.POST, instance=po, prefix="items")
         if form.is_valid() and formset.is_valid():
-            purchase_order_service.save_purchase_order_from_forms(form, formset)
-            return JsonResponse(
-                {
-                    "ok": True,
-                    "id": po.pk,
-                    "message": "Purchase order updated",
-                    "redirect": reverse("purchase_order_detail", kwargs={"pk": po.pk}),
-                }
-            )
+            try:
+                purchase_order_service.save_purchase_order_from_forms(form, formset)
+                return JsonResponse(
+                    {
+                        "ok": True,
+                        "id": po.pk,
+                        "message": "Purchase order updated",
+                        "redirect": reverse(
+                            "purchase_order_detail", kwargs={"pk": po.pk}
+                        ),
+                    }
+                )
+            except PurchaseOrderServiceError as exc:
+                return JsonResponse({"ok": False, "message": str(exc)}, status=400)
         ctx = {
             "form": form,
             "formset": formset,
             "is_edit": True,
             "po": po,
             "item_prices": _build_item_prices_dict(),
+            "item_vendor_hints": _build_item_vendor_hints_dict(),
         }
         if _is_partial_post(request):
             return JsonResponse(build_form_error_payload(form, formset), status=400)
@@ -658,6 +753,7 @@ def purchase_order_detail(request, pk: int):
         "po": po,
         "items": items,
         "badge_class": badge_class,
+        "is_receivable": po.status in RECEIVABLE_STATUSES,
         "rows": rows,
         "list_url": reverse("purchase_orders_list"),
         "list_title": "Purchase Orders",
@@ -676,49 +772,14 @@ def purchase_order_detail(request, pk: int):
 
 def purchase_order_receive(request, pk: int):
     po = get_object_or_404(PurchaseOrder, pk=pk)
-    items = (
-        po.purchaseorderitem_set.select_related("item")
-        .annotate(_received_total=Sum("grnitem__quantity_received"))
-        .all()
-    )
+    items = _get_receive_items(po)
     if request.method == "POST":
         form = GRNForm(request.POST)
-        if form.is_valid():
-            any_received = False
-            items_data: list[dict[str, Any]] = []
-            for item in items:
-                qty_field = f"item_{item.pk}"
-                try:
-                    qty = Decimal(request.POST.get(qty_field, 0) or 0)
-                except Exception:
-                    qty = Decimal("0")
-                if qty < 0:
-                    form.add_error(
-                        None,
-                        f"Received quantity for {item.item.name} cannot be negative.",
-                    )
-                    continue
-                if qty:
-                    any_received = True
-                    remaining = item.quantity_ordered - item.received_total
-                    if qty > remaining:
-                        form.add_error(
-                            None,
-                            f"Received quantity for {item.item.name} exceeds remaining",
-                        )
-                        continue
-                    items_data.append(
-                        {
-                            "item_id": item.item_id,
-                            "po_item_id": item.pk,
-                            "quantity_ordered_on_po": item.quantity_ordered,
-                            "quantity_received": qty,
-                            "unit_price_at_receipt": item.unit_price,
-                        }
-                    )
-            if not any_received:
-                form.add_error(None, "No quantities received")
-            elif not form.errors:
+        if po.status not in RECEIVABLE_STATUSES:
+            form.add_error(None, "Only sent purchase orders can receive goods.")
+        elif form.is_valid():
+            items_data = _build_receive_items_data(request, form, items)
+            if not form.errors:
                 grn_data = {
                     "po_id": po.pk,
                     "supplier_id": po.supplier_id,
@@ -734,13 +795,20 @@ def purchase_order_receive(request, pk: int):
                 )
                 if success:
                     return redirect("purchase_order_detail", pk=pk)
-                messages.error(request, msg, extra_tags="toast")
+                form.add_error(None, msg)
     else:
         form = GRNForm()
+        if po.status not in RECEIVABLE_STATUSES:
+            form.add_error(None, "Only sent purchase orders can receive goods.")
     return render(
         request,
         "inventory/purchase_orders/receive.html",
-        {"form": form, "po": po, "items": items},
+        {
+            "form": form,
+            "po": po,
+            "items": items,
+            "can_receive": po.status in RECEIVABLE_STATUSES,
+        },
     )
 
 
@@ -756,59 +824,27 @@ class PurchaseOrderReceivePartialView(View):
 
     def get(self, request, pk: int):
         po = get_object_or_404(PurchaseOrder, pk=pk)
-        items = (
-            po.purchaseorderitem_set.select_related("item")
-            .annotate(_received_total=Sum("grnitem__quantity_received"))
-            .all()
-        )
+        items = _get_receive_items(po)
         form = GRNForm()
-        ctx = {"form": form, "po": po, "items": items}
+        if po.status not in RECEIVABLE_STATUSES:
+            form.add_error(None, "Only sent purchase orders can receive goods.")
+        ctx = {
+            "form": form,
+            "po": po,
+            "items": items,
+            "can_receive": po.status in RECEIVABLE_STATUSES,
+        }
         return render(request, self.template_name, ctx)
 
     def post(self, request, pk: int):
         po = get_object_or_404(PurchaseOrder, pk=pk)
-        items = (
-            po.purchaseorderitem_set.select_related("item")
-            .annotate(_received_total=Sum("grnitem__quantity_received"))
-            .all()
-        )
+        items = _get_receive_items(po)
         form = GRNForm(request.POST)
-        if form.is_valid():
-            any_received = False
-            items_data: list[dict[str, Any]] = []
-            for item in items:
-                qty_field = f"item_{item.pk}"
-                try:
-                    qty = Decimal(request.POST.get(qty_field, 0) or 0)
-                except Exception:
-                    qty = Decimal("0")
-                if qty < 0:
-                    form.add_error(
-                        None,
-                        f"Received quantity for {item.item.name} cannot be negative.",
-                    )
-                    continue
-                if qty:
-                    any_received = True
-                    remaining = item.quantity_ordered - item.received_total
-                    if qty > remaining:
-                        form.add_error(
-                            None,
-                            f"Received quantity for {item.item.name} exceeds remaining",
-                        )
-                        continue
-                    items_data.append(
-                        {
-                            "item_id": item.item_id,
-                            "po_item_id": item.pk,
-                            "quantity_ordered_on_po": item.quantity_ordered,
-                            "quantity_received": qty,
-                            "unit_price_at_receipt": item.unit_price,
-                        }
-                    )
-            if not any_received:
-                form.add_error(None, "No quantities received")
-            elif not form.errors:
+        if po.status not in RECEIVABLE_STATUSES:
+            form.add_error(None, "Only sent purchase orders can receive goods.")
+        elif form.is_valid():
+            items_data = _build_receive_items_data(request, form, items)
+            if not form.errors:
                 grn_data = {
                     "po_id": po.pk,
                     "supplier_id": po.supplier_id,
@@ -833,8 +869,15 @@ class PurchaseOrderReceivePartialView(View):
                     )
                 return JsonResponse({"ok": False, "message": msg}, status=400)
 
-        # If we reach here, show the partial again with errors
-        ctx = {"form": form, "po": po, "items": items}
+        if _is_partial_post(request):
+            return JsonResponse(build_form_error_payload(form), status=400)
+
+        ctx = {
+            "form": form,
+            "po": po,
+            "items": items,
+            "can_receive": po.status in RECEIVABLE_STATUSES,
+        }
         return render(request, self.template_name, ctx, status=400)
 
 

--- a/templates/inventory/_ml_dashboard_table.html
+++ b/templates/inventory/_ml_dashboard_table.html
@@ -87,6 +87,9 @@
           <td class="px-4 py-3">
             {% if row.days_cover is not None and row.days_cover < 7 %}
               <a href="{% url 'purchase_order_create' %}?item={{ row.item.pk }}"
+                 data-modal-url="{% url 'purchase_order_create_partial' %}?item={{ row.item.pk }}"
+                 data-modal-type="drawer"
+                 data-modal-prefetch="hover"
                  class="inline-flex items-center gap-1 px-3 py-1 rounded-lg border border-primary text-primary text-xs font-semibold hover:bg-primary hover:text-white transition">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />

--- a/templates/inventory/purchase_orders/_receive_partial.html
+++ b/templates/inventory/purchase_orders/_receive_partial.html
@@ -7,6 +7,11 @@
   <div class="p-4">
   <form method="post" enctype="multipart/form-data" data-modal-form data-requires-line-items action="{% url 'purchase_order_receive_partial' po.pk %}">
       {% csrf_token %}
+      {% if form.non_field_errors %}
+        <div class="mb-3 px-3 py-2 rounded-md border border-red-200 bg-red-50 text-red-700 text-sm">
+          {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
+        </div>
+      {% endif %}
       <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
         {% for field in form %}
           {% include "components/form_field.html" with field=field %}
@@ -22,7 +27,7 @@
       </div>
       <div class="mt-4 flex items-center justify-end gap-2">
         <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Cancel</button>
-        <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">Submit GRN</button>
+        <button type="submit" {% if can_receive is False %}disabled{% endif %} class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong disabled:opacity-50 disabled:cursor-not-allowed">Submit GRN</button>
       </div>
     </form>
   </div>

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -29,7 +29,13 @@
   </div>
 {% endblock %}
 {% block actions %}
-  <a href="{% url 'purchase_order_receive' po.pk %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Receive Goods</a>
+  {% if is_receivable %}
+  <a href="{% url 'purchase_order_receive' po.pk %}"
+     data-modal-url="{% url 'purchase_order_receive_partial' po.pk %}"
+     data-modal-type="drawer"
+     data-modal-prefetch="hover"
+     class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Receive Goods</a>
+  {% endif %}
   <!-- More actions dropdown -->
   <div class="relative" x-data="{ open: false }" @keydown.escape="open = false" @click.outside="open = false">
     <button type="button" @click="open = !open" :aria-expanded="open.toString()" class="inline-flex items-center gap-1 px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">
@@ -37,7 +43,11 @@
       <svg class="w-4 h-4 transition-transform" :class="open ? 'rotate-180' : ''" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>
     </button>
     <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95" class="absolute right-0 mt-1 w-44 rounded-lg bg-surface border border-border shadow-card z-30 py-1" role="menu">
-      <a href="{% url 'purchase_order_edit' po.pk %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Edit</a>
+      <a href="{% url 'purchase_order_edit' po.pk %}"
+         data-modal-url="{% url 'purchase_order_edit_partial' po.pk %}"
+         data-modal-type="drawer"
+         data-modal-prefetch="hover"
+         class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Edit</a>
       {% if po.status == 'DRAFT' %}
       <form action="{% url 'purchase_order_mark_ordered' po.pk %}" method="post">
         {% csrf_token %}

--- a/templates/inventory/purchase_orders/receive.html
+++ b/templates/inventory/purchase_orders/receive.html
@@ -5,6 +5,11 @@
   <p class="text-sm text-gray-600">Record quantities received and attach supporting documents.</p>
 {% endblock %}
 {% block fields %}
+  {% if form.non_field_errors %}
+    <div class="mb-3 px-3 py-2 rounded-md border border-red-200 bg-red-50 text-red-700 text-sm">
+      {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
+    </div>
+  {% endif %}
   <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
     {% for field in form %}
       {% include "components/form_field.html" with field=field %}

--- a/tests/test_goods_receiving_service_django.py
+++ b/tests/test_goods_receiving_service_django.py
@@ -21,6 +21,7 @@ def test_create_grn_updates_stock_and_po(item_factory):
         {"supplier_id": supplier.pk, "order_date": date.today()},
         [{"item_id": item.item_id, "quantity_ordered": 10, "unit_price": 1.0}],
     )
+    PurchaseOrder.objects.filter(pk=po_id).update(status="SENT")
     po_item = PurchaseOrderItem.objects.get(
         purchase_order_id=po_id, item_id=item.item_id
     )
@@ -59,6 +60,7 @@ def test_grn_realizes_estimated_saving_entries(item_factory):
         {"supplier_id": supplier.pk, "order_date": date.today()},
         [{"item_id": item.item_id, "quantity_ordered": 2, "unit_price": 90.0}],
     )
+    PurchaseOrder.objects.filter(pk=po_id).update(status="SENT")
     po_item = PurchaseOrderItem.objects.get(
         purchase_order_id=po_id, item_id=item.item_id
     )
@@ -86,3 +88,57 @@ def test_grn_realizes_estimated_saving_entries(item_factory):
     )
     assert ledger.status == SavingsLedger.Status.VERIFIED
     assert ledger.confirmed_saving == Decimal("24.00")
+
+
+@pytest.mark.django_db
+def test_create_grn_rejects_over_receipt_and_preserves_stock(item_factory):
+    supplier = Supplier.objects.create(name="Over Receipt Vendor")
+    item = item_factory(name="Over Receipt Item", current_stock=0)
+    po_id = purchase_order_service.create_po(
+        {"supplier_id": supplier.pk, "order_date": date.today(), "status": "SENT"},
+        [{"item_id": item.item_id, "quantity_ordered": 10, "unit_price": 1.0}],
+    )
+    po = PurchaseOrder.objects.get(pk=po_id)
+    po.status = "SENT"
+    po.save(update_fields=["status"])
+    po_item = PurchaseOrderItem.objects.get(
+        purchase_order_id=po_id, item_id=item.item_id
+    )
+    grn_data = {
+        "po_id": po_id,
+        "supplier_id": supplier.pk,
+        "received_date": date.today(),
+        "received_by_user_id": "tester",
+    }
+
+    success, msg, _ = goods_receiving_service.create_grn(
+        grn_data,
+        [
+            {
+                "item_id": item.item_id,
+                "po_item_id": po_item.pk,
+                "quantity_ordered_on_po": po_item.quantity_ordered,
+                "quantity_received": 7,
+                "unit_price_at_receipt": po_item.unit_price,
+            }
+        ],
+    )
+    assert success, msg
+
+    success, msg, _ = goods_receiving_service.create_grn(
+        grn_data,
+        [
+            {
+                "item_id": item.item_id,
+                "po_item_id": po_item.pk,
+                "quantity_ordered_on_po": po_item.quantity_ordered,
+                "quantity_received": 4,
+                "unit_price_at_receipt": po_item.unit_price,
+            }
+        ],
+    )
+
+    assert success is False
+    assert "exceeds remaining" in msg
+    item.refresh_from_db()
+    assert item.current_stock == Decimal("7")

--- a/tests/test_purchase_order_drawer_partial.py
+++ b/tests/test_purchase_order_drawer_partial.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 import json
 from datetime import date
+from decimal import Decimal
 
 import pytest
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
-from inventory.models import PurchaseOrder, Supplier
+from inventory.models import (
+    GoodsReceivedNote,
+    GRNItem,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    Supplier,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -129,3 +136,127 @@ def test_purchase_order_full_form_notes_not_inside_two_column_grid(po_staff_clie
     )
     assert grid is not None
     assert grid.find("textarea", attrs={"name": "notes"}) is None
+
+
+def test_purchase_order_detail_actions_use_drawers(po_staff_client, item_factory):
+    supplier = Supplier.objects.create(name="Detail Drawer Supplier")
+    item = item_factory(name="Detail Drawer Item")
+    po = PurchaseOrder.objects.create(
+        supplier=supplier,
+        order_date=date.today(),
+        status="SENT",
+    )
+    PurchaseOrderItem.objects.create(
+        purchase_order=po,
+        item=item,
+        quantity_ordered=Decimal("3.00"),
+        unit_price=Decimal("4.00"),
+    )
+
+    resp = po_staff_client.get(reverse("purchase_order_detail", args=[po.pk]))
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.content.decode(), "html.parser")
+
+    receive = soup.find(
+        "a",
+        attrs={
+            "data-modal-url": reverse("purchase_order_receive_partial", args=[po.pk])
+        },
+    )
+    edit = soup.find(
+        "a",
+        attrs={"data-modal-url": reverse("purchase_order_edit_partial", args=[po.pk])},
+    )
+    assert receive is not None
+    assert receive.get("data-modal-type") == "drawer"
+    assert edit is not None
+    assert edit.get("data-modal-type") == "drawer"
+
+
+def test_purchase_order_receive_partial_rejects_draft_json(
+    po_staff_client, item_factory
+):
+    supplier = Supplier.objects.create(name="Draft Receive Supplier")
+    item = item_factory(name="Draft Receive Item")
+    po = PurchaseOrder.objects.create(
+        supplier=supplier,
+        order_date=date.today(),
+        status="DRAFT",
+    )
+    poi = PurchaseOrderItem.objects.create(
+        purchase_order=po,
+        item=item,
+        quantity_ordered=Decimal("3.00"),
+        unit_price=Decimal("4.00"),
+    )
+
+    resp = po_staff_client.post(
+        reverse("purchase_order_receive_partial", args=[po.pk]),
+        {
+            "partial": "1",
+            "received_date": date.today().isoformat(),
+            f"item_{poi.pk}": "1",
+        },
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        HTTP_ACCEPT="application/json",
+    )
+
+    assert resp.status_code == 400
+    data = resp.json()
+    assert data["ok"] is False
+    assert "Only sent purchase orders can receive goods" in data["message"]
+
+
+def test_purchase_order_edit_partial_rejects_deleting_received_line(
+    po_staff_client, item_factory
+):
+    supplier = Supplier.objects.create(name="Received Line Supplier")
+    item = item_factory(name="Received Line Item")
+    po = PurchaseOrder.objects.create(
+        supplier=supplier,
+        order_date=date.today(),
+        status="SENT",
+    )
+    poi = PurchaseOrderItem.objects.create(
+        purchase_order=po,
+        item=item,
+        quantity_ordered=Decimal("3.00"),
+        unit_price=Decimal("4.00"),
+    )
+    grn = GoodsReceivedNote.objects.create(
+        purchase_order=po,
+        supplier=supplier,
+        received_date=date.today(),
+    )
+    GRNItem.objects.create(
+        grn=grn,
+        po_item=poi,
+        item=item,
+        quantity_ordered_on_po="3.00",
+        quantity_received="1.00",
+        unit_price_at_receipt="4.00",
+    )
+
+    resp = po_staff_client.post(
+        reverse("purchase_order_edit_partial", args=[po.pk]),
+        {
+            "partial": "1",
+            "supplier": str(supplier.pk),
+            "order_date": date.today().isoformat(),
+            "expected_delivery_date": "",
+            "status": "SENT",
+            "notes": "",
+            "items-TOTAL_FORMS": "1",
+            "items-INITIAL_FORMS": "1",
+            "items-MIN_NUM_FORMS": "0",
+            "items-MAX_NUM_FORMS": "1000",
+            "items-0-po_item_id": str(poi.pk),
+            "items-0-item": str(item.pk),
+            "items-0-quantity_ordered": "3.00",
+            "items-0-unit_price": "4.00",
+            "items-0-DELETE": "on",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "Cannot delete" in resp.json()["message"]


### PR DESCRIPTION
## What changed

- Made purchase order edit saves transactional and blocked edits that would delete or reduce already received PO lines below received quantities.
- Centralized PO receipt validation for full-page and drawer submits, with service-level guards for receivable statuses, over-receipts, mismatched PO lines, and non-positive quantities.
- Updated PO detail and low-stock PO actions to launch the drawer workflows while keeping full-page URLs as fallbacks.
- Added JSON error payload support for non-formset modal forms and regression coverage for drawer actions, draft receipt rejection, received-line edit protection, and over-receipt stock preservation.

## Why

The app had duplicate full-page and modal paths for the same PO workflows, and some correctness checks lived only in the view layer. That could let different entry points behave differently or allow receipt/edit state to drift.

## Impact

Users should now stay in the PO drawer flow for create/edit/receive actions, while transaction and receipt rules are enforced below the UI. Existing full-page routes remain available as fallback routes.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests/test_purchase_order_drawer_partial.py tests/test_goods_receiving_service_django.py tests/test_crud_post_submit_audit.py -q`
- `.\.venv\Scripts\python.exe -m black --check inventory\views\form_errors.py inventory\services\purchase_order_service.py inventory\services\goods_receiving_service.py inventory\views\purchase_orders.py inventory\forms\purchase_forms.py tests\test_purchase_order_drawer_partial.py tests\test_goods_receiving_service_django.py`
- `.\.venv\Scripts\python.exe -m ruff check inventory\forms\purchase_forms.py inventory\services\goods_receiving_service.py inventory\services\purchase_order_service.py inventory\views\form_errors.py inventory\views\purchase_orders.py tests\test_goods_receiving_service_django.py tests\test_purchase_order_drawer_partial.py`
- `git diff --check`