### PR TITLE
[codex] stabilize purchase order creation

### DIFF
--- a/inventory/forms/purchase_forms.py
+++ b/inventory/forms/purchase_forms.py
@@ -37,7 +37,7 @@ def _resolve_supplier_from_raw(raw: str) -> Supplier:
     if exact:
         return exact
 
-    candidates = list(qs.filter(name__istartswith=raw)[:2])
+    candidates = list(qs.filter(name__icontains=raw).order_by("name")[:2])
     if len(candidates) == 1:
         return candidates[0]
     if len(candidates) > 1:
@@ -101,6 +101,7 @@ class PurchaseOrderForm(StyledFormMixin, forms.ModelForm):
                         "hx-trigger": "keyup changed delay:300ms",
                         "hx-target": "#supplier-options",
                         "hx-swap": "innerHTML",
+                        "hx-params": "supplier",
                         "list": "supplier-options",
                     }
                 ),
@@ -153,6 +154,8 @@ class PurchaseOrderItemForm(StyledFormMixin, forms.ModelForm):
 
     def __init__(self, *args, item_suggest_url: str | None = None, **kwargs):
         super().__init__(*args, **kwargs)
+        for field_name in ("item", "quantity_ordered", "unit_price"):
+            self.fields[field_name].widget.attrs["required"] = "required"
         self.apply_styling()
 
     def clean_quantity_ordered(self):
@@ -214,6 +217,8 @@ PurchaseOrderItemFormSet = forms.inlineformset_factory(
     PurchaseOrderItem,
     form=PurchaseOrderItemForm,
     extra=1,
+    min_num=1,
+    validate_min=True,
     can_delete=True,
 )
 

--- a/inventory/services/purchase_order_service.py
+++ b/inventory/services/purchase_order_service.py
@@ -103,9 +103,12 @@ def save_purchase_order_from_forms(
 def _validate_po_update_formset(formset: PurchaseOrderItemFormSet) -> None:
     """Prevent edits that would detach or invalidate existing receipt history."""
 
+    active_line_count = 0
     for item_form in formset.forms:
         if not getattr(item_form, "cleaned_data", None):
             continue
+        if not item_form.cleaned_data.get("DELETE"):
+            active_line_count += 1
         po_item = item_form.instance
         if not po_item.pk:
             continue
@@ -125,6 +128,10 @@ def _validate_po_update_formset(formset: PurchaseOrderItemFormSet) -> None:
                     f"quantity ({received_total})."
                 )
             )
+    if active_line_count == 0:
+        raise PurchaseOrderServiceError(
+            "Purchase Order must contain at least one item."
+        )
 
 
 def create_po(po_data: Dict[str, Any], items_data: List[Dict[str, Any]]) -> int:

--- a/inventory/views/suppliers.py
+++ b/inventory/views/suppliers.py
@@ -481,7 +481,9 @@ class SupplierSearchView(TemplateView):
                 if key.endswith("supplier"):
                     query = val
                     break
-        suppliers = Supplier.objects.filter(name__icontains=query)[:20]
+        suppliers = Supplier.objects.filter(
+            is_active=True, name__icontains=query
+        ).order_by("name")[:20]
         ctx["suppliers"] = suppliers
         return ctx
 

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -717,6 +717,10 @@
       const hiddenDept = form.querySelector("#id_department");
       const uiDept = form.querySelector("#department-ui");
       if (hiddenDept && uiDept) hiddenDept.value = uiDept.value;
+      if (typeof form.checkValidity === "function" && !form.checkValidity()) {
+        if (typeof form.reportValidity === "function") form.reportValidity();
+        return;
+      }
       if (hiddenDept && !hiddenDept.value) {
         showInlineError("Please select a department");
         if (window.notifications)

--- a/static/js/purchase-order-drawer.js
+++ b/static/js/purchase-order-drawer.js
@@ -195,6 +195,11 @@
             updateExpectedDeliveryDate(form, formsetEl, itemLeadTimes);
             return;
           }
+          row
+            .querySelectorAll("input, select, textarea")
+            .forEach(function (field) {
+              if (field !== deleteInput) field.removeAttribute("required");
+            });
           row.style.display = "none";
           updateExpectedDeliveryDate(form, formsetEl, itemLeadTimes);
         } else {

--- a/tests/js/modal-po-validation.test.js
+++ b/tests/js/modal-po-validation.test.js
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+
+describe("modal purchase order validation", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div id="modal-root" class="hidden"><div id="modal-content"></div></div>
+      <form id="po-drawer-form" data-modal-form data-requires-line-items action="/purchase-orders/create/partial/">
+        <input name="csrfmiddlewaretoken" value="token" />
+        <input name="supplier" required value="" />
+        <input name="order_date" required value="" />
+        <div id="items-formset">
+          <select name="items-0-item" required><option value=""></option></select>
+          <input name="items-0-quantity_ordered" required type="number" value="" />
+          <input name="items-0-unit_price" required type="number" value="" />
+        </div>
+      </form>`;
+    global.fetch = jest.fn();
+    window.notifications = { showToast: jest.fn() };
+    require("../../static/js/modal.js");
+  });
+
+  test("reports native required errors before posting modal form", () => {
+    const form = document.getElementById("po-drawer-form");
+    form.checkValidity = jest.fn(() => false);
+    form.reportValidity = jest.fn();
+
+    form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+
+    expect(form.checkValidity).toHaveBeenCalled();
+    expect(form.reportValidity).toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/test_purchase_order_drawer_partial.py
+++ b/tests/test_purchase_order_drawer_partial.py
@@ -10,7 +10,13 @@ import pytest
 from bs4 import BeautifulSoup
 from django.urls import reverse
 
-from inventory.models import PurchaseOrder, PurchaseOrderItem, Supplier
+from inventory.models import (
+    GoodsReceivedNote,
+    GRNItem,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    Supplier,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -49,6 +55,121 @@ def test_purchase_order_create_partial_get_has_drawer_hooks(po_staff_client):
     )
     assert grid is not None
     assert grid.find("textarea", attrs={"name": "notes"}) is None
+
+
+def test_purchase_order_create_partial_marks_required_fields(po_staff_client):
+    resp = po_staff_client.get(reverse("purchase_order_create_partial"))
+
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.content.decode(), "html.parser")
+
+    assert soup.find("input", attrs={"name": "supplier"}).has_attr("required")
+    assert soup.find("input", attrs={"name": "supplier"}).get("hx-params") == "supplier"
+    assert soup.find("input", attrs={"name": "order_date"}).has_attr("required")
+    assert soup.find("select", attrs={"name": "items-0-item"}).has_attr("required")
+    assert soup.find("input", attrs={"name": "items-0-quantity_ordered"}).has_attr(
+        "required"
+    )
+    assert soup.find("input", attrs={"name": "items-0-unit_price"}).has_attr(
+        "required"
+    )
+    assert soup.find("textarea", attrs={"name": "notes"}).get("required") is None
+
+
+def test_supplier_search_matches_partial_name_case_insensitive(po_staff_client):
+    Supplier.objects.create(name="Acme Produce", is_active=True)
+    Supplier.objects.create(name="Dormant Produce", is_active=False)
+    Supplier.objects.create(name="Paper Goods", is_active=True)
+
+    resp = po_staff_client.get(reverse("supplier_search"), {"q": "PROD"})
+
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    assert "Acme Produce" in content
+    assert "Dormant Produce" not in content
+    assert "Paper Goods" not in content
+
+
+def test_purchase_order_create_accepts_unique_supplier_substring(
+    po_staff_client, item_factory
+):
+    supplier = Supplier.objects.create(name="North Market Foods", is_active=True)
+    item = item_factory(name="PO Substring Item")
+
+    resp = po_staff_client.post(
+        reverse("purchase_order_create_partial"),
+        {
+            "partial": "1",
+            "supplier": "market",
+            "order_date": date.today().isoformat(),
+            "expected_delivery_date": "",
+            "status": "DRAFT",
+            "notes": "",
+            "items-TOTAL_FORMS": "1",
+            "items-INITIAL_FORMS": "0",
+            "items-MIN_NUM_FORMS": "1",
+            "items-MAX_NUM_FORMS": "1000",
+            "items-0-item": str(item.pk),
+            "items-0-quantity_ordered": "2.00",
+            "items-0-unit_price": "3.00",
+        },
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    po = PurchaseOrder.objects.get(pk=data["id"])
+    assert po.supplier_id == supplier.pk
+
+
+def test_purchase_order_create_rejects_numeric_unknown_supplier(
+    po_staff_client, item_factory
+):
+    item = item_factory(name="PO Numeric Supplier Item")
+
+    resp = po_staff_client.post(
+        reverse("purchase_order_create_partial"),
+        {
+            "partial": "1",
+            "supplier": "999999",
+            "order_date": date.today().isoformat(),
+            "expected_delivery_date": "",
+            "status": "DRAFT",
+            "notes": "",
+            "items-TOTAL_FORMS": "1",
+            "items-INITIAL_FORMS": "0",
+            "items-MIN_NUM_FORMS": "1",
+            "items-MAX_NUM_FORMS": "1000",
+            "items-0-item": str(item.pk),
+            "items-0-quantity_ordered": "2.00",
+            "items-0-unit_price": "3.00",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "Choose a valid supplier from the list." in resp.json()["message"]
+
+
+def test_purchase_order_create_requires_at_least_one_item(po_staff_client):
+    supplier = Supplier.objects.create(name="No Line Supplier", is_active=True)
+
+    resp = po_staff_client.post(
+        reverse("purchase_order_create_partial"),
+        {
+            "partial": "1",
+            "supplier": str(supplier.pk),
+            "order_date": date.today().isoformat(),
+            "expected_delivery_date": "",
+            "status": "DRAFT",
+            "notes": "",
+            "items-TOTAL_FORMS": "0",
+            "items-INITIAL_FORMS": "0",
+            "items-MIN_NUM_FORMS": "1",
+            "items-MAX_NUM_FORMS": "1000",
+        },
+    )
+
+    assert resp.status_code == 400
+    assert "at least" in resp.json()["message"].lower()
 
 
 def test_purchase_order_create_partial_post_validation_returns_json(po_staff_client):


### PR DESCRIPTION
## Summary
- Make PO supplier search active-only and case-insensitive for partial supplier names.
- Require supplier, order date, and at least one valid item line before PO drawer submission.
- Preserve valid supplier resolution for typed names and reject invalid numeric supplier input.

## Root cause
The drawer supplier field used a datalist-backed text input, but backend resolution only accepted exact or prefix matches while the search endpoint returned inactive suppliers too. Modal AJAX submission also bypassed native required-field reporting before posting.

## Validation
- `.\.venv\Scripts\python.exe -m ruff check inventory\forms\purchase_forms.py inventory\views\suppliers.py inventory\services\purchase_order_service.py tests\test_purchase_order_drawer_partial.py`
- `.\.venv\Scripts\python.exe -m pytest tests\test_purchase_forms.py tests\test_purchase_order_service_django.py tests\test_purchase_order_drawer_partial.py -k "not detail_actions_use_drawers"`
- `npm.cmd test -- modal-po-validation.test.js --runInBand`

## Note
The skipped `detail_actions_use_drawers` assertion appears pre-existing: the current detail template renders the Receive Goods link without drawer data attributes.
