### PR TITLE
[codex] clarify item action icons

### DIFF
--- a/inventory/forms/item_forms.py
+++ b/inventory/forms/item_forms.py
@@ -151,8 +151,10 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
         # On create (unbound form), avoid pre-filling values so placeholders show
         if not self.is_bound and not self.instance.pk:
             # Do not set a default unit/category
-            self.fields["unit_id"].initial = None
-            self.fields["category_id"].initial = None
+            if "unit_id" not in self.initial:
+                self.fields["unit_id"].initial = None
+            if "category_id" not in self.initial:
+                self.fields["category_id"].initial = None
             # Clear numeric defaults to show placeholders
             for f in [
                 "initial_purchase_price",
@@ -163,7 +165,7 @@ class ItemForm(StyledFormMixin, forms.ModelForm):
             ]:
                 if f in self.fields:
                     # Using empty string ensures the input renders blank
-                    self.initial[f] = ""
+                    self.initial.setdefault(f, "")
 
         self.apply_styling()
 

--- a/inventory/ui_urls.py
+++ b/inventory/ui_urls.py
@@ -30,6 +30,7 @@ from .views.indents import (
 from .views.items.detail import (
     ItemDeleteView,
     ItemDetailView,
+    ItemDuplicateView,
     ItemEditView,
     ItemInlineUpdateView,
     ItemToggleActiveView,
@@ -139,6 +140,11 @@ urlpatterns = [
     # Backward-compat name used in templates/tests
     path("items/upload/", ItemsBulkUploadView.as_view(), name="upload_csv"),
     path("items/<int:pk>/edit/", ItemEditView.as_view(), name="item_edit"),
+    path(
+        "items/<int:pk>/duplicate/",
+        ItemDuplicateView.as_view(),
+        name="item_duplicate",
+    ),
     path("items/<int:pk>/delete/", ItemDeleteView.as_view(), name="item_delete"),
     path(
         "items/<int:pk>/toggle/",

--- a/inventory/views/items/detail.py
+++ b/inventory/views/items/detail.py
@@ -67,6 +67,55 @@ class ItemEditView(View):
         return render(request, self.template_name, ctx, status=400)
 
 
+class ItemDuplicateView(View):
+    """Open a create drawer prefilled from an existing item."""
+
+    template_name = "inventory/_item_create_partial.html"
+
+    def get(self, request, pk: int):
+        try:
+            source = get_object_or_404(
+                Item.objects.select_related(
+                    "unit", "category", "preferred_supplier"
+                ).prefetch_related("departments"),
+                pk=pk,
+            )
+        except (DatabaseError, ValueError):  # pragma: no cover - defensive
+            logger.exception("Error retrieving item %s for duplication", pk)
+            raise Http404("Item not found")
+
+        initial = {
+            "name": self._copy_name(source.name),
+            "unit_id": source.unit_id,
+            "category_id": source.category_id,
+            "departments": list(source.departments.values_list("pk", flat=True)),
+            "initial_purchase_price": source.initial_purchase_price,
+            "preferred_supplier": source.preferred_supplier_id,
+            "minimum_order_qty": source.minimum_order_qty,
+            "lead_time_days": source.lead_time_days,
+            "reorder_point": source.reorder_point,
+            "current_stock": source.current_stock,
+            "notes": source.notes,
+            "is_active": source.is_active,
+        }
+        form = ItemForm(initial=initial)
+        return render(
+            request,
+            self.template_name,
+            {"form": form, "duplicate_source": source},
+        )
+
+    @staticmethod
+    def _copy_name(name: str) -> str:
+        base = f"Copy of {name}"
+        if not Item.objects.filter(name=base).exists():
+            return base
+        index = 2
+        while Item.objects.filter(name=f"{base} {index}").exists():
+            index += 1
+        return f"{base} {index}"
+
+
 class ItemInlineUpdateView(View):
     """Minimal inline update endpoint for quick edits in the items table."""
 

--- a/static/js/items-table.js
+++ b/static/js/items-table.js
@@ -365,8 +365,8 @@
     if (!itemId) return;
     // Detect current active state from status cell text
     const statusCell = row.querySelector('td[data-col="status"]');
-    const currentlyActive =
-      statusCell && /Active/i.test(statusCell.textContent || "");
+    const statusText = (statusCell?.textContent || "").trim().toLowerCase();
+    const currentlyActive = statusText === "active";
     const csrf = getCsrfToken();
     // Optimistic: flip badge immediately
     if (statusCell) {

--- a/templates/inventory/_item_create_partial.html
+++ b/templates/inventory/_item_create_partial.html
@@ -1,7 +1,7 @@
 {% load form_tags %}
 <div class="bg-surface rounded-2xl shadow-card border border-border overflow-hidden drawer-panel max-w-drawer-xl flex flex-col min-h-0 max-h-[90vh]">
   <div class="shrink-0 px-4 py-3 border-b border-border bg-surfaceSubtle flex items-center justify-between">
-    <h3 class="text-lg font-semibold text-bodyText">Add New Item</h3>
+    <h3 class="text-lg font-semibold text-bodyText">{% if duplicate_source %}Duplicate Item - {{ duplicate_source.name }}{% else %}Add New Item{% endif %}</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
   </div>
   <form method="post" data-modal-form action="{% url 'items_list' %}" class="flex flex-col flex-1 min-h-0">
@@ -79,7 +79,7 @@
       </div>
       <div class="flex flex-wrap gap-2 justify-end">
         <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" data-modal-close>Cancel</button>
-        <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Create</button>
+        <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">{% if duplicate_source %}Create Duplicate{% else %}Create{% endif %}</button>
       </div>
     </div>
   </form>

--- a/templates/inventory/_items_table.html
+++ b/templates/inventory/_items_table.html
@@ -53,7 +53,7 @@
   <th scope="col" class="sticky z-10 px-4 py-2.5 bg-surfaceSubtle border-b border-border group-data-[shadow=true]:shadow-md" data-col="abc_class" data-field="abc_class" data-sort="col8" aria-sort="none">
           <div class="flex items-center gap-1"><span>ABC</span></div>
         </th>
-        <th scope="col" class="sticky z-10 w-30 px-4 py-2.5 bg-surfaceSubtle border-b border-border group-data-[shadow=true]:shadow-md">
+        <th scope="col" class="sticky z-10 w-40 px-4 py-2.5 bg-surfaceSubtle border-b border-border group-data-[shadow=true]:shadow-md">
           Actions
         </th>
       </tr>
@@ -156,40 +156,52 @@
         <div class="flex items-center gap-1">
 
           <a
+            href="{% url 'item_detail' item.item_id %}"
+            data-modal-url="{% url 'item_detail' item.item_id %}?partial=1"
+            data-modal-type="drawer"
+            data-modal-prefetch="hover"
+            class="inline-flex items-center justify-center w-8 h-8 p-0 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary hover:text-success"
+            title="View details for {{ item.name }}"
+            aria-label="View details for {{ item.name }}"
+          >
+            {% icon 'eye' 'w-4 h-4' %}
+          </a>
+          <a
             href="{% url 'item_edit' item.item_id %}"
             data-modal-url="{% url 'item_edit' item.item_id %}?partial=1"
             data-modal-type="drawer"
             data-modal-prefetch="hover"
             class="inline-flex items-center justify-center w-8 h-8 p-0 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary hover:text-accent"
-            title="Edit"
-            aria-label="Edit {{ item.name }}"
+            title="Edit item {{ item.name }}"
+            aria-label="Edit item {{ item.name }}"
           >
             {% icon 'pencil' 'w-4 h-4' %}
           </a>
           <a
-            href="{% url 'item_detail' item.item_id %}"
-            data-modal-url="{% url 'item_detail' item.item_id %}?partial=1"
+            href="{% url 'item_duplicate' item.item_id %}"
+            data-modal-url="{% url 'item_duplicate' item.item_id %}?partial=1"
+            data-modal-type="drawer"
             data-modal-prefetch="hover"
-            class="inline-flex items-center justify-center w-8 h-8 p-0 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary hover:text-success"
-            title="View Details"
-            aria-label="View details {{ item.name }}"
+            class="inline-flex items-center justify-center w-8 h-8 p-0 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary hover:text-info"
+            title="Duplicate item {{ item.name }}"
+            aria-label="Duplicate item {{ item.name }}"
           >
-            {% icon 'eye' 'w-4 h-4' %}
+            {% icon 'document-duplicate' 'w-4 h-4' %}
           </a>
           <button
             type="button"
             data-action="archive"
             class="inline-flex items-center justify-center w-8 h-8 p-0 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary hover:text-warning"
-            title="{% if item.is_active %}Archive{% else %}Activate{% endif %}"
-            aria-label="{% if item.is_active %}Archive{% else %}Activate{% endif %} {{ item.name }}"
+            title="{% if item.is_active %}Deactivate item{% else %}Activate item{% endif %} {{ item.name }}"
+            aria-label="{% if item.is_active %}Deactivate item{% else %}Activate item{% endif %} {{ item.name }}"
           >
             {% icon 'archive-box' 'w-4 h-4' %}
           </button>
           <button
             type="button"
             class="inline-flex items-center justify-center w-8 h-8 p-0 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary hover:text-danger"
-            title="Delete"
-            aria-label="Delete {{ item.name }}"
+            title="Delete item {{ item.name }}"
+            aria-label="Delete item {{ item.name }}"
             data-action="delete"
           >
             {% icon 'trash' 'w-4 h-4' %}

--- a/tests/js/items-table.test.js
+++ b/tests/js/items-table.test.js
@@ -19,7 +19,7 @@ describe("items-table delete", () => {
     window.notifications = { showToast: jest.fn() };
     // Require script after mocks and DOM setup
     jest.isolateModules(() => {
-      require("./items-table.js");
+      require("../../static/js/items-table.js");
     });
   });
 
@@ -54,7 +54,7 @@ describe("items-table view", () => {
     window.modal = { open: jest.fn() };
     window.notifications = { showToast: jest.fn() };
     jest.isolateModules(() => {
-      require("./items-table.js");
+      require("../../static/js/items-table.js");
     });
   });
 
@@ -66,6 +66,35 @@ describe("items-table view", () => {
       headers: { "X-Requested-With": "fetch" },
     });
     expect(window.modal.open).toHaveBeenCalledWith("<div>ok</div>");
+  });
+});
+
+describe("items-table activate/deactivate", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML =
+      '<table><tr class="item-row" data-item-id="1"><td data-col="status"><span>Inactive</span></td><td><button data-action="archive">Toggle</button></td></tr></table>';
+    document.cookie = "csrftoken=abc";
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+    window.htmx = { ajax: jest.fn() };
+    jest.isolateModules(() => {
+      require("../../static/js/items-table.js");
+    });
+  });
+
+  test("inactive rows are treated as activate actions", async () => {
+    const btn = document.querySelector('[data-action="archive"]');
+    btn.click();
+    await flushPromises();
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/items/1/toggle/",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(JSON.parse(localStorage.getItem("items_pending_toast"))).toEqual({
+      message: "Item activated",
+      type: "success",
+    });
   });
 });
 
@@ -81,7 +110,7 @@ describe("column visibility menu", () => {
       </div>`;
     // Require script after DOM setup
     jest.isolateModules(() => {
-      require("./items-table.js");
+      require("../../static/js/items-table.js");
     });
     document.dispatchEvent(new Event("DOMContentLoaded"));
   });
@@ -141,7 +170,7 @@ describe("stock_status column toggle", () => {
         <table><tr><td data-col="stock_status">val</td></tr></table>
       </div>`;
     jest.isolateModules(() => {
-      require("./items-table.js");
+      require("../../static/js/items-table.js");
     });
     document.dispatchEvent(new Event("DOMContentLoaded"));
   });
@@ -172,7 +201,7 @@ describe("sorting aria updates", () => {
         </tbody>
       </table>`;
     jest.isolateModules(() => {
-      require("./items-table.js");
+      require("../../static/js/items-table.js");
     });
   });
 
@@ -209,7 +238,7 @@ describe("details toggle", () => {
         <tr id="details-1" class="hidden"><td colspan="10">Details</td></tr>
       </table>`;
     jest.isolateModules(() => {
-      require("./items-table.js");
+      require("../../static/js/items-table.js");
     });
   });
 
@@ -243,7 +272,7 @@ describe("inline row edit", () => {
         </tr>
       </table>`;
     jest.isolateModules(() => {
-      require("./items-table.js");
+      require("../../static/js/items-table.js");
     });
   });
 

--- a/tests/test_item_views.py
+++ b/tests/test_item_views.py
@@ -1,9 +1,10 @@
 from decimal import Decimal
 
 import pytest
+from bs4 import BeautifulSoup
 from django.urls import reverse
 
-from inventory.models import Item, StockTransaction
+from inventory.models import Category, Item, StockTransaction, Supplier, Unit
 from inventory.models.departments import Department
 from inventory.services import item_service
 
@@ -181,6 +182,46 @@ def test_item_edit_view_preselects_category(client, monkeypatch):
 
     # Check that the page loads successfully
     assert "Widget" in content
+
+
+def test_item_duplicate_view_prefills_create_drawer_without_saving(client):
+    unit = Unit.objects.create(purchase_unit="kg", base_unit="kg", conversion_factor=1)
+    category = Category.objects.create(category="Food", sub_category="Dry")
+    supplier = Supplier.objects.create(name="Acme")
+    dept = Department.objects.create(name="Kitchen")
+    item = Item.objects.create(
+        name="Widget",
+        unit=unit,
+        category=category,
+        preferred_supplier=supplier,
+        initial_purchase_price=Decimal("2.50"),
+        minimum_order_qty=Decimal("3.00"),
+        lead_time_days=4,
+        reorder_point=Decimal("5.00"),
+        current_stock=Decimal("7.00"),
+        notes="copy me",
+        is_active=True,
+    )
+    item.departments.add(dept)
+
+    resp = client.get(reverse("item_duplicate", args=[item.pk]))
+
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    soup = BeautifulSoup(content, "html.parser")
+    assert "Duplicate Item" in content
+    assert "Copy of Widget" in content
+    assert "copy me" in content
+    assert 'name="unit_id"' in content
+    assert f'value="{unit.pk}" selected' in content
+    assert f'value="{category.pk}" selected' in content
+    assert f'value="{supplier.pk}" selected' in content
+    dept_checkbox = soup.find(
+        "input", {"name": "departments", "value": str(dept.pk)}
+    )
+    assert dept_checkbox is not None
+    assert dept_checkbox.has_attr("checked")
+    assert Item.objects.count() == 1
 
 
 def test_items_list_view_shows_empty_categories(client, monkeypatch):

--- a/tests/test_items_table_accessibility.py
+++ b/tests/test_items_table_accessibility.py
@@ -44,3 +44,19 @@ def test_no_dropdown_filter_controls_present():
         "Filter Status",
     ]:
         assert f'aria-label="{label}"' not in content
+
+
+def test_item_action_icons_have_clear_labels():
+    content = Path("templates/inventory/_items_table.html").read_text()
+    for label in [
+        "View details",
+        "Edit item",
+        "Duplicate item",
+        "Delete item",
+    ]:
+        assert f'title="{label}' in content
+        assert f'aria-label="{label}' in content
+    for label in ["Deactivate item", "Activate item"]:
+        assert label in content
+
+    assert "item_duplicate" in content


### PR DESCRIPTION
## Summary

Clarifies the item table action icons so users can distinguish view, edit, duplicate, delete, and activate/deactivate actions.

## What changed

- Added specific `title` and `aria-label` text to each item-table action icon.
- Added a duplicate item action that opens a prefilled create drawer without saving a new item until the user submits it.
- Preserved the existing drawer/create flow for duplicate saves.
- Fixed client-side activate/deactivate detection so an `Inactive` badge is not treated as active.
- Added Python and Jest coverage for the labels, duplicate drawer behavior, and activation feedback.

## Validation

- `.venv\Scripts\python.exe -m pytest tests/test_items_table_accessibility.py tests/test_item_views.py tests/test_item_form.py tests/test_items_list.py` - 40 passed
- `npm.cmd test -- tests/js/items-table.test.js --runInBand` - 8 passed, 2 skipped
- `.venv\Scripts\python.exe -m ruff check inventory\views\items\detail.py inventory\ui_urls.py inventory\forms\item_forms.py tests\test_item_views.py tests\test_items_table_accessibility.py` - passed
- `.venv\Scripts\python.exe manage.py check --settings=inventory_app.settings.test` - no issues