### PR TITLE
[codex] fix predictive supplier suggestions

### DIFF
--- a/static/js/predictive-datalist-overlay.js
+++ b/static/js/predictive-datalist-overlay.js
@@ -86,9 +86,9 @@
       }
 
       const options = Array.from(datalist.querySelectorAll("option"));
-      const items = options.filter(
-        (o) => !q || (o.value || o.textContent || "").toLowerCase().includes(q),
-      );
+      const optionText = (option) =>
+        `${option.value || ""} ${option.textContent || ""}`.toLowerCase();
+      const items = options.filter((o) => !q || optionText(o).includes(q));
       overlay.innerHTML = "";
       activeIndex = -1;
       items.forEach((o, idx) => {

--- a/tests/js/predictive-datalist-overlay.test.js
+++ b/tests/js/predictive-datalist-overlay.test.js
@@ -1,0 +1,28 @@
+/** @jest-environment jsdom */
+
+describe("predictive datalist overlay", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <input id="supplier" name="supplier" list="supplier-options" data-predictive-input="1" />
+      <datalist id="supplier-options">
+        <option value="42">Acme Produce</option>
+        <option value="77">Paper Goods</option>
+      </datalist>`;
+    jest.isolateModules(() => {
+      require("../../static/js/predictive-datalist-overlay.js");
+    });
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+  });
+
+  test("filters options by display label when option value is an id", () => {
+    const input = document.getElementById("supplier");
+
+    input.value = "prod";
+    input.dispatchEvent(new Event("focus"));
+
+    const overlay = document.querySelector(".predictive-overlay");
+    expect(overlay.textContent).toContain("Acme Produce");
+    expect(overlay.textContent).not.toContain("Paper Goods");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix predictive datalist filtering so supplier-style options can match typed supplier names.
- Add a Jest regression for options where the value is an ID and the visible label is the searchable supplier name.

## Root Cause
The predictive datalist overlay filtered against `option.value` before `option.textContent`. Supplier suggestions render IDs as option values and names as option labels, so typing part of a supplier name could show no overlay matches even after valid results loaded.

## Validation
- `npm.cmd test -- predictive-datalist-overlay.test.js predictive-dropdown.test.js modal-po-validation.test.js --runInBand`
- `.\.venv\Scripts\python.exe -m pytest tests\test_purchase_order_drawer_partial.py -k "supplier_search_matches or required_fields or unique_supplier_substring or numeric_unknown_supplier"`
