### PR TITLE
fix: improve production readiness accessibility labels

### DIFF
--- a/templates/components/action_menu.html
+++ b/templates/components/action_menu.html
@@ -1,16 +1,16 @@
 {% load icon_tags %}
 <div class="flex gap-2">
-  <a href="{{ view_url }}" class="text-primary no-underline focus:outline-none focus:ring-2 focus:ring-primary" title="View">
+  <a href="{{ view_url }}" class="text-primary no-underline focus:outline-none focus:ring-2 focus:ring-primary" title="View" aria-label="View">
     {% icon 'eye' 'w-5 h-5' aria_label='' %}
     <span class="sr-only">View</span>
   </a>
-  <a href="{{ edit_url }}" class="text-primary no-underline focus:outline-none focus:ring-2 focus:ring-primary" title="Edit">
+  <a href="{{ edit_url }}" class="text-primary no-underline focus:outline-none focus:ring-2 focus:ring-primary" title="Edit" aria-label="Edit">
     {% icon 'pencil-square' 'w-5 h-5' aria_label='' %}
     <span class="sr-only">Edit</span>
   </a>
   <form action="{{ approve_url }}" method="post" class="inline">
     {% csrf_token %}
-    <button type="submit" class="text-primary focus:outline-none focus:ring-2 focus:ring-primary" title="Approve">
+    <button type="submit" class="text-primary focus:outline-none focus:ring-2 focus:ring-primary" title="Approve" aria-label="Approve">
       {% icon 'check' 'w-5 h-5' aria_label='' %}
       <span class="sr-only">Approve</span>
     </button>

--- a/templates/inventory/items_list.html
+++ b/templates/inventory/items_list.html
@@ -68,7 +68,7 @@
               </div>
             </div>
             <div class="relative" data-col-menu-container>
-              <button type="button" class="inline-flex items-center justify-center w-8 h-8 p-0 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" aria-label="Show/Hide Columns" title="Show/Hide Columns" aria-haspopup="true" aria-expanded="false" aria-controls="columns-menu" data-col-menu-button>{% icon 'cog-6-tooth' 'w-4 h-4' %}</button>
+              <button type="button" class="inline-flex items-center justify-center w-8 h-8 p-0 text-sm font-medium rounded-md transition bg-surface text-bodyText border border-border hover:bg-surfaceSubtle focus:outline-none focus:ring-2 focus:ring-primary" aria-label="Show or hide table columns" title="Show or hide table columns" aria-haspopup="true" aria-expanded="false" aria-controls="columns-menu" data-col-menu-button>{% icon 'cog-6-tooth' 'w-4 h-4' %}</button>
               <!-- Column visibility dropdown -->
               <div id="columns-menu" data-col-menu class="hidden absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-surface ring-1 ring-black ring-opacity-5 p-3 z-40">
                 <p class="text-xs font-medium text-table-headerText mb-2">Toggle Columns</p>

--- a/templates/inventory/suppliers_card.html
+++ b/templates/inventory/suppliers_card.html
@@ -10,7 +10,7 @@
       {% if row.email %}<p class="text-sm text-gray-500"><a href="mailto:{{ row.email }}" class="hover:text-primary transition">{{ row.email }}</a></p>{% endif %}
     </div>
     <div class="flex gap-2">
-      <a href="{% url 'supplier_edit' row.supplier_id %}" data-modal-url="{% url 'supplier_edit' row.supplier_id %}?partial=1" class="text-primary" title="Edit">{% icon 'pencil' 'w-5 h-5' %}</a>
+      <a href="{% url 'supplier_edit' row.supplier_id %}" data-modal-url="{% url 'supplier_edit' row.supplier_id %}?partial=1" class="text-primary" title="Edit supplier {{ row.name }}" aria-label="Edit supplier {{ row.name }}">{% icon 'pencil' 'w-5 h-5' %}</a>
       <form hx-post="{% url 'supplier_toggle_active' row.supplier_id %}" hx-target="#suppliers_cards" method="post" class="inline deactivate-form" data-open-pos="{{ row.open_po_count }}" data-is-active="{% if row.is_active %}true{% else %}false{% endif %}" data-supplier-name="{{ row.name }}">
         {% csrf_token %}
         <input type="hidden" name="q" value="{{ q }}" />
@@ -20,7 +20,10 @@
         <input type="hidden" name="sort" value="{{ sort }}" />
         <input type="hidden" name="direction" value="{{ direction }}" />
         <input type="hidden" name="view" value="cards" />
-        <button type="submit" title="Toggle" class="inline-flex items-center justify-center w-8 h-8 rounded-md border border-border bg-surfaceSubtle hover:bg-surface transition focus:outline-none focus:ring-2 focus:ring-primary">
+        <button type="submit"
+                title="{% if row.is_active %}Deactivate{% else %}Activate{% endif %} supplier {{ row.name }}"
+                aria-label="{% if row.is_active %}Deactivate{% else %}Activate{% endif %} supplier {{ row.name }}"
+                class="inline-flex items-center justify-center w-8 h-8 rounded-md border border-border bg-surfaceSubtle hover:bg-surface transition focus:outline-none focus:ring-2 focus:ring-primary">
           {% if row.is_active %}{% icon 'check' 'w-5 h-5 text-success' %}<span class="sr-only">Deactivate</span>{% else %}{% icon 'x-mark' 'w-5 h-5 text-danger' %}<span class="sr-only">Activate</span>{% endif %}
         </button>
       </form>

--- a/tests/test_global_usability_accessibility.py
+++ b/tests/test_global_usability_accessibility.py
@@ -61,3 +61,35 @@ def test_column_menu_icon_buttons_have_labels_and_tooltips():
         content = read_template(template_path)
         assert 'aria-label="Show or hide table columns"' in content
         assert 'title="Show or hide table columns"' in content
+
+
+def test_items_column_menu_uses_descriptive_label_and_tooltip():
+    content = read_template("templates/inventory/items_list.html")
+
+    assert 'aria-label="Show or hide table columns"' in content
+    assert 'title="Show or hide table columns"' in content
+    assert "Show/Hide Columns" not in content
+
+
+def test_supplier_card_icon_actions_have_specific_labels_and_tooltips():
+    content = read_template("templates/inventory/suppliers_card.html")
+
+    assert 'title="Edit supplier {{ row.name }}"' in content
+    assert 'aria-label="Edit supplier {{ row.name }}"' in content
+    assert (
+        'title="{% if row.is_active %}Deactivate{% else %}Activate{% endif %} '
+        'supplier {{ row.name }}"'
+    ) in content
+    assert (
+        'aria-label="{% if row.is_active %}Deactivate{% else %}Activate{% endif %} '
+        'supplier {{ row.name }}"'
+    ) in content
+    assert 'title="Toggle"' not in content
+
+
+def test_shared_action_menu_icon_actions_have_aria_labels():
+    content = read_template("templates/components/action_menu.html")
+
+    for label in ["View", "Edit", "Approve"]:
+        assert f'title="{label}"' in content
+        assert f'aria-label="{label}"' in content

--- a/tests/test_items_table_accessibility.py
+++ b/tests/test_items_table_accessibility.py
@@ -12,9 +12,9 @@ def test_column_menu_has_accessibility_attrs():
     btn_match = re.search(r"<button[^>]*data-col-menu-button[^>]*>", content)
     assert btn_match, "Column menu button not found"
     btn = btn_match.group(0)
-    assert 'title="Show/Hide Columns"' in btn
+    assert 'title="Show or hide table columns"' in btn
     assert 'aria-controls="columns-menu"' in btn
-    assert 'aria-label="Show/Hide Columns"' in btn
+    assert 'aria-label="Show or hide table columns"' in btn
 
 
 def test_inline_item_create_marks_required_fields():


### PR DESCRIPTION
## Summary
- Replace the vague Items column-menu label with a descriptive `Show or hide table columns` label and tooltip.
- Add specific labels/tooltips for supplier card edit and activate/deactivate icon actions.
- Add aria labels to the shared action-menu icon links/buttons while keeping existing visual text and titles.
- Update accessibility tests to lock these labels.

## Validation
- `python -m pytest tests/test_global_usability_accessibility.py -q` -> 8 passed
- `python -m pytest tests/test_global_usability_accessibility.py tests/test_supplier_form.py tests/test_items_table_accessibility.py tests/test_ui_authenticated_smoke.py -q` -> 99 passed, 11 skipped
- `python -m ruff check tests/test_global_usability_accessibility.py tests/test_items_table_accessibility.py` -> all checks passed
- `python manage.py check` -> no issues