### PR TITLE
[codex] improve global accessibility and validation

### DIFF
--- a/static/js/forms.js
+++ b/static/js/forms.js
@@ -2,6 +2,45 @@
 // Adds event listeners to inputs to show success/error feedback
 
 document.addEventListener("DOMContentLoaded", () => {
+  const humanizeName = (value) =>
+    String(value || "This field")
+      .replace(/^id_/, "")
+      .replace(/[_-]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .replace(/\b\w/g, (char) => char.toUpperCase());
+
+  const labelFor = (input) => {
+    if (!input) return "This field";
+    const explicitLabel = input.id
+      ? document.querySelector(`label[for="${input.id}"]`)
+      : null;
+    const labelText = explicitLabel ? explicitLabel.textContent.trim() : "";
+    return (
+      labelText.replace(/\s*\*\s*$/, "") ||
+      humanizeName(input.name || input.id)
+    );
+  };
+
+  const validationMessageFor = (input) => {
+    const label = labelFor(input);
+    if (input.validity.valueMissing) return `${label} is required.`;
+    if (input.validity.typeMismatch)
+      return `Enter a valid ${label.toLowerCase()}.`;
+    if (input.validity.rangeUnderflow)
+      return `${label} must be at least ${input.min}.`;
+    if (input.validity.rangeOverflow)
+      return `${label} must be no more than ${input.max}.`;
+    if (input.validity.stepMismatch)
+      return `${label} must use a valid increment.`;
+    if (input.validity.tooShort) return `${label} is too short.`;
+    if (input.validity.tooLong) return `${label} is too long.`;
+    if (input.validity.patternMismatch)
+      return `${label} has an invalid format.`;
+    if (input.validationMessage) return input.validationMessage;
+    return `${label} is invalid.`;
+  };
+
   const forms = document.querySelectorAll("form");
   forms.forEach((form) => {
     const inputs = form.querySelectorAll("input, select, textarea");
@@ -27,7 +66,7 @@ document.addEventListener("DOMContentLoaded", () => {
             success.classList.add("hidden");
           }
           if (error) {
-            error.textContent = input.validationMessage;
+            error.textContent = validationMessageFor(input);
             error.classList.remove("hidden");
           }
         }

--- a/static/js/modal.js
+++ b/static/js/modal.js
@@ -714,11 +714,65 @@
           } catch (_) {}
         } catch (_) {}
       };
+      const humanizeName = (value) =>
+        String(value || "This field")
+          .replace(/^id_/, "")
+          .replace(/[_-]+/g, " ")
+          .replace(/\s+/g, " ")
+          .trim()
+          .replace(/\b\w/g, (char) => char.toUpperCase());
+      const labelFor = (control) => {
+        if (!(control instanceof HTMLElement)) return "This field";
+        const id = control.getAttribute("id");
+        const label = id ? form.querySelector(`label[for="${cssEscape(id)}"]`) : null;
+        const text = label ? label.textContent.trim() : "";
+        return (
+          text.replace(/\s*\*\s*$/, "") ||
+          humanizeName(control.getAttribute("name") || id)
+        );
+      };
+      const validationMessageFor = (control) => {
+        const label = labelFor(control);
+        const validity = control.validity || {};
+        if (validity.valueMissing) return `${label} is required.`;
+        if (validity.typeMismatch)
+          return `Enter a valid ${label.toLowerCase()}.`;
+        if (validity.rangeUnderflow)
+          return `${label} must be at least ${control.getAttribute("min")}.`;
+        if (validity.rangeOverflow)
+          return `${label} must be no more than ${control.getAttribute("max")}.`;
+        if (validity.stepMismatch)
+          return `${label} must use a valid increment.`;
+        if (validity.tooShort) return `${label} is too short.`;
+        if (validity.tooLong) return `${label} is too long.`;
+        if (validity.patternMismatch) return `${label} has an invalid format.`;
+        return `${label} is invalid.`;
+      };
+      const collectNativeValidationErrors = () => {
+        const errors = { form: {} };
+        form.querySelectorAll("input, select, textarea").forEach((control) => {
+          if (
+            !(control instanceof HTMLElement) ||
+            control.disabled ||
+            typeof control.checkValidity !== "function" ||
+            control.checkValidity()
+          ) {
+            return;
+          }
+          const name = control.getAttribute("name") || control.getAttribute("id");
+          if (!name) return;
+          errors.form[name] = [validationMessageFor(control)];
+        });
+        return Object.keys(errors.form).length ? errors : null;
+      };
       const hiddenDept = form.querySelector("#id_department");
       const uiDept = form.querySelector("#department-ui");
       if (hiddenDept && uiDept) hiddenDept.value = uiDept.value;
       if (typeof form.checkValidity === "function" && !form.checkValidity()) {
-        if (typeof form.reportValidity === "function") form.reportValidity();
+        showInlineError(
+          "Please fix the highlighted fields.",
+          { errors: collectNativeValidationErrors() },
+        );
         return;
       }
       if (hiddenDept && !hiddenDept.value) {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -105,9 +105,10 @@ class NotificationManager {
    */
   show(message, type = "info", duration = null, options = {}) {
     const style = options.style || "toast";
+    const displayMessage = this.decodeMessage(message);
 
     if (style === "banner") {
-      return this.showBannerNotification(message, type, options);
+      return this.showBannerNotification(displayMessage, type, options);
     }
 
     // Manage queue for toast notifications
@@ -116,7 +117,7 @@ class NotificationManager {
     }
 
     const notification = this.createNotificationElement(
-      message,
+      displayMessage,
       type,
       style,
       options,
@@ -201,6 +202,14 @@ class NotificationManager {
     }
 
     return notification;
+  }
+
+  decodeMessage(message) {
+    const text = String(message || "");
+    if (!/[&][A-Za-z0-9#]+;/.test(text)) return text;
+    const textarea = document.createElement("textarea");
+    textarea.innerHTML = text;
+    return textarea.value;
   }
 
   showBannerNotification(message, type, options) {

--- a/templates/components/filter_bar.html
+++ b/templates/components/filter_bar.html
@@ -165,9 +165,11 @@ Single filter form (id=filters). Optional:
       {% if not hide_labels %}<span class="text-label text-xs font-medium text-bodyText mb-1">&nbsp;</span>{% endif %}
       <a
         href="{{ reset_href }}"
+        aria-label="Clear all table filters"
+        title="Clear all table filters"
         class="inline-flex items-center justify-center h-9 px-3 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary"
       >
-        Reset
+        Clear filters
       </a>
     </div>
   {% endif %}

--- a/templates/inventory/_indents_table.html
+++ b/templates/inventory/_indents_table.html
@@ -30,7 +30,7 @@
         <button type="button" data-density-btn data-value="comfortable" class="inline-flex items-center px-2 py-1.5 text-xs font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" title="Comfortable rows">Comfortable</button>
       </div>
       <div class="relative" data-col-menu-container x-data="{open:false}" @click.outside="open=false">
-      <button type="button" data-col-menu-button @click="open=!open" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">
+      <button type="button" data-col-menu-button @click="open=!open" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" aria-label="Show or hide table columns" title="Show or hide table columns">
         Columns
         <svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
       </button>

--- a/templates/inventory/_suppliers_table.html
+++ b/templates/inventory/_suppliers_table.html
@@ -29,7 +29,7 @@
         <button type="button" data-density-btn data-value="comfortable" class="inline-flex items-center px-2 py-1.5 text-xs font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" title="Comfortable rows">Comfortable</button>
       </div>
       <div class="relative" data-col-menu-container x-data="{open:false}" @click.outside="open=false">
-      <button type="button" data-col-menu-button @click="open=!open" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">
+      <button type="button" data-col-menu-button @click="open=!open" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" aria-label="Show or hide table columns" title="Show or hide table columns">
         Columns
         <svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
       </button>

--- a/templates/inventory/indents_list.html
+++ b/templates/inventory/indents_list.html
@@ -52,7 +52,7 @@
 {% block filters %}
   {% url 'indents_table' as indents_table_url %}
   <div class="mb-4">
-    {% include "components/filter_bar.html" with hide_labels=True search_placeholder="Search MRN, requester, department…" hx_get=indents_table_url hx_target="#indents_table" hx_indicator="#indents-loading" filters=filters search_delay="400ms" %}
+    {% include "components/filter_bar.html" with hide_labels=True search_placeholder="Search MRN, requester, department…" hx_get=indents_table_url hx_target="#indents_table" hx_indicator="#indents-loading" filters=filters search_delay="400ms" reset_href=request.path %}
   </div>
 {% endblock %}
 

--- a/templates/inventory/purchase_orders/_cards.html
+++ b/templates/inventory/purchase_orders/_cards.html
@@ -51,7 +51,8 @@
     <div class="flex justify-end gap-2 pt-3 border-t border-border">
       <a href="{% url 'purchase_order_detail' po.pk %}"
          class="text-primary hover:text-primary-dark"
-         title="View">
+         title="View purchase order {{ po.pk }}"
+         aria-label="View purchase order {{ po.pk }}">
         {% icon 'eye' 'w-5 h-5' %}
         <span class="sr-only">View</span>
       </a>
@@ -60,7 +61,8 @@
          data-modal-type="drawer"
          data-modal-prefetch="hover"
          class="text-primary hover:text-primary-dark"
-         title="Edit">
+         title="Edit purchase order {{ po.pk }}"
+         aria-label="Edit purchase order {{ po.pk }}">
         {% icon 'pencil-square' 'w-5 h-5' %}
         <span class="sr-only">Edit</span>
       </a>
@@ -69,7 +71,8 @@
          data-modal-type="drawer"
          data-modal-prefetch="hover"
          class="text-primary hover:text-primary-dark"
-         title="Receive Goods">
+         title="Receive goods for purchase order {{ po.pk }}"
+         aria-label="Receive goods for purchase order {{ po.pk }}">
         {% icon 'arrow-down-tray' 'w-5 h-5' %}
         <span class="sr-only">Receive</span>
       </a>

--- a/templates/inventory/purchase_orders/_table.html
+++ b/templates/inventory/purchase_orders/_table.html
@@ -15,7 +15,7 @@
     </div>
     <div class="flex items-center gap-2">
 <div class="relative" data-col-menu-container x-data="{open:false}" @click.outside="open=false">
-      <button type="button" data-col-menu-button @click="open=!open" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary">
+      <button type="button" data-col-menu-button @click="open=!open" class="inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-md transition focus:outline-none bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:ring-2 focus:ring-primary" aria-label="Show or hide table columns" title="Show or hide table columns">
         Columns
         <svg class="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
       </button>
@@ -134,7 +134,9 @@
          data-modal-url="{% url 'purchase_order_edit_partial' po.pk %}"
          data-modal-type="drawer"
          data-modal-prefetch="hover"
-         class="text-primary" title="Edit">
+         class="text-primary"
+         title="Edit purchase order {{ po.pk }}"
+         aria-label="Edit purchase order {{ po.pk }}">
         {% icon 'pencil-square' 'w-5 h-5' %}
         <span class="sr-only">Edit</span>
       </a>
@@ -143,7 +145,9 @@
          data-modal-url="{% url 'purchase_order_receive_partial' po.pk %}"
          data-modal-type="drawer"
          data-modal-prefetch="hover"
-         class="text-primary" title="Receive">
+         class="text-primary"
+         title="Receive goods for purchase order {{ po.pk }}"
+         aria-label="Receive goods for purchase order {{ po.pk }}">
         {% icon 'arrow-down-tray' 'w-5 h-5' %}
         <span class="sr-only">Receive</span>
       </a>

--- a/templates/inventory/purchase_orders/list.html
+++ b/templates/inventory/purchase_orders/list.html
@@ -89,7 +89,7 @@
 {% endblock %}
 
 {% block filters %}
-{% include "components/filter_bar.html" with filter_bar_card=True filters=filters predictive_names=predictive_filter_names hx_get=po_hx_get hx_target=po_hx_target hx_indicator="#purchase-orders-loading" search_placeholder="Search PO #, supplier, notes…" show_date_range=True start_date=start_date end_date=end_date page_size_options=page_size_options page_size=page_size export_href=export_href export_label="Export CSV" view_toggle_table_href=view_toggle_table_href view_toggle_cards_href=view_toggle_cards_href view_toggle_current=view_toggle_current sort=sort direction=direction %}
+{% include "components/filter_bar.html" with filter_bar_card=True filters=filters predictive_names=predictive_filter_names hx_get=po_hx_get hx_target=po_hx_target hx_indicator="#purchase-orders-loading" search_placeholder="Search PO #, supplier, notes…" show_date_range=True start_date=start_date end_date=end_date page_size_options=page_size_options page_size=page_size export_href=export_href export_label="Export CSV" view_toggle_table_href=view_toggle_table_href view_toggle_cards_href=view_toggle_cards_href view_toggle_current=view_toggle_current sort=sort direction=direction reset_href=request.path %}
 {% endblock %}
 
 {% block extra_top %}{% endblock %}

--- a/templates/inventory/recipes/_recipes_table.html
+++ b/templates/inventory/recipes/_recipes_table.html
@@ -144,7 +144,8 @@
                       data-modal-url="{% url 'recipe_view_partial' recipe.recipe_id %}"
                       data-modal-type="drawer"
                       data-modal-prefetch="hover"
-                      aria-label="View {{ recipe.name }}">
+                      title="View recipe {{ recipe.name }}"
+                      aria-label="View recipe {{ recipe.name }}">
                 {% icon 'eye' 'w-4 h-4' %}
               </button>
               <button type="button"
@@ -152,18 +153,21 @@
                       data-modal-url="{% url 'recipe_edit_partial' recipe.recipe_id %}"
                       data-modal-type="drawer"
                       data-modal-prefetch="hover"
-                      aria-label="Edit {{ recipe.name }}">
+                      title="Edit recipe {{ recipe.name }}"
+                      aria-label="Edit recipe {{ recipe.name }}">
                 {% icon 'pencil-square' 'w-4 h-4' %}
               </button>
               <a href="{% url 'recipe_detail' recipe.recipe_id %}"
                  class="inline-flex items-center justify-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary"
-                 aria-label="Open {{ recipe.name }} details">
+                 title="Open recipe details {{ recipe.name }}"
+                 aria-label="Open recipe details {{ recipe.name }}">
                 {% icon 'arrow-top-right-on-square' 'w-4 h-4' %}
               </a>
               <button type="button"
                       onclick="confirmDelete('{% url 'recipe_delete' recipe.recipe_id %}', '{{ recipe.name|escapejs }}', 'Recipe')"
                       class="inline-flex items-center justify-center px-3 py-1.5 text-xs font-medium rounded-md transition bg-surface text-danger border border-border hover:bg-danger-soft focus:outline-none focus:ring-2 focus:ring-danger"
-                      aria-label="Delete {{ recipe.name }}">
+                      title="Delete recipe {{ recipe.name }}"
+                      aria-label="Delete recipe {{ recipe.name }}">
                 {% icon 'trash' 'w-4 h-4' %}
               </button>
             </div>

--- a/templates/inventory/recipes/list.html
+++ b/templates/inventory/recipes/list.html
@@ -26,7 +26,7 @@
 
 {% block filters %}
   {% url 'recipes_table' as recipes_table_url %}
-  {% include "components/filter_bar.html" with search_placeholder="Search recipes..." hx_get=recipes_table_url hx_target="#recipes-table-container" hx_indicator="#recipes-table-loading" q=q %}
+  {% include "components/filter_bar.html" with search_placeholder="Search recipes..." hx_get=recipes_table_url hx_target="#recipes-table-container" hx_indicator="#recipes-table-loading" q=q reset_href=request.path %}
 {% endblock %}
 
 {% block table_id %}recipes-table-wrapper{% endblock %}

--- a/templates/inventory/suppliers_list.html
+++ b/templates/inventory/suppliers_list.html
@@ -76,7 +76,7 @@
 {% block filters %}
   {% url hx_view_name as suppliers_view_url %}
   {% with hx_tgt='#'|add:container_id %}
-  {% include "components/filter_bar.html" with filter_bar_card=True search_placeholder="Search suppliers..." hx_get=suppliers_view_url hx_target=hx_tgt filters=filters page_size_options=page_size_options page_size=page_size sort=sort direction=direction export_href=export_href export_label="Export CSV" view_toggle_table_href=view_toggle_table_href view_toggle_cards_href=view_toggle_cards_href view_toggle_current=view_toggle_current hx_indicator="#htmx-spinner" %}
+  {% include "components/filter_bar.html" with filter_bar_card=True search_placeholder="Search suppliers..." hx_get=suppliers_view_url hx_target=hx_tgt filters=filters page_size_options=page_size_options page_size=page_size sort=sort direction=direction export_href=export_href export_label="Export CSV" view_toggle_table_href=view_toggle_table_href view_toggle_cards_href=view_toggle_cards_href view_toggle_current=view_toggle_current hx_indicator="#htmx-spinner" reset_href=request.path %}
   {% endwith %}
 {% endblock %}
 

--- a/tests/js/forms-validation.test.js
+++ b/tests/js/forms-validation.test.js
@@ -1,0 +1,28 @@
+/** @jest-environment jsdom */
+
+describe("global form validation feedback", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <form>
+        <div>
+          <label for="id_supplier">Supplier</label>
+          <input id="id_supplier" name="supplier" required />
+          <p data-feedback="success" class="hidden"></p>
+          <p data-feedback="error" class="hidden"></p>
+        </div>
+      </form>`;
+    require("../../static/js/forms.js");
+    document.dispatchEvent(new Event("DOMContentLoaded"));
+  });
+
+  test("shows app-owned required messages instead of browser text", () => {
+    const input = document.getElementById("id_supplier");
+    const error = document.querySelector('[data-feedback="error"]');
+
+    input.dispatchEvent(new Event("blur", { bubbles: true }));
+
+    expect(error.textContent).toBe("Supplier is required.");
+    expect(error.classList.contains("hidden")).toBe(false);
+  });
+});

--- a/tests/js/modal-po-validation.test.js
+++ b/tests/js/modal-po-validation.test.js
@@ -20,7 +20,7 @@ describe("modal purchase order validation", () => {
     require("../../static/js/modal.js");
   });
 
-  test("reports native required errors before posting modal form", () => {
+  test("shows explicit required errors before posting modal form", () => {
     const form = document.getElementById("po-drawer-form");
     form.checkValidity = jest.fn(() => false);
     form.reportValidity = jest.fn();
@@ -28,7 +28,9 @@ describe("modal purchase order validation", () => {
     form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
 
     expect(form.checkValidity).toHaveBeenCalled();
-    expect(form.reportValidity).toHaveBeenCalled();
+    expect(form.reportValidity).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Supplier is required.");
+    expect(document.body.textContent).toContain("Order Date is required.");
     expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/tests/js/notifications.test.js
+++ b/tests/js/notifications.test.js
@@ -1,0 +1,22 @@
+/** @jest-environment jsdom */
+
+describe("notifications", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    document.body.innerHTML = `<div id="notification-container"></div>`;
+    global.requestAnimationFrame = (callback) => callback();
+    require("../../static/js/notifications.js");
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("decodes HTML entity apostrophes before rendering toast text", () => {
+    window.notifications.showToast("Can&#x27;t save supplier", "error", 0);
+
+    expect(document.body.textContent).toContain("Can't save supplier");
+    expect(document.body.textContent).not.toContain("&#x27;");
+  });
+});

--- a/tests/test_global_usability_accessibility.py
+++ b/tests/test_global_usability_accessibility.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+
+def read_template(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def test_filter_bar_exposes_clear_filters_control():
+    content = read_template("templates/components/filter_bar.html")
+
+    assert "Clear filters" in content
+    assert 'aria-label="Clear all table filters"' in content
+    assert 'title="Clear all table filters"' in content
+
+
+def test_multi_filter_lists_pass_reset_href_to_shared_filter_bar():
+    templates = [
+        "templates/inventory/indents_list.html",
+        "templates/inventory/suppliers_list.html",
+        "templates/inventory/purchase_orders/list.html",
+        "templates/inventory/recipes/list.html",
+    ]
+
+    for template_path in templates:
+        content = read_template(template_path)
+        assert "reset_href=" in content, f"{template_path} must wire clear filters"
+
+
+def test_purchase_order_action_icons_have_labels_and_tooltips():
+    table = read_template("templates/inventory/purchase_orders/_table.html")
+    cards = read_template("templates/inventory/purchase_orders/_cards.html")
+
+    for content in [table, cards]:
+        assert 'title="Edit purchase order' in content
+        assert 'aria-label="Edit purchase order' in content
+        assert 'title="Receive goods for purchase order' in content
+        assert 'aria-label="Receive goods for purchase order' in content
+
+
+def test_recipe_action_icons_have_labels_and_tooltips():
+    content = read_template("templates/inventory/recipes/_recipes_table.html")
+
+    for label in [
+        "View recipe",
+        "Edit recipe",
+        "Open recipe details",
+        "Delete recipe",
+    ]:
+        assert f'title="{label}' in content
+        assert f'aria-label="{label}' in content
+
+
+def test_column_menu_icon_buttons_have_labels_and_tooltips():
+    templates = [
+        "templates/inventory/_suppliers_table.html",
+        "templates/inventory/_indents_table.html",
+        "templates/inventory/purchase_orders/_table.html",
+    ]
+
+    for template_path in templates:
+        content = read_template(template_path)
+        assert 'aria-label="Show or hide table columns"' in content
+        assert 'title="Show or hide table columns"' in content

--- a/tests/test_items_table_accessibility.py
+++ b/tests/test_items_table_accessibility.py
@@ -28,7 +28,7 @@ def test_items_search_has_placeholder_and_reset_control():
     assert "Search items by nan" not in content
     assert "Search items..." in content or "Search items…" in content
     filter_bar = Path("templates/components/filter_bar.html").read_text()
-    assert "Reset" in filter_bar
+    assert "Clear filters" in filter_bar
 
 
 def test_no_dropdown_filter_controls_present():


### PR DESCRIPTION
## Summary

- Add accessible labels and tooltips to icon-only table/card actions for purchase orders, recipes, indents, and suppliers.
- Wire the shared table filter bar to a clear "Clear filters" affordance on multi-filter list pages.
- Replace generic browser validation text with explicit app-owned validation messages in global forms and modal drawer submits.
- Decode HTML entity text before rendering toast notifications so apostrophes and quotes display correctly.

## Impact

This improves screen reader support, makes icon actions easier to understand, keeps table filtering easier to reset, and makes validation/toast messages more human-readable.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests/test_accessibility.py tests/test_items_table_accessibility.py tests/test_global_usability_accessibility.py -q` -> `14 passed, 2 warnings`
- `npm.cmd test -- forms-validation.test.js notifications.test.js modal-po-validation.test.js items-table.test.js --runInBand` -> `4 passed`, `11 passed`, `2 skipped`
- `git diff --check` -> clean, with line-ending warnings only