### PR TITLE
docs: add production readiness audit package

### DIFF
--- a/docs/production-readiness/go-live-plan.md
+++ b/docs/production-readiness/go-live-plan.md
@@ -1,0 +1,171 @@
+# Inventory-App Go-Live Checklist And Deployment Plan
+
+Last reviewed: 2026-05-28
+
+## Go/No-Go Rule
+
+Go only when all P0 workflows pass automated checks and local or staging browser UAT, no major page returns a server error, migrations are verified against the target database, and remaining risks are documented as P1/P2 or owner-confirmation items.
+
+Current recommendation before completing browser UAT: **No-go for production cutover**. Draft PRs #853 and #854 reduce known code and UX risk, but owner/business confirmation and manual end-to-end workflow evidence are still required before production cutover.
+
+## 1. Code Freeze
+
+- Freeze feature changes except release-blocker fixes.
+- Merge only reviewed, focused branches into `feature/django-refactor`.
+- Require every release-blocker fix to include a regression test where practical.
+- Run focused validation before each release-branch merge.
+- Keep secrets in environment variables only; do not commit credentials or exported production data.
+
+## 2. Staging Deployment
+
+- Deploy the latest `feature/django-refactor` release candidate to staging.
+- Confirm environment variables:
+  - `DJANGO_SECRET_KEY`
+  - `DATABASE_URL`
+  - `DJANGO_DEBUG=False`
+  - `DJANGO_ALLOWED_HOSTS`
+  - `DATABASE_SSL_REQUIRE` if required by the provider
+  - static/media storage settings
+- Confirm static assets are built with `npm run build`.
+- Smoke-test `/healthz`, `/`, `/items/`, `/suppliers/`, `/recipes/`, `/indents/`, `/purchase-orders/`, `/grns/`, `/stock-movements/`, `/stock-takes/`, and `/vendor-prices/`.
+
+## 3. Database Backup And Migration Verification
+
+- Take a database backup immediately before production deployment.
+- Record backup location, timestamp, and restore owner.
+- Run migrations through Django deployment tooling, not manual table patches.
+- Verify expected production tables and columns exist, including:
+  - `sales_transactions`
+  - `savings_ledger`
+  - `vendor_item_prices`
+  - `chef_bulletins`
+  - `trial_recipe_versions`
+  - `recovery_actions`
+  - `goods_received_notes.grn_number`
+- Run read-only SQL checks in the production database after migration.
+- Do not run destructive migrations unless the owner has approved a tested rollback path.
+
+## 4. Seed And QA Data Cleanup
+
+- Use only `QA` or `CODX` prefixes for manual UAT records.
+- Before go-live, remove or deactivate QA records from staging or production-like data:
+  - Items
+  - Suppliers
+  - Recipes
+  - Indents
+  - Purchase orders
+  - GRNs
+  - Stock transactions
+  - Stock takes
+  - Vendor prices
+- Do not delete records that are linked to transactions unless the app explicitly supports safe deletion. Prefer deactivation or a database restore on disposable staging data.
+
+## 5. Automated Quality Gate
+
+Run from the project root:
+
+```powershell
+.\.venv\Scripts\python.exe manage.py check --settings=inventory_app.settings.test
+.\.venv\Scripts\python.exe -m pytest tests\test_purchase_order_drawer_partial.py tests\test_purchase_order_service_django.py tests\test_goods_receiving_service_django.py tests\test_stock_service_django.py tests\test_stock_forms.py tests\test_stock_take_workflow.py tests\test_indent_forms.py tests\test_indent_issue_service.py tests\test_recipe_drawer.py tests\test_item_form.py tests\test_items_filters.py tests\test_supplier_form.py -q
+.\.venv\Scripts\python.exe -m pytest tests\test_global_usability_accessibility.py tests\test_supplier_form.py tests\test_items_table_accessibility.py tests\test_ui_authenticated_smoke.py -q
+npm.cmd test -- modal-po-validation.test.js recipe-components.test.js predictive-dropdown.test.js forms-validation.test.js notifications.test.js column-filters.test.js items-table.test.js --runInBand
+```
+
+Before final release, run `make ci` or document any unrelated known failures with exact failing tests.
+
+## 6. Smoke Test Checklist
+
+- Login succeeds with the intended owner/admin account.
+- Navigation groups render: Insights, Procurement, Stock, Master Data.
+- No major page returns HTTP 500.
+- Drawers open and close consistently for item, supplier, recipe, indent, PO, receiving, and stock movement forms.
+- Required fields show visible markers and actionable validation messages.
+- Destructive actions require confirmation.
+- Toasts show plain English without HTML entities.
+- CSV exports download for Items, Suppliers, POs, and any implemented stock/GRN exports.
+- Logout ends the session and browser back does not restore private screens.
+
+## 7. Full UAT Checklist
+
+Complete the QA matrix in `docs/production-readiness/qa-matrix.md` and attach evidence for these eight workflows:
+
+1. Create item -> update item -> receive stock -> adjust stock -> stock movement appears.
+2. Create supplier -> link supplier to item/vendor price -> create PO.
+3. Create recipe -> request ingredients -> create indent.
+4. Approve indent -> consolidate/order plan -> create PO.
+5. Receive PO -> GRN created -> item stock updated -> PO status updated.
+6. Create stock take -> enter count -> review variance -> complete -> stock adjusted.
+7. Record wastage -> stock reduces -> wastage transaction appears.
+8. Transfer stock -> source/destination department movement appears.
+
+## 8. Rollback Plan
+
+- Keep the previous production image/release available.
+- Keep the pre-deploy database backup available and restore-tested.
+- If deployment fails before migrations, roll back application release only.
+- If deployment fails after migrations, assess whether migrations are backward compatible:
+  - If compatible, roll back application release and keep migrated database.
+  - If not compatible, restore the database backup and roll back application release together.
+- Record the incident timeline, failed health checks, logs, and owner decision.
+
+## 9. Monitoring, Logging, And Error Tracking
+
+- Monitor HTTP 500s, login failures, migration errors, and slow requests.
+- Watch workflows with stock impact: GRNs, stock movements, indent issue, and stock take completion.
+- Confirm logs do not expose secrets, passwords, or full credential strings.
+- Configure alerting for repeated server errors and failed deployment health checks.
+- Review stock transaction anomalies daily during hypercare.
+
+## 10. User Access, Roles, And Training
+
+- Confirm user groups map to app roles:
+  - Owner
+  - Purchase
+  - Storekeeper
+  - Head Chef
+  - Kitchen Staff
+- Confirm unauthorized users cannot mutate restricted workflows.
+- Prepare short training notes for:
+  - Creating items and suppliers
+  - Creating and approving indents
+  - Consolidating approved indents into POs
+  - Receiving goods and checking GRNs
+  - Recording wastage, adjustments, and transfers
+  - Running stock takes
+  - Reading owner dashboards and recovery actions
+
+## 11. Known Limitations Requiring Owner Confirmation
+
+- Whether ad-hoc GRNs without POs are allowed in production.
+- Whether negative stock is ever allowed and who can override it.
+- Whether same-day duplicate PO generation from consolidation should be blocked or warned.
+- Whether completed stock takes can ever be reopened.
+- Whether delete actions should hard-delete, soft-delete, or deactivate linked records.
+- Whether vendor prices are a read-only comparison tool or full CRUD master data for procurement.
+
+## 12. Production Deployment Steps
+
+1. Announce code freeze and maintenance window.
+2. Confirm latest release candidate commit and tag.
+3. Take and verify database backup.
+4. Deploy application release.
+5. Run Django migrations.
+6. Build and collect static assets if required by the platform.
+7. Run health check.
+8. Run smoke checklist.
+9. Run critical workflow UAT with QA/CODX data.
+10. Remove QA/CODX data or restore clean staging copy as appropriate.
+11. Announce go-live or rollback decision.
+
+## 13. Seven-Day Hypercare
+
+| Day | Activity |
+| --- | --- |
+| Day 0 | Monitor deploy, login, page load, and P0 workflows continuously for the first business cycle. |
+| Day 1 | Review stock transactions, GRNs, PO statuses, and failed form submissions. |
+| Day 2 | Validate owner dashboard numbers against expected operational data. |
+| Day 3 | Review user feedback and fix P0/P1 issues only. |
+| Day 4 | Audit imports/exports and cleanup any accidental QA records. |
+| Day 5 | Review role permissions and destructive-action logs. |
+| Day 6 | Prepare post-launch bug list and training clarifications. |
+| Day 7 | Owner sign-off, decide whether to reopen feature work, and archive hypercare evidence. |

--- a/docs/production-readiness/qa-matrix.md
+++ b/docs/production-readiness/qa-matrix.md
@@ -1,0 +1,47 @@
+# Production Readiness QA Matrix
+
+Use `QA` or `CODX` prefixes for all manual records created during local or staging UAT. Mark each row `Pass`, `Fail`, `Blocked`, or `Not implemented`, and link the exact issue or commit for every failure.
+
+| Page | Feature/Form | Create | Read/View | Update/Edit | Delete/Cancel | Filters/Search | Import/Export | Status transitions | Stock/accounting impact | Result | Notes/Bugs fixed |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Dashboard | Overview KPIs and alerts | N/A | Load KPIs, alerts, charts | N/A | N/A | Date/window controls | N/A | N/A | Reads stock, purchase, sales, variance totals | Pending UAT | Verify no server errors and values are plausible. |
+| Items | Item CRUD | Add `QA Item` with category, unit, reorder point, supplier, departments | Detail drawer/page opens | Edit all fields | Delete unused item; deactivate linked item | Search, category, subcategory, unit, supplier, department, status, stock status | CSV export and bulk upload | Active/inactive | Reorder point, low-stock status, stock value | Automated partial pass; UAT pending | Existing tests cover reorder point/category persistence. |
+| Items | Item table actions | N/A | View icon opens detail | Edit icon opens drawer | Delete/activate/deactivate confirm | Sorting, pagination, columns, compact view | Export filtered CSV | Active/inactive | No stock mutation unless explicit action | Automated partial pass; UAT pending | PR #854 standardizes the column-menu label; browser spot-check still required. |
+| Suppliers | Supplier CRUD | Add `QA Supplier` without fake phone/email defaults | Detail drawer opens | Edit contact fields | Delete unused supplier; block/delete linked supplier safely | Search, status, table/cards, columns, compact view | CSV export, bulk upload, bulk delete | Active/inactive | Supplier availability in PO and item forms | Automated partial pass; UAT pending | Required fields: name and contact person; PR #854 improves card action labels. |
+| Recipes | Recipe CRUD | Create final recipe and sub-recipe with positive ingredient | Detail/view partial shows costing | Edit ingredient rows and unchanged name | Delete/cancel with linked-data check | Search, type, sort, pagination | N/A | Active/inactive if exposed | Cost, yield, loss, margin, target food cost | Automated partial pass; UAT pending | Existing tests cover hidden ids, duplicate-name, positive row validation. |
+| Recipes | Recipe to indent | Create ingredient request from recipe | Indent created with items | N/A | Cancel if allowed | N/A | N/A | Recipe request to submitted indent | No stock change until fulfilment | Pending UAT | Confirm sub-recipes expand correctly. |
+| Indents | Indent CRUD/status | Create `QA Indent` with department and one positive item | Detail and table rows load | Edit when allowed | Cancel/delete when allowed | MRN/search, status, department, requester, sort, pagination | Print/PDF/export | Submitted, approved, processing, completed, cancelled | Fulfilment reduces stock | Automated partial pass; UAT pending | Existing tests cover empty indent rejection and issue transaction boundary. |
+| Indents | Fulfilment | N/A | Issue form loads | Enter partial/full issue quantities | Cancel issue | N/A | N/A | Approved to processing/completed | Creates ISSUE transaction, blocks over-issue | Pending UAT | Browser-test `Issue Selected` with QA stock. |
+| Order Planner | Consolidation | Generate from approved indents | Preview groups by supplier | Quantity overrides/exclusions | Cancel preview | Supplier/item eligibility | Create POs | Approved indent to PO link | Planned quantities only, no stock mutation | Pending UAT | Add more tests if duplicate PO lines are reproduced. |
+| Purchase Orders | PO CRUD | Create `QA PO` with supplier/order date/line | Detail opens | Edit line and notes | Cancel/delete if supported | Search, status, supplier, dates, table/cards | CSV export, print/download | Draft to sent to received/cancelled if supported | Pending/received totals and item last purchase price | Automated partial pass; UAT pending | PR #853 fixes detail receive drawer behavior and PO line price history updates. |
+| Purchase Orders | Supplier search | Select supplier by partial/case-insensitive name | N/A | Preserve supplier on edit | N/A | Full and partial name suggestions | N/A | N/A | Supplier drives PO/vendor price hints | Automated partial pass; UAT pending | Existing form resolves exact, id, and unique partial active supplier. |
+| Receiving/GRNs | PO receiving | Receive partial and full quantities | GRN detail/list load | N/A | Cancel receive | GRN list filters | GRN export/download | PO partial/full received | Creates GRN, updates stock and PO progress | Automated partial pass; UAT pending | Existing tests cover over-receipt rejection and stock preservation. |
+| Receiving/GRNs | Ad-hoc receiving | Create ad-hoc GRN if business-approved | Detail/list load | N/A | Cancel | Filters/search | Export | GRN received | Updates stock without PO | Pending owner confirmation | Confirm ad-hoc receiving is intended before go-live. |
+| Stock Movements | Receive stock | Item and quantity required; date defaults today | Transaction appears | N/A | N/A | Search/type/date range and clear dates | Bulk upload | RECEIVING | Increases item stock | Automated partial pass; UAT pending | Verify in-app validation messages. |
+| Stock Movements | Adjust stock | Item, quantity change, reason required | Transaction appears | N/A | N/A | Search/type/date range | Bulk upload | ADJUSTMENT | Positive/negative adjustment, prevent unintended negative stock | Automated partial pass; UAT pending | Existing tests cover missing reason errors; PR #853 adds bulk negative-stock rollback coverage. |
+| Stock Movements | Wastage | Item, quantity, category required; photo optional | Transaction appears | N/A | N/A | Search/type/date range | N/A | WASTAGE | Reduces stock | Automated partial pass; UAT pending | Verify negative stock prevention. |
+| Stock Movements | Transfer | Item, quantity, from and to departments required | Transaction appears | N/A | N/A | Search/type/date range | N/A | TRANSFER | Department movement; item total policy must be confirmed | Pending UAT | Source and destination cannot match. |
+| Stock Takes | Start/count/review | Start `QA Stock Take` | Count page and review page load | Enter counts | Cannot edit or discard after completion unless intended | List/status filters | N/A | Draft, in progress, completed | Variance creates adjustment transactions | Automated partial pass; UAT pending | PR #853 blocks direct discard of completed stock takes; confirm all-department behavior. |
+| Vendor Prices | Price comparison | CRUD if implemented | List/comparison loads | Edit if implemented | Delete if implemented | Search/filter | Export if implemented | N/A | Used by PO/order planner if enabled | Pending UAT | Current route appears list/comparison focused. |
+| Global UX | Navigation/search/notifications/profile | N/A | Menus, notifications, profile load | Profile/password pages | Logout/session handling | Global search if present | N/A | N/A | N/A | Smoke automated pass; UAT pending | Verify no HTML entities in toasts and focus is sane. |
+| Imports/exports | Bulk uploads/downloads | Upload valid QA CSV | Error rows visible | N/A | Cancel upload | N/A | Download filtered CSVs | N/A | Depends on imported data | Pending UAT | Keep QA data identifiable and cleanable. |
+
+## P0 Browser UAT Checklist
+
+1. Create item -> edit item -> receive stock -> adjust stock -> transaction appears.
+2. Create supplier -> link to item/vendor price if supported -> create PO.
+3. Create recipe -> request ingredients -> indent appears.
+4. Approve indent -> order planner consolidation -> create PO.
+5. Receive PO -> GRN created -> item stock updated -> PO status/progress updated.
+6. Create stock take -> enter count -> review variance -> complete -> stock adjusted.
+7. Record wastage -> stock reduces -> wastage transaction appears.
+8. Transfer stock -> source/destination department movement appears and same-department transfer is blocked.
+
+## Current Evidence
+
+- P0 regression red checks were observed for PO detail receive drawer wiring, PO item price history updates, bulk negative-stock rollback, and completed stock-take discard protection.
+- P0 focused Python suite after fixes: `74 passed`.
+- P0 focused Jest suite after fixing stale column-filter import: `7 passed` suites, `18 passed, 2 skipped`.
+- P0 authenticated route smoke after fixes: `80 passed, 11 skipped`.
+- P1 accessibility/smoke suite after fixes: `99 passed, 11 skipped`.
+- `manage.py check`: no issues on P0 and P1 branches.

--- a/docs/production-readiness/route-process-audit.md
+++ b/docs/production-readiness/route-process-audit.md
@@ -1,0 +1,107 @@
+# Inventory-App Route And Process Audit
+
+Last reviewed: 2026-05-28
+Target branch: `feature/django-refactor`
+Documentation branch: `feature/prod-readiness-audit-docs`
+
+## Summary
+
+Inventory-App is a Django 5.2 application with HTML UI routes in `inventory/ui_urls.py`, API routes in `inventory/urls.py`, and navigation in `inventory_app/navigation.py`. Business logic is concentrated in `inventory/services/`; forms live in `inventory/forms/`; UI templates live under `templates/inventory/` and shared components under `templates/components/`.
+
+## Core, Auth, And Admin
+
+| Route | Area | View | Process | Readiness notes |
+| --- | --- | --- | --- | --- |
+| `/` | Insights dashboard | `core.views.root_view` | Owner dashboard, KPIs, alerts, trends | Smoke-load before release; verify role-scoped navigation. |
+| `/login/`, `/accounts/login/` | Auth | Django auth views | Login/session start | UAT with QA account only; verify failed-login and logout paths. |
+| `/accounts/logout/` | Auth | Django auth views | Session end | Verify logout redirects and back button does not restore authenticated state. |
+| `/accounts/password-reset-info/` | Auth | `password_reset_info_view` | Password reset guidance | Confirm no credentials or sensitive settings are exposed. |
+| `/admin/` | Admin | Django admin | Admin CRUD | Superuser-only; smoke-load and confirm no model admin server errors. |
+| `/healthz` | Ops | `health_check` | Runtime health | Use for deployment health checks. |
+| `/kpis/`, `/dashboard-data/` | Insights API | `dashboard_kpis`, `ajax_dashboard_data` | Dashboard partial data | Verify JSON/partial responses under authenticated session. |
+
+## Insights
+
+| Route | View/template | Process | Validation or service owner |
+| --- | --- | --- | --- |
+| `/recipes/food-cost-report/` | `food_cost_report`, `inventory/recipes/food_cost_report.html` | Recipe cost, margin, target food cost review | Recipe model properties and recipe service. |
+| `/savings-ledger/` | `savings_ledger_list` | Estimated/confirmed/lost savings review | `SavingsLedger`, vendor savings service. |
+| `/recovery-actions/`, `/recovery-actions/<id>/` | `recovery_actions_list`, `recovery_action_detail` | Owner action tracking | `RecoveryActionForm`, recovery action service. |
+| `/recovery-actions/<id>/status/` | `recovery_action_status` | Status update | `RecoveryActionStatusForm`; verify role rules. |
+| `/pos-sales/` | `pos_sales_import` | POS import and recipe mapping | `POSSalesImportForm`, POS sales import service. |
+| `/variance-report/` | `variance_report` | Ideal vs actual stock variance | `variance_service.build_variance_report`. |
+| `/chef-bulletins/`, `/chef-bulletins/<id>/` | Chef bulletin views | Recipe alerts and detail | Chef bulletin service. |
+| `/chef-bulletins/<id>/decision/` | `chef_bulletin_decision` | Accept/reject/trial decision | Verify status, trial recipe, and recovery action impact. |
+| `/history-reports/` | `history_reports` | Stock audit trail | Stock transaction filters. |
+| `/visualizations/` | `visualizations` | Stock charts | Verify filters and chart data. |
+| `/ml-dashboard/` | `ml_dashboard` | Reorder suggestions | ML service/cache; confirm helpful empty state. |
+
+## Master Data
+
+| Route | View/template | Process | Validation or service owner |
+| --- | --- | --- | --- |
+| `/items/`, `/items/table/` | `ItemsListView`, `ItemsTableView`, item table templates | List, search, filters, sorting, pagination, table actions | `inventory/views/items/list.py`, `list_utils`. |
+| `/items/create/`, `/items/create/partial/` | `ItemCreateHTMXView`, `ItemCreatePartialView` | Add item drawer/fallback | `ItemForm`; verify name/unit required, category and reorder point persistence. |
+| `/items/<id>/edit/` | `ItemEditView` | Update item | `ItemForm`; verify departments, preferred supplier, active flag. |
+| `/items/<id>/duplicate/` | `ItemDuplicateView` | Prefill a new item from existing data | Confirm it does not save until submitted. |
+| `/items/<id>/delete/` | `ItemDeleteView` | Delete or deactivate safely | Protect linked transaction history. |
+| `/items/<id>/toggle/` | `ItemToggleActiveView` | Activate/deactivate | Confirm list filters reflect state. |
+| `/items/export/`, `/items/upload/`, `/items/bulk-upload/` | Export/upload views | CSV import/export | Verify headers, validation errors, and QA data cleanup. |
+| `/items/search/`, `/items/meta/<id>/`, `/items/distinct/<field>/` | Lookup endpoints | Autocomplete/filter metadata | Verify empty and filtered responses. |
+| `/suppliers/`, `/suppliers/table/`, `/suppliers/cards/` | Supplier list views | List, search, status, view mode, columns, pagination | `SupplierForm`, `supplier_service`, `list_utils`. |
+| `/suppliers/create/`, `/suppliers/<id>/edit/` | Supplier drawer views | Create/update supplier | Required fields: name and contact person; no fake phone/email defaults. |
+| `/suppliers/<id>/toggle/`, `/suppliers/<id>/delete/` | Supplier action views | Activate/deactivate/delete | Delete is blocked when open POs exist; linked-data behavior needs UAT. |
+| `/suppliers/bulk-upload/`, `/suppliers/bulk-delete/` | Bulk supplier views | CSV load/deactivation | Verify confirmation and error reporting. |
+| `/suppliers/search/` | `SupplierSearchView` | Supplier autocomplete | Active suppliers only, partial name friendly. |
+| `/recipes/`, `/recipes/table/` | Recipe list views | List, search, filters, sorting | `RecipeForm`, `RecipeItemFormSet`, recipe service. |
+| `/recipes/create/`, `/recipes/create/partial/` | Recipe create views | Create recipe with ingredients/sub-recipes | Require at least one positive ingredient row. |
+| `/recipes/<id>/edit/partial/` | `RecipeEditPartialView` | Edit recipe and line items | Hidden ingredient ids must render; unchanged unique name must not fail duplicate check. |
+| `/recipes/<id>/view/partial/`, `/recipes/<id>/` | Recipe detail views | Read recipe costing and components | Verify cost breakdown and zero-cost warnings. |
+| `/recipes/<id>/create-indent/` | `recipe_create_indent` | Request ingredients from a recipe | Verify quantities and indent status. |
+| `/recipes/<id>/delete/` | `RecipeDeleteView` | Delete recipe | Confirm linked sales/sub-recipe protection. |
+
+## Procurement
+
+| Route | View/template | Process | Validation or service owner |
+| --- | --- | --- | --- |
+| `/indents/`, `/indents/table/` | Indent list/table views | List, filters, status, overdue, pagination | `IndentForm`, `IndentItemFormSet`. |
+| `/indents/create/` | `IndentCreateView` | Create request | Department required; at least one positive item required. |
+| `/indents/<id>/`, `/indents/<id>/update/` | Detail/update views | Read/edit when allowed | Verify impossible transitions are blocked. |
+| `/indents/<id>/status/<status>/` | `indent_update_status` | Approve/reject/cancel/process | Verify valid status graph only. |
+| `/indents/<id>/issue/` | `issue_indent` | Fulfil/issue stock | `indent_issue_service`; blocks over-issue and reduces stock. |
+| `/indents/<id>/pdf/` | `indent_pdf` | Print/export | Verify PDF response and permissions. |
+| `/indents/generate-from-low-stock/` | `generate_low_stock_indent` | Create indent from low stock | Verify reorder point logic and duplicate prevention. |
+| `/indents/consolidate/preview/` | `consolidate_indents` | Order planner preview | `indent_consolidation_service`; groups approved lines by supplier. |
+| `/indents/consolidate/` | `indents_consolidate` | Generate POs | Verify no duplicate PO lines and correct indent links. |
+| `/purchase-orders/`, `/purchase-orders/table/`, `/purchase-orders/cards/` | PO list views | Search, filters, view modes, progress, actions | `PurchaseOrderForm`, `PurchaseOrderItemFormSet`. |
+| `/purchase-orders/create/partial/` | PO create drawer | Create PO | Supplier, order date, and one valid line required. |
+| `/purchase-orders/<id>/edit/partial/` | PO edit drawer | Update PO | Received lines cannot be deleted incorrectly. |
+| `/purchase-orders/<id>/mark-ordered/` | `mark_ordered` | Draft to sent | Confirm idempotency and invalid status handling. |
+| `/purchase-orders/<id>/receive/partial/` | PO receive drawer | Receive against PO | `goods_receiving_service.create_grn`; blocks over-receipt. |
+| `/purchase-orders/export/` | PO export | CSV download | Verify filters are respected. |
+| `/grns/`, `/grns/<id>/` | GRN list/detail | Receiving history | Verify GRN number, stock impact, attachments. |
+| `/grns/create/`, `/grns/create/adhoc/` | GRN create views | PO and ad-hoc receiving | Confirm ad-hoc receiving is intended before go-live. |
+| `/grns/<id>/export/` | GRN export | Download/print | Verify file response. |
+| `/vendor-prices/` | `vendor_prices_list` | Vendor price comparison | Confirm CRUD requirements; current route is list/comparison focused. |
+
+## Stock
+
+| Route | View/template | Process | Validation or service owner |
+| --- | --- | --- | --- |
+| `/stock-movements/` | `stock_movements`, stock movement partials | Receive, adjust, wastage, transfer, bulk upload | `stock_forms.py`, `stock_service.record_stock_transaction`. |
+| `/stock/users/search/`, `/stock/pos/search/` | Search views | User and PO autocomplete | Verify partial matching and empty states. |
+| `/stock-takes/` | `stock_take_list` | List stock takes | Confirm status display and review action. |
+| `/stock-takes/new/` | `create_stock_take` | Start count | Date defaults to today; department optional if all-department count is intended. |
+| `/stock-takes/<id>/count/` | `stock_take_count` | Enter physical quantities | Snapshot system quantity and save counts. |
+| `/stock-takes/<id>/review/` | `stock_take_review` | Review and complete | Completing creates adjustment transactions for variances. |
+
+## API Surface
+
+The API router exposes CRUD-style endpoints for items, suppliers, stock transactions, indents, indent items, purchase orders, purchase order items, goods received notes, GRN items, recipes, recipe items, sale transactions, and POS menu item mappings. Additional endpoints support item export, item similarity checks, unit/subcategory lookups, and what-if reorder calculations.
+
+## Findings From The 2026-05-28 Pass
+
+- P0 fixes were split into draft PR #853: PO detail receive actions use the drawer partial, PO line price edits update item price history, bulk stock transactions cannot drive negative stock and roll back as a batch, and completed stock takes cannot be discarded by direct POST.
+- P1 UX/accessibility fixes were split into draft PR #854: Items column menu, supplier card actions, and the shared action menu now use clearer labels/tooltips/aria labels.
+- Existing automated coverage already checks many previously known blockers: item category/reorder persistence, recipe edit hidden ids and duplicate-name handling, indent non-empty requirement, indent issue transaction boundaries, PO supplier search, GRN over-receipt, and stock form validation.
+- Remaining go-live risk is operational breadth, not a single known crashing code path: complete local/staging browser UAT must still be run across all critical workflows before production sign-off.


### PR DESCRIPTION
## Summary
- Add a route/process audit covering core/auth/admin, insights, master data, procurement, stock, and API surfaces.
- Add a CRUD/process-flow QA matrix with the critical manual UAT checklist and current automated evidence.
- Add a go-live checklist and deployment plan covering code freeze, staging, backup/migration verification, QA cleanup, smoke/UAT, rollback, monitoring, roles/training, known limitations, deployment steps, and 7-day hypercare.

## Validation
- `python manage.py check` -> no issues
- `git diff --cached --check` -> no whitespace errors

## Notes
- This is a docs-only PR. It references draft PR #853 for P0 workflow fixes and draft PR #854 for P1 UX/accessibility label fixes.
- Current go/no-go recommendation remains no-go until local/staging browser UAT and owner confirmations are complete.