### PR TITLE
[codex] fix recipe workflow validation

### DIFF
--- a/inventory/forms/recipe_forms.py
+++ b/inventory/forms/recipe_forms.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 
 from django import forms
+from django.forms.models import BaseInlineFormSet
 
 from ..models import Item, Recipe, RecipeItem
 from ..services.form_service import FormService
@@ -181,6 +182,17 @@ class RecipeForm(StyledFormMixin, forms.ModelForm):
             return ini
         return Recipe.Type.FINAL
 
+    def clean_name(self):
+        name = (self.cleaned_data.get("name") or "").strip()
+        if not name:
+            return name
+        duplicate_qs = Recipe.objects.filter(name=name)
+        if self.instance and self.instance.pk:
+            duplicate_qs = duplicate_qs.exclude(pk=self.instance.pk)
+        if duplicate_qs.exists():
+            raise forms.ValidationError("A recipe with this name already exists.")
+        return name
+
     def clean(self):
         cleaned_data = super().clean()
         combined = cleaned_data.get("description_and_plating", "")
@@ -232,12 +244,15 @@ class RecipeItemForm(StyledFormMixin, forms.ModelForm):
         choices=[],
         widget=IngredientSelect(
             attrs={
-                "data-placeholder": "Select ingredient",
+                "class": INPUT_CLASS + " predictive",
+                "data-min-chars": "2",
+                "data-placeholder": "Type 2+ chars to search ingredients",
             }
         ),
         label="Ingredient",
     )
     quantity = forms.DecimalField(
+        required=False,
         min_value=0.01,
         decimal_places=2,
         widget=forms.NumberInput(
@@ -266,6 +281,7 @@ class RecipeItemForm(StyledFormMixin, forms.ModelForm):
         label="Unit",
     )
     loss_pct = forms.DecimalField(
+        required=False,
         initial=0,
         min_value=0,
         max_value=100,
@@ -394,10 +410,34 @@ class RecipeItemForm(StyledFormMixin, forms.ModelForm):
         return instance
 
 
+class BaseRecipeItemFormSet(BaseInlineFormSet):
+    def clean(self):
+        super().clean()
+        if any(self.errors):
+            return
+
+        has_positive_ingredient = False
+        for form in self.forms:
+            cleaned = getattr(form, "cleaned_data", {})
+            if not cleaned or cleaned.get("DELETE"):
+                continue
+            has_ingredient = bool(cleaned.get("item") or cleaned.get("sub_recipe"))
+            quantity = cleaned.get("quantity")
+            if has_ingredient and quantity is not None and quantity > 0:
+                has_positive_ingredient = True
+                break
+
+        if not has_positive_ingredient:
+            raise forms.ValidationError(
+                "Add at least one ingredient with a positive quantity."
+            )
+
+
 RecipeItemFormSet = forms.inlineformset_factory(
     Recipe,
     RecipeItem,
     form=RecipeItemForm,
+    formset=BaseRecipeItemFormSet,
     fk_name="recipe",
     fields=["ingredient", "quantity", "unit", "loss_pct"],
     extra=1,
@@ -408,6 +448,7 @@ RecipeItemEditFormSet = forms.inlineformset_factory(
     Recipe,
     RecipeItem,
     form=RecipeItemForm,
+    formset=BaseRecipeItemFormSet,
     fk_name="recipe",
     fields=["ingredient", "quantity", "unit", "loss_pct"],
     extra=0,

--- a/static/js/predictive-dropdown.js
+++ b/static/js/predictive-dropdown.js
@@ -97,6 +97,10 @@
 
     const emptyOption = rawOptions.find((o) => !o.value && !o.disabled);
     const options = rawOptions.filter((o) => o.value && !o.disabled);
+    const minChars = Math.max(
+      0,
+      parseInt(originalSelect.getAttribute("data-min-chars") || "0", 10) || 0,
+    );
 
     // Placeholder
     const attrPlaceholder =
@@ -153,10 +157,22 @@
       dropdown.style.width = rect.width + "px";
     }
 
+    function searchOptions(query) {
+      const q = String(query || "").toLowerCase();
+      if (minChars && q.trim().length < minChars) {
+        renderOptions([]);
+        return;
+      }
+      renderOptions(options.filter((o) => o.text.toLowerCase().includes(q)));
+    }
+
     // Input typing behavior
     textInput.addEventListener("input", (e) => {
-      const q = e.target.value.toLowerCase();
-      const filtered = options.filter((o) => o.text.toLowerCase().includes(q));
+      const q = e.target.value;
+      const canSearch = !minChars || q.trim().length >= minChars;
+      const filtered = canSearch
+        ? options.filter((o) => o.text.toLowerCase().includes(q.toLowerCase()))
+        : [];
       renderOptions(filtered);
       dropdown.classList.remove("hidden");
 
@@ -195,7 +211,7 @@
     });
 
     textInput.addEventListener("focus", () => {
-      renderOptions(options);
+      searchOptions(textInput.value);
       dropdown.classList.remove("hidden");
       document.body.appendChild(dropdown);
       // Reposition on scroll/resize

--- a/static/js/recipe-components.js
+++ b/static/js/recipe-components.js
@@ -122,6 +122,73 @@
     return row.querySelector('input[id$="-unit_display"]');
   }
 
+  function recipeHasPositiveIngredientLine(form) {
+    var selects = Array.from(
+      form.querySelectorAll('select[name^="items-"][name$="-ingredient"]'),
+    );
+    return selects.some(function (select) {
+      var row = select.closest("tr");
+      if (!row || row.id === "items-empty-row" || row.classList.contains("hidden")) {
+        return false;
+      }
+      var deleteField = row.querySelector('input[id$="-DELETE"]');
+      if (deleteField && deleteField.checked) {
+        return false;
+      }
+      if (!String(select.value || "").trim()) {
+        return false;
+      }
+      var baseName = String(select.name || "").replace(/-ingredient$/, "");
+      var qty = form.querySelector('input[name="' + baseName + '-quantity"]');
+      return qty && toNumber(qty.value) > 0;
+    });
+  }
+
+  function setRecipeLineRequirement(form, shouldShow) {
+    var alert = form.querySelector("[data-recipe-line-error]");
+    if (!alert) {
+      return;
+    }
+    if (shouldShow) {
+      alert.classList.remove("hidden");
+    } else {
+      alert.classList.add("hidden");
+    }
+  }
+
+  function bindRecipeLineRequirement(form) {
+    if (!form || form.dataset.recipeLineRequirementBound === "1") {
+      return;
+    }
+    if (!form.hasAttribute("data-requires-line-items")) {
+      return;
+    }
+    form.dataset.recipeLineRequirementBound = "1";
+    form.addEventListener("submit", function (event) {
+      if (recipeHasPositiveIngredientLine(form)) {
+        setRecipeLineRequirement(form, false);
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      setRecipeLineRequirement(form, true);
+      var alert = form.querySelector("[data-recipe-line-error]");
+      if (alert) {
+        alert.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+    });
+    form.addEventListener("input", function () {
+      if (recipeHasPositiveIngredientLine(form)) {
+        setRecipeLineRequirement(form, false);
+      }
+    });
+    form.addEventListener("change", function () {
+      if (recipeHasPositiveIngredientLine(form)) {
+        setRecipeLineRequirement(form, false);
+      }
+    });
+  }
+
   function setSubRecipeBadgeVisible(row, show) {
     var badge = row.querySelector("[data-recipe-sub-badge]");
     if (!badge) {
@@ -749,6 +816,7 @@
     }
 
     table.dataset.recipeInitialized = "1";
+    bindRecipeLineRequirement(table.closest("form"));
 
     var totalForms = scope.querySelector("#id_items-TOTAL_FORMS");
     var emptyRow = scope.querySelector("#items-empty-row");

--- a/templates/inventory/recipes/_components_form_table.html
+++ b/templates/inventory/recipes/_components_form_table.html
@@ -14,6 +14,9 @@
   {% for cform in formset.forms %}
   <tr class="form-row" data-form-index="{{ forloop.counter0 }}" data-recipe-row="true" data-has-item="0" data-quantity="0" data-cost-per-base-unit="0">
     <td class="px-3 py-2">
+      {% for hidden in cform.hidden_fields %}
+        <div class="hidden">{{ hidden }}</div>
+      {% endfor %}
       <div class="min-w-[12rem] flex flex-col gap-1">
         <span class="hidden self-start rounded px-1.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide bg-info-soft text-info-text" data-recipe-sub-badge>Sub-recipe</span>
         {% include "components/form_field_table.html" with field=cform.ingredient %}
@@ -37,6 +40,9 @@
   <!-- empty form template row -->
   <tr class="form-row hidden" id="items-empty-row" data-recipe-row="true" data-has-item="0" data-quantity="0" data-cost-per-base-unit="0">
     <td class="px-3 py-2">
+      {% for hidden in formset.empty_form.hidden_fields %}
+        <div class="hidden">{{ hidden }}</div>
+      {% endfor %}
       <div class="min-w-[12rem] flex flex-col gap-1">
         <span class="hidden self-start rounded px-1.5 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide bg-info-soft text-info-text" data-recipe-sub-badge>Sub-recipe</span>
         {% include "components/form_field_table.html" with field=formset.empty_form.ingredient %}

--- a/templates/inventory/recipes/_form_partial.html
+++ b/templates/inventory/recipes/_form_partial.html
@@ -46,6 +46,9 @@
         {% endfor %}
       </ul>
       {% endif %}
+      <div class="hidden rounded-md border border-danger bg-danger/10 px-3 py-2 text-sm text-danger" data-recipe-line-error role="alert">
+        Add at least one ingredient with a positive quantity.
+      </div>
       {% include "inventory/recipes/_components_form_table.html" with formset=formset table_id="items-table" %}
       <div class="mt-3 flex items-center justify-between">
         <button type="button" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" data-modal-close>Cancel</button>

--- a/templates/inventory/recipes/detail.html
+++ b/templates/inventory/recipes/detail.html
@@ -9,7 +9,7 @@
 {% block form_summary %}
   <p class="text-sm text-gray-600">Capture ingredients and yields to keep production aligned.</p>
 {% endblock %}
-{% block form_attrs %}id="recipe-form"{% endblock %}
+{% block form_attrs %}id="recipe-form" data-requires-line-items{% endblock %}
 {% block fields %}
   <div class="space-y-4">
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between rounded-2xl border border-border bg-surfaceSubtle px-4 py-3">
@@ -54,6 +54,9 @@
     {% endfor %}
   </ul>
   {% endif %}
+  <div class="hidden rounded-md border border-danger bg-danger/10 px-3 py-2 text-sm text-danger" data-recipe-line-error role="alert">
+    Add at least one ingredient with a positive quantity.
+  </div>
   {% include "inventory/recipes/_components_form_table.html" with formset=formset table_id="items-table" %}
   <div class="mt-2">
     <button type="button" id="add-row" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Add Item</button>

--- a/tests/js/predictive-dropdown.test.js
+++ b/tests/js/predictive-dropdown.test.js
@@ -9,7 +9,7 @@ describe("predictive dropdown", () => {
         <option value="b">Beta</option>
       </select>`;
     jest.isolateModules(() => {
-      require("./predictive-dropdown.js");
+      require("../../static/js/predictive-dropdown.js");
     });
     document.dispatchEvent(new Event("DOMContentLoaded"));
   });
@@ -33,5 +33,32 @@ describe("predictive dropdown", () => {
     document.body.appendChild(wrapper);
     wrapper.dispatchEvent(new Event("htmx:afterSwap", { bubbles: true }));
     expect(wrapper.querySelector("#dept_text")).not.toBeNull();
+  });
+
+  test("waits for the configured minimum search length before showing suggestions", () => {
+    document.body.innerHTML = `
+      <select id="ingredient" class="predictive" data-min-chars="2">
+        <option value="">Type 2+ chars</option>
+        <option value="i:1">Flour</option>
+        <option value="i:2">Fish</option>
+      </select>`;
+
+    window.initPredictiveDropdowns(document);
+
+    const input = document.getElementById("ingredient_text");
+    input.focus();
+    input.dispatchEvent(new Event("focus"));
+    let dropdown = document.querySelector(".predictive-dropdown-list");
+    expect(dropdown.querySelectorAll(".predictive-dropdown-option")).toHaveLength(0);
+
+    input.value = "f";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(dropdown.querySelectorAll(".predictive-dropdown-option")).toHaveLength(0);
+
+    input.value = "fl";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    dropdown = document.querySelector(".predictive-dropdown-list");
+    expect(dropdown.querySelectorAll(".predictive-dropdown-option")).toHaveLength(1);
+    expect(dropdown.textContent).toContain("Flour");
   });
 });

--- a/tests/js/recipe-components.test.js
+++ b/tests/js/recipe-components.test.js
@@ -20,7 +20,7 @@ describe("recipe cost helpers", () => {
       </div>`;
 
     jest.isolateModules(() => {
-      require("./recipe-components.js");
+      require("../../static/js/recipe-components.js");
     });
   });
 

--- a/tests/test_recipe_drawer.py
+++ b/tests/test_recipe_drawer.py
@@ -51,6 +51,43 @@ def test_recipe_create_partial_invalid_ajax_returns_json(client, item_factory):
 
 
 @pytest.mark.django_db
+def test_recipe_create_partial_requires_positive_ingredient_row(client):
+    url = reverse("recipe_create_partial")
+    data = {
+        "name": "No Ingredient Recipe",
+        "description_and_plating": "",
+        "is_active": "on",
+        "type": Recipe.Type.FINAL,
+        "default_yield_qty": "1",
+        "default_yield_unit": "portion",
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "0",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-ingredient": "",
+        "items-0-quantity": "",
+        "items-0-unit": "",
+        "items-0-unit_display": "",
+        "items-0-loss_pct": "",
+        "items-0-DELETE": "",
+    }
+
+    response = client.post(
+        url,
+        data,
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["errors"]["formset_non_form"] == [
+        "Add at least one ingredient with a positive quantity."
+    ]
+    assert not Recipe.objects.filter(name="No Ingredient Recipe").exists()
+
+
+@pytest.mark.django_db
 def test_recipe_create_partial_invalid_non_ajax_returns_html(client, item_factory):
     item = item_factory(name="Flour")
     url = reverse("recipe_create_partial")
@@ -424,6 +461,75 @@ def test_recipe_edit_partial_drawer_header_prefills_thumbnail_and_notes(client):
     )
     assert toggle is not None
     assert not toggle.has_attr("checked")
+
+
+@pytest.mark.django_db
+def test_recipe_edit_partial_renders_hidden_ingredient_ids(client, item_factory):
+    item = item_factory(name="Hidden Id Flour")
+    recipe = Recipe.objects.create(name="Hidden Id Bread", is_active=True)
+    recipe_item = RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=Decimal("1"),
+        unit="kg",
+        loss_pct=Decimal("0"),
+    )
+
+    response = client.get(reverse("recipe_edit_partial", args=[recipe.pk]))
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.content, "html.parser")
+    hidden_id = soup.find("input", {"name": "items-0-id"})
+    assert hidden_id is not None
+    assert hidden_id["value"] == str(recipe_item.pk)
+
+
+@pytest.mark.django_db
+def test_recipe_edit_partial_allows_unchanged_recipe_name(client, item_factory):
+    item = item_factory(name="Edit Same Flour")
+    recipe = Recipe.objects.create(
+        name="Edit Same Bread",
+        is_active=True,
+        type=Recipe.Type.FINAL,
+        default_yield_qty=Decimal("1"),
+        default_yield_unit="portion",
+    )
+    recipe_item = RecipeItem.objects.create(
+        recipe=recipe,
+        item=item,
+        quantity=Decimal("1"),
+        unit="kg",
+        loss_pct=Decimal("0"),
+    )
+    data = {
+        "name": recipe.name,
+        "description_and_plating": "",
+        "is_active": "on",
+        "type": recipe.type,
+        "default_yield_qty": "1",
+        "default_yield_unit": "portion",
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "1",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-id": str(recipe_item.pk),
+        "items-0-ingredient": f"i:{item.pk}",
+        "items-0-quantity": "2",
+        "items-0-unit": "kg",
+        "items-0-unit_display": "kg",
+        "items-0-loss_pct": "0",
+        "items-0-DELETE": "",
+    }
+
+    response = client.post(
+        reverse("recipe_edit_partial", args=[recipe.pk]),
+        data,
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+
+    assert response.status_code == 200
+    saved_line = recipe.items.get()
+    assert saved_line.quantity == Decimal("2")
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What changed

- Enforced that recipe create/edit formsets include at least one non-deleted ingredient or sub-recipe row with a positive quantity.
- Added an in-form pre-submit message for the same ingredient requirement in drawer and full-page recipe forms.
- Upgraded recipe ingredient selection to the existing predictive dropdown pattern with suggestions after two typed characters.
- Rendered inline formset hidden IDs so editing existing ingredient rows no longer raises `Id: This field is required`.
- Tightened recipe name uniqueness validation so editing a recipe with its unchanged name is allowed while true duplicate names are still rejected.

## Why

Recipe creation could be attempted without valid ingredient rows, ingredient selection was difficult on larger item lists, and edit submissions could fail because existing row IDs were not posted back. The uniqueness check also needed to distinguish the current recipe from a real name collision.

## Validation

- `./.venv/Scripts/python.exe -m pytest tests/test_recipe_drawer.py -q` -> 18 passed
- `npm.cmd test -- recipe-components.test.js predictive-dropdown.test.js --runInBand` -> 2 suites passed, 4 tests passed
- `./.venv/Scripts/python.exe -m ruff check inventory/forms/recipe_forms.py tests/test_recipe_drawer.py` -> passed
- `./.venv/Scripts/python.exe manage.py check` -> no issues

Full Python suite was not run because the repo has known unrelated pre-existing failures.