### PR TITLE
[codex] fix indent item validation and fulfilment

### DIFF
--- a/inventory/forms/indent_forms.py
+++ b/inventory/forms/indent_forms.py
@@ -150,6 +150,23 @@ class IndentItemForm(ItemNameResolutionMixin, StyledFormMixin, forms.ModelForm):
 
 
 class _IndentItemFormSetBase(forms.BaseInlineFormSet):
+    def clean(self):
+        super().clean()
+        if any(self.errors):
+            return
+
+        has_item = False
+        for form in self.forms:
+            cleaned = getattr(form, "cleaned_data", {}) or {}
+            if cleaned.get("DELETE"):
+                continue
+            if cleaned.get("item") and cleaned.get("requested_qty"):
+                has_item = True
+                break
+
+        if not has_item:
+            raise forms.ValidationError("Add at least one item to the indent.")
+
     def save(self, commit=True):
         instances = super().save(commit=False)
         # Default issued_qty to 0 for all instances to satisfy NOT NULL constraints

--- a/inventory/services/indent_issue_service.py
+++ b/inventory/services/indent_issue_service.py
@@ -61,20 +61,21 @@ def issue_indent(indent_id: int, lines: Iterable[IssueLine], user) -> IssueResul
     - Marks Indent COMPLETED when fully issued
     """
 
-    indent = Indent.objects.select_for_update(of=("self",)).get(pk=indent_id)
     uname, uid = _user_ident(user)
-
-    # Fetch all relevant IndentItems and Items in bulk
-    by_id = {
-        ii.indent_item_id: ii
-        for ii in IndentItem.objects.select_for_update()
-        .select_related("item")
-        .filter(indent_id=indent_id)
-    }
 
     updated = 0
     skipped_reasons: list[str] = []
     with transaction.atomic():
+        indent = Indent.objects.select_for_update(of=("self",)).get(pk=indent_id)
+        # Fetch all relevant IndentItems and Items in bulk after entering the
+        # transaction so row locks are valid on PostgreSQL.
+        by_id = {
+            ii.indent_item_id: ii
+            for ii in IndentItem.objects.select_for_update()
+            .select_related("item")
+            .filter(indent_id=indent_id)
+        }
+
         for line in lines:
             qty = _as_decimal(getattr(line, "issue_qty", 0))
             if qty is None or qty <= 0:

--- a/templates/inventory/_indent_create_partial.html
+++ b/templates/inventory/_indent_create_partial.html
@@ -40,6 +40,7 @@
       </datalist>
       {% endif %}
       {{ formset.management_form }}
+      <div data-line-items-error class="mt-3 text-sm text-danger hidden" role="alert"></div>
       {% if formset.non_form_errors %}
       <ul class="text-danger list-disc pl-5">
         {% for error in formset.non_form_errors %}
@@ -173,7 +174,8 @@
         });
         if (submitBtn) submitBtn.disabled = !!hasDup;
       }
-      function ensureHiddenIdsOnSubmit(){ const form=document.getElementById('indent-form'); if(!form||form._boundSubmit) return; form._boundSubmit=true; form.addEventListener('submit', function(ev){ let invalid=false; const inputs=form.querySelectorAll('input[name^="items-"][name$="-item"]'); inputs.forEach((itemInput)=>{ const listId=itemInput.getAttribute('list'); const list=listId?document.getElementById(listId):null; const typed=(itemInput.value||'').trim(); let id=''; if(list){ const opts=Array.from(list.querySelectorAll('option')); const match=opts.find(o=>((o.value||'').trim().toLowerCase()===typed.toLowerCase())||((o.textContent||'').trim().toLowerCase()===typed.toLowerCase())); if(match) id=match.dataset.id||match.getAttribute('data-id')||''; } if(!id){ const m=typed.match(/^(\d+)\s*-|\(\s*id\s*[:#-]?\s*(\d+)\s*\)$/i); if(m) id=m[1]||m[2]||''; }
+      function setLineItemsError(message){ const box=document.querySelector('[data-line-items-error]'); if(!box) return; if(message){ box.textContent=message; box.classList.remove('hidden'); } else { box.textContent=''; box.classList.add('hidden'); } }
+      function ensureHiddenIdsOnSubmit(){ const form=document.getElementById('indent-form'); if(!form||form._boundSubmit) return; form._boundSubmit=true; form.addEventListener('submit', function(ev){ let invalid=false; const inputs=form.querySelectorAll('input[name^="items-"][name$="-item"]'); const hasTypedItem=Array.from(inputs).some((itemInput)=>(itemInput.value||'').trim()); if(!hasTypedItem){ invalid=true; setLineItemsError('Add at least one item to the indent.'); } else { setLineItemsError(''); } inputs.forEach((itemInput)=>{ const listId=itemInput.getAttribute('list'); const list=listId?document.getElementById(listId):null; const typed=(itemInput.value||'').trim(); let id=''; if(list){ const opts=Array.from(list.querySelectorAll('option')); const match=opts.find(o=>((o.value||'').trim().toLowerCase()===typed.toLowerCase())||((o.textContent||'').trim().toLowerCase()===typed.toLowerCase())); if(match) id=match.dataset.id||match.getAttribute('data-id')||''; } if(!id){ const m=typed.match(/^(\d+)\s*-|\(\s*id\s*[:#-]?\s*(\d+)\s*\)$/i); if(m) id=m[1]||m[2]||''; }
           const err=itemInput.closest('div')?.querySelector('[data-item-error]'); if(!typed){ if(err){ err.classList.add('hidden'); } return; } if(!id){ invalid=true; if(err){ err.textContent='Choose a valid item from the list.'; err.classList.remove('hidden'); } return; }
           let hidden=form.querySelector(`input[type="hidden"][data-item-hidden-for='${itemInput.name}']`); if(!hidden){ hidden=document.createElement('input'); hidden.type='hidden'; hidden.setAttribute('data-item-hidden-for', itemInput.name); form.appendChild(hidden); }
           hidden.name=itemInput.name; hidden.value=id; if(!itemInput.dataset.originalName) itemInput.dataset.originalName=itemInput.name; itemInput.name=itemInput.dataset.originalName + '_display'; setTimeout(()=>{ itemInput.name=itemInput.dataset.originalName; }, 0);

--- a/tests/test_indent_forms.py
+++ b/tests/test_indent_forms.py
@@ -1,6 +1,7 @@
 import pytest
 
 from inventory.forms.indent_forms import IndentForm, IndentItemForm, IndentItemFormSet
+from inventory.models import Department
 from inventory.models.enums import IndentStatus
 
 
@@ -34,6 +35,24 @@ def test_indent_form_and_formset_save(item_factory):
     assert indent.status == IndentStatus.SUBMITTED
     assert indent.indentitem_set.count() == 1
     assert indent.indentitem_set.first().item_id == item.pk
+
+
+@pytest.mark.django_db
+def test_indent_item_formset_requires_at_least_one_item():
+    Department.objects.create(name="Kitchen")
+    formset_data = {
+        "items-TOTAL_FORMS": "1",
+        "items-INITIAL_FORMS": "0",
+        "items-MIN_NUM_FORMS": "0",
+        "items-MAX_NUM_FORMS": "1000",
+        "items-0-item": "",
+        "items-0-requested_qty": "",
+        "items-0-notes": "",
+    }
+    formset = IndentItemFormSet(formset_data, prefix="items")
+
+    assert not formset.is_valid()
+    assert formset.non_form_errors() == ["Add at least one item to the indent."]
 
 
 @pytest.mark.django_db

--- a/tests/test_indent_issue_service.py
+++ b/tests/test_indent_issue_service.py
@@ -1,0 +1,60 @@
+from decimal import Decimal
+
+import pytest
+from django.db import transaction
+
+from inventory.models import Indent, IndentItem, StockTransaction
+from inventory.services import indent_issue_service
+
+
+@pytest.mark.django_db(transaction=True)
+def test_issue_indent_locks_indent_inside_atomic_without_source_or_department(
+    item_factory, django_user_model, monkeypatch
+):
+    user = django_user_model.objects.create_user(username="issuer")
+    item = item_factory(name="Issue Rice", current_stock=Decimal("5.00"))
+    indent = Indent.objects.create(
+        mrn="MRN-ISSUE-001",
+        requested_by="Chef",
+        department=None,
+        status="APPROVED",
+    )
+    indent_item = IndentItem.objects.create(
+        indent=indent,
+        item=item,
+        requested_qty=Decimal("2.00"),
+        issued_qty=Decimal("0.00"),
+    )
+    original_select_for_update = Indent.objects.select_for_update
+
+    def guarded_select_for_update(*args, **kwargs):
+        assert transaction.get_connection().in_atomic_block
+        return original_select_for_update(*args, **kwargs)
+
+    monkeypatch.setattr(Indent.objects, "select_for_update", guarded_select_for_update)
+
+    result = indent_issue_service.issue_indent(
+        indent.indent_id,
+        [
+            indent_issue_service.IssueLine(
+                indent_item_id=indent_item.indent_item_id,
+                issue_qty=Decimal("2.00"),
+                source_location="",
+            )
+        ],
+        user,
+    )
+
+    assert result.ok
+    item.refresh_from_db()
+    indent_item.refresh_from_db()
+    indent.refresh_from_db()
+    assert item.current_stock == Decimal("3.00")
+    assert indent_item.issued_qty == Decimal("2.00")
+    assert indent.status == "COMPLETED"
+    assert StockTransaction.objects.filter(
+        item=item,
+        transaction_type="ISSUE",
+        related_indent=indent,
+        quantity_change=Decimal("-2.00"),
+    ).exists()


### PR DESCRIPTION
## Summary

- Require at least one valid item line before a new indent can be submitted.
- Show a clear line-item error in the New Indent drawer before an empty submit.
- Move indent fulfilment row locks inside the atomic transaction so PostgreSQL issue processing does not 500.
- Add regression coverage for empty indent validation and issuing stock with blank source and no department.

## Root Cause

Blank extra formset rows were treated as valid, allowing empty indents. The fulfilment service also called `select_for_update()` before entering `transaction.atomic()`, which can fail on PostgreSQL even when source/department data is blank but otherwise acceptable.

## Validation

- `python -m pytest tests/test_indent_forms.py tests/test_indent_issue_service.py tests/test_aa_views.py::test_indent_create_atomic_on_error` -> 6 passed
- `python -m ruff check inventory/forms/indent_forms.py inventory/services/indent_issue_service.py tests/test_indent_forms.py tests/test_indent_issue_service.py` -> passed