### PR TITLE
fix: harden production readiness p0 workflows

### DIFF
--- a/inventory/models/orders.py
+++ b/inventory/models/orders.py
@@ -171,19 +171,20 @@ class PurchaseOrderItem(models.Model):
             self.line_total = self.quantity_ordered * self.unit_price
 
         is_new = self.pk is None
+        old_unit_price = None
+        if not is_new:
+            old_unit_price = (
+                type(self)
+                .objects.filter(pk=self.pk)
+                .values_list("unit_price", flat=True)
+                .first()
+            )
         super().save(*args, **kwargs)
 
         # Update item's last purchase price when PO item is created/updated
         if self.item and self.unit_price:
             # Only update if this is a new record or price changed
-            update_price = False
-            if is_new:
-                update_price = True
-            else:
-                # Check if price changed
-                old_item = PurchaseOrderItem.objects.get(pk=self.pk)
-                if old_item.unit_price != self.unit_price:
-                    update_price = True
+            update_price = is_new or old_unit_price != self.unit_price
 
             if update_price:
                 # Update item's price history

--- a/inventory/services/stock_service.py
+++ b/inventory/services/stock_service.py
@@ -96,6 +96,12 @@ def record_stock_transactions_bulk(transactions: List[Dict[str, Any]]) -> bool:
             for tx in transactions:
                 item_id = tx["item_id"]
                 quantity_change = Decimal(str(tx["quantity_change"]))
+                item = Item.objects.select_for_update().get(pk=item_id)
+                current = item.current_stock or Decimal("0")
+                if quantity_change < 0 and current + quantity_change < 0:
+                    raise ValueError(
+                        f"Stock cannot go negative for item {item_id}."
+                    )
                 updated = Item.objects.filter(pk=item_id).update(
                     current_stock=F("current_stock") + quantity_change
                 )
@@ -111,6 +117,7 @@ def record_stock_transactions_bulk(transactions: List[Dict[str, Any]]) -> bool:
                     related_indent_id=tx.get("related_indent_id"),
                     related_po_id=tx.get("related_po_id"),
                     notes=tx.get("notes"),
+                    reason_category=tx.get("reason_category"),
                 )
         get_low_stock_items.cache_clear()
         return True

--- a/inventory/views/stock_take.py
+++ b/inventory/views/stock_take.py
@@ -165,6 +165,13 @@ def stock_take_review(request, pk: int):
 
     if request.method == "POST":
         action = request.POST.get("action")
+        if st.status == "COMPLETED":
+            messages.info(
+                request,
+                "This stock take is already completed and cannot be changed.",
+                extra_tags="toast",
+            )
+            return redirect("stock_take_review", pk=pk)
         if action == "complete" and st.status != "COMPLETED":
             user_id = getattr(request.user, "username", None) or "System"
             user_int = getattr(request.user, "pk", None)

--- a/templates/inventory/purchase_orders/detail.html
+++ b/templates/inventory/purchase_orders/detail.html
@@ -44,7 +44,11 @@
       <button type="submit" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Send to Supplier</button>
     </form>
   {% elif po.status == 'SENT' %}
-    <a href="{% url 'purchase_order_receive' po.pk %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Receive Goods</a>
+    <a href="{% url 'purchase_order_receive' po.pk %}"
+       data-modal-url="{% url 'purchase_order_receive_partial' po.pk %}"
+       data-modal-type="drawer"
+       data-modal-prefetch="hover"
+       class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">Receive Goods</a>
   {% elif po.status == 'RECEIVED' %}
     <a href="{% url 'grn_list' %}" class="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md transition bg-accent text-white hover:bg-accent-strong focus:outline-none focus:ring-2 focus:ring-accent-strong">View GRNs</a>
   {% endif %}
@@ -66,7 +70,11 @@
           <button type="submit" class="w-full text-left px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Send to Supplier</button>
         </form>
       {% elif po.status == 'SENT' %}
-        <a href="{% url 'purchase_order_receive' po.pk %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Receive Goods</a>
+        <a href="{% url 'purchase_order_receive' po.pk %}"
+           data-modal-url="{% url 'purchase_order_receive_partial' po.pk %}"
+           data-modal-type="drawer"
+           data-modal-prefetch="hover"
+           class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">Receive Goods</a>
       {% endif %}
       <div class="border-t border-border my-1"></div>
       <a href="{% url 'grn_list' %}" class="block px-4 py-2 text-sm text-bodyText hover:bg-surfaceSubtle" role="menuitem">View GRNs</a>

--- a/tests/js/column-filters.test.js
+++ b/tests/js/column-filters.test.js
@@ -19,7 +19,7 @@ describe("column-filters dropdown", () => {
     global.fetch = jest.fn();
     window.fetch = global.fetch;
     jest.isolateModules(() => {
-      require("./column-filters.js");
+      require("../../static/js/column-filters.js");
     });
     document.dispatchEvent(new Event("DOMContentLoaded"));
   });

--- a/tests/test_purchase_order_service_django.py
+++ b/tests/test_purchase_order_service_django.py
@@ -155,3 +155,31 @@ def test_create_po_creates_estimated_vendor_savings(item_factory):
     assert entry.status == SavingsLedger.Status.ESTIMATED
     assert entry.estimated_saving == Decimal("0.00")
     assert entry.lost_saving == Decimal("100.00")
+
+
+@pytest.mark.django_db
+def test_updating_purchase_order_item_price_updates_item_last_purchase_price(
+    item_factory,
+):
+    supplier = Supplier.objects.create(name="Price History Vendor")
+    item = item_factory(
+        name="Price History Item",
+        last_purchase_price=Decimal("12.00"),
+    )
+    po = PurchaseOrder.objects.create(
+        supplier=supplier,
+        order_date=date.today(),
+        status="DRAFT",
+    )
+    po_item = PurchaseOrderItem.objects.create(
+        purchase_order=po,
+        item=item,
+        quantity_ordered=Decimal("2.00"),
+        unit_price=Decimal("15.00"),
+    )
+
+    po_item.unit_price = Decimal("18.50")
+    po_item.save()
+
+    item.refresh_from_db()
+    assert item.last_purchase_price == Decimal("18.50")

--- a/tests/test_stock_service_django.py
+++ b/tests/test_stock_service_django.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import pytest
 
 from inventory.models import StockTransaction
@@ -41,3 +43,29 @@ def test_record_and_remove_bulk_transactions(item_factory):
     item2.refresh_from_db()
     assert item1.current_stock == 10
     assert item2.current_stock == 10
+
+
+@pytest.mark.django_db
+def test_bulk_stock_transactions_prevent_negative_stock_and_roll_back(item_factory):
+    item1 = item_factory(name="Bulk Safe Item", current_stock=Decimal("3.00"))
+    item2 = item_factory(name="Bulk Untouched Item", current_stock=Decimal("4.00"))
+    txs = [
+        {
+            "item_id": item1.item_id,
+            "quantity_change": Decimal("-5.00"),
+            "transaction_type": "ADJUSTMENT",
+        },
+        {
+            "item_id": item2.item_id,
+            "quantity_change": Decimal("2.00"),
+            "transaction_type": "RECEIVING",
+        },
+    ]
+
+    assert stock_service.record_stock_transactions_bulk(txs) is False
+
+    item1.refresh_from_db()
+    item2.refresh_from_db()
+    assert item1.current_stock == Decimal("3.00")
+    assert item2.current_stock == Decimal("4.00")
+    assert StockTransaction.objects.count() == 0

--- a/tests/test_stock_take_workflow.py
+++ b/tests/test_stock_take_workflow.py
@@ -1,0 +1,40 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+
+from inventory.models import StockTake, StockTakeItem, StockTransaction
+
+pytestmark = pytest.mark.django_db
+
+
+def test_completed_stock_take_cannot_be_discarded(client, django_user_model, item_factory):
+    user = django_user_model.objects.get(username="admin")
+    item = item_factory(name="Completed Stock Take Item", current_stock=Decimal("8.00"))
+    stock_take = StockTake.objects.create(
+        date=date.today(),
+        status="COMPLETED",
+        created_by=user,
+    )
+    StockTakeItem.objects.create(
+        stock_take=stock_take,
+        item=item,
+        system_qty=Decimal("8.000"),
+        physical_qty=Decimal("7.000"),
+    )
+    StockTransaction.objects.create(
+        item=item,
+        quantity_change=Decimal("-1.00"),
+        transaction_type="ADJUSTMENT",
+        notes=f"Stock take #{stock_take.pk} variance adjustment",
+    )
+
+    response = client.post(
+        reverse("stock_take_review", args=[stock_take.pk]),
+        {"action": "discard"},
+    )
+
+    assert response.status_code == 302
+    assert StockTake.objects.filter(pk=stock_take.pk).exists()
+    assert StockTransaction.objects.filter(item=item).count() == 1


### PR DESCRIPTION
## Summary
- Route purchase-order detail Receive Goods actions through the existing drawer partial for parity with list/card/table surfaces.
- Preserve item price history when an existing purchase-order line unit price changes.
- Prevent bulk stock transactions from driving item stock below zero and roll back the whole bulk batch on failure.
- Block direct POST discard attempts for completed stock takes.
- Repair the stale Jest column-filter import so the existing suite runs against `static/js/column-filters.js`.

## Validation
- `python -m pytest tests/test_purchase_order_drawer_partial.py::test_purchase_order_detail_actions_use_drawers tests/test_purchase_order_service_django.py::test_updating_purchase_order_item_price_updates_item_last_purchase_price -q` -> 2 passed
- `python -m pytest tests/test_stock_service_django.py::test_bulk_stock_transactions_prevent_negative_stock_and_roll_back tests/test_stock_take_workflow.py::test_completed_stock_take_cannot_be_discarded -q` -> 2 passed
- `python -m pytest tests/test_purchase_order_drawer_partial.py tests/test_purchase_order_service_django.py tests/test_goods_receiving_service_django.py tests/test_stock_service_django.py tests/test_stock_forms.py tests/test_stock_take_workflow.py tests/test_indent_forms.py tests/test_indent_issue_service.py tests/test_recipe_drawer.py tests/test_item_form.py tests/test_items_filters.py tests/test_supplier_form.py -q` -> 74 passed
- `npm.cmd test -- modal-po-validation.test.js recipe-components.test.js predictive-dropdown.test.js forms-validation.test.js notifications.test.js column-filters.test.js items-table.test.js --runInBand` -> 7 suites passed, 18 passed, 2 skipped
- `python manage.py check` -> no issues
- `python -m ruff check inventory\models\orders.py inventory\services\stock_service.py inventory\views\stock_take.py tests\test_purchase_order_service_django.py tests\test_stock_service_django.py tests\test_stock_take_workflow.py` -> all checks passed
- `python -m pytest tests\test_ui_authenticated_smoke.py -q` -> 80 passed, 11 skipped