### PR TITLE
[codex] fix stock movement validation

### DIFF
--- a/inventory/forms/stock_forms.py
+++ b/inventory/forms/stock_forms.py
@@ -83,10 +83,16 @@ ADJUSTMENT_REASONS = [
 SELECT_CLASS = INPUT_CLASS + " cursor-pointer"
 
 
-def _item_autocomplete_field(item_suggest_url: str, *, label: str = "Item"):
+def _item_autocomplete_field(
+    item_suggest_url: str,
+    *,
+    label: str = "Item",
+    required_message: str = "Choose a valid item from the list.",
+):
     return forms.CharField(
         label=label,
         required=True,
+        error_messages={"required": required_message},
         widget=forms.TextInput(
             attrs={
                 "class": INPUT_CLASS,
@@ -102,9 +108,15 @@ def _item_autocomplete_field(item_suggest_url: str, *, label: str = "Item"):
 
 
 class StockReceivingForm(ItemNameResolutionMixin, StyledFormMixin, forms.ModelForm):
+    use_required_attribute = False
+
     item = forms.ModelChoiceField(
         queryset=Item.objects.filter(is_active=True).order_by("name"),
         empty_label="— Select item —",
+        error_messages={
+            "required": "Choose an item to receive.",
+            "invalid_choice": "Choose a valid item from the list.",
+        },
         widget=forms.Select(attrs={"class": SELECT_CLASS}),
     )
     transaction_date = forms.DateField(
@@ -130,8 +142,17 @@ class StockReceivingForm(ItemNameResolutionMixin, StyledFormMixin, forms.ModelFo
     def __init__(self, *args, item_suggest_url=None, **kwargs):
         super().__init__(*args, **kwargs)
         if item_suggest_url:
-            self.fields["item"] = _item_autocomplete_field(item_suggest_url)
+            self.fields["item"] = _item_autocomplete_field(
+                item_suggest_url,
+                required_message="Choose an item to receive.",
+            )
         self.fields["quantity_change"].required = True
+        self.fields["quantity_change"].error_messages.update(
+            {
+                "required": "Enter the quantity received.",
+                "invalid": "Enter a valid quantity received.",
+            }
+        )
         self.fields["quantity_change"].widget = forms.NumberInput(
             attrs={
                 "class": INPUT_CLASS,
@@ -170,6 +191,8 @@ class StockReceivingForm(ItemNameResolutionMixin, StyledFormMixin, forms.ModelFo
 
 
 class StockAdjustmentForm(ItemNameResolutionMixin, StyledFormMixin, forms.ModelForm):
+    use_required_attribute = False
+
     item = forms.ModelChoiceField(
         queryset=Item.objects.filter(is_active=True).order_by("name"),
         empty_label="— Select item —",
@@ -207,8 +230,28 @@ class StockAdjustmentForm(ItemNameResolutionMixin, StyledFormMixin, forms.ModelF
     def __init__(self, *args, item_suggest_url=None, **kwargs):
         super().__init__(*args, **kwargs)
         if item_suggest_url:
-            self.fields["item"] = _item_autocomplete_field(item_suggest_url)
+            self.fields["item"] = _item_autocomplete_field(
+                item_suggest_url,
+                required_message="Choose an item to adjust.",
+            )
+        else:
+            self.fields["item"].error_messages.update(
+                {
+                    "required": "Choose an item to adjust.",
+                    "invalid_choice": "Choose a valid item from the list.",
+                }
+            )
+        self.fields["reason_category"].error_messages.update(
+            {"required": "Choose why this adjustment is needed."}
+        )
+        self.fields["quantity_change"].label = "Quantity Change (+/-)"
         self.fields["quantity_change"].required = True
+        self.fields["quantity_change"].error_messages.update(
+            {
+                "required": "Enter the stock change quantity.",
+                "invalid": "Enter a valid stock change quantity.",
+            }
+        )
         self.fields["quantity_change"].widget = forms.NumberInput(
             attrs={
                 "class": INPUT_CLASS,
@@ -233,6 +276,8 @@ class StockAdjustmentForm(ItemNameResolutionMixin, StyledFormMixin, forms.ModelF
 
 
 class StockWastageForm(ItemNameResolutionMixin, StyledFormMixin, forms.ModelForm):
+    use_required_attribute = False
+
     item = forms.ModelChoiceField(
         queryset=Item.objects.filter(is_active=True).order_by("name"),
         empty_label="— Select item —",
@@ -286,8 +331,27 @@ class StockWastageForm(ItemNameResolutionMixin, StyledFormMixin, forms.ModelForm
     def __init__(self, *args, item_suggest_url=None, **kwargs):
         super().__init__(*args, **kwargs)
         if item_suggest_url:
-            self.fields["item"] = _item_autocomplete_field(item_suggest_url)
+            self.fields["item"] = _item_autocomplete_field(
+                item_suggest_url,
+                required_message="Choose an item to record as wastage.",
+            )
+        else:
+            self.fields["item"].error_messages.update(
+                {
+                    "required": "Choose an item to record as wastage.",
+                    "invalid_choice": "Choose a valid item from the list.",
+                }
+            )
+        self.fields["reason_category"].error_messages.update(
+            {"required": "Choose a wastage category."}
+        )
         self.fields["quantity_change"].required = True
+        self.fields["quantity_change"].error_messages.update(
+            {
+                "required": "Enter the quantity wasted.",
+                "invalid": "Enter a valid quantity wasted.",
+            }
+        )
         self.fields["quantity_change"].widget = forms.NumberInput(
             attrs={
                 "class": INPUT_CLASS,
@@ -321,6 +385,8 @@ class StockTransferForm(StyledFormMixin, forms.Form):
     """D3: Transfer stock between departments."""
 
     from ..models import Department
+
+    use_required_attribute = False
 
     item = forms.ModelChoiceField(
         queryset=Item.objects.filter(is_active=True).order_by("name"),
@@ -363,8 +429,33 @@ class StockTransferForm(StyledFormMixin, forms.Form):
         from ..models import Department as Dept
 
         qs = Dept.objects.all().order_by("name")
+        self.fields["item"].error_messages.update(
+            {
+                "required": "Choose an item to transfer.",
+                "invalid_choice": "Choose a valid item from the list.",
+            }
+        )
+        self.fields["quantity"].error_messages.update(
+            {
+                "required": "Enter the transfer quantity.",
+                "invalid": "Enter a valid transfer quantity.",
+                "min_value": "Transfer quantity must be greater than zero.",
+            }
+        )
         self.fields["from_department"].queryset = qs
+        self.fields["from_department"].error_messages.update(
+            {
+                "required": "Choose the department stock is moving from.",
+                "invalid_choice": "Choose a valid source department.",
+            }
+        )
         self.fields["to_department"].queryset = qs
+        self.fields["to_department"].error_messages.update(
+            {
+                "required": "Choose the department stock is moving to.",
+                "invalid_choice": "Choose a valid destination department.",
+            }
+        )
         self.apply_styling()
 
     def clean(self):

--- a/inventory/views/stock.py
+++ b/inventory/views/stock.py
@@ -387,6 +387,10 @@ def stock_movements(request):
     params = request.GET.copy()
     params.pop("page", None)
     query_string = params.urlencode()
+    date_clear_params = params.copy()
+    date_clear_params.pop("date_from", None)
+    date_clear_params.pop("date_to", None)
+    date_clear_query_string = date_clear_params.urlencode()
 
     total_transactions = qs.count()
     pending_orders = PurchaseOrder.objects.filter(status__in=["SENT"]).count()
@@ -428,6 +432,7 @@ def stock_movements(request):
         "pending_orders": pending_orders,
         "filter_date_from": date_from,
         "filter_date_to": date_to,
+        "date_clear_query_string": date_clear_query_string,
         "filter_item_q": item_q,
         "filter_type": tx_type_filter,
     }

--- a/templates/inventory/_adjust_form_modal.html
+++ b/templates/inventory/_adjust_form_modal.html
@@ -1,7 +1,20 @@
-<form method="post" action="" class="space-y-3">
+<form method="post" action="" class="space-y-4">
   {% csrf_token %}
   <input type="hidden" name="submit_adjust" value="1" />
-  {{ adjust_form.as_p }}
+  {% if adjust_form.non_field_errors %}
+    <ul class="text-sm text-danger list-disc pl-5">
+      {% for error in adjust_form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+  {% endif %}
+  <div class="grid gap-4 md:grid-cols-2">
+    {% for field in adjust_form %}
+      {% if field.name == "notes" %}
+        {% include "components/form_field.html" with field=field container_class="md:col-span-2" %}
+      {% else %}
+        {% include "components/form_field.html" with field=field %}
+      {% endif %}
+    {% endfor %}
+  </div>
   <div class="flex items-center justify-end gap-2">
     <button type="button" data-close class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Cancel</button>
     <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">Save</button>

--- a/templates/inventory/_receive_form_modal.html
+++ b/templates/inventory/_receive_form_modal.html
@@ -1,7 +1,20 @@
-<form method="post" action="" class="space-y-3">
+<form method="post" action="" class="space-y-4">
   {% csrf_token %}
   <input type="hidden" name="submit_receive" value="1" />
-  {{ receive_form.as_p }}
+  {% if receive_form.non_field_errors %}
+    <ul class="text-sm text-danger list-disc pl-5">
+      {% for error in receive_form.non_field_errors %}<li>{{ error }}</li>{% endfor %}
+    </ul>
+  {% endif %}
+  <div class="grid gap-4 md:grid-cols-2">
+    {% for field in receive_form %}
+      {% if field.name == "notes" %}
+        {% include "components/form_field.html" with field=field container_class="md:col-span-2" %}
+      {% else %}
+        {% include "components/form_field.html" with field=field %}
+      {% endif %}
+    {% endfor %}
+  </div>
   <div class="flex items-center justify-end gap-2">
     <button type="button" data-close class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Cancel</button>
     <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">Record</button>

--- a/templates/inventory/_recent_transactions_table.html
+++ b/templates/inventory/_recent_transactions_table.html
@@ -20,6 +20,9 @@
       <input type="date" name="date_to" value="{{ filter_date_to|default:'' }}"
              class="px-3 py-1.5 text-sm border border-border rounded-md bg-surface text-bodyText focus:outline-none focus:ring-2 focus:ring-primary" />
       <button type="submit" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Filter</button>
+      {% if filter_date_from or filter_date_to %}
+      <a href="{% url 'stock_movements' %}{% if date_clear_query_string %}?{{ date_clear_query_string }}{% endif %}" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Clear dates</a>
+      {% endif %}
       {% if filter_item_q or filter_type or filter_date_from or filter_date_to %}
       <a href="{% url 'stock_movements' %}" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary">Clear</a>
       {% endif %}

--- a/templates/inventory/stock_movements.html
+++ b/templates/inventory/stock_movements.html
@@ -81,7 +81,7 @@
       </div>
     </div>
     <div class="p-4">
-  {% include "inventory/_recent_transactions_table.html" with page_obj=page_obj query_string=query_string table_id="recent-transactions" filter_item_q=filter_item_q filter_type=filter_type filter_date_from=filter_date_from filter_date_to=filter_date_to %}
+  {% include "inventory/_recent_transactions_table.html" with page_obj=page_obj query_string=query_string table_id="recent-transactions" filter_item_q=filter_item_q filter_type=filter_type filter_date_from=filter_date_from filter_date_to=filter_date_to date_clear_query_string=date_clear_query_string %}
     </div>
   </div>
 

--- a/tests/test_stock_forms.py
+++ b/tests/test_stock_forms.py
@@ -1,10 +1,12 @@
 import pytest
+from bs4 import BeautifulSoup
 from django import forms as django_forms
 from django.urls import reverse
 
 from inventory.forms.stock_forms import (
     StockAdjustmentForm,
     StockReceivingForm,
+    StockTransferForm,
     StockWastageForm,
 )
 from inventory.models import Item
@@ -64,3 +66,108 @@ def test_stock_wastage_form_includes_phase7_reasons_and_optional_photo():
     assert "STAFF_MEAL" in values
     assert "wastage_photo" in form.fields
     assert form.fields["wastage_photo"].required is False
+
+
+@pytest.mark.django_db
+def test_stock_movement_modals_mark_required_fields_and_skip_native_prompts(client):
+    resp = client.get(reverse("stock_movements"))
+    content = resp.content.decode()
+
+    for label in [
+        "Item",
+        "Quantity",
+        "Quantity Change (+/-)",
+        "Reason",
+        "Wastage Category",
+        "From Department",
+        "To Department",
+    ]:
+        assert f"{label}<span class=\"text-danger\"> *</span>" in content
+
+    for field_name in [
+        "receive-item",
+        "receive-quantity_change",
+        "adjust-item",
+        "adjust-quantity_change",
+        "adjust-reason_category",
+        "waste-item",
+        "waste-quantity_change",
+        "waste-reason_category",
+        "transfer-item",
+        "transfer-quantity",
+        "transfer-from_department",
+        "transfer-to_department",
+    ]:
+        assert f'name="{field_name}" required' not in content
+
+
+@pytest.mark.django_db
+def test_stock_forms_show_contextual_required_messages():
+    receive_form = StockReceivingForm(data={}, prefix="receive")
+    adjust_form = StockAdjustmentForm(data={}, prefix="adjust")
+    waste_form = StockWastageForm(data={}, prefix="waste")
+    transfer_form = StockTransferForm(data={}, prefix="transfer")
+
+    assert not receive_form.is_valid()
+    assert receive_form.errors["item"] == ["Choose an item to receive."]
+    assert receive_form.errors["quantity_change"] == ["Enter the quantity received."]
+
+    assert not adjust_form.is_valid()
+    assert adjust_form.errors["item"] == ["Choose an item to adjust."]
+    assert adjust_form.errors["quantity_change"] == ["Enter the stock change quantity."]
+    assert adjust_form.errors["reason_category"] == [
+        "Choose why this adjustment is needed."
+    ]
+
+    assert not waste_form.is_valid()
+    assert waste_form.errors["item"] == ["Choose an item to record as wastage."]
+    assert waste_form.errors["quantity_change"] == ["Enter the quantity wasted."]
+    assert waste_form.errors["reason_category"] == ["Choose a wastage category."]
+
+    assert not transfer_form.is_valid()
+    assert transfer_form.errors["item"] == ["Choose an item to transfer."]
+    assert transfer_form.errors["quantity"] == ["Enter the transfer quantity."]
+    assert transfer_form.errors["from_department"] == [
+        "Choose the department stock is moving from."
+    ]
+    assert transfer_form.errors["to_department"] == [
+        "Choose the department stock is moving to."
+    ]
+
+
+@pytest.mark.django_db
+def test_stock_movement_modal_post_shows_contextual_errors(client):
+    resp = client.post(
+        reverse("stock_movements"),
+        {"submit_waste": "1"},
+        follow=True,
+    )
+    content = resp.content.decode()
+
+    assert "Choose an item to record as wastage." in content
+    assert "Enter the quantity wasted." in content
+    assert "Choose a wastage category." in content
+
+
+@pytest.mark.django_db
+def test_stock_movements_date_filter_has_clear_dates_control(client):
+    resp = client.get(
+        reverse("stock_movements"),
+        {
+            "item_q": "rice",
+            "type": "WASTAGE",
+            "date_from": "2026-05-01",
+            "date_to": "2026-05-27",
+        },
+    )
+
+    content = resp.content.decode()
+    soup = BeautifulSoup(content, "html.parser")
+    clear_dates = soup.find("a", string="Clear dates")
+
+    assert clear_dates is not None
+    href = clear_dates["href"]
+    assert "item_q=rice" in href
+    assert "type=WASTAGE" in href
+    assert "date_from" not in href
+    assert "date_to" not in href


### PR DESCRIPTION
## What changed

- Added contextual form-level validation messages for Receive Stock, Adjust Stock, Record Wastage, and Transfer Stock.
- Rendered Receive and Adjust modals through the shared field component so required markers and inline errors match the rest of the UI.
- Added a `Clear dates` control for stock movement date filters while preserving item/type filters.
- Covered required markers, app-level errors, missing selection handling, and date-filter reset behavior with focused tests.

## Why

Stock movement modals were relying too much on browser-native missing-field prompts, and Receive/Adjust used raw `as_p` rendering instead of the app's consistent field/error UI.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_stock_forms.py tests\test_crud_post_submit_audit.py` -> 12 passed
- `.\.venv\Scripts\python.exe -m ruff check inventory\forms\stock_forms.py inventory\views\stock.py tests\test_stock_forms.py` -> all checks passed
