### PR TITLE
[codex] fix supplier form usability

### DIFF
--- a/inventory/forms/supplier_forms.py
+++ b/inventory/forms/supplier_forms.py
@@ -6,6 +6,17 @@ from .base import INPUT_CLASS, StyledFormMixin
 
 
 class SupplierForm(StyledFormMixin, forms.ModelForm):
+    contact_person = forms.CharField(
+        required=True,
+        widget=forms.TextInput(
+            attrs={
+                "class": INPUT_CLASS,
+                "placeholder": "Primary contact person",
+                "aria-label": "Contact person",
+            }
+        ),
+    )
+
     supplier_rating = forms.IntegerField(
         validators=[MinValueValidator(1), MaxValueValidator(5)],
         required=False,
@@ -66,14 +77,12 @@ class SupplierForm(StyledFormMixin, forms.ModelForm):
             "phone": forms.TextInput(
                 attrs={
                     "class": INPUT_CLASS,
-                    "placeholder": "+1 (555) 123-4567",
                     "aria-label": "Phone number",
                 }
             ),
             "email": forms.EmailInput(
                 attrs={
                     "class": INPUT_CLASS,
-                    "placeholder": "supplier@company.com",
                     "aria-label": "Email address",
                 }
             ),

--- a/templates/components/form_field.html
+++ b/templates/components/form_field.html
@@ -3,15 +3,15 @@
   {% if field.field.widget.input_type == "checkbox" %}
     <div class="inline-flex items-center gap-2 h-9">
       {{ field|add_class:"h-4 w-4 rounded border-form-border text-primary focus:ring-primary" }}
-      <label for="{{ field.id_for_label }}" class="text-sm font-medium text-bodyText">{{ field.label }}</label>
+      <label for="{{ field.id_for_label }}" class="text-sm font-medium text-bodyText">{{ field.label }}{% if field.field.required %}<span class="text-danger"> *</span>{% endif %}</label>
     </div>
   {% elif field.field.widget.input_type == "radio" %}
     <div class="inline-flex items-center gap-2 h-9">
       {{ field|add_class:"h-4 w-4 rounded-full border-form-border text-primary focus:ring-primary" }}
-      <label for="{{ field.id_for_label }}" class="text-sm font-medium text-bodyText">{{ field.label }}</label>
+      <label for="{{ field.id_for_label }}" class="text-sm font-medium text-bodyText">{{ field.label }}{% if field.field.required %}<span class="text-danger"> *</span>{% endif %}</label>
     </div>
   {% else %}
-    <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-bodyText">{{ field.label }}</label>
+    <label for="{{ field.id_for_label }}" class="block text-sm font-medium text-bodyText">{{ field.label }}{% if field.field.required %}<span class="text-danger"> *</span>{% endif %}</label>
     {% if field.field.widget.attrs.class %}
       {{ field|add_class:"leading-normal" }}
     {% elif field_class %}

--- a/templates/inventory/_supplier_form_partial.html
+++ b/templates/inventory/_supplier_form_partial.html
@@ -3,18 +3,18 @@
     <h3 class="text-lg font-semibold">{% if is_edit %}Edit Supplier — {{ supplier.name }}{% else %}Add Supplier{% endif %}</h3>
     <button type="button" class="inline-flex items-center px-3 py-1.5 text-xs font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Close</button>
   </div>
-  <div class="p-4">
+  <div class="max-h-[calc(100vh-8rem)] overflow-y-auto" data-supplier-form-scroll>
     <form method="post" data-modal-form action="{% if is_edit %}{% url 'supplier_edit' supplier.supplier_id %}?partial=1{% else %}{% url 'supplier_create' %}?partial=1{% endif %}">
       {% csrf_token %}
       <input type="hidden" name="partial" value="1"/>
-      <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1">
+      <div class="grid gap-4 grid-cols-2 max-sm:grid-cols-1 p-4">
         {% for field in form %}
         {% include "components/form_field.html" with field=field container_class="col-span-2" %}
         {% endfor %}
-        <div class="col-span-2 flex flex-row-reverse flex-wrap gap-2 justify-end items-center">
-          <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">{% if is_edit %}Save{% else %}Create{% endif %}</button>
-          <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Cancel</button>
-        </div>
+      </div>
+      <div class="sticky bottom-0 border-t border-border bg-surface/95 backdrop-blur px-4 py-3 flex flex-row-reverse flex-wrap gap-2 justify-end items-center" data-supplier-form-footer>
+        <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">{% if is_edit %}Save{% else %}Create{% endif %}</button>
+        <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Cancel</button>
       </div>
     </form>
   </div>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -112,7 +112,9 @@
         <input type="hidden" name="page_size" value="{{ page_size }}" />
         <input type="hidden" name="sort" value="{{ sort }}" />
         <input type="hidden" name="direction" value="{{ direction }}" />
-        <button type="submit" title="Toggle">
+        <button type="submit"
+                title="{% if row.is_active %}Deactivate{% else %}Activate{% endif %} supplier {{ row.name }}"
+                aria-label="{% if row.is_active %}Deactivate{% else %}Activate{% endif %} supplier {{ row.name }}">
           {% if row.is_active %}
           {% icon 'check' 'w-5 h-5 text-success' %}
           <span class="sr-only">Deactivate</span>
@@ -130,7 +132,8 @@
                 data-modal-type="drawer"
                 data-modal-prefetch="hover"
                 class="text-gray-500 hover:text-primary"
-                title="View">
+                title="View supplier {{ row.name }}"
+                aria-label="View supplier {{ row.name }}">
           {% icon 'eye' 'w-5 h-5' %}
           <span class="sr-only">View</span>
         </button>
@@ -140,7 +143,8 @@
           data-modal-type="drawer"
           data-modal-prefetch="hover"
           class="text-primary"
-          title="Edit"
+          title="Edit supplier {{ row.name }}"
+          aria-label="Edit supplier {{ row.name }}"
         >
           {% icon 'pencil-square' 'w-5 h-5' %}
           <span class="sr-only">Edit</span>
@@ -148,7 +152,8 @@
         <button type="button"
                 onclick="confirmDelete('{% url 'supplier_delete' row.supplier_id %}', '{{ row.name|escapejs }}', 'Supplier')"
                 class="text-danger hover:text-danger"
-                title="Delete">
+                title="Delete supplier {{ row.name }}"
+                aria-label="Delete supplier {{ row.name }}">
           {% icon 'trash' 'w-5 h-5' %}
           <span class="sr-only">Delete</span>
         </button>

--- a/tests/test_supplier_form.py
+++ b/tests/test_supplier_form.py
@@ -1,4 +1,5 @@
 import pytest
+from bs4 import BeautifulSoup
 from django.template.loader import render_to_string
 from django.urls import reverse
 
@@ -30,10 +31,68 @@ def test_supplier_form_partial_renders_all_fields():
         assert f'name="{field}"' in content
 
 
+def test_supplier_form_marks_required_fields_and_keeps_contact_inputs_empty():
+    form = SupplierForm()
+    content = render_to_string(
+        "inventory/_supplier_form_partial.html",
+        {"form": form, "is_edit": False},
+    )
+    soup = BeautifulSoup(content, "html.parser")
+
+    assert "Name*" in soup.get_text("", strip=True)
+    assert "Contact person*" in soup.get_text("", strip=True)
+
+    phone = soup.find("input", {"name": "phone"})
+    email = soup.find("input", {"name": "email"})
+    assert phone is not None
+    assert email is not None
+    assert not phone.get("placeholder")
+    assert not email.get("placeholder")
+    assert not phone.get("value")
+    assert not email.get("value")
+
+
+def test_supplier_form_footer_stays_visible_while_form_scrolls():
+    form = SupplierForm()
+    content = render_to_string(
+        "inventory/_supplier_form_partial.html",
+        {"form": form, "is_edit": False},
+    )
+    soup = BeautifulSoup(content, "html.parser")
+
+    scroll_area = soup.select_one("[data-supplier-form-scroll]")
+    footer = soup.select_one("[data-supplier-form-footer]")
+    assert scroll_area is not None
+    assert "overflow-y-auto" in scroll_area.get("class", [])
+    assert footer is not None
+    assert "sticky" in footer.get("class", [])
+
+
+@pytest.mark.django_db
+def test_supplier_table_action_icons_have_descriptive_labels(client):
+    Supplier.objects.create(name="Lima Produce")
+
+    response = client.get(reverse("suppliers_table"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    for label in [
+        "Deactivate supplier Lima Produce",
+        "View supplier Lima Produce",
+        "Edit supplier Lima Produce",
+        "Delete supplier Lima Produce",
+    ]:
+        assert f'title="{label}"' in content
+        assert f'aria-label="{label}"' in content
+
+
 @pytest.mark.django_db
 def test_supplier_edit_view_returns_json(client):
-    supplier = Supplier.objects.create(name="Old")
+    supplier = Supplier.objects.create(name="Old", contact_person="Original Contact")
     url = reverse("supplier_edit", args=[supplier.pk])
-    resp = client.post(url, {"name": "New", "is_active": True})
+    resp = client.post(
+        url,
+        {"name": "New", "contact_person": "Updated Contact", "is_active": True},
+    )
     assert resp.status_code == 200
     assert resp.json()["ok"] is True


### PR DESCRIPTION
## Summary

- Marks supplier Name and Contact person as required in the shared form-field rendering.
- Removes hardcoded Phone and Email placeholders so new supplier forms start empty.
- Makes the supplier drawer easier to use by adding a scrollable body with sticky Save/Cancel actions.
- Adds descriptive titles and aria labels to supplier table action icons.

## Impact

Users can see which supplier fields are required, enter phone/email from a blank state, keep the save action visible while scrolling the drawer, and identify icon actions through accessible labels/tooltips.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_supplier_form.py tests\test_item_form.py tests\test_items_table_accessibility.py` -> 18 passed
- `.\.venv\Scripts\python.exe -m pytest tests\test_supplier_service_django.py tests\test_ui_authenticated_smoke.py -k "supplier or suppliers"` -> 21 passed, 2 skipped
- `.\.venv\Scripts\python.exe -m ruff check inventory\forms\supplier_forms.py tests\test_supplier_form.py` -> passed