### PR TITLE
[codex] fix indent processing issue flow

### DIFF
--- a/inventory/views/indents.py
+++ b/inventory/views/indents.py
@@ -1108,15 +1108,15 @@ def issue_indent(request, pk: int):
     items = list(
         indent.indentitem_set.select_related("item").order_by("indent_item_id").all()
     )
-    shortage_rows = [
-        item
-        for item in items
-        if max(
-            Decimal("0"),
-            Decimal(str(item.requested_qty or 0)) - Decimal(str(item.issued_qty or 0)),
-        )
-        > Decimal(str(getattr(item.item, "current_stock", 0) or 0))
-    ]
+    for item in items:
+        requested = Decimal(str(item.requested_qty or 0))
+        issued = Decimal(str(item.issued_qty or 0))
+        available = Decimal(str(getattr(item.item, "current_stock", 0) or 0))
+        pending = max(Decimal("0"), requested - issued)
+        item.remaining_qty = pending
+        item.available_qty = available
+        item.max_issue_qty = min(pending, available)
+    shortage_rows = [item for item in items if item.remaining_qty > item.available_qty]
     # Build formset for all items in this indent
     if request.method == "POST":
         Formset = forms.formset_factory(
@@ -1156,6 +1156,10 @@ def issue_indent(request, pk: int):
         )  # type: ignore
         initial = IndentIssueFormset.initial_for_indent(indent.indent_id)
         formset = Formset(initial=initial)
+
+    for item, form in zip(items, formset.forms):
+        max_issue_qty = getattr(item, "max_issue_qty", Decimal("0"))
+        form.fields["issue_qty"].widget.attrs["max"] = f"{max_issue_qty:.2f}"
 
     # Pair items with forms for template rendering
     pairs = list(zip(items, formset.forms))

--- a/templates/inventory/_indent_detail_partial.html
+++ b/templates/inventory/_indent_detail_partial.html
@@ -35,6 +35,9 @@
     {# ── Read-only view ───────────────────────────────────────────────── #}
     {% include "components/detail_table.html" with rows=rows %}
     <div class="flex flex-wrap gap-2">
+      {% if indent.status|upper == 'APPROVED' or indent.status|upper == 'PROCESSING' %}
+      <a href="{% url 'issue_indent' indent.indent_id %}" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-accent text-white hover:bg-accent-strong focus:ring-2 focus:ring-accent-strong">Issue Stock</a>
+      {% endif %}
       <a href="{% url 'indent_pdf' indent.indent_id %}" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Download PDF</a>
       {% if wa_url %}
       <a href="{{ wa_url }}" target="_blank" rel="noopener" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Prepare WhatsApp Message</a>
@@ -54,7 +57,6 @@
         <form action="{% url 'indent_update_status' indent.indent_id 'CANCELLED' %}" method="post" class="inline">{% csrf_token %}<button type="submit" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-danger text-white hover:bg-danger-strong focus:ring-2 focus:ring-danger-soft">Cancel</button></form>
       {% elif indent.status|upper == 'APPROVED' %}
         <form action="{% url 'indent_update_status' indent.indent_id 'PROCESSING' %}" method="post" class="inline">{% csrf_token %}<button type="submit" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Mark Processing</button></form>
-        <form action="{% url 'indent_update_status' indent.indent_id 'COMPLETED' %}" method="post" class="inline">{% csrf_token %}<button type="submit" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Mark Completed</button></form>
         <form action="{% url 'indent_update_status' indent.indent_id 'CANCELLED' %}" method="post" class="inline">{% csrf_token %}<button type="submit" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-danger text-white hover:bg-danger-strong focus:ring-2 focus:ring-danger-soft">Cancel</button></form>
       {% elif indent.status|upper == 'PROCESSING' %}
         <form action="{% url 'indent_update_status' indent.indent_id 'COMPLETED' %}" method="post" class="inline">{% csrf_token %}<button type="submit" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-transparent text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">Mark Completed</button></form>

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -141,6 +141,12 @@
           {% icon 'printer' 'w-4 h-4' %}
           <span class="sr-only">Download PDF</span>
         </a>
+        {% if row.status|upper == 'APPROVED' or row.status|upper == 'PROCESSING' %}
+        <a href="{% url 'issue_indent' row.indent_id %}" class="inline-flex items-center justify-center w-8 h-8 p-0 text-xs font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary hover:text-accent" title="Issue stock" aria-label="Issue stock">
+          {% icon 'archive-box-arrow-down' 'w-4 h-4' %}
+          <span class="sr-only">Issue stock</span>
+        </a>
+        {% endif %}
   {% if row.status|upper == 'SUBMITTED' %}
   {% if request.user.is_staff or request.user.is_superuser or perms.inventory.change_indent %}
         <form action="{% url 'indent_update_status' row.indent_id 'APPROVED' %}"

--- a/templates/inventory/indent_issue_form.html
+++ b/templates/inventory/indent_issue_form.html
@@ -34,9 +34,12 @@
               <td class="px-3 py-2 align-top">{{ row.item.name }}</td>
               <td class="px-3 py-2 text-right align-top">{{ row.requested_qty }}</td>
               <td class="px-3 py-2 text-right align-top">{{ row.issued_qty|default:0 }}</td>
-              <td class="px-3 py-2 text-right align-top">{{ row.remaining_qty }}</td>
-              <td class="px-3 py-2 text-right align-top" data-testid="available-stock">{{ row.item.current_stock|default:0 }}</td>
-              <td class="px-3 py-2 text-right align-top">{{ form.issue_qty }}{{ form.indent_item_id }}</td>
+              <td class="px-3 py-2 text-right align-top" data-testid="pending-qty">{{ row.remaining_qty|floatformat:2 }}</td>
+              <td class="px-3 py-2 text-right align-top" data-testid="available-stock">{{ row.available_qty|floatformat:2 }}</td>
+              <td class="px-3 py-2 text-right align-top">
+                {{ form.issue_qty }}{{ form.indent_item_id }}
+                <span class="mt-1 block text-xs text-gray-500" data-testid="issue-available-help">Available: {{ row.available_qty|floatformat:2 }}</span>
+              </td>
               <td class="px-3 py-2 align-top">{{ form.source_location }}</td>
             </tr>
           {% endfor %}

--- a/tests/test_indent_issue_flow.py
+++ b/tests/test_indent_issue_flow.py
@@ -54,6 +54,17 @@ def test_issue_indent_page_shows_available_stock_and_location_select(
     assert "Freezer" not in options
     issue_qty = soup.find("input", attrs={"name": "form-0-issue_qty"})
     assert issue_qty["value"] == "20.00"
+    assert issue_qty["max"] == "20.00"
+    assert (
+        soup.find("span", attrs={"data-testid": "issue-available-help"}).get_text(
+            strip=True
+        )
+        == "Available: 20.00"
+    )
+    assert (
+        soup.find("td", attrs={"data-testid": "pending-qty"}).get_text(strip=True)
+        == "100.00"
+    )
     assert "Create PO for shortage" in resp.content.decode()
 
 
@@ -86,3 +97,62 @@ def test_issue_indent_post_issues_available_qty_and_leaves_shortage(
         transaction_type="ISSUE",
         quantity_change=Decimal("-20.00"),
     ).exists()
+
+
+def test_issue_indent_post_over_available_returns_detail_without_error(
+    client, item_factory
+):
+    item = item_factory(name="Follow Short Issue Item", current_stock=Decimal("20.00"))
+    indent, line = _create_indent_line(item)
+
+    resp = client.post(
+        reverse("issue_indent", kwargs={"pk": indent.pk}),
+        {
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-indent_item_id": str(line.pk),
+            "form-0-issue_qty": "100.00",
+            "form-0-source_location": "Main Store",
+        },
+        follow=True,
+    )
+
+    assert resp.status_code == 200
+    assert "Something went wrong" not in resp.content.decode()
+    assert resp.request["PATH_INFO"] == reverse(
+        "indent_detail", kwargs={"pk": indent.pk}
+    )
+
+
+def test_processing_indent_table_has_issue_action(client, item_factory):
+    item = item_factory(name="Processing List Item", current_stock=Decimal("20.00"))
+    indent, _line = _create_indent_line(item)
+    indent.status = IndentStatus.PROCESSING
+    indent.save(update_fields=["status"])
+
+    resp = client.get(reverse("indents_table"))
+
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.content.decode(), "html.parser")
+    issue_url = reverse("issue_indent", kwargs={"pk": indent.pk})
+    issue_link = soup.find("a", href=issue_url)
+    assert issue_link is not None
+    assert issue_link["aria-label"] == "Issue stock"
+
+
+def test_indent_drawer_has_issue_action_for_processing_indent(client, item_factory):
+    item = item_factory(name="Processing Drawer Item", current_stock=Decimal("20.00"))
+    indent, _line = _create_indent_line(item)
+    indent.status = IndentStatus.PROCESSING
+    indent.save(update_fields=["status"])
+
+    resp = client.get(reverse("indent_detail", kwargs={"pk": indent.pk}) + "?partial=1")
+
+    assert resp.status_code == 200
+    soup = BeautifulSoup(resp.content.decode(), "html.parser")
+    issue_url = reverse("issue_indent", kwargs={"pk": indent.pk})
+    issue_link = soup.find("a", href=issue_url)
+    assert issue_link is not None
+    assert issue_link.get_text(strip=True) == "Issue Stock"


### PR DESCRIPTION
## Summary

- Show pending and available stock directly on the indent issue screen.
- Cap the Issue Now input to the available quantity for each line.
- Add Issue Stock actions from the indents table and detail drawer for approved/processing indents.
- Remove the invalid completed action from approved indents in the drawer.
- Add regression coverage for over-available issue submits and the missing issue actions.

## Root Cause

The issue page rendered `remaining_qty` without assigning it in the issue view, and the common list/drawer paths exposed status transitions without a direct route to the actual stock-issuing screen. That made processing hard to discover and left users without available quantity context while issuing.

## Validation

- `python -m pytest tests/test_indent_issue_flow.py tests/test_indent_issue_service.py tests/test_indent_forms.py tests/test_aa_views.py::test_indent_create_atomic_on_error` -> 11 passed
- `python -m ruff check inventory/views/indents.py tests/test_indent_issue_flow.py tests/test_indent_issue_service.py tests/test_indent_forms.py` -> passed